### PR TITLE
Publish: issue + PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report a problem with Spine
+title: "[bug] "
+labels: bug
+---
+
+**What happened?**
+
+**What did you expect to happen?**
+
+**Steps to reproduce**
+1.
+2.
+
+**Environment**
+- Spine / `agent-orchestrator` version:
+- Python version:
+- OS:
+- Codegen model / provider:
+
+**Logs or trace** (please redact any secrets)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/synaptixs/spine/discussions
+    about: Ask questions, share ideas, and discuss usage here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for Spine
+title: "[feat] "
+labels: enhancement
+---
+
+**Problem / motivation**
+What are you trying to do that's hard or impossible today?
+
+**Proposed solution**
+
+**Alternatives considered**
+
+**Additional context**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## What & why
+
+<!-- What does this change do, and why? Link any related issue. -->
+
+## How it was tested
+
+<!-- Commands run, scenarios covered. -->
+
+## Checklist
+- [ ] Quality gate green locally (`mypy src tests`, `ruff format --check .`)
+- [ ] Tests added/updated where it matters
+- [ ] No secrets committed
+- [ ] Docs updated if behavior changed


### PR DESCRIPTION
Adds GitHub issue templates (bug, feature, Discussions link) and a PR template. Requires @ssmith-synaptixs code-owner approval + the 'security scan' check.