### PR TITLE
Publish v1.24.0 (79e2234)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "1.23.0"
+version = "1.24.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }
@@ -52,6 +52,11 @@ java = [
 typescript = [
     "tree-sitter>=0.21",
     "tree-sitter-typescript>=0.21",
+]
+# C# / .NET PKG front-end. Same lazy-import contract as the `java` extra.
+csharp = [
+    "tree-sitter>=0.21",
+    "tree-sitter-c-sharp>=0.21",
 ]
 # Onboard external MCP servers (DBs, Atlassian, …) as orchestrator tools. The
 # MCP client lazy-imports this, so the base install stays MCP-free.
@@ -140,7 +145,7 @@ files = ["src", "tests"]
 # tree-sitter is an optional extra (the `java`/`typescript` PKG front-ends); not
 # installed in the default/CI env, so don't fail type-checking on its absence.
 [[tool.mypy.overrides]]
-module = ["tree_sitter", "tree_sitter.*", "tree_sitter_java", "tree_sitter_typescript"]
+module = ["tree_sitter", "tree_sitter.*", "tree_sitter_java", "tree_sitter_typescript", "tree_sitter_c_sharp"]
 ignore_missing_imports = true
 
 # `textual` is the optional `tui` extra; not installed in the default/CI env.

--- a/src/orchestrator/catalog/profile.py
+++ b/src/orchestrator/catalog/profile.py
@@ -22,6 +22,7 @@ _LANG_BY_SUFFIX = {
     ".tsx": "typescript",
     ".js": "javascript",
     ".jsx": "javascript",
+    ".cs": "csharp",
     ".go": "go",
     ".rb": "ruby",
 }
@@ -103,7 +104,21 @@ def _read_markers(root: Path) -> str:
             blobs.append(_safe_read(path))
     for req in root.glob("requirements*.txt"):
         blobs.append(_safe_read(req))
+    blobs.extend(_read_dotnet_markers(root))  # .csproj/.sln can live in subdirs
     return "\n".join(blobs).lower()
+
+
+def _read_dotnet_markers(root: Path, *, limit: int = 50) -> list[str]:
+    """A bounded set of .NET project files (SDK + PackageReference live here)."""
+    blobs: list[str] = []
+    for dirpath, dirnames, files in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in DEFAULT_IGNORE_DIRS and not d.startswith(".")]
+        for fn in files:
+            if fn.endswith((".csproj", ".sln")):
+                blobs.append(_safe_read(Path(dirpath) / fn))
+                if len(blobs) >= limit:
+                    return blobs
+    return blobs
 
 
 def _safe_read(path: Path) -> str:
@@ -120,6 +135,8 @@ def _detect_framework(markers: str, languages: frozenset[str]) -> str | None:
         ("flask", "flask"),
         ("springframework", "spring"),
         ('"react"', "react"),
+        ("microsoft.aspnetcore", "aspnet"),
+        ("microsoft.net.sdk.web", "aspnet"),
     ):
         if needle in markers:
             return name
@@ -147,6 +164,12 @@ def _detect_test_runner(root: Path, markers: str, languages: frozenset[str]) -> 
         return "jest"
     if "junit" in markers:
         return "junit"
+    if "xunit" in markers:
+        return "xunit"
+    if "nunit" in markers:
+        return "nunit"
+    if "mstest" in markers or "microsoft.net.test.sdk" in markers:
+        return "mstest"
     if "python" in languages:
         return "pytest"
     return None

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -1204,6 +1204,38 @@ def understand(
     )
 
 
