### PR TITLE
Publish v1.23.0 (afecc09)

### DIFF
--- a/.github/workflows/publish-synaptixs.yml
+++ b/.github/workflows/publish-synaptixs.yml
@@ -1,0 +1,50 @@
+name: Reserve synaptixs
+
+# One-time (or rare) publish of a minimal `synaptixs` placeholder to reserve the
+# company name on PyPI / TestPyPI. Tokenless OIDC trusted publishing — pick the
+# index with the `index` input. One-time setup: register a PENDING trusted publisher
+# for the `synaptixs` project on EACH index you target:
+#   Owner: synaptixs   Repository: spine
+#   Workflow: publish-synaptixs.yml   Environment: pypi   (and a second for: testpypi)
+on:
+  workflow_dispatch:
+    inputs:
+      index:
+        description: Which index to publish the placeholder to
+        type: choice
+        options:
+          - testpypi
+          - pypi
+        default: testpypi
+
+permissions:
+  contents: read
+
+jobs:
+  reserve:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.index }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build the synaptixs placeholder
+        run: cd reserve-synaptixs && uv build
+
+      - name: Publish to TestPyPI
+        if: ${{ inputs.index == 'testpypi' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: reserve-synaptixs/dist
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: ${{ inputs.index == 'pypi' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: reserve-synaptixs/dist

--- a/reserve-synaptixs/README.md
+++ b/reserve-synaptixs/README.md
@@ -1,0 +1,9 @@
+# synaptixs
+
+Reserved by **Synaptixs**. The product is **Spine** — install it with:
+
+```
+pip install synaptixs-spine
+```
+
+See https://github.com/synaptixs/spine

--- a/reserve-synaptixs/pyproject.toml
+++ b/reserve-synaptixs/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "synaptixs"
+version = "0.0.1"
+description = "Reserved by Synaptixs. The product is Spine — install 'synaptixs-spine'."
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.8"
+authors = [{ name = "Synaptixs" }]
+
+[project.urls]
+Repository = "https://github.com/synaptixs/spine"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/synaptixs"]

--- a/reserve-synaptixs/src/synaptixs/__init__.py
+++ b/reserve-synaptixs/src/synaptixs/__init__.py
@@ -1,0 +1,3 @@
+"""Reserved namespace for Synaptixs. The product is Spine — `pip install synaptixs-spine`."""
+
+__version__ = "0.0.1"


### PR DESCRIPTION
Automated sync from the private repo @ afecc09 (v1.23.0).

## What's in this release
- ci: add synaptixs name-reservation placeholder + publish workflow

Merge to release.