### PR TITLE
Publish v2.0.1 (4db4835)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ build/
 # Local smoke-test artefacts
 .smoke-api.log
 
+# Generated per-run backlog ledger (./BACKLOG.md) — a local artifact of `sdlc
+# feature` runs, never committed to this repo.
+/BACKLOG.md
+
 # Claude Code session lockfiles
 .claude/
 
@@ -31,3 +35,11 @@ build/
 .env.*
 !.env.example
 *.pem
+
+# Local-only validation artefacts from live-proving against private target repos —
+# findings/reports/extracts must NEVER be committed. Clones live in /tmp; reports
+# under docs/ are already ignored. Neutral catch-alls for any stray in-repo copy:
+/.local/
+*.local.md
+*.local.json
+*.local.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "2.0.0"
+version = "2.0.1"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -587,7 +587,9 @@ def sdlc_feature(
     ] = False,
     language: Annotated[
         str,
-        typer.Option("--language", help="Target language: auto (detect), python, java, or typescript."),
+        typer.Option(
+            "--language", help="Target language: auto (detect), python, java, typescript, or csharp."
+        ),
     ] = "auto",
 ) -> None:
     """Linear pipeline for ONE intent, end to end.

--- a/src/orchestrator/pkg/csharp_extractor.py
+++ b/src/orchestrator/pkg/csharp_extractor.py
@@ -295,27 +295,52 @@ def _framework_edges(
 
 
 def _endpoint_edges(types: list[_TypeRec], source: bytes, rel: str, batch: FactBatch) -> None:
-    """Attribute-routed controllers → Endpoint + EXPOSES (route→handler)."""
+    """Attribute-routed controllers → Endpoint + EXPOSES (route→handler).
+
+    The route is sourced, in order, from the HTTP-verb attribute's own argument
+    (``[HttpGet("x")]``), then a sibling method-level ``[Route("x")]`` (the very
+    common ``[Route(...)] + [HttpGet]`` split), then the class-level ``[Route]``
+    prefix. A method-level ``[Route]`` with no verb attribute (responds to all
+    verbs) is emitted as ``ANY`` — but only on a controller, so a stray ``[Route]``
+    on a plain class doesn't masquerade as an endpoint."""
     for rec in types:
         class_route = ""
         for aname, anode in _attributes(rec.node, source):
             if aname == "Route":
                 class_route = _attr_string_arg(anode, source)
                 break
+        controller = _is_controller(rec, source)
         for _mname, mid, mnode in rec.methods:
-            verb, route = "", ""
+            verb, http_route, method_route = "", "", ""
             for aname, anode in _attributes(mnode, source):
                 if aname in _HTTP_VERB_ATTRS:
                     verb = _HTTP_VERB_ATTRS[aname]
-                    route = _attr_string_arg(anode, source)
-                    break
+                    http_route = _attr_string_arg(anode, source)
+                elif aname == "Route":
+                    method_route = _attr_string_arg(anode, source)
             if not verb:
-                continue
-            full = _join_route(class_route, route)
+                if not (controller and method_route):
+                    continue
+                verb = "ANY"  # [Route]-only action handles every HTTP method
+            full = _join_route(class_route, http_route or method_route)
             line = mnode.start_point[0] + 1
             eid = f"csharp:endpoint:{verb} {full}"
             batch.add_node(Node(eid, NodeKind.ENDPOINT, f"{verb} {full}", "csharp", Provenance(rel, line)))
             batch.add_edge(Edge(eid, mid, EdgeKind.EXPOSES, Provenance(rel, line)))