+@app.command("state")
+def state(
+    path: Annotated[Path, typer.Argument(help="Repo or directory to summarize.")] = Path("."),
+    lens: Annotated[str, typer.Option("--lens", help="Audience: developer | stakeholder.")] = "developer",
+    out: Annotated[
+        Path | None,
+        typer.Option("--out", help="Write the report to this file (default: print to stdout)."),
+    ] = None,
+    refresh: Annotated[
+        bool, typer.Option("--refresh", help="Re-extract the PKG instead of using the commit cache.")
+    ] = False,
+) -> None:
+    """Current State — a team-facing snapshot of what a repo is today and how healthy it looks.
+
+    Synthesized from the Product Knowledge Graph + project profile (deterministic, no LLM),
+    layered on top of `understand`. `--lens developer` gives the technical view;
+    `--lens stakeholder` gives plain language. A report is a *view* of the code — re-run to
+    refresh; nothing is written unless `--out` is given.
+    """
+    from orchestrator.knowledge.current_state import build_current_state
+
+    if lens not in ("developer", "stakeholder"):
+        typer.echo("ERROR: --lens must be 'developer' or 'stakeholder'.", err=True)
+        raise typer.Exit(code=2)
+    markdown = build_current_state(path, lens=lens, refresh=refresh)
+    if out is not None:
+        out.write_text(markdown, encoding="utf-8")
+        typer.echo(f"wrote {out}")
+    else:
+        typer.echo(markdown)
+
+
 @catalog_app.command("list")
 def catalog_list(
     as_json: Annotated[bool, typer.Option("--json", help="Emit the catalog as JSON.")] = False,

--- a/src/orchestrator/knowledge/current_state.py
+++ b/src/orchestrator/knowledge/current_state.py
@@ -1,0 +1,449 @@
+"""Current State — a team-facing snapshot synthesized from the PKG + profile.
+
+Built *on top of* the Product Knowledge Graph (the engine): a deterministic,
+recomputed-from-facts view of *what a project is today and how healthy it looks*,
+rendered for two audiences:
+
+- ``developer`` — architecture layers, areas, API surface, coupling, hotspots,
+  test coverage, and prioritized recommendations.
+- ``stakeholder`` — the same derivation in plain language, no jargon.
+
+Language-agnostic: heuristics (controllers, layers, data-access) degrade gracefully
+when a signal isn't present. Generated code (Designer/Reference/migrations) is
+flagged and excluded from hotspots so it doesn't skew the picture. No LLM.
+
+See ``docs/specs/current-state.md``. Results are a *view*, never authored — re-run to
+refresh.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from orchestrator.pkg.facts import EdgeKind, FactBatch, Node, NodeKind
+
+if TYPE_CHECKING:
+    from orchestrator.catalog.profile import ProjectProfile
+
+_GENERATED = (
+    ".designer.cs",
+    "reference.cs",
+    "connected services",
+    ".g.cs",
+    "assemblyinfo",
+    "/migrations/",
+    ".generated.",
+)
+_FRAMEWORK_PREFIXES = ("System", "Microsoft", "java", "javax", "android")
+_DATA_SHAPE_SUFFIXES = ("ViewModel", "Dto", "Entity", "Request", "Response", "Model", "Details", "Item")
+
+
+def _area(name: str) -> str:
+    """Group a module/namespace into a top-level area (first two dotted segments)."""
+    return ".".join(name.split(".")[:2])
+
+
+def _is_generated(node: Node) -> bool:
+    f = (node.provenance.file if node.provenance else "").lower()
+    return any(p in f for p in _GENERATED)
+
+
+def _is_framework(qualified: str) -> bool:
+    return qualified.split(".")[0] in _FRAMEWORK_PREFIXES
+
+
+def _is_interface(node: Node) -> bool:
+    # C#/Java convention: IName. (A best-effort signal; harmless elsewhere.)
+    return len(node.name) > 1 and node.name[0] == "I" and node.name[1].isupper()
+
+
+def _layer(node: Node) -> str:
+    name, nid = node.name, node.id.lower()
+    if _is_interface(node):
+        return "Interfaces / contracts"
+    if name.endswith("Controller"):
+        return "API · controllers"
+    if name.endswith(("Repository", "Context", "Dao", "DbContext")) or ".data" in nid:
+        return "Data access"
+    if name.endswith(("Service", "Manager", "Handler", "Provider")) or ".biz" in nid or ".service" in nid:
+        return "Business logic"
+    if name.endswith(_DATA_SHAPE_SUFFIXES):
+        return "Data shapes (VM/DTO/model)"
+    if name in ("Program", "Startup") or name.endswith(("Middleware", "Filter")):
+        return "App wiring / infra"
+    return "Other"
+
+
+@dataclass
+class CurrentState:
+    """Computed metrics for a repository's current state."""
+
+    languages: list[str]
+    framework: str | None
+    test_runner: str | None
+    counts: dict[str, int]
+    namespaces: int
+    areas: int
+    layers: Counter[str]
+    area_types: Counter[str]
+    area_funcs: Counter[str]
+    controllers: int
+    endpoints: int
+    busiest_controllers: list[tuple[str, int]]
+    coupling: Counter[tuple[str, str]]
+    external_deps: Counter[str]
+    interfaces: int
+    hotspots: list[tuple[str, int, str]]
+    size_dist: Counter[str]
+    tested_areas: int
+    untested_top: list[tuple[str, int]]
+    dup_names: list[tuple[str, int]]
+    data_access: list[str]
+    generated: int
+    has_calls: bool
+    auth_surface: list[str] = field(default_factory=list)
+    recent_areas: list[tuple[str, int]] = field(default_factory=list)
+    recommendations: list[tuple[str, str]] = field(default_factory=list)
+
+
+_AUTH_KW = ("auth", "login", "permission", "role", "identity", "token", "jwt", "session", "secur")
+
+
+def _recent_areas(root: Path | None) -> list[tuple[str, int]]:
+    """Top areas by recent churn, from `git log` (empty if no git/history)."""
+    if root is None:
+        return []
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "log", "--name-only", "--pretty=format:", "-n", "60"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if out.returncode != 0:
+        return []
+    exts = (".cs", ".py", ".java", ".ts", ".tsx")
+    changed = Counter(
+        "/".join(line.strip().split("/")[:2])
+        for line in out.stdout.splitlines()
+        if line.strip().endswith(exts)
+    )
+    return changed.most_common(6)
+
+
+def compute_current_state(
+    batch: FactBatch, profile: ProjectProfile, *, root: Path | None = None
+) -> CurrentState:
+    """Synthesize the current-state metrics from PKG facts + the project profile."""
+    nodes = [n for n in batch.nodes if not n.external]
+    by_id = {n.id: n for n in nodes}
+    counts = {k.value: 0 for k in NodeKind}
+    for n in nodes:
+        counts[n.kind.value] += 1
+
+    contains = [e for e in batch.edges if e.kind is EdgeKind.CONTAINS]
+    members: Counter[str] = Counter(
+        e.src for e in contains if by_id.get(e.src) and by_id[e.src].kind is NodeKind.TYPE
+    )
+    types = [n for n in nodes if n.kind is NodeKind.TYPE]
+    mods = [n for n in nodes if n.kind is NodeKind.MODULE]
+    internal = {m.name.split(".")[0] for m in mods}
+
+    layers = Counter(_layer(n) for n in types if not _is_generated(n))
+
+    area_types: Counter[str] = Counter()
+    for e in contains:
+        s, d = by_id.get(e.src), by_id.get(e.dst)
+        if s and s.kind is NodeKind.MODULE and d and d.kind is NodeKind.TYPE:
+            area_types[_area(s.name)] += 1
+    area_funcs: Counter[str] = Counter(
+        _area(n.id.split(":", 1)[-1]) for n in nodes if n.kind is NodeKind.FUNCTION
+    )
+
+    controllers = [n for n in types if n.name.endswith("Controller") and not _is_generated(n)]
+    ctrl_ids = {c.id for c in controllers}
+    ep_by_ctrl: Counter[str] = Counter()
+    for e in contains:
+        if e.src in ctrl_ids and by_id.get(e.dst) and by_id[e.dst].kind is NodeKind.FUNCTION:
+            ep_by_ctrl[e.src] += 1
+    busiest = [(by_id[cid].name, n) for cid, n in ep_by_ctrl.most_common(8)]
+
+    coupling: Counter[tuple[str, str]] = Counter()
+    external: Counter[str] = Counter()
+    for e in batch.edges:
+        if e.kind is not EdgeKind.IMPORTS:
+            continue
+        src = by_id.get(e.src)
+        if not src:
+            continue
+        dst_name = e.dst.split(":", 1)[-1]
+        if _is_framework(dst_name) or dst_name.split(".")[0] not in internal:
+            external[".".join(dst_name.split(".")[:2])] += 1
+        else:
+            sa, da = _area(src.name), _area(dst_name)
+            if sa != da:
+                coupling[(sa, da)] += 1
+
+    interfaces = sum(1 for n in types if _is_interface(n) and not _is_generated(n))
+
+    hotspots = [
+        (by_id[t].name, c, str(by_id[t].provenance))
+        for t, c in members.most_common()
+        if not _is_generated(by_id[t])
+    ][:10]
+
+    size_dist: Counter[str] = Counter()
+    for n in types:
+        c = members.get(n.id, 0)
+        bucket = (
+            "god (>40)" if c > 40 else ">25" if c > 25 else ">10" if c > 10 else "1-10" if c > 0 else "marker"
+        )
+        size_dist[bucket] += 1
+
+    def _is_test(n: Node) -> bool:
+        f = (n.provenance.file if n.provenance else "").lower()
+        return "test" in n.name.lower() or ".tests" in n.id.lower() or "/test" in f
+
+    tested = {_area(n.id.split(":", 1)[-1]) for n in types if _is_test(n)}
+    untested_top = [(a, c) for a, c in area_types.most_common(5) if a not in tested]
+
+    dup_names = [
+        (nm, c) for nm, c in Counter(n.name for n in types if not _is_generated(n)).most_common() if c > 1
+    ][:10]
+
+    repos = [n for n in types if n.name.endswith(("Repository", "Dao")) and not _is_generated(n)]
+    data_access: list[str] = []
+    if any("entityframework" in d.lower() for d in external) or any(
+        n.name.endswith("DbContext") for n in types
+    ):
+        data_access.append("Entity Framework (DbContext)")
+    if any("hibernate" in d.lower() or "sqlalchemy" in d.lower() for d in external):
+        data_access.append("ORM (Hibernate/SQLAlchemy)")
+    if any(d in external for d in ("System.Data",)) or (repos and not data_access):
+        data_access.append("raw SQL / ADO.NET (no ORM)")
+
+    has_calls = any(e.kind is EdgeKind.CALLS for e in batch.edges)
+    auth_surface = [
+        n.name for n in types if any(k in n.name.lower() for k in _AUTH_KW) and not _is_generated(n)
+    ][:12]
+
+    state = CurrentState(
+        languages=sorted(profile.languages),
+        framework=profile.framework,
+        test_runner=profile.test_runner,
+        counts=counts,
+        namespaces=len(mods),
+        areas=len(area_types),
+        layers=layers,
+        area_types=area_types,
+        area_funcs=area_funcs,
+        controllers=len(controllers),
+        endpoints=sum(ep_by_ctrl.values()),
+        busiest_controllers=busiest,
+        coupling=coupling,
+        external_deps=external,
+        interfaces=interfaces,
+        hotspots=hotspots,
+        size_dist=size_dist,
+        tested_areas=len(tested),
+        untested_top=untested_top,
+        dup_names=dup_names,
+        data_access=data_access,
+        generated=sum(1 for n in types if _is_generated(n)),
+        has_calls=has_calls,
+        auth_surface=auth_surface,
+        recent_areas=_recent_areas(root),
+    )
+    state.recommendations = _recommend(state)
+    return state
+
+
+def _recommend(s: CurrentState) -> list[tuple[str, str]]:
+    """Derive a prioritized to-do from the metrics. (priority, text)."""
+    recs: list[tuple[str, str]] = []
+    if s.tested_areas == 0 and s.counts.get("Type", 0) > 20:
+        first = ", ".join(f"`{n}` ({c})" for n, c in s.busiest_controllers[:2]) or "the core areas"
+        recs.append(("P1", f"Add automated tests — 0/{s.areas} areas covered. Start with {first}."))
+    if "raw SQL / ADO.NET (no ORM)" in s.data_access:
+        recs.append(("P1", "SQL-injection / data-layer security pass — raw SQL with no ORM is the top risk."))
+    if s.controllers and s.endpoints:
+        recs.append(
+            ("P1", f"Audit endpoint auth — ~{s.endpoints} endpoints; verify each controller's access rules.")
+        )
+    fat = [(n, c) for n, c in s.busiest_controllers if c > 25]
+    if fat:
+        recs.append(
+            ("P2", "Break up fat controllers: " + ", ".join(f"`{n}` ({c})" for n, c in fat[:4]) + ".")
+        )
+    gods = s.size_dist.get("god (>40)", 0)
+    if gods:
+        big = ", ".join(f"`{n}` ({c})" for n, c, _ in s.hotspots[:2])
+        recs.append(("P2", f"Refactor {gods} god-classes (>40 members), e.g. {big}."))
+    if s.dup_names:
+        recs.append(
+            ("P3", "De-duplicate type names: " + ", ".join(f"`{n}`×{c}" for n, c in s.dup_names[:4]) + ".")
+        )
+    return recs
+
+
+def _mid(area: str) -> str:
+    return "a" + re.sub(r"[^A-Za-z0-9]", "", area)[:24]
+
+
+def render_current_state(state: CurrentState, *, lens: str = "developer") -> str:
+    """Render the current state as markdown for the given lens (developer/stakeholder)."""
+    if lens == "stakeholder":
+        return _render_stakeholder(state)
+    return _render_developer(state)
+
+
+def _render_stakeholder(s: CurrentState) -> str:
+    lang = "C# / .NET" if "csharp" in s.languages else (", ".join(s.languages) or "unknown")
+    app = "web API / service" if s.controllers else "library / service"
+    health = "✅ has automated tests" if s.tested_areas else "⚠️ no automated tests detected"
+    out = [
+        "# Current State",
+        "",
+        f"This is a **{lang}** {app}. It's built from about **{s.counts.get('Type', 0)} components** "
+        f"across ~**{s.areas} areas**, with **{s.counts.get('Function', 0)} operations**"
+        + (
+            f" and **~{s.endpoints} endpoints** across **{s.controllers} controllers**"
+            if s.controllers
+            else ""
+        )
+        + ".",
+        "",
+        f"**Health:** {health}.",
+        "",
+    ]
+    if s.recommendations:
+        out += ["**What to do next:**"]
+        out += [f"- {text}" for _p, text in s.recommendations[:4]]
+    return "\n".join(out) + "\n"
+
+
+def _render_developer(s: CurrentState) -> str:
+    o: list[str] = [
+        "# Current State",
+        "",
+        "_Derived from the code (PKG) + profile. No LLM — re-run to refresh._",
+        "",
+    ]
+    o += [
+        "## At a glance",
+        "",
+        f"- Stack: `{', '.join(s.languages) or '—'}` · framework `{s.framework or '—'}`"
+        f" · tests `{s.test_runner or 'none detected'}`",
+        f"- Size: {s.namespaces} namespaces (≈{s.areas} areas) · "
+        + " · ".join(f"{v} {k.lower()}s" for k, v in s.counts.items() if v),
+        f"- API surface: {s.controllers} controllers · ~{s.endpoints} endpoints"
+        if s.controllers
+        else "- API surface: none detected",
+        f"- Data access: {', '.join(s.data_access) or '—'}",
+        f"- Call graph: {'available' if s.has_calls else 'not extracted for this language yet'}",
+        "",
+        "## Architecture — layers",
+        "",
+        "| Layer | Components |",
+        "|---|---|",
+    ]
+    o += [f"| {lyr} | {c} |" for lyr, c in s.layers.most_common()]
+    if s.coupling:
+        o += ["", "## Area dependency map", "", "```mermaid", "flowchart LR"]
+        seen: set[str] = set()
+        for (sa, da), c in s.coupling.most_common(9):
+            for a in (sa, da):
+                if a not in seen:
+                    o.append(f'  {_mid(a)}["{a}"]')
+                    seen.add(a)
+            o.append(f"  {_mid(sa)} -->|{c}| {_mid(da)}")
+        o += ["```"]
+    if s.busiest_controllers:
+        o += ["", "## API surface — busiest controllers", "", "| Controller | Endpoints |", "|---|---|"]
+        o += [f"| `{n}` | {c} |" for n, c in s.busiest_controllers]
+    o += ["", "## Areas — size (top 12)", "", "| Area | Types | Functions |", "|---|---|---|"]
+    o += [f"| {a} | {c} | {s.area_funcs.get(a, 0)} |" for a, c in s.area_types.most_common(12)]
+    if s.external_deps:
+        o += ["", "## External dependencies (top)", ""]
+        o += [f"- {d} ({c})" for d, c in s.external_deps.most_common(8)]
+    o += [
+        "",
+        "## Complexity",
+        "",
+        "Size distribution: " + " · ".join(f"{k}: {v}" for k, v in s.size_dist.most_common()),
+        "",
+        "| Largest component | Members | Location |",
+        "|---|---|---|",
+    ]
+    o += [f"| `{n}` | {c} | {loc} |" for n, c, loc in s.hotspots]
+    o += [
+        "",
+        "## Test coverage",
+        "",
+        f"- **{s.tested_areas} of {s.areas} areas** have any test type."
+        + (
+            " Largest untested: " + ", ".join(f"{a} ({c})" for a, c in s.untested_top)
+            if s.untested_top
+            else ""
+        ),
+    ]
+    if s.recent_areas:
+        o += [
+            "",
+            "## Recent activity (last ~60 commits)",
+            "",
+            "Most-churned areas: " + ", ".join(f"{a} ({c})" for a, c in s.recent_areas),
+        ]
+    if s.auth_surface:
+        o += [
+            "",
+            "## Security surface",
+            "",
+            f"- {len(s.auth_surface)} auth/security-related types (by name): "
+            + ", ".join(f"`{n}`" for n in s.auth_surface),
+            "- ⚠️ Attribute-level auth (`[Authorize]`/decorators) isn't extracted yet — "
+            "endpoint access rules can't be confirmed from the graph alone.",
+        ]
+    if s.dup_names:
+        o += [
+            "",
+            "## Naming smells",
+            "",
+            "Duplicate type names: " + ", ".join(f"`{n}`×{c}" for n, c in s.dup_names[:8]),
+        ]
+    if s.recommendations:
+        o += ["", "## Recommendations — prioritized actions", ""]
+        for pri, text in s.recommendations:
+            o.append(f"- **{pri}** — {text}")
+    o += [
+        "",
+        "## Caveats",
+        "- Heuristic synthesis from naming + structure. "
+        + ("Call graph not yet available for this language." if not s.has_calls else ""),
+        f"- {s.generated} generated types flagged + excluded from hotspots.",
+    ]
+    return "\n".join(o) + "\n"
+
+
+def build_current_state(root: Path | str, *, lens: str = "developer", refresh: bool = False) -> str:
+    """Extract the PKG + profile for ``root`` and render the current-state markdown."""
+    from orchestrator.catalog.profile import ProjectProfile
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+    from orchestrator.pkg.persistence import load_or_extract
+
+    root_path = Path(root)
+    batch = RepoCodeExtractor().extract(root_path) if refresh else load_or_extract(root_path)
+    profile = ProjectProfile.from_repo(root_path)
+    state = compute_current_state(batch, profile, root=root_path)
+    return render_current_state(state, lens=lens)
+
+
+__all__ = ["CurrentState", "build_current_state", "compute_current_state", "render_current_state"]

--- a/src/orchestrator/pkg/csharp_extractor.py
+++ b/src/orchestrator/pkg/csharp_extractor.py
@@ -1,0 +1,275 @@
+"""C# / .NET front-end for the PKG extractor (Track 1: a fourth language).
+
+Maps C# source onto the same universal ``facts`` vocabulary the Python/Java/TS
+extractors use — so the knowledge graph stays language-neutral. Parsing is via
+tree-sitter (accurate ASTs), an OPTIONAL dependency: install the ``csharp`` extra
+(``uv pip install 'synaptixs-spine[csharp]'``). The import is lazy so the base
+install stays stdlib-only and importing this module never fails.
+
+Emits the high-confidence declaration subset, precision-first like the Java
+front-end: ``Module`` (the file, named by its namespace), ``Type`` (class /
+interface / struct / enum / record / delegate), ``Function`` (method /
+constructor / operator), ``Field`` (field / property / event / enum member /
+positional record param); ``IMPORTS`` (``using``), ``CONTAINS``, and
+``IMPLEMENTS`` (base list) edges. ``CALLS`` is intentionally NOT emitted yet —
+C# call resolution needs overload/type inference, and a guessed edge would poison
+grounding (Phase 1.3).
+
+Node ids are namespace-qualified (``csharp:Namespace.Type``) so partial classes
+split across files collapse onto one node.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from orchestrator.pkg.extractor import rel_module_name
+from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+
+if TYPE_CHECKING:
+    from tree_sitter import Node as TSNode
+
+_NAMESPACE_RE = re.compile(r"^\s*namespace\s+([\w.]+)", re.M)
+_TYPE_DECLS = frozenset(
+    {
+        "class_declaration",
+        "interface_declaration",
+        "struct_declaration",
+        "enum_declaration",
+        "record_declaration",
+        "record_struct_declaration",
+        "delegate_declaration",  # a named type, but a leaf (no bases/members)
+    }
+)
+
+
+class CSharpExtractor:
+    """C# front-end (tree-sitter). Install the ``csharp`` extra to use it."""
+
+    language: str = "csharp"
+    suffixes: tuple[str, ...] = (".cs",)
+
+    def module_name(self, path: Path, root: Path) -> str:
+        # C#'s closest thing to a package is the (first) namespace, which lives in
+        # the file; fall back to the repo-relative path when there's none.
+        try:
+            # utf-8-sig strips a leading BOM, which is common in .NET files and would
+            # otherwise defeat the ^namespace match.
+            m = _NAMESPACE_RE.search(path.read_text(encoding="utf-8-sig"))
+        except OSError:
+            m = None
+        return m.group(1) if m else rel_module_name(path, root)
+
+    def extract(self, *, path: Path, module: str, rel: str) -> FactBatch:
+        parser = _csharp_parser()
+        source = path.read_bytes()
+        tree = parser.parse(source)
+        batch = FactBatch()
+        module_id = f"csharp:{module}" if module else "csharp:<root>"
+        batch.add_node(Node(module_id, NodeKind.MODULE, module or rel, "csharp", Provenance(rel, 1)))
+
+        self._usings(tree.root_node, module_id, source, rel, batch)
+        self._walk(tree.root_node.named_children, module_id, "", source, rel, batch)
+        return batch
+
+    def _usings(self, root: TSNode, module_id: str, source: bytes, rel: str, batch: FactBatch) -> None:
+        """Emit IMPORTS edges to each ``using`` target namespace."""
+        for node in root.named_children:
+            if node.type != "using_directive" or not node.named_children:
+                continue
+            target = _text(node.named_children[-1], source)
+            if not target:
+                continue
+            tid = f"csharp:{target}"
+            batch.add_node(Node(tid, NodeKind.MODULE, target, "csharp", external=True))
+            batch.add_edge(Edge(module_id, tid, EdgeKind.IMPORTS, Provenance(rel, node.start_point[0] + 1)))
+
+    def _walk(
+        self,
+        nodes: list[TSNode],
+        module_id: str,
+        namespace: str,
+        source: bytes,
+        rel: str,
+        batch: FactBatch,
+    ) -> None:
+        """Walk siblings, descending into namespaces and emitting top-level types.
+
+        Handles both block ``namespace N { ... }`` and file-scoped ``namespace N;``
+        (whose types are subsequent siblings — so the namespace sticks for the rest).
+        """
+        current_ns = namespace
+        for node in nodes:
+            if node.type == "file_scoped_namespace_declaration":
+                current_ns = _join_ns(namespace, _field_text(node, "name", source))
+            elif node.type == "namespace_declaration":
+                ns = _join_ns(namespace, _field_text(node, "name", source))
+                body = node.child_by_field_name("body")
+                if body is not None:
+                    self._walk(body.named_children, module_id, ns, source, rel, batch)
+            elif node.type in _TYPE_DECLS:
+                self._emit_type(node, module_id, None, current_ns, source, rel, batch)
+
+    def _emit_type(
+        self,
+        node: TSNode,
+        module_id: str,
+        parent_type_id: str | None,
+        namespace: str,
+        source: bytes,
+        rel: str,
+        batch: FactBatch,
+    ) -> None:
+        name = _field_text(node, "name", source)
+        if not name:
+            return
+        # Top-level types key on the (tree) namespace so partial classes split across
+        # files merge; nested types key on the enclosing type id.
+        if parent_type_id is None:
+            type_id = f"csharp:{_join_ns(namespace, name)}"
+            contains_parent = module_id
+        else:
+            type_id = f"{parent_type_id}.{name}"
+            contains_parent = parent_type_id
+        line = node.start_point[0] + 1
+        batch.add_node(
+            Node(type_id, NodeKind.TYPE, name, "csharp", Provenance(rel, line, node.end_point[0] + 1))
+        )
+        batch.add_edge(Edge(contains_parent, type_id, EdgeKind.CONTAINS, Provenance(rel, line)))
+
+        if node.type == "delegate_declaration":
+            return  # a delegate is a leaf named type — no bases, members, or param-fields
+
+        for base in _base_types(node, source):
+            target = _resolve_type(base, namespace)
+            if target is not None:
+                batch.add_edge(Edge(type_id, target, EdgeKind.IMPLEMENTS, Provenance(rel, line)))
+
+        # Positional record parameters (`record Money(decimal Amount, ...)`) are
+        # effectively properties → emit as FIELD.
+        for child in node.named_children:
+            if child.type == "parameter_list":
+                for param in child.named_children:
+                    if param.type == "parameter":
+                        pname = _field_text(param, "name", source)
+                        if pname:
+                            self._add_member(
+                                type_id, pname, NodeKind.FIELD, param.start_point[0] + 1, rel, batch
+                            )
+
+        body = node.child_by_field_name("body")
+        if body is None:
+            return
+        for member in body.named_children:
+            mline = member.start_point[0] + 1
+            if member.type in ("method_declaration", "constructor_declaration"):
+                mname = _field_text(member, "name", source)
+                if mname:
+                    self._add_member(type_id, mname, NodeKind.FUNCTION, mline, rel, batch)
+            elif member.type == "indexer_declaration":  # `public T this[int i] { ... }`
+                self._add_member(type_id, "this[]", NodeKind.FIELD, mline, rel, batch)
+            elif member.type == "property_declaration":
+                pname = _field_text(member, "name", source)
+                if pname:
+                    self._add_member(type_id, pname, NodeKind.FIELD, mline, rel, batch)
+            elif member.type in ("field_declaration", "event_field_declaration"):
+                for fname in _field_names(member, source):
+                    self._add_member(type_id, fname, NodeKind.FIELD, mline, rel, batch)
+            elif member.type == "event_declaration":  # property-style event (add/remove)
+                ename = _field_text(member, "name", source)
+                if ename:
+                    self._add_member(type_id, ename, NodeKind.FIELD, mline, rel, batch)
+            elif member.type == "operator_declaration":
+                op = _field_text(member, "operator", source)
+                if op:
+                    self._add_member(type_id, f"operator{op}", NodeKind.FUNCTION, mline, rel, batch)
+            elif member.type == "conversion_operator_declaration":
+                ty = _field_text(member, "type", source)
+                if ty:
+                    self._add_member(type_id, f"operator {ty}", NodeKind.FUNCTION, mline, rel, batch)
+            elif member.type == "enum_member_declaration":
+                ename = _field_text(member, "name", source) or _text(member, source)
+                if ename:
+                    self._add_member(type_id, ename, NodeKind.FIELD, mline, rel, batch)
+            elif member.type in _TYPE_DECLS:
+                self._emit_type(member, module_id, type_id, namespace, source, rel, batch)
+
+    @staticmethod
+    def _add_member(type_id: str, name: str, kind: NodeKind, line: int, rel: str, batch: FactBatch) -> None:
+        mid = f"{type_id}.{name}"
+        batch.add_node(Node(mid, kind, name, "csharp", Provenance(rel, line)))
+        batch.add_edge(Edge(type_id, mid, EdgeKind.CONTAINS, Provenance(rel, line)))
+
+
+def _join_ns(prefix: str, name: str) -> str:
+    if prefix and name:
+        return f"{prefix}.{name}"
+    return name or prefix
+
+
+def _resolve_type(name: str, namespace: str) -> str | None:
+    """Best-effort base-type id (precision-first). Simple names assume same namespace."""
+    name = name.split("<", 1)[0].strip()  # drop generics: IList<T> → IList
+    if not name:
+        return None
+    if "." in name:
+        return f"csharp:{name}"
+    return f"csharp:{_join_ns(namespace, name)}" if namespace else f"csharp:{name}"
+
+
+def _base_types(node: TSNode, source: bytes) -> list[str]:
+    """Type names from a declaration's ``base_list`` (base class + interfaces)."""
+    for child in node.named_children:
+        if child.type == "base_list":
+            return [
+                _text(c, source)
+                for c in child.named_children
+                if c.type in ("identifier", "qualified_name", "generic_name")
+            ]
+    return []
+
+
+def _field_names(field_decl: TSNode, source: bytes) -> list[str]:
+    """Declared names in a (possibly multi) field declaration."""
+    names: list[str] = []
+    for child in field_decl.named_children:
+        if child.type != "variable_declaration":
+            continue
+        for declarator in child.named_children:
+            if declarator.type == "variable_declarator" and declarator.named_children:
+                names.append(_text(declarator.named_children[0], source))
+    return [n for n in names if n]
+
+
+def _field_text(node: TSNode, field: str, source: bytes) -> str:
+    child = node.child_by_field_name(field)
+    return _text(child, source) if child is not None else ""
+
+
+def _text(node: TSNode | None, source: bytes) -> str:
+    if node is None:
+        return ""
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace").strip()
+
+
+def _csharp_parser() -> Any:
+    try:
+        import tree_sitter_c_sharp
+        from tree_sitter import Language, Parser
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise RuntimeError(
+            "C# extraction needs tree-sitter; install the extra: "
+            "uv pip install 'tree-sitter>=0.21' 'tree-sitter-c-sharp>=0.21'"
+        ) from exc
+    language = Language(tree_sitter_c_sharp.language())
+    try:
+        return Parser(language)
+    except TypeError:  # older tree-sitter API
+        parser = Parser()
+        parser.language = language
+        return parser
+
+
+__all__ = ["CSharpExtractor"]

--- a/src/orchestrator/pkg/extractor.py
+++ b/src/orchestrator/pkg/extractor.py
@@ -89,6 +89,8 @@ DEFAULT_IGNORE_DIRS = frozenset(
         "build",
         "dist",
         ".tox",
+        "obj",  # .NET build output (generated *.g.cs, *.AssemblyInfo.cs)
+        "bin",  # .NET build output
     }
 )
 
