### PR TITLE
Publish v1.23.0 (c6aacf8)

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -48,7 +48,7 @@ loop into *operate → self-remediate* with end-to-end provenance.
 ## Try it (about 10 minutes)
 
 ```bash
-pip install --extra-index-url https://pypi.org/simple/ synaptixs-spine
+pip install synaptixs-spine
 orchestrator init && orchestrator doctor                       # scaffold .env, check readiness
 orchestrator sdlc feature --source file://./spec.md --safe     # build locally — no pushes, no PRs
 ```
@@ -71,9 +71,8 @@ Open an issue (or start a discussion) on anything — especially:
 
 ## Honest status
 
-Single-tenant today (RBAC is in progress). Published on **TestPyPI** while the PyPI
-name is sorted — see the [Setup guide](SETUP.md) for the install line. Codegen is
-strongest on Python; Java/TypeScript are supported. The *operate → remediate*
+Single-tenant today (RBAC is in progress). On **PyPI** — `pip install synaptixs-spine`.
+Codegen is strongest on Python; Java/TypeScript are supported. The *operate → remediate*
 extension is wired and tested but not yet proven against live production data — try it
 with the runbook and tell us where it bends.
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,10 @@ It's built for teams who want agents that are **inspectable, reproducible, and s
 to run on real code** — not demos.
 
 ```bash
-pip install --extra-index-url https://pypi.org/simple/ synaptixs-spine
+pip install synaptixs-spine
 orchestrator init && orchestrator doctor                  # scaffold .env, check readiness
 orchestrator sdlc feature --source file://./spec.md --safe   # build locally — no pushes, no PRs
 ```
-
-> The published name collides with an unrelated PyPI project — see the
-> [Setup & Install guide](SETUP.md) for the exact install one-liner.
 
 ---
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -54,47 +54,28 @@ You do **not** need Docker, a database, or any servers for Steps 1–6.
 The published package is `synaptixs-spine`; the command it gives you is
 `orchestrator`.
 
-### From TestPyPI (just the tool)
-
-The name collides with an unrelated project on the real PyPI, so install the
-**TestPyPI** build directly. This one-liner resolves the newest wheel from the
-**simple index** — the same index pip reads, so it's always current (the JSON
-API used by older snippets lags minutes behind a release):
+### From PyPI (just the tool)
 
 ```bash
-WHL=$(curl -s -H 'Accept: application/vnd.pypi.simple.v1+json' \
-  https://test.pypi.org/simple/synaptixs-spine/ \
-  | python3 -c "import sys,json,re
-fs=[f for f in json.load(sys.stdin)['files'] if f['filename'].endswith('.whl')]
-key=lambda f:[int(n) for n in re.findall(r'\d+', f['filename'].split('-')[1])]
-print(max(fs,key=key)['url'])")
-pip install --upgrade --extra-index-url https://pypi.org/simple/ "synaptixs-spine @ $WHL"
-
+pip install synaptixs-spine
 orchestrator --help
 ```
 
-The `[sdlc]` / `[mcp]` / `[tui]` extras aren't carried by a direct-wheel install;
-add them explicitly when needed, e.g. `pip install 'synaptixs-spine[sdlc]'`
-(the `[tui]` extra adds the `orchestrator tui` terminal UI — see Step 7).
+Optional extras, added when you need them:
+- `pip install 'synaptixs-spine[sdlc]'` — run the generated tests (the `sdlc feature`/`run` path)
+- `pip install 'synaptixs-spine[tui]'` — the `orchestrator tui` terminal UI (Step 7)
+- `[mcp]` (MCP client), `[otel]` (live tracing)
 
 ### Upgrading
 
-- **TestPyPI install:** re-run the one-liner above — it already passes
-  `--upgrade` and resolves the newest wheel from the simple index. Verify with
-  `pip show synaptixs-spine`.
+- **PyPI install:** `pip install --upgrade synaptixs-spine` (verify with `pip show synaptixs-spine`).
 - **Source checkout:** `git pull && uv sync --extra dev`.
-- **Pin / manual fallback** (if you want an exact version, or the resolver ever
-  misbehaves): list the wheels and install one directly —
-  ```bash
-  curl -s https://test.pypi.org/simple/synaptixs-spine/ | grep -o 'https://[^"]*\.whl'
-  pip install --upgrade --extra-index-url https://pypi.org/simple/ "synaptixs-spine @ <wheel-url>"
-  ```
 
 ### From source (needed for Step 7's pipeline, or to develop)
 
 ```bash
 git clone https://github.com/synaptixs/spine
-cd agent-orachestrator
+cd spine
 uv sync --extra dev            # installs the project + dev tools
 uv run orchestrator --help     # in this layout, prefix CLI calls with `uv run`
 ```


### PR DESCRIPTION
Automated sync from the private repo @ c6aacf8 (v1.23.0).

## What's in this release
- docs: simplify install to 'pip install synaptixs-spine' (now on real PyPI)

Merge to release.