+
+
+def _is_controller(rec: _TypeRec, source: bytes) -> bool:
+    """A type is a controller if it's named ``*Controller``, carries
+    ``[ApiController]``, or derives from a ``*Controller`` / ``ControllerBase`` base
+    (covers custom bases like ``BaseController``)."""
+    if rec.name.endswith("Controller"):
+        return True
+    if any(aname == "ApiController" for aname, _ in _attributes(rec.node, source)):
+        return True
+    return any(
+        _last_segment(b).endswith("Controller") or _last_segment(b) == "ControllerBase"
+        for b in _base_types(rec.node, source)
+    )
 
 
 def _minimal_api_edges(root: TSNode, module_id: str, source: bytes, rel: str, batch: FactBatch) -> None:

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -435,8 +435,9 @@ _IMPLEMENT_SYSTEM_CSHARP = (
     "Write source files only (NO test files here). Put each public type in the "
     "source project shown in the layout, one public type per file; the file name "
     "matches the type name; declare the namespace shown in the layout (a "
-    "file-scoped `namespace <Name>;` is fine). Target `net8.0` with nullable "
-    "reference types enabled. Use only the BCL or packages already referenced in "
+    "file-scoped `namespace <Name>;` is fine). Target the framework shown in the "
+    "layout, with nullable reference types enabled. Use only the BCL or packages "
+    "already referenced in "
     "the source `.csproj` — to add one, edit the `.csproj` with a "
     "`<PackageReference>`. Every file must be complete and compilable."
 )
@@ -659,11 +660,12 @@ class LLMCodegenAdapter:
                 "- Declare any new dependency in `package.json` (edit it); don't invent unrelated paths.\n\n"
             )
         if layout.language == "csharp":