@@ -430,9 +432,9 @@ class PythonExtractor:
 def default_extractors() -> list[LanguageExtractor]:
     """The language front-ends used when none are passed explicitly.
 
-    Always Python (stdlib ``ast``). Java and TypeScript are added **only when
-    their tree-sitter grammar is importable** (the ``java`` / ``typescript``
-    extras) so the base install stays stdlib-only — this is what makes
+    Always Python (stdlib ``ast``). Java, TypeScript, and C# are added **only when
+    their tree-sitter grammar is importable** (the ``java`` / ``typescript`` /
+    ``csharp`` extras) so the base install stays stdlib-only — this is what makes
     ``understand`` / grounding / ``pkg extract`` multi-language without forcing
     the parser dependency on everyone.
     """
@@ -448,6 +450,10 @@ def default_extractors() -> list[LanguageExtractor]:
         from orchestrator.pkg.typescript_extractor import TypeScriptExtractor
 
         extractors.append(TypeScriptExtractor())
+    if has_tree_sitter and importlib.util.find_spec("tree_sitter_c_sharp"):
+        from orchestrator.pkg.csharp_extractor import CSharpExtractor
+
+        extractors.append(CSharpExtractor())
     return extractors
 
 

--- a/tests/catalog/test_profile.py
+++ b/tests/catalog/test_profile.py
@@ -39,6 +39,27 @@ def test_java_repo(tmp_path: Path) -> None:
     assert prof.test_runner == "junit"
 
 
