### PR TITLE
Publish v1.22.1

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+# Categorizes GitHub's auto-generated release notes (grouped by PR label).
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: ✨ Features
+      labels: [feature, enhancement]
+    - title: 🐛 Fixes
+      labels: [bug, fix]
+    - title: 📚 Docs
+      labels: [documentation, docs]
+    - title: 🔧 Maintenance
+      labels: [chore, ci, dependencies]
+    - title: Other changes
+      labels: ["*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release notes
+
+# On every release to main (a develop -> main merge), publish a GitHub Release for
+# the current version with auto-generated notes. Idempotent: if a release for the
+# version tag already exists, it does nothing. Notes are categorized by .github/release.yml.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write # create the tag + release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history so release notes can diff against the prior tag
+
+      - name: Read version from pyproject.toml
+        id: ver
+        run: |
+          set -euo pipefail
+          v="$(python -c "import tomllib,pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $v"
+
+      - name: Create release if the tag doesn't exist yet
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag="v${VERSION}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists — nothing to do."
+            exit 0
+          fi
+          echo "Creating release $tag with auto-generated notes."
+          gh release create "$tag" \
+            --target "${GITHUB_SHA}" \
+            --title "Spine $tag" \
+            --generate-notes

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -5,7 +5,7 @@ requirement and your repo; it opens a **reviewed, tested pull request** — with
 human in control at two gates. We're looking for early users and honest feedback.
 
 > *Spine* is the product; it installs as the **`agent-orchestrator`** package and its
-> command is **`orchestrator`**. Apache-2.0, open source.
+> command is **`orchestrator`**. MIT-licensed, open source.
 
 ---
 
@@ -80,4 +80,4 @@ with the runbook and tell us where it bends.
 ---
 
 **Build something, or hit a wall this didn't cover? [Open an issue.](../../issues)**
-Spine is Apache-2.0 — see [CONTRIBUTING.md](CONTRIBUTING.md) and [LICENSE](LICENSE).
+Spine is MIT-licensed — see [CONTRIBUTING.md](CONTRIBUTING.md) and [LICENSE](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,118 +1,57 @@
-# Contributing to agent-orchestrator
+# Contributing to Spine
 
-Thanks for your interest. agent-orchestrator is in early development — the Phase 1 walking skeleton is not yet complete, so the public API surface, schemas, and package boundaries are still moving. Please read this guide before opening a pull request.
+Thanks for your interest! Spine (distributed as the `agent-orchestrator` package)
+is open source under the MIT license, and community input genuinely shapes it.
 
-## Current state of contributions
+## Ways to contribute
 
-| You want to... | Status |
+| You want to… | How |
 |---|---|
-| Open an issue (bug, design question, spec feedback) | Welcome anytime. |
-| Submit a PR fixing a clearly scoped bug | Welcome. |
-| Submit a PR for a new feature | Open an issue first to align on direction. We are likely to decline unsolicited feature PRs until Phase 2. |
-| Propose changes to specs in `docs/specs/` | Open an issue — these change frequently and central coordination matters. |
-| Add a new agent template or tool contract example | Welcome once the registry and MCP gateway are merged (end of Sprint 4). |
+| **Report a bug** | Open a [bug report](https://github.com/synaptixs/spine/issues/new?template=bug_report.md) — include version, OS, model/provider, and steps. |
+| **Request a feature or enhancement** | Open a [feature request](https://github.com/synaptixs/spine/issues/new?template=feature_request.md). |
+| **Ask a question / share an idea / give feedback** | Start a [Discussion](https://github.com/synaptixs/spine/discussions). |
+| **Report a security issue** | Follow [SECURITY.md](SECURITY.md) — please don't open a public issue. |
+| **Fix a clearly-scoped bug** | A focused PR is welcome (see below). |
+| **Build a new feature** | Open an issue or discussion first to align on direction before writing code. |
 
-If you're not sure whether your change is in scope, open an issue and ask.
+## How changes get reviewed and shipped
 
-## Code of Conduct
+Maintainers triage issues and discussions and decide what lands. Releases flow
+through a protected branch: changes are reviewed on a PR into `develop`, then a
+maintainer opens a `develop → main` release PR, which requires a code-owner review
+and a passing `security scan` check before it merges. Each `main` release gets
+published release notes.
 
-By participating in this project you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md). Report unacceptable behavior to `conduct@fibonacci.example` (replace with real contact).
+For larger features, the core team often develops them ahead of time and publishes
+them on a release cadence — so opening an issue first avoids duplicated effort.
+
+## Opening a pull request
+
+1. Fork the repo and create a branch from `main` (e.g. `fix/email-validator-edge-case`).
+2. Make your change with tests; keep it focused — one concern per PR.
+3. Make sure the quality gate is green locally:
+   ```bash
+   mypy src tests
+   ruff format --check .
+   ```
+4. Open the PR with a clear description of **what** and **why**, linking any issue.
+5. A maintainer reviews; the `security scan` check must pass.
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) for commit
+messages (e.g. `fix(planner): handle empty claims list`).
 
 ## Development setup
 
-### Prerequisites
+See [SETUP.md](SETUP.md) for the full local stack and [USER_GUIDE.md](USER_GUIDE.md)
+for the everyday workflow. In short: Python 3.12+, [`uv`](https://docs.astral.sh/uv/),
+then `uv sync`.
 
-- Python 3.12+
-- Node.js 20+
-- `uv` for Python dependency management
-- `pnpm` for JavaScript workspaces
-- Docker (for local Postgres, Redis, MinIO)
+## Code of Conduct
 
-### Initial setup
-
-```bash
-git clone https://github.com/synaptixs/spine.git
-cd agent-orachestrator
-
-# Bring up local services
-docker compose -f docker-compose.dev.yml up -d
-
-# Install Python and TS deps
-uv sync
-pnpm install
-
-# Install pre-commit hooks
-uv run pre-commit install
-```
-
-### Running tests
-
-```bash
-# Python: per-package unit tests
-uv run pytest packages/orchestrator-core/tests
-
-# Full unit suite
-uv run pytest
-
-# Integration tests (require docker-compose services running)
-uv run pytest -m integration
-
-# TypeScript
-pnpm test
-```
-
-## Branching and pull requests
-
-- Base branch: `main`.
-- Branch naming: `type/short-description` — e.g. `fix/planner-timeout`, `feat/evidence-verifier`, `docs/glossary-spec`.
-- Keep PRs focused. One conceptual change per PR. Large PRs will be asked to split.
-- Rebase, don't merge, when updating your branch against `main`.
-- PRs must pass: lint, type check, unit tests, and pre-commit hooks. CI runs these on every push.
-
-### Pull request template
-
-When opening a PR, include:
-
-1. **What and why.** One paragraph. Why does this change exist?
-2. **How to test.** Reproducible steps for a reviewer.
-3. **Risk.** What could break? What did you not test?
-4. **Linked issue.** `Closes #N` if applicable.
-
-## Commit conventions
-
-We use [Conventional Commits](https://www.conventionalcommits.org/). Examples:
-
-```
-feat(planner): support sequential workflow pattern
-fix(verifier): handle empty claims list without crashing
-docs(specs): clarify mandatory output fields in agent template
-refactor(registry): extract validator into separate service
-test(runtime): add golden test for manager-with-specialists
-chore(deps): bump langgraph to 0.2.x
-```
-
-Scope is the package name (without the `orchestrator-` prefix) or a top-level area (`docs`, `infra`, `ci`).
-
-## Code style
-
-- **Python:** `ruff` for lint + format, `mypy --strict` for type checking. Both run in pre-commit.
-- **TypeScript:** `eslint` + `prettier`. Strict mode on.
-- **No `# type: ignore` or `any`** without a comment explaining why.
-- **No bare `except Exception:`** — use the typed errors in `orchestrator-core/errors.py`.
-- **No commented-out code.** Delete it; git remembers.
-- **Public APIs need docstrings.** Internal helpers do not unless the *why* is non-obvious.
-
-## Testing expectations
-
-- Every new module ships with unit tests. Coverage floor for `orchestrator-core`, `orchestrator-registry`, `orchestrator-ir`, `orchestrator-verifier` is 80%.
-- Integration tests live alongside unit tests but are marked `@pytest.mark.integration`.
-- Changes that touch agent behavior must include or update an entry in the eval suite.
-- Don't mock what you can run for real cheaply. Mock LLMs in unit tests; use real LLMs in nightly E2E.
-
-## Security
-
-Do not file security issues as public GitHub issues. See [SECURITY.md](SECURITY.md).
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). Report
+unacceptable behavior through the contact channel in [SECURITY.md](SECURITY.md).
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).
+By contributing, you agree that your contributions are licensed under the project's
+[MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -140,11 +140,18 @@ MCP server so Claude Code / Codex / your IDE can call the pipeline (with the sam
 
 ---
 
-## Contributing
+## Contributing & feedback
 
-Issues and PRs are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md),
-[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), and [SECURITY.md](SECURITY.md).
+We'd love your input. Pick the channel that fits:
+
+- 🐛 **Bug?** Open a [bug report](https://github.com/synaptixs/spine/issues/new?template=bug_report.md).
+- 💡 **Feature idea / enhancement?** Open a [feature request](https://github.com/synaptixs/spine/issues/new?template=feature_request.md).
+- 💬 **Question, feedback, or idea to discuss?** Start a [Discussion](https://github.com/synaptixs/spine/discussions).
+- 🔒 **Security issue?** Please follow [SECURITY.md](SECURITY.md) — don't open a public issue.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) and the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+for how contributions are reviewed.
 
 ## License
 
-Apache License 2.0. See [LICENSE](LICENSE).
+MIT License. See [LICENSE](LICENSE).

--- a/SETUP.md
+++ b/SETUP.md
@@ -350,4 +350,4 @@ new type stubs, then re-run `uv run mypy`.
 | Pydantic model specifications | `docs/specs/models.md` |
 | Contributing guidelines | `CONTRIBUTING.md` |
 | Security policy | `SECURITY.md` |
-| License | `LICENSE` (Apache-2.0) |
+| License | `LICENSE` (MIT) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,16 @@
 [project]
 name = "agent-orchestrator"
-version = "1.22.0"
+version = "1.22.1"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = { text = "MIT" }
 requires-python = ">=3.12"
 authors = [{ name = "Neeraj Rohilla", email = "nnmrohilla@gmail.com" }]
 keywords = ["llm", "agents", "sdlc", "orchestration", "temporal", "codegen"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Code Generators",
 ]


### PR DESCRIPTION
Automated sync from the private repo @ 93bc40d (v1.22.1).

## What's in this release
- docs+ci: community feedback channels, release-notes automation, MIT license fix
- fix(public): make publish-public.sh PR step bash 3.2-safe

Merge to release.