+            tfm = layout.target_framework or "net8.0"
             return (
                 "PROJECT LAYOUT (authoritative — overrides any default path guidance):\n"
                 f"- C# namespace is `{layout.package_name}`. Put each public type at "
                 f"`{layout.source_dir}/<TypeName>.cs`, one public type per file, declaring "
-                f"`namespace {layout.package_name};` (target net8.0, nullable enabled).\n"
+                f"`namespace {layout.package_name};` (target {tfm}, nullable enabled).\n"
                 f"- Put xUnit tests at `{layout.tests_dir}/<TypeName>Tests.cs` (the test "
                 "project already references the source project).\n"
                 f"- Declare any new dependency as a `<PackageReference>` in the source "

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -95,8 +95,9 @@ async def _changed_files(path: Path) -> list[str]:
             rel = rel.strip().strip('"')
             # Drop build/cache/venv output — these are test-run byproducts, not the
             # change (e.g. Maven target/, a stray .sdlc-venv when a repo's .gitignore
-            # doesn't cover them).
-            if rel.split("/", 1)[0] in _BUILD_DIRS:
+            # doesn't cover them, or .NET bin/ obj/ nested under a project dir).
+            segments = rel.split("/")
+            if segments[0] in _BUILD_DIRS or "bin" in segments or "obj" in segments:
                 continue
             changed.add(rel)
         return sorted(changed)
@@ -159,6 +160,7 @@ async def run_feature(
     from orchestrator.sdlc.layout import is_effectively_empty, resolve_layout
     from orchestrator.sdlc.scaffold import scaffold
     from orchestrator.sdlc.testenv import (
+        detect_dotnet_tfm,
         dotnet_toolchain_available,
         java_toolchain_available,
         make_test_environment,
@@ -244,6 +246,10 @@ async def run_feature(
     #     (existing package) is detected and reused — never scaffolded.
     lang = _resolve_language(path, language)
     layout = resolve_layout(path, mode=layout_mode, package_name=package_name, repo=repo_url, language=lang)
+    if lang == "csharp":
+        # Target the installed SDK so a greenfield scaffold builds AND runs (a TFM
+        # with no matching runtime fails at the test host, not at build).
+        layout = replace(layout, target_framework=detect_dotnet_tfm())
     if layout.mode == "new":
         was_empty = is_effectively_empty(path)
         created = scaffold(path, layout)

--- a/src/orchestrator/sdlc/layout.py
+++ b/src/orchestrator/sdlc/layout.py
@@ -51,6 +51,10 @@ class TargetLayout:
     scaffolded: bool = False
     language: str = "python"
     build_tool: str = ""  # "maven"|"gradle" (Java) | "npm"|"yarn"|"pnpm" (TypeScript) | ""
+    # Greenfield C# target-framework moniker (e.g. "net8.0"/"net10.0"). Empty → the
+    # scaffold's default; the runner sets it from the installed SDK so the generated
+    # project both builds AND runs (a TFM with no matching runtime fails at test host).
+    target_framework: str = ""
 
     def module_rel_path(self, module: str) -> str:
         """Worktree-relative path for a new source module/class (no leading dir)."""

--- a/src/orchestrator/sdlc/scaffold.py
+++ b/src/orchestrator/sdlc/scaffold.py
@@ -21,6 +21,8 @@ from orchestrator.sdlc.layout import TargetLayout
 
 # Project-type GUID for SDK-style C# projects (what `dotnet sln add` writes).
 _CSHARP_SLN_PROJECT_TYPE = "9A19103F-16F7-4668-BE54-9A1E7A4F7556"
+# Greenfield C# target framework when the installed SDK can't be probed (LTS).
+_DEFAULT_DOTNET_TFM = "net8.0"
 
 _PYPROJECT_TEMPLATE = """\
 [build-system]
@@ -92,7 +94,33 @@ def scaffold(root: Path | str, layout: TargetLayout, *, profile: ProjectProfile 
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         created.append(rel)
+    if layout.language == "csharp":
+        created += _ensure_dotnet_gitignore(root_path)
     return created
+
+
+def _ensure_dotnet_gitignore(root: Path) -> list[str]:
+    """Guarantee ``bin/`` and ``obj/`` are ignored so ``dotnet`` build output never
+    lands in a commit/PR. The scaffold's own ``.gitignore`` covers them, but a
+    brownfield or scratch worktree with a pre-existing ``.gitignore`` (never
+    clobbered) may not — append the missing rules rather than overwrite."""
+    gi = root / ".gitignore"
+    if not gi.exists():
+        return []  # the scaffold just wrote its .gitignore (already has bin/ obj/)
+    existing = gi.read_text(encoding="utf-8")
+    have = {ln.strip().rstrip("/") for ln in existing.splitlines()}
+    missing = [d for d in ("bin", "obj") if d not in have]
+    if not missing:
+        return []
+    sep = "" if existing.endswith("\n") else "\n"
+    gi.write_text(
+        existing
+        + sep
+        + "\n# .NET build output (appended by the SDLC scaffold)\n"
+        + "".join(f"{d}/\n" for d in missing),
+        encoding="utf-8",
+    )
+    return [".gitignore"]
 
 
 def _python_files(layout: TargetLayout) -> dict[str, str]:
@@ -177,12 +205,15 @@ def _csharp_files(layout: TargetLayout) -> dict[str, str]:
     test_name = f"{name}.Tests"
     src_csproj = f"{src_dir}/{name}.csproj"
     test_csproj = f"{test_dir}/{test_name}.csproj"
+    # Target the installed SDK (set by the runner) so the project runs, not just
+    # builds; fall back to the LTS default when unset (unit tests, no SDK probe).
+    tfm = layout.target_framework or _DEFAULT_DOTNET_TFM
     # ProjectReference from the test project back to the source project (relative).
     ref = os.path.relpath(src_csproj, start=test_dir).replace("/", "\\")
     return {
         f"{name}.sln": _sln(name, src_csproj, test_name, test_csproj),
-        src_csproj: _CSPROJ_LIB.format(name=name),
-        test_csproj: _CSPROJ_TEST.format(ref=ref),
+        src_csproj: _CSPROJ_LIB.format(name=name, tfm=tfm),
+        test_csproj: _CSPROJ_TEST.format(ref=ref, tfm=tfm),
         # SDK-style projects anchor their own dirs in git; xUnit's default template
         # has no source files, so a placeholder keeps the source dir non-empty.
         f"{src_dir}/.gitkeep": "",
@@ -241,7 +272,7 @@ _CSPROJ_LIB = """\
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>{tfm}</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>{name}</RootNamespace>
@@ -254,7 +285,7 @@ _CSPROJ_TEST = """\
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>{tfm}</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/orchestrator/sdlc/testenv.py
+++ b/src/orchestrator/sdlc/testenv.py
@@ -242,6 +242,27 @@ def dotnet_toolchain_available() -> bool:
     return shutil.which("dotnet") is not None
 
 
+def detect_dotnet_tfm(default: str = "net8.0") -> str:
+    """The installed SDK's target-framework moniker (``net{major}.0``), or ``default``.
+
+    A greenfield project must target a framework whose RUNTIME is installed — a
+    ``net8.0`` project on a box with only the .NET 10 runtime builds but can't launch
+    the test host (roll-forward doesn't cross majors). So the scaffold targets the
+    SDK actually present. Best-effort: falls back to ``default`` if ``dotnet`` is
+    missing or its version can't be parsed."""
+    import subprocess
+
+    exe = shutil.which("dotnet")
+    if exe is None:
+        return default
+    try:
+        proc = subprocess.run([exe, "--version"], capture_output=True, text=True, timeout=30)  # noqa: S603
+    except (OSError, subprocess.SubprocessError):
+        return default
+    m = re.match(r"\s*(\d+)\.", proc.stdout)
+    return f"net{m.group(1)}.0" if m else default
+
+
 def node_toolchain_available(package_manager: str = "npm") -> bool:
     """True if both ``node`` and the package manager are on PATH (TS prerequisite)."""
     return shutil.which("node") is not None and shutil.which(package_manager or "npm") is not None
@@ -403,6 +424,7 @@ __all__ = [
     "NodeToolEnvironment",
     "TestEnvironment",
     "VenvTestEnvironment",
+    "detect_dotnet_tfm",
     "dotnet_toolchain_available",
     "java_toolchain_available",
     "make_test_environment",

--- a/src/orchestrator/sdlc/testrunner.py
+++ b/src/orchestrator/sdlc/testrunner.py
@@ -185,10 +185,17 @@ class DotnetTestRunner:
 
     async def run(self, *, path: str) -> TestRunResult:
         env = {k: v for k, v in os.environ.items() if not k.startswith(_SECRET_ENV_PREFIXES)}
+        # `dotnet test` with no argument needs exactly one project/solution in cwd.
+        # In a monorepo the solution is often NESTED (e.g. backend/App/App.sln), so
+        # point it at the single .sln when there is one; otherwise let dotnet resolve
+        # at the root (greenfield scaffold writes the .sln at the root).
+        target = _discover_dotnet_target(Path(path))
+        args = ["test", "--nologo"]
+        if target:
+            args.insert(1, target)  # `dotnet test <solution> --nologo`
         proc = await asyncio.create_subprocess_exec(
             self._dotnet,
-            "test",
-            "--nologo",
+            *args,
             cwd=path,
             env=env,
             stdout=asyncio.subprocess.PIPE,
@@ -239,6 +246,26 @@ class NodeTestRunner:
             output = output[-_MAX_OUTPUT_CHARS:]
         rc = proc.returncode if proc.returncode is not None else -1
         return TestRunResult(passed=rc == 0, returncode=rc, output=output)
+
+
+_DOTNET_SKIP_DIRS = {"bin", "obj", "node_modules", ".git", ".vs"}
+
+
+def _discover_dotnet_target(root: Path) -> str | None:
+    """The single ``.sln`` in the worktree (so a nested solution is found), else the
+    single ``.csproj``, else ``None`` (run ``dotnet test`` at the root). Returns a
+    path only when it's unambiguous — multiple solutions stay at the root so this
+    never guesses which one to test."""
+    for ext in ("*.sln", "*.csproj"):
+        hits: list[Path] = []
+        for p in root.rglob(ext):
+            if _DOTNET_SKIP_DIRS.isdisjoint(part.lower() for part in p.relative_to(root).parts):
+                hits.append(p)
+        if len(hits) == 1:
+            return str(hits[0])
+        if hits:  # several solutions/projects → ambiguous; defer to the root
+            return None
+    return None
 
 
 class StubTestRunner:

--- a/tests/pkg/test_csharp_extractor.py
+++ b/tests/pkg/test_csharp_extractor.py
@@ -245,6 +245,48 @@ def test_controller_endpoints_expose_handlers(tmp_path: Path) -> None:
     assert (post_id, "csharp:Shop.Api.OrdersController.Create", EdgeKind.EXPOSES) in edges
 
 
+ROUTE_SPLIT_CONTROLLER = """\
+namespace App.Web;
+
+public class SearchController : BaseController
+{
+    [Route("api/getInfo")]
+    [HttpGet]
+    public IActionResult GetInfo(string login) { return null; }
+
+    [Route("api/saveThing")]
+    [HttpPost]
+    public IActionResult SaveThing() { return null; }
+
+    [Route("api/anyVerb")]
+    public IActionResult AnyVerb() { return null; }
+}
+"""
+
+
+def test_method_level_route_attribute_distinguishes_endpoints(tmp_path: Path) -> None:
+    # The common ASP.NET pattern: a separate method-level [Route("api/x")] carries the
+    # path and [HttpGet]/[HttpPost] carries only the verb (no class [Route], no route
+    # arg on the verb attr). Each must become a DISTINCT endpoint — not collapse to "/".
+    batch, _ = _facts(tmp_path, ROUTE_SPLIT_CONTROLLER, name="SearchController.cs")
+    by_id = {n.id: n for n in batch.nodes}
+    assert by_id["csharp:endpoint:GET /api/getInfo"].kind is NodeKind.ENDPOINT
+    assert by_id["csharp:endpoint:POST /api/saveThing"].kind is NodeKind.ENDPOINT
+    # a [Route]-only action (no verb attr) on a controller → ANY.
+    assert by_id["csharp:endpoint:ANY /api/anyVerb"].kind is NodeKind.ENDPOINT
+    edges = {(e.src, e.dst, e.kind) for e in batch.edges}
+    base = "csharp:App.Web.SearchController"
+    assert ("csharp:endpoint:GET /api/getInfo", f"{base}.GetInfo", EdgeKind.EXPOSES) in edges
+    assert ("csharp:endpoint:POST /api/saveThing", f"{base}.SaveThing", EdgeKind.EXPOSES) in edges
+
+
+def test_route_only_method_on_plain_class_is_not_an_endpoint(tmp_path: Path) -> None:
+    # precision-first: a [Route] on a non-controller class must NOT become an endpoint.
+    src = 'namespace N { public class Helper { [Route("x")] public int F() { return 0; } } }\n'
+    batch, _ = _facts(tmp_path, src, name="Helper.cs")
+    assert not [n for n in batch.nodes if n.kind is NodeKind.ENDPOINT]
+
+
 def test_intra_type_calls_resolve_to_siblings(tmp_path: Path) -> None:
     batch, _ = _facts(tmp_path, CONTROLLER, name="OrdersController.cs")
     calls = {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.CALLS}

--- a/tests/sdlc/test_scaffold.py
+++ b/tests/sdlc/test_scaffold.py
@@ -151,6 +151,29 @@ def test_scaffold_csharp_is_idempotent(tmp_path: Path) -> None:
     assert scaffold(tmp_path, _CSHARP_LAYOUT) == []
 
 
+def test_scaffold_csharp_appends_dotnet_ignores_to_existing_gitignore(tmp_path: Path) -> None:
+    # A scratch/brownfield repo may already have a .gitignore (never clobbered) that
+    # lacks bin/ obj/ — the scaffold must append them so build output isn't committed.
+    (tmp_path / ".gitignore").write_text(".venv/\n__pycache__/\n", encoding="utf-8")
+    created = scaffold(tmp_path, _CSHARP_LAYOUT)
+    assert ".gitignore" in created  # appended (counts as changed)
+    gi = (tmp_path / ".gitignore").read_text()
+    assert ".venv/" in gi  # pre-existing rules preserved
+    assert "bin/" in gi and "obj/" in gi  # .NET build output now ignored
+
+
+def test_scaffold_csharp_honors_target_framework(tmp_path: Path) -> None:
+    from dataclasses import replace
+
+    # The runner sets target_framework from the installed SDK so the project runs,
+    # not just builds; both csproj files must carry it (default stays net8.0).
+    scaffold(tmp_path, replace(_CSHARP_LAYOUT, target_framework="net10.0"))
+    src = (tmp_path / "src" / "Widgets" / "Widgets.csproj").read_text()
+    test = (tmp_path / "tests" / "Widgets.Tests" / "Widgets.Tests.csproj").read_text()
+    assert "<TargetFramework>net10.0</TargetFramework>" in src
+    assert "<TargetFramework>net10.0</TargetFramework>" in test
+
+
 def test_flat_layout_pythonpath(tmp_path: Path) -> None:
     flat = TargetLayout("pkg", "pkg", "tests", src_layout=False, mode="new")
     scaffold(tmp_path, flat)

--- a/tests/sdlc/test_testenv.py
+++ b/tests/sdlc/test_testenv.py
@@ -332,6 +332,24 @@ def test_dotnet_toolchain_available(monkeypatch: pytest.MonkeyPatch) -> None:
     assert testenv.dotnet_toolchain_available() is False
 
 
+def test_detect_dotnet_tfm(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.sdlc import testenv
+
+    class _Proc:
+        stdout = "10.0.301\n"
+
+    monkeypatch.setattr("orchestrator.sdlc.testenv.shutil.which", lambda _n: "/usr/bin/dotnet")
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: _Proc())
+    assert testenv.detect_dotnet_tfm() == "net10.0"  # net{major}.0 from the SDK version
+
+
+def test_detect_dotnet_tfm_falls_back_without_dotnet(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.sdlc import testenv
+
+    monkeypatch.setattr("orchestrator.sdlc.testenv.shutil.which", lambda _n: None)
+    assert testenv.detect_dotnet_tfm(default="net8.0") == "net8.0"
+
+
 async def test_dotnet_runner_passes_on_zero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
     from orchestrator.sdlc.testrunner import DotnetTestRunner
 
@@ -352,3 +370,40 @@ async def test_dotnet_runner_fails_and_captures_output(monkeypatch: pytest.Monke
     monkeypatch.setattr("orchestrator.sdlc.testrunner.asyncio.create_subprocess_exec", fake_exec)
     result = await DotnetTestRunner().run(path="/wt")
     assert not result.passed and "CS0103" in result.output
+
+
+async def test_dotnet_runner_targets_a_nested_solution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A monorepo's solution is often nested (not at the worktree root); the runner
+    # must point `dotnet test` at it instead of failing to find a project at root.
+    sln_dir = tmp_path / "backend" / "App"
+    sln_dir.mkdir(parents=True)
+    (sln_dir / "App.sln").write_text("")
+    captured: list[tuple[object, ...]] = []
+
+    async def fake_exec(*a: object, **k: object) -> _FakeProc:
+        captured.append(a)
+        return _FakeProc(0, b"Passed!")
+
+    from orchestrator.sdlc.testrunner import DotnetTestRunner
+
+    monkeypatch.setattr("orchestrator.sdlc.testrunner.asyncio.create_subprocess_exec", fake_exec)
+    await DotnetTestRunner().run(path=str(tmp_path))
+    argv = captured[0]
+    assert "test" in argv and str(sln_dir / "App.sln") in argv  # targeted the nested .sln
+
+
+async def test_dotnet_runner_no_target_runs_at_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # No solution/project (or several) → no path argument; dotnet resolves at root.
+    captured: list[tuple[object, ...]] = []
+
+    async def fake_exec(*a: object, **k: object) -> _FakeProc:
+        captured.append(a)
+        return _FakeProc(0, b"Passed!")
+
+    from orchestrator.sdlc.testrunner import DotnetTestRunner
+
+    monkeypatch.setattr("orchestrator.sdlc.testrunner.asyncio.create_subprocess_exec", fake_exec)
+    await DotnetTestRunner().run(path=str(tmp_path))
+    assert captured[0] == ("dotnet", "test", "--nologo")

--- a/uv.lock
+++ b/uv.lock
@@ -3066,7 +3066,7 @@ wheels = [
 
 [[package]]
 name = "synaptixs-spine"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Automated sync from the private repo @ 4db4835 (v2.0.1).

## What's in this release
- chore: genericize examples — no private target-repo names in published files
- feat(csharp): close Track 1 (1.4 live-proven); nested-.sln discovery; 2.0.1
- chore: untrack BACKLOG.md (generated per-run ledger), gitignore it
- fix(csharp): keep .NET build output out of commits; CLI lists csharp (1.4 live run)
- fix(csharp): scaffold targets the installed .NET SDK's framework (1.4 build-proving)
- fix(pkg): C# endpoints — source route from method-level [Route] (1.4 live-proving)
- chore(sync): auto-reconcile public develop with main in publish-public.sh
- ci: fix TestPyPI workflow — restore contents:read for checkout

Merge to release.