+def test_csharp_aspnet_with_xunit(tmp_path: Path) -> None:
+    _write(tmp_path, "src/Api/Program.cs", "namespace App; public class P { }")
+    _write(
+        tmp_path,
+        "src/Api/Api.csproj",
+        '<Project Sdk="Microsoft.NET.Sdk.Web">'
+        '<ItemGroup><PackageReference Include="Microsoft.AspNetCore.Mvc"/></ItemGroup></Project>',
+    )
+    _write(
+        tmp_path,
+        "tests/Api.Tests/Api.Tests.csproj",
+        '<Project Sdk="Microsoft.NET.Sdk"><ItemGroup>'
+        '<PackageReference Include="xunit"/>'
+        '<PackageReference Include="Microsoft.NET.Test.Sdk"/></ItemGroup></Project>',
+    )
+    prof = ProjectProfile.from_repo(tmp_path)
+    assert "csharp" in prof.languages
+    assert prof.framework == "aspnet"
+    assert prof.test_runner == "xunit"
+
+
 def test_greenfield_empty_repo(tmp_path: Path) -> None:
     prof = ProjectProfile.from_repo(tmp_path)
     assert prof.languages == frozenset()

--- a/tests/knowledge/test_current_state.py
+++ b/tests/knowledge/test_current_state.py
@@ -1,0 +1,106 @@
+"""Current State — synthesis from PKG facts + profile, two lenses. Deterministic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from orchestrator.catalog.profile import ProjectProfile
+from orchestrator.knowledge.current_state import (
+    build_current_state,
+    compute_current_state,
+    render_current_state,
+)
+from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+
+
+def _node(nid: str, kind: NodeKind, name: str, file: str = "f.cs") -> Node:
+    return Node(nid, kind, name, "csharp", Provenance(file, 1))
+
+
+def _synthetic_batch() -> FactBatch:
+    b = FactBatch()
+    mod = _node("c:App.Api", NodeKind.MODULE, "App.Api")
+    b.add_node(mod)
+    ctrl = _node("c:App.Api.UserController", NodeKind.TYPE, "UserController", "UserController.cs")
+    b.add_node(ctrl)
+    b.add_edge(Edge(mod.id, ctrl.id, EdgeKind.CONTAINS, Provenance("UserController.cs", 1)))
+    for i in range(30):  # a fat controller: 30 endpoints
+        m = _node(f"{ctrl.id}.Get{i}", NodeKind.FUNCTION, f"Get{i}", "UserController.cs")
+        b.add_node(m)
+        b.add_edge(Edge(ctrl.id, m.id, EdgeKind.CONTAINS, Provenance("UserController.cs", i)))
+    svc = _node("c:App.Biz.UserService", NodeKind.TYPE, "UserService", "UserService.cs")
+    iface = _node("c:App.Biz.IUserService", NodeKind.TYPE, "IUserService", "IUserService.cs")
+    biz = _node("c:App.Biz", NodeKind.MODULE, "App.Biz")
+    for n in (biz, svc, iface):
+        b.add_node(n)
+    b.add_edge(Edge(biz.id, svc.id, EdgeKind.CONTAINS, Provenance("UserService.cs", 1)))
+    b.add_edge(Edge(biz.id, iface.id, EdgeKind.CONTAINS, Provenance("IUserService.cs", 1)))
+    # API depends on Biz (coupling)
+    b.add_edge(Edge(mod.id, "c:App.Biz", EdgeKind.IMPORTS, Provenance("UserController.cs", 1)))
+    return b
+
+
+_PROFILE = ProjectProfile(
+    languages=frozenset({"csharp"}),
+    framework="aspnet",
+    has_db=False,
+    has_migrations=False,
+    test_runner=None,
+    task_type="feature",
+)
+
+
+def test_compute_metrics() -> None:
+    s = compute_current_state(_synthetic_batch(), _PROFILE)
+    assert s.controllers == 1
+    assert s.endpoints == 30
+    assert s.interfaces == 1
+    assert s.layers["API · controllers"] == 1
+    assert s.layers["Interfaces / contracts"] == 1
+    assert ("App.Api", "App.Biz") in s.coupling
+    assert s.tested_areas == 0
+
+
+def test_recommendations_flag_tests_and_fat_controller() -> None:
+    s = compute_current_state(_synthetic_batch(), _PROFILE)
+    text = " ".join(t for _p, t in s.recommendations)
+    assert any(p == "P1" for p, _ in s.recommendations)  # tests / security
+    assert "fat controllers" in text.lower()  # 30 > 25 endpoints
+    assert "UserController" in text
+
+
+def test_developer_lens_renders_sections() -> None:
+    s = compute_current_state(_synthetic_batch(), _PROFILE)
+    md = render_current_state(s, lens="developer")
+    assert "# Current State" in md
+    assert "## Architecture — layers" in md
+    assert "## Recommendations" in md
+    assert "```mermaid" in md  # coupling diagram
+    assert "UserController" in md
+
+
+def test_stakeholder_lens_is_plain_language() -> None:
+    s = compute_current_state(_synthetic_batch(), _PROFILE)
+    md = render_current_state(s, lens="stakeholder")
+    assert "# Current State" in md
+    assert "web API" in md
+    assert "## " not in md.split("\n", 1)[1]  # no technical section headers in the body
+
+
+def test_auth_surface_and_recency_degrade(tmp_path: Path) -> None:
+    b = _synthetic_batch()
+    b.add_node(_node("c:App.Biz.AuthService", NodeKind.TYPE, "AuthService", "AuthService.cs"))
+    s = compute_current_state(b, _PROFILE, root=tmp_path)  # tmp_path has no git history
+    assert "AuthService" in s.auth_surface
+    assert s.recent_areas == []  # git recency degrades gracefully without a repo
+    md = render_current_state(s, lens="developer")
+    assert "## Security surface" in md
+
+
+def test_build_current_state_end_to_end_python(tmp_path: Path) -> None:
+    # works on any language (Python extractor is always available — no grammar extra)
+    (tmp_path / "svc.py").write_text(
+        "class OrderService:\n    def place(self) -> int:\n        return 1\n", encoding="utf-8"
+    )
+    md = build_current_state(tmp_path, lens="developer", refresh=True)
+    assert "# Current State" in md and "## At a glance" in md

--- a/tests/pkg/test_csharp_extractor.py
+++ b/tests/pkg/test_csharp_extractor.py
@@ -1,0 +1,178 @@
+"""PKG: the C# front-end maps C# source onto the universal facts (Track 1).
+
+tree-sitter is an optional extra, so these skip cleanly when it's absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestrator.pkg.csharp_extractor import CSharpExtractor
+from orchestrator.pkg.facts import EdgeKind, FactBatch, NodeKind
+
+pytest.importorskip("tree_sitter_c_sharp", reason="install the 'csharp' extra")
+
+INVOICE = """\
+using System;
+using System.Collections.Generic;
+
+namespace Billing.Core
+{
+    public interface IRepository { }
+
+    public class InvoiceService : BaseService, IRepository
+    {
+        private readonly int _count;
+        public string Name { get; set; }
+
+        public InvoiceService(int count) { _count = count; }
+        public decimal Total(Invoice inv) { return inv.Amount; }
+
+        public enum Status { Open, Paid }
+    }
+
+    public record Money(decimal Amount, string Currency);
+}
+"""
+
+
+def _facts(tmp_path: Path, src: str = INVOICE, name: str = "Invoice.cs") -> tuple[FactBatch, str]:
+    f = tmp_path / name
+    f.write_text(src, encoding="utf-8")
+    ex = CSharpExtractor()
+    module = ex.module_name(f, tmp_path)
+    return ex.extract(path=f, module=module, rel=f"src/{name}"), module
+
+
+def test_module_name_is_the_namespace(tmp_path: Path) -> None:
+    _, module = _facts(tmp_path)
+    assert module == "Billing.Core"
+
+
+def test_emits_type_method_field_nodes(tmp_path: Path) -> None:
+    batch, _ = _facts(tmp_path)
+    by_id = {n.id: n for n in batch.nodes}
+    assert by_id["csharp:Billing.Core.InvoiceService"].kind is NodeKind.TYPE
+    assert by_id["csharp:Billing.Core.IRepository"].kind is NodeKind.TYPE
+    # method + constructor are Functions
+    assert by_id["csharp:Billing.Core.InvoiceService.Total"].kind is NodeKind.FUNCTION
+    assert by_id["csharp:Billing.Core.InvoiceService.InvoiceService"].kind is NodeKind.FUNCTION
+    # field + property + enum member are Fields
+    assert by_id["csharp:Billing.Core.InvoiceService._count"].kind is NodeKind.FIELD
+    assert by_id["csharp:Billing.Core.InvoiceService.Name"].kind is NodeKind.FIELD
+    assert by_id["csharp:Billing.Core.InvoiceService.Status.Open"].kind is NodeKind.FIELD
+    # nested enum is a Type; record is a Type with positional params as Fields
+    assert by_id["csharp:Billing.Core.InvoiceService.Status"].kind is NodeKind.TYPE
+    assert by_id["csharp:Billing.Core.Money"].kind is NodeKind.TYPE
+    assert by_id["csharp:Billing.Core.Money.Amount"].kind is NodeKind.FIELD
+
+
+def test_imports_and_contains_edges(tmp_path: Path) -> None:
+    batch, _ = _facts(tmp_path)
+    edges = {(e.src, e.dst, e.kind) for e in batch.edges}
+    assert ("csharp:Billing.Core", "csharp:System", EdgeKind.IMPORTS) in edges
+    assert (
+        "csharp:Billing.Core.InvoiceService",
+        "csharp:Billing.Core.InvoiceService.Total",
+        EdgeKind.CONTAINS,
+    ) in edges
+
+
+def test_implements_resolves_same_namespace(tmp_path: Path) -> None:
+    batch, _ = _facts(tmp_path)
+    impls = {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.IMPLEMENTS}
+    # both base entries resolve to same-namespace ids; IRepository lands on the real node
+    assert ("csharp:Billing.Core.InvoiceService", "csharp:Billing.Core.IRepository") in impls
+    assert ("csharp:Billing.Core.InvoiceService", "csharp:Billing.Core.BaseService") in impls
+
+
+def test_does_not_emit_calls(tmp_path: Path) -> None:
+    # Precision-first: C# call resolution needs overload/type inference, so no CALLS yet.
+    batch, _ = _facts(tmp_path)
+    assert not [e for e in batch.edges if e.kind is EdgeKind.CALLS]
+
+
+def test_repo_extractor_dispatches_csharp_by_suffix(tmp_path: Path) -> None:
+    from orchestrator.pkg.extractor import PythonExtractor, RepoCodeExtractor
+
+    (tmp_path / "A.cs").write_text(INVOICE, encoding="utf-8")
+    (tmp_path / "m.py").write_text("def f() -> int:\n    return 1\n", encoding="utf-8")
+    batch = RepoCodeExtractor([PythonExtractor(), CSharpExtractor()]).extract(tmp_path)
+    langs = {n.language for n in batch.nodes}
+    assert "csharp" in langs and "python" in langs
+
+
+def test_file_scoped_namespace(tmp_path: Path) -> None:
+    src = "namespace App;\n\npublic class Widget { public void Render() { } }\n"
+    batch, module = _facts(tmp_path, src, name="Widget.cs")
+    assert module == "App"
+    by_id = {n.id: n for n in batch.nodes}
+    assert by_id["csharp:App.Widget"].kind is NodeKind.TYPE
+    assert by_id["csharp:App.Widget.Render"].kind is NodeKind.FUNCTION
+
+
+def test_unnamespaced_file_falls_back_to_path(tmp_path: Path) -> None:
+    _, module = _facts(tmp_path, "public class Bare { }\n", name="Bare.cs")
+    assert module == "Bare.cs"
+
+
+WALLET = """\
+namespace Pay.Domain
+{
+    public delegate decimal Rate(decimal amount);
+
+    public partial class Wallet<T> : BaseWallet<T> where T : class
+    {
+        public event System.EventHandler? Changed;
+        public event System.EventHandler Added, Removed;
+        public static Wallet<T> operator +(Wallet<T> a, Wallet<T> b) => a;
+        public void Add(T item) { }
+    }
+
+    public partial class Wallet<T> { public void Remove(T item) { } }
+}
+"""
+
+
+def test_delegates_events_operators_and_partial_merge(tmp_path: Path) -> None:
+    batch, _ = _facts(tmp_path, WALLET, name="Wallet.cs")
+    by_id = {n.id: n for n in batch.nodes}
+    # delegate is a (leaf) Type
+    assert by_id["csharp:Pay.Domain.Rate"].kind is NodeKind.TYPE
+    # events → Field (including a multi-declarator event line)
+    assert by_id["csharp:Pay.Domain.Wallet.Changed"].kind is NodeKind.FIELD
+    assert by_id["csharp:Pay.Domain.Wallet.Added"].kind is NodeKind.FIELD
+    assert by_id["csharp:Pay.Domain.Wallet.Removed"].kind is NodeKind.FIELD
+    # operator → Function
+    assert by_id["csharp:Pay.Domain.Wallet.operator+"].kind is NodeKind.FUNCTION
+    # generic name is clean ("Wallet", not "Wallet<T>") and the two `partial` halves
+    # merge onto one Type carrying both methods
+    assert by_id["csharp:Pay.Domain.Wallet"].kind is NodeKind.TYPE
+    assert "csharp:Pay.Domain.Wallet.Add" in by_id
+    assert "csharp:Pay.Domain.Wallet.Remove" in by_id
+
+
+def test_delegate_has_no_spurious_fields(tmp_path: Path) -> None:
+    # a delegate's parameters must NOT be emitted as Fields (it's a leaf type).
+    batch, _ = _facts(tmp_path, WALLET, name="Wallet.cs")
+    assert not [n for n in batch.nodes if n.id.startswith("csharp:Pay.Domain.Rate.")]
+
+
+def test_bom_and_file_scoped_namespace_qualifies_ids(tmp_path: Path) -> None:
+    # .NET files often start with a UTF-8 BOM and use a file-scoped namespace; the
+    # type id must still be namespace-qualified, never leaked to the file path.
+    src = "﻿namespace MediatR;\n\npublic readonly struct Unit { }\n"
+    batch, module = _facts(tmp_path, src, name="Unit.cs")
+    assert module == "MediatR"
+    by_id = {n.id: n for n in batch.nodes}
+    assert by_id["csharp:MediatR.Unit"].kind is NodeKind.TYPE
+    assert not [n for n in batch.nodes if ".cs." in n.id]  # no path-leaked ids
+
+
+def test_indexer_is_a_field(tmp_path: Path) -> None:
+    src = "namespace N { public class Bag { public int this[int i] { get => 0; set { } } } }\n"
+    batch, _ = _facts(tmp_path, src, name="Bag.cs")
+    by_id = {n.id: n for n in batch.nodes}
+    assert by_id["csharp:N.Bag.this[]"].kind is NodeKind.FIELD


### PR DESCRIPTION
Automated sync from the private repo @ 79e2234 (v1.24.0).

## What's in this release
- chore(release): 1.24.0 — C# PKG front-end + Current State feature
- feat(knowledge): current-state +git recency, security surface, naming smells
- feat(knowledge): formalize Current State — orchestrator state command + renderer
- fix(pkg): ignore .NET build output (obj/ bin/) during extraction
- feat(catalog): detect ASP.NET framework + .NET test runners (xunit/nunit/mstest)
- fix(catalog): detect C# (.cs) in the project profiler
- feat(pkg): C# extractor — capture indexers (this[] -> Field)
- feat(pkg): C# extractor — delegates/events/operators + BOM/namespace-id fix
- docs(spec): Current State — team-facing view layered on the PKG
- feat(pkg): C# front-end for the Product Knowledge Graph (Track 1, Phase 1.1)
- docs(spec): restructure language-support plan into sequential per-language tracks
- docs(spec): C/C++ PKG language-support blueprint + phased plan

Merge to release.