### PR TITLE
Publish v2.2.0 (e54ee4c)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -31,9 +31,11 @@ radius) and grounds new code in what already exists. Full guide:
 
 | Capability | Status | How to use |
 |---|---|---|
-| Multi-language comprehension + codegen — Python, Java, TypeScript, C# | ✅ | automatic per repo |
+| Multi-language comprehension + codegen — Python, Java, TypeScript, C#, C | ✅ | automatic per repo |
 | Framework-aware edges — ASP.NET Core endpoints, EF Core entities (C#) | ✅ | emitted into the PKG on `pkg extract` / `understand` |
+| C `#include` graph + header/source merge; codegen on **CMake or Meson** | ✅ | `.c`/`.h` per repo; `sdlc feature --language c` |
 | Committed `memory-bank/` for humans + any AI tool | ✅ | `orchestrator understand --out memory-bank` |
+| Current State report — architecture / component / call-graph diagrams (no LLM) | ✅ | `orchestrator state . --lens developer\|stakeholder` |
 | PKG extraction / export | ✅ | `orchestrator pkg extract`, `orchestrator pkg export` |
 | Repo profile / audit | ✅ | `orchestrator profile <repo>`, `orchestrator audit <repo>` |
 

--- a/KNOWLEDGE_GRAPH.md
+++ b/KNOWLEDGE_GRAPH.md
@@ -116,7 +116,7 @@ walking edges, not by guessing.
 
 ```mermaid
 flowchart LR
-    src["Source files<br/>(.py · .java · .ts/.tsx · .cs)"] --> ext["Language extractor<br/>(tree-sitter / AST)"]
+    src["Source files<br/>(.py · .java · .ts/.tsx · .cs · .c/.h)"] --> ext["Language extractor<br/>(tree-sitter / AST)"]
     ext --> facts["Facts<br/>Nodes + Edges + Provenance"]
     facts --> cache["Per-commit cache"]
     facts --> store["Fact store<br/>(queryable)"]
@@ -133,11 +133,17 @@ flowchart LR
   | Java | ✅ | `pip install 'synaptixs-spine[java]'` |
   | TypeScript / TSX | ✅ | `pip install 'synaptixs-spine[typescript]'` |
   | C# | ✅ + framework edges | `pip install 'synaptixs-spine[csharp]'` |
+  | C | ✅ + `#include` graph | `pip install 'synaptixs-spine[c]'` |
 
   C# additionally lifts **framework edges** into the graph: ASP.NET Core controllers
   and Minimal-API routes become `Endpoint` nodes with `EXPOSES` edges to their
   handlers, and EF Core entities (`DbSet<T>` / `[Table]`) become `Entity` nodes with
   `REFERENCES` edges following navigation properties.
+
+  C uses the **translation unit (file)** as the module and builds the **`#include`
+  graph** (`IMPORTS`); a function prototype in a `.h` and its definition in a `.c`
+  **merge onto one node** (the definition wins), `CALLS` resolve across files by name,
+  and a struct member whose type is another struct becomes a `REFERENCES` data edge.
 - **Cached per commit.** Re-running on an unchanged tree reuses the cache; `--refresh`
   forces a re-extract. So `understand` is cheap to re-run as the code evolves.
 
@@ -156,6 +162,22 @@ orchestrator understand . --refresh       # re-extract instead of using the comm
 It produces: `architecture.md`, `domain-model.md`, `tech-context.md`, `conventions.md`,
 `glossary.md`, and `progress.md`. **Commit `memory-bank/`** so your whole team — and any
 AI tool — reads the same code-true project truth.
+
+### `orchestrator state` — the team-facing current-state report
+A higher-level view rendered from the same graph (deterministic, no LLM) — *what the repo
+is today and how healthy it looks*:
+
+```bash
+orchestrator state .                       # developer view (architecture, components, hotspots)
+orchestrator state . --lens stakeholder    # plain-language view
+orchestrator state . --out STATE.md        # write to a file (otherwise printed)
+```
+
+It renders a **system-architecture diagram** (top components grouped into zones with
+weighted dependency arrows from the import/`#include` graph), a **component-dependency**
+table, **call-graph hotspots** (most-depended-upon functions), complexity / god-components,
+test-coverage and recent-activity signals, a name-based security surface, and prioritized
+recommendations. A report is a *view* — re-run to refresh.
 
 ### `orchestrator pkg extract` — inspect the raw graph
 ```bash
@@ -277,8 +299,9 @@ reviews honest.
 
 - **Static, not runtime.** The PKG is built from source structure; it doesn't capture
   runtime behavior, dynamic dispatch it can't see, or values only known at execution.
-- **Parser coverage.** Python/Java/TypeScript/C# today. Other languages aren't extracted
-  yet (their files are simply not represented).
+- **Parser coverage.** Python/Java/TypeScript/C#/C today. Other languages aren't
+  extracted yet (their files are simply not represented). For C, parsing is
+  pre-preprocessor — heavy macro use yields partial facts (we never run `cpp`).
 - **Heuristic edges.** Some edges (e.g. data-layer foreign keys) are inferred and improve
   over time; treat them as strong hints, not proofs.
 - **Domain meaning is separate.** The PKG knows *structure*, not business intent — that's

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ writes) so you can inspect everything first.
 **Code-grounded understanding.** Before generating, it builds a **Product Knowledge
 Graph** of your repo — modules, types, functions, call sites, blast radius — and
 grounds new code in what already exists, so output reads like your team wrote it.
-Works across **Python, Java, TypeScript, and C#**. `orchestrator understand` writes a
+Works across **Python, Java, TypeScript, C#, and C**. `orchestrator understand` writes a
 committed, code-true `memory-bank/` your whole team (and any AI tool) can read.
 
 **Governed autonomy.** The workflow itself is a typed, validated artifact. A planner
@@ -124,8 +124,9 @@ The autonomous multi-feature pipeline + web dashboard needs Temporal + Postgres 
 see the [Setup guide](SETUP.md).
 
 **Which languages and models?**
-Code generation and comprehension cover **Python, Java, TypeScript, and C#**
-(C# also extracts ASP.NET Core endpoints and EF Core entities into the graph). Any
+Code generation and comprehension cover **Python, Java, TypeScript, C#, and C**
+(C# also extracts ASP.NET Core endpoints and EF Core entities; C builds the
+`#include` graph and merges header declarations with their source definitions). Any
 LiteLLM-supported provider (Anthropic, OpenAI, Bedrock) or a local Ollama model;
 you can set a different model per stage.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -64,8 +64,10 @@ orchestrator --help
 Optional extras, added when you need them:
 - `pip install 'synaptixs-spine[sdlc]'` — run the generated tests (the `sdlc feature`/`run` path)
 - `pip install 'synaptixs-spine[tui]'` — the `orchestrator tui` terminal UI (Step 7)
-- `[java]`, `[typescript]`, `[csharp]` — language parsers for comprehension + grounding
-  (Python needs no extra). C# codegen also needs the **.NET SDK** (`dotnet`) on your PATH.
+- `[java]`, `[typescript]`, `[csharp]`, `[c]` — language parsers for comprehension +
+  grounding (Python needs no extra). C# codegen also needs the **.NET SDK** (`dotnet`)
+  on PATH; C codegen needs a C compiler plus **CMake** (greenfield) or **Meson + Ninja**
+  (matching the target repo's build system).
 - `[mcp]` (MCP client), `[otel]` (live tracing)
 
 ### Upgrading
@@ -127,17 +129,36 @@ there; greenfield repos get a stub that fills in as features land. Re-run anytim
 to refresh (`--refresh` re-extracts instead of using the commit cache). Commit
 `memory-bank/` so your team — and any AI tool — reads the same project truth.
 
+For a **team-facing snapshot of what the repo is today and how healthy it looks**, use
+the Current State report (also no LLM — synthesized from the same graph):
+
+```bash
+orchestrator state .                       # developer view, to stdout
+orchestrator state . --lens stakeholder    # plain-language view
+orchestrator state . --out STATE.md        # write it to a file
+```
+
+It renders a **system-architecture diagram** (top components grouped into zones, with
+weighted dependency arrows from the import/`#include` graph), a **component-dependency**
+table, **call-graph hotspots**, complexity/god-components, test-coverage and recent-activity
+signals, a name-based security surface, and prioritized recommendations. A report is a
+*view* — re-run to refresh; nothing is written unless `--out` is given.
+
 > **Deep dive:** see **[KNOWLEDGE_GRAPH.md](KNOWLEDGE_GRAPH.md)** for the full PKG
 > guide — the data model, the CLI (`pkg extract` / `export` / `docs`), how grounding
 > uses it, and how it works for brownfield and greenfield projects.
 
 > **Multi-language.** Comprehension covers **Python** out of the box and **Java**,
-> **TypeScript**, and **C#** when the matching parser extra is installed
-> (`pip install 'synaptixs-spine[java]'` / `[typescript]` / `[csharp]`). `understand`,
-> codegen grounding, and `pkg extract` then process `.java` / `.ts` / `.cs` too. For
-> **C#**, the graph additionally captures ASP.NET Core endpoints (`EXPOSES`) and EF
-> Core entities (`REFERENCES`); end-to-end codegen (`sdlc feature` / `run`) scaffolds a
-> solution + xUnit project and runs `dotnet test`, so it needs the **.NET SDK** on PATH.
+> **TypeScript**, **C#**, and **C** when the matching parser extra is installed
+> (`pip install 'synaptixs-spine[java]'` / `[typescript]` / `[csharp]` / `[c]`).
+> `understand`, codegen grounding, and `pkg extract` then process `.java` / `.ts` /
+> `.cs` / `.c` / `.h` too. For **C#**, the graph additionally captures ASP.NET Core
+> endpoints (`EXPOSES`) and EF Core entities (`REFERENCES`); codegen scaffolds a
+> solution + xUnit project and runs `dotnet test` (needs the **.NET SDK**). For **C**,
+> it builds the `#include` graph and merges header declarations with their source
+> definitions; codegen scaffolds a **CMake** project (greenfield) or works in a brownfield
+> **Meson** repo, building + testing via `ctest` / `meson test` (needs a C compiler plus
+> CMake or Meson+Ninja).
 
 ### Working with existing repos (brownfield) — and how knowledge grows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "2.0.1"
+version = "2.2.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }
@@ -57,6 +57,11 @@ typescript = [
 csharp = [
     "tree-sitter>=0.21",
     "tree-sitter-c-sharp>=0.21",
+]
+# C PKG front-end (.c/.h). Same lazy-import contract as the `java` extra.
+c = [
+    "tree-sitter>=0.21",
+    "tree-sitter-c>=0.21",
 ]
 # Onboard external MCP servers (DBs, Atlassian, …) as orchestrator tools. The
 # MCP client lazy-imports this, so the base install stays MCP-free.
@@ -145,7 +150,7 @@ files = ["src", "tests"]
 # tree-sitter is an optional extra (the `java`/`typescript` PKG front-ends); not
 # installed in the default/CI env, so don't fail type-checking on its absence.
 [[tool.mypy.overrides]]
-module = ["tree_sitter", "tree_sitter.*", "tree_sitter_java", "tree_sitter_typescript", "tree_sitter_c_sharp"]
+module = ["tree_sitter", "tree_sitter.*", "tree_sitter_java", "tree_sitter_typescript", "tree_sitter_c_sharp", "tree_sitter_c"]
 ignore_missing_imports = true
 
 # `textual` is the optional `tui` extra; not installed in the default/CI env.

--- a/src/orchestrator/catalog/catalog.py
+++ b/src/orchestrator/catalog/catalog.py
@@ -42,6 +42,12 @@ _SEED: tuple[Capability, ...] = (
         CapabilitySelector(languages=frozenset({"csharp"}), task_types=frozenset({"feature"})),
     ),
     Capability(
+        "c-conventions",
+        CapabilityKind.SKILL,
+        "Match the repo's C conventions",
+        CapabilitySelector(languages=frozenset({"c"}), task_types=frozenset({"feature"})),
+    ),
+    Capability(
         "repo-pkg-grounding",
         CapabilityKind.SKILL,
         "Ground codegen on the repo's knowledge graph",

--- a/src/orchestrator/catalog/profile.py
+++ b/src/orchestrator/catalog/profile.py
@@ -23,6 +23,8 @@ _LANG_BY_SUFFIX = {
     ".js": "javascript",
     ".jsx": "javascript",
     ".cs": "csharp",
+    ".c": "c",
+    ".h": "c",
     ".go": "go",
     ".rb": "ruby",
 }

--- a/src/orchestrator/catalog/skills.py
+++ b/src/orchestrator/catalog/skills.py
@@ -130,6 +130,10 @@ NATIVE_SKILLS: tuple[Skill, ...] = (
         "Match the repo's C# conventions — namespaces, file/type layout, nullable types.",
     ),
     Skill(
+        "c-conventions",
+        "Match the repo's C conventions — header/source split, include guards, naming.",
+    ),
+    Skill(
         "repo-pkg-grounding",
         "Reuse existing symbols — use the pkg_* tools to find them before writing code.",
     ),

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -588,7 +588,8 @@ def sdlc_feature(
     language: Annotated[
         str,
         typer.Option(
-            "--language", help="Target language: auto (detect), python, java, typescript, or csharp."
+            "--language",
+            help="Target language: auto (detect), python, java, typescript, csharp, or c.",
         ),
     ] = "auto",
 ) -> None:

--- a/src/orchestrator/knowledge/current_state.py
+++ b/src/orchestrator/knowledge/current_state.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from orchestrator.catalog.profile import ProjectProfile
 
 _GENERATED = (
+    # C# / .NET
     ".designer.cs",
     "reference.cs",
     "connected services",
@@ -37,19 +38,52 @@ _GENERATED = (
     "assemblyinfo",
     "/migrations/",
     ".generated.",
+    # Vendored / generated / build-output trees (language-agnostic conventions) — keep
+    # third-party and generated code out of "what is THIS project" metrics. Matched as
+    # lowercased path substrings, so they catch e.g. lib/.../external/cJSON.c, ipfw/objs/.
+    "/external/",
+    "/third_party/",
+    "/third-party/",
+    "/3rdparty/",
+    "/vendor/",
+    "/vendored/",
+    "/subprojects/",
+    "/contrib/",
+    "/generated/",
+    "/objs/",
+    "/.deps/",
+    "/node_modules/",
 )
 _FRAMEWORK_PREFIXES = ("System", "Microsoft", "java", "javax", "android")
 _DATA_SHAPE_SUFFIXES = ("ViewModel", "Dto", "Entity", "Request", "Response", "Model", "Details", "Item")
 
 
 def _area(name: str) -> str:
-    """Group a module/namespace into a top-level area (first two dotted segments)."""
+    """Group a module into a top-level area (a coarse component).
+
+    Slash-path modules (C/C++ translation units, e.g. ``src/smf/smf-sm.c``) group by
+    their first two path segments (the directory component → ``src/smf``); dotted
+    namespaces (Python/Java/C#) group by the first two dotted segments (``App.Api``)."""
+    if "/" in name:
+        return "/".join(name.split("/")[:2])
     return ".".join(name.split(".")[:2])
 
 
-def _is_generated(node: Node) -> bool:
-    f = (node.provenance.file if node.provenance else "").lower()
+def _zone(area: str) -> str:
+    """The architectural zone an area belongs to — its first path/namespace segment
+    (``src/smf`` → ``src``; ``App.Api`` → ``App``)."""
+    return area.split("/")[0].split(".")[0]
+
+
+def _is_generated_path(file: str) -> bool:
+    # Normalize with a leading "/" so a `/vendor/`-style marker also matches a
+    # vendored directory at the repo root (e.g. "subprojects/...", "third_party/...").
+    f = "/" + file.lower().lstrip("/")
     return any(p in f for p in _GENERATED)
+
+
+def _is_generated(node: Node) -> bool:
+    return _is_generated_path(node.provenance.file if node.provenance else "")
 
 
 def _is_framework(qualified: str) -> bool:
@@ -105,6 +139,7 @@ class CurrentState:
     data_access: list[str]
     generated: int
     has_calls: bool
+    call_hotspots: list[tuple[str, int]] = field(default_factory=list)
     auth_surface: list[str] = field(default_factory=list)
     recent_areas: list[tuple[str, int]] = field(default_factory=list)
     recommendations: list[tuple[str, str]] = field(default_factory=list)
@@ -130,11 +165,11 @@ def _recent_areas(root: Path | None) -> list[tuple[str, int]]:
         return []
     if out.returncode != 0:
         return []
-    exts = (".cs", ".py", ".java", ".ts", ".tsx")
+    exts = (".cs", ".py", ".java", ".ts", ".tsx", ".c", ".h", ".cc", ".cpp", ".cxx", ".hpp", ".hh")
     changed = Counter(
         "/".join(line.strip().split("/")[:2])
         for line in out.stdout.splitlines()
-        if line.strip().endswith(exts)
+        if line.strip().endswith(exts) and not _is_generated_path(line.strip())
     )
     return changed.most_common(6)
 
@@ -162,10 +197,10 @@ def compute_current_state(
     area_types: Counter[str] = Counter()
     for e in contains:
         s, d = by_id.get(e.src), by_id.get(e.dst)
-        if s and s.kind is NodeKind.MODULE and d and d.kind is NodeKind.TYPE:
+        if s and s.kind is NodeKind.MODULE and d and d.kind is NodeKind.TYPE and not _is_generated(d):
             area_types[_area(s.name)] += 1
     area_funcs: Counter[str] = Counter(
-        _area(n.id.split(":", 1)[-1]) for n in nodes if n.kind is NodeKind.FUNCTION
+        _area(n.id.split(":", 1)[-1]) for n in nodes if n.kind is NodeKind.FUNCTION and not _is_generated(n)
     )
 
     controllers = [n for n in types if n.name.endswith("Controller") and not _is_generated(n)]
@@ -230,6 +265,12 @@ def compute_current_state(
     if any(d in external for d in ("System.Data",)) or (repos and not data_access):
         data_access.append("raw SQL / ADO.NET (no ORM)")
 
+    call_in: Counter[str] = Counter(e.dst for e in batch.edges if e.kind is EdgeKind.CALLS)
+    call_hotspots = [
+        (by_id[fid].name, c)
+        for fid, c in call_in.most_common()
+        if fid in by_id and by_id[fid].kind is NodeKind.FUNCTION and not _is_generated(by_id[fid])
+    ][:10]
     has_calls = any(e.kind is EdgeKind.CALLS for e in batch.edges)
     auth_surface = [
         n.name for n in types if any(k in n.name.lower() for k in _AUTH_KW) and not _is_generated(n)
@@ -259,6 +300,7 @@ def compute_current_state(
         data_access=data_access,
         generated=sum(1 for n in types if _is_generated(n)),
         has_calls=has_calls,
+        call_hotspots=call_hotspots,
         auth_surface=auth_surface,
         recent_areas=_recent_areas(root),
     )
@@ -296,6 +338,68 @@ def _recommend(s: CurrentState) -> list[tuple[str, str]]:
 
 def _mid(area: str) -> str:
     return "a" + re.sub(r"[^A-Za-z0-9]", "", area)[:24]
+
+
+_ZONE_LABELS = {
+    "src": "src — applications / services",
+    "lib": "lib — libraries",
+    "tests": "tests",
+    "test": "tests",
+    "app": "app",
+}
+
+
+def _zone_label(zone: str) -> str:
+    return _ZONE_LABELS.get(zone, zone)
+
+
+def _architecture_mermaid(s: CurrentState) -> list[str]:
+    """A system-architecture flowchart: the top components grouped into zone
+    subgraphs, with the strongest cross-component dependency edges (from the
+    `#include` / import graph). Bounded so it stays readable."""
+    from collections import defaultdict
+
+    def _is_test_area(a: str) -> bool:
+        return _zone(a) in ("tests", "test")
+
+    # The architecture is the PRODUCTION structure — drop edges originating in test
+    # code (test→lib isn't architecture) and test areas from the size-based picks.
+    edges = [(ab, c) for ab, c in s.coupling.most_common(40) if not _is_test_area(ab[0])][:14]
+    nodes: list[str] = []
+    seen: set[str] = set()
+
+    def add(a: str) -> None:
+        if a not in seen:
+            seen.add(a)
+            nodes.append(a)
+
+    for (a, b), _c in edges:
+        add(a)
+        add(b)
+    for a, _c in s.area_types.most_common(24):
+        if not _is_test_area(a):
+            add(a)
+    nodes = nodes[:18]
+    nodeset = set(nodes)
+    edges = [(ab, c) for ab, c in edges if ab[0] in nodeset and ab[1] in nodeset]
+
+    by_zone: dict[str, list[str]] = defaultdict(list)
+    for a in nodes:
+        by_zone[_zone(a)].append(a)
+
+    out = ["```mermaid", "flowchart LR"]
+    for zone in sorted(by_zone):
+        zid = "z_" + re.sub(r"[^A-Za-z0-9]", "", zone)[:16]
+        out.append(f'  subgraph {zid}["{_zone_label(zone)}"]')
+        for a in sorted(by_zone[zone]):
+            t, f = s.area_types.get(a, 0), s.area_funcs.get(a, 0)
+            out.append(f'    {_mid(a)}["{a}<br/>{t} types · {f} fns"]')
+        out.append("  end")
+    for (a, b), c in edges:
+        if a in nodeset and b in nodeset:
+            out.append(f"  {_mid(a)} -->|{c}| {_mid(b)}")
+    out.append("```")
+    return out
 
 
 def render_current_state(state: CurrentState, *, lens: str = "developer") -> str:
@@ -349,23 +453,27 @@ def _render_developer(s: CurrentState) -> str:
         else "- API surface: none detected",
         f"- Data access: {', '.join(s.data_access) or '—'}",
         f"- Call graph: {'available' if s.has_calls else 'not extracted for this language yet'}",
-        "",
-        "## Architecture — layers",
-        "",
-        "| Layer | Components |",
-        "|---|---|",
     ]
-    o += [f"| {lyr} | {c} |" for lyr, c in s.layers.most_common()]
     if s.coupling:
-        o += ["", "## Area dependency map", "", "```mermaid", "flowchart LR"]
-        seen: set[str] = set()
-        for (sa, da), c in s.coupling.most_common(9):
-            for a in (sa, da):
-                if a not in seen:
-                    o.append(f'  {_mid(a)}["{a}"]')
-                    seen.add(a)
-            o.append(f"  {_mid(sa)} -->|{c}| {_mid(da)}")
-        o += ["```"]
+        o += [
+            "",
+            "## System architecture",
+            "",
+            "_Components (top areas) grouped by zone; arrows are dependency strength "
+            "(import / `#include` count)._",
+            "",
+        ]
+        o += _architecture_mermaid(s)
+        o += [
+            "",
+            "### Component dependencies (strongest)",
+            "",
+            "| From | → | To | Strength |",
+            "|---|---|---|---|",
+        ]
+        o += [f"| `{a}` | → | `{b}` | {c} |" for (a, b), c in s.coupling.most_common(10)]
+    o += ["", "## Architecture — layers", "", "| Layer | Components |", "|---|---|"]
+    o += [f"| {lyr} | {c} |" for lyr, c in s.layers.most_common()]
     if s.busiest_controllers:
         o += ["", "## API surface — busiest controllers", "", "| Controller | Endpoints |", "|---|---|"]
         o += [f"| `{n}` | {c} |" for n, c in s.busiest_controllers]
@@ -384,6 +492,17 @@ def _render_developer(s: CurrentState) -> str:
         "|---|---|---|",
     ]
     o += [f"| `{n}` | {c} | {loc} |" for n, c, loc in s.hotspots]
+    if s.call_hotspots:
+        o += [
+            "",
+            "## Call graph — most-depended-upon functions",
+            "",
+            "_Functions with the most incoming calls — the code most other code relies on._",
+            "",
+            "| Function | Called from (sites) |",
+            "|---|---|",
+        ]
+        o += [f"| `{n}` | {c} |" for n, c in s.call_hotspots]
     o += [
         "",
         "## Test coverage",

--- a/src/orchestrator/pkg/c_extractor.py
+++ b/src/orchestrator/pkg/c_extractor.py
@@ -1,0 +1,457 @@
+"""C front-end for the PKG extractor (Track 2: a fifth language, new model).
+
+C is procedural — no classes, namespaces, inheritance, or templates — so the model
+the Python/Java/TS/C# front-ends use (a type that contains its methods) doesn't
+apply. The unit here is the **translation unit (the file)**: the module contains
+free functions, types, and globals directly.
+
+Maps C source onto the universal ``facts`` vocabulary. Parsing is via tree-sitter
+(``tree-sitter-c``), an OPTIONAL dependency — install the ``c`` extra. The import is
+lazy so the base install stays stdlib-only.
+
+Emitted (precision-first):
+- ``Module`` — the file (``.c`` or ``.h``), keyed by its repo-relative path.
+- ``Type`` — ``struct`` / ``union`` / ``enum`` (and ``typedef`` of one); ``Field`` —
+  struct/union members, enum constants, and file/global variables.
+- ``Function`` — free functions. **Header/source merge:** a node is keyed by name
+  (C has external linkage — a name is globally unique), so a prototype in a ``.h``
+  and the definition in a ``.c`` collapse onto one node. A prototype is emitted as
+  an ``external`` placeholder and the definition as grounded, so the definition's
+  provenance always wins (the FactBatch dedup upgrades the placeholder), regardless
+  of file order — and a header-only declaration (never defined in-repo) correctly
+  stays external. ``static`` symbols have internal linkage, so they're keyed by
+  ``file::name`` to avoid merging same-named statics across files.
+- ``IMPORTS`` — ``#include``. A ``"local.h"`` include is resolved in-repo (relative
+  to the including file, then the repo root) → a grounded edge to that file's
+  module; a ``<system.h>`` include (or an unresolved one) → an external module node.
+- ``CONTAINS`` — module → function / type / global, and type → member.
+- ``CALLS`` — from each call expression to the called function (name-keyed, so
+  cross-file calls resolve; C has no overloading). Unresolved externals (libc,
+  macros) point at an ungrounded id — a deliberate, documented trade-off.
+- ``REFERENCES`` — a struct/union member whose type is another struct/union (the C
+  data edge), name-keyed like CALLS.
+
+Preprocessor caveat: parsing is pre-expansion. Heavy macro use yields partial facts
+(we never run ``cpp``); this is documented, not worked around.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from orchestrator.pkg.extractor import rel_module_name
+from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+
+if TYPE_CHECKING:
+    from tree_sitter import Node as TSNode
+
+_TYPE_SPECIFIERS = ("struct_specifier", "union_specifier", "enum_specifier")
+# Preprocessor conditionals (notably the ``#ifndef`` include guard) wrap the real
+# declarations; flatten them so guarded types/functions are still seen.
+_PREPROC_CONTAINERS = ("preproc_ifdef", "preproc_if", "preproc_else", "preproc_elif")
+# Declarator wrappers around the actual name (a returned/declared pointer, array, …).
+_DECLARATOR_WRAPPERS = (
+    "pointer_declarator",
+    "array_declarator",
+    "init_declarator",
+    "function_declarator",
+    "parenthesized_declarator",
+)
+
+
+class CExtractor:
+    """C front-end (tree-sitter). Install the ``c`` extra to use it."""
+
+    language: str = "c"
+    suffixes: tuple[str, ...] = (".c", ".h")
+
+    def module_name(self, path: Path, root: Path) -> str:
+        # The translation unit is the file; its name is the repo-relative path.
+        return rel_module_name(path, root)
+
+    def extract(self, *, path: Path, module: str, rel: str) -> FactBatch:
+        parser = _c_parser()
+        source = path.read_bytes()
+        tree = parser.parse(source)
+        batch = FactBatch()
+        module_id = f"c:{module}" if module else f"c:{rel}"
+        batch.add_node(Node(module_id, NodeKind.MODULE, module or rel, "c", Provenance(rel, 1)))
+
+        top_level = list(_iter_top_level(tree.root_node))
+        # Pass 1: declarations → nodes + CONTAINS; record this file's function ids so a
+        # call to a local `static` function resolves to its file-scoped id (not global).
+        local_funcs: dict[str, str] = {}
+        for node in top_level:
+            self._top_level(node, module_id, path, source, rel, batch, local_funcs)
+        # Pass 2: CALLS — walk each definition's body now that local function ids exist.
+        for node in top_level:
+            if node.type == "function_definition":
+                self._calls(node, source, rel, batch, local_funcs)
+        return batch
+
+    # --- top-level dispatch --------------------------------------------------
+
+    def _top_level(
+        self,
+        node: TSNode,
+        module_id: str,
+        path: Path,
+        source: bytes,
+        rel: str,
+        batch: FactBatch,
+        local_funcs: dict[str, str],
+    ) -> None:
+        if node.type == "preproc_include":
+            self._include(node, module_id, path, source, rel, batch)
+        elif node.type == "type_definition":
+            self._typedef(node, module_id, source, rel, batch)
+        elif node.type in _TYPE_SPECIFIERS:
+            name = _field_text(node, "name", source)
+            if name and _has_body(node):
+                self._emit_type(node, name, module_id, source, rel, batch)
+        elif node.type == "function_definition":
+            self._function(node, module_id, source, rel, batch, local_funcs, is_definition=True)
+        elif node.type == "declaration":
+            self._declaration(node, module_id, source, rel, batch, local_funcs)
+
+    # --- includes ------------------------------------------------------------
+
+    def _include(
+        self, node: TSNode, module_id: str, path: Path, source: bytes, rel: str, batch: FactBatch
+    ) -> None:
+        target = node.child_by_field_name("path")
+        if target is None:
+            return
+        line = node.start_point[0] + 1
+        if target.type == "system_lib_string":
+            name = _text(target, source).strip("<>")
+            tid = f"c:{name}"
+            batch.add_node(Node(tid, NodeKind.MODULE, name, "c", external=True))
+            batch.add_edge(Edge(module_id, tid, EdgeKind.IMPORTS, Provenance(rel, line)))
+            return
+        # A "quoted" include: resolve in-repo (relative to this file, then repo root).
+        raw = _string_content(target, source)
+        if not raw:
+            return
+        resolved = _resolve_include(path, rel, raw)
+        if resolved is not None:
+            tid = f"c:{resolved}"
+            batch.add_node(Node(tid, NodeKind.MODULE, resolved, "c", Provenance(resolved, 1)))
+        else:
+            tid = f"c:{raw}"
+            batch.add_node(Node(tid, NodeKind.MODULE, raw, "c", external=True))
+        batch.add_edge(Edge(module_id, tid, EdgeKind.IMPORTS, Provenance(rel, line)))
+
+    # --- types ---------------------------------------------------------------
+
+    def _typedef(self, node: TSNode, module_id: str, source: bytes, rel: str, batch: FactBatch) -> None:
+        spec = next((c for c in node.named_children if c.type in _TYPE_SPECIFIERS), None)
+        typedef_name = _last_type_identifier(node, source)
+        if spec is not None:
+            name = typedef_name or _field_text(spec, "name", source)
+            if name:
+                self._emit_type(spec, name, module_id, source, rel, batch)
+
+    def _emit_type(
+        self, spec: TSNode, name: str, module_id: str, source: bytes, rel: str, batch: FactBatch
+    ) -> None:
+        type_id = f"c:{name}"
+        line = spec.start_point[0] + 1
+        batch.add_node(Node(type_id, NodeKind.TYPE, name, "c", Provenance(rel, line, spec.end_point[0] + 1)))
+        batch.add_edge(Edge(module_id, type_id, EdgeKind.CONTAINS, Provenance(rel, line)))
+
+        body = spec.child_by_field_name("body")
+        if body is None:
+            return
+        if spec.type == "enum_specifier":
+            for enumerator in body.named_children:
+                if enumerator.type == "enumerator":
+                    ename = _field_text(enumerator, "name", source)
+                    if ename:
+                        self._add_member(type_id, ename, enumerator.start_point[0] + 1, rel, batch)
+            return
+        for field in body.named_children:
+            if field.type != "field_declaration":
+                continue
+            fline = field.start_point[0] + 1
+            member_type = _member_type_name(field, source)
+            for mname in _declared_names(field, source):
+                self._add_member(type_id, mname, fline, rel, batch)
+            # REFERENCES: a member whose type is another struct/union (the C data edge).
+            if member_type is not None and member_type != name:
+                batch.add_edge(Edge(type_id, f"c:{member_type}", EdgeKind.REFERENCES, Provenance(rel, fline)))
+
+    @staticmethod
+    def _add_member(type_id: str, name: str, line: int, rel: str, batch: FactBatch) -> None:
+        mid = f"{type_id}.{name}"
+        batch.add_node(Node(mid, NodeKind.FIELD, name, "c", Provenance(rel, line)))
+        batch.add_edge(Edge(type_id, mid, EdgeKind.CONTAINS, Provenance(rel, line)))
+
+    # --- functions + globals -------------------------------------------------
+
+    def _function(
+        self,
+        node: TSNode,
+        module_id: str,
+        source: bytes,
+        rel: str,
+        batch: FactBatch,
+        local_funcs: dict[str, str],
+        *,
+        is_definition: bool,
+    ) -> str | None:
+        fdeclr = _function_declarator(node.child_by_field_name("declarator"))
+        if fdeclr is None:
+            return None
+        name = _declarator_name(fdeclr, source)
+        if not name:
+            return None
+        static = _is_static(node, source)
+        fid = f"c:{rel}::{name}" if static else f"c:{name}"
+        line = node.start_point[0] + 1
+        # A prototype (declaration) is a placeholder; the definition is grounded, so the
+        # definition's provenance wins on merge no matter which file is parsed first.
+        batch.add_node(
+            Node(fid, NodeKind.FUNCTION, name, "c", Provenance(rel, line), external=not is_definition)
+        )
+        batch.add_edge(Edge(module_id, fid, EdgeKind.CONTAINS, Provenance(rel, line)))
+        local_funcs[name] = fid
+        return fid
+
+    def _declaration(
+        self,
+        node: TSNode,
+        module_id: str,
+        source: bytes,
+        rel: str,
+        batch: FactBatch,
+        local_funcs: dict[str, str],
+    ) -> None:
+        declarators = [c for c in node.named_children if c.type in ("identifier", *_DECLARATOR_WRAPPERS)]
+        type_node = node.child_by_field_name("type")
+        # A struct/union/enum definition written as a declaration (`struct S { … };`).
+        if not declarators and type_node is not None and type_node.type in _TYPE_SPECIFIERS:
+            name = _field_text(type_node, "name", source)
+            if name and _has_body(type_node):
+                self._emit_type(type_node, name, module_id, source, rel, batch)
+            return
+        static = _is_static(node, source)
+        extern = _has_storage(node, source, "extern")
+        for d in declarators:
+            if _function_declarator(d) is not None:  # a function prototype
+                self._function(node, module_id, source, rel, batch, local_funcs, is_definition=False)
+                continue
+            vname = _declarator_name(d, source)
+            if not vname:
+                continue
+            vid = f"c:{rel}::{vname}" if static else f"c:{vname}"
+            line = d.start_point[0] + 1
+            batch.add_node(Node(vid, NodeKind.FIELD, vname, "c", Provenance(rel, line), external=extern))
+            batch.add_edge(Edge(module_id, vid, EdgeKind.CONTAINS, Provenance(rel, line)))
+
+    # --- calls (2.3) ---------------------------------------------------------
+
+    def _calls(
+        self, fdef: TSNode, source: bytes, rel: str, batch: FactBatch, local_funcs: dict[str, str]
+    ) -> None:
+        fdeclr = _function_declarator(fdef.child_by_field_name("declarator"))
+        if fdeclr is None:
+            return
+        name = _declarator_name(fdeclr, source)
+        caller = local_funcs.get(name)
+        if caller is None:
+            return
+        body = fdef.child_by_field_name("body")
+        if body is None:
+            return
+        for callee, line in _calls_in(body, source):
+            # A local static callee keeps its file-scoped id; everything else is global.
+            target = local_funcs.get(callee, f"c:{callee}")
+            batch.add_edge(Edge(caller, target, EdgeKind.CALLS, Provenance(rel, line)))
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _iter_top_level(root: TSNode) -> list[TSNode]:
+    """Top-level declarations, descending through preprocessor conditionals so the
+    contents of an ``#ifndef`` include guard are treated as top-level."""
+    out: list[TSNode] = []
+    for child in root.named_children:
+        if child.type in _PREPROC_CONTAINERS:
+            out.extend(_iter_top_level(child))
+        else:
+            out.append(child)
+    return out
+
+
+def _resolve_include(path: Path, rel: str, include: str) -> str | None:
+    """Resolve a ``"quoted"`` include to a repo-relative path of an EXISTING in-repo
+    file, or ``None`` (→ external). Tries, in order: relative to the including file,
+    relative to the repo root, then — for a bare ``"foo.h"`` reached via an ``-I``
+    include directory — a uniquely-named header anywhere in the repo. The root is
+    derived by stripping ``rel`` from the file's absolute path."""
+    abs_path = path.resolve()
+    root = abs_path
+    for _ in Path(rel).parts:
+        root = root.parent
+    for base in (abs_path.parent, root):
+        cand = (base / include).resolve()
+        try:
+            within = cand.relative_to(root)
+        except ValueError:
+            continue
+        if cand.is_file():
+            return within.as_posix()
+    # Include-dir convention: a header named like the include, unique in the repo.
+    return _header_index(root).get(Path(include).name)
+
+
+_HEADER_INDEX_CACHE: dict[str, dict[str, str]] = {}
+
+
+def _header_index(root: Path) -> dict[str, str]:
+    """``{basename: repo-relative-path}`` for every ``.h`` whose basename is UNIQUE in
+    the repo (built once per root, cached). Ambiguous basenames are dropped so a bare
+    include never resolves to the wrong file (precision-first)."""
+    key = str(root)
+    cached = _HEADER_INDEX_CACHE.get(key)
+    if cached is not None:
+        return cached
+    seen: dict[str, str | None] = {}
+    for p in root.rglob("*.h"):
+        try:
+            rel = p.relative_to(root).as_posix()
+        except ValueError:
+            continue
+        seen[p.name] = rel if p.name not in seen else None  # None marks ambiguous
+    idx = {b: r for b, r in seen.items() if r is not None}
+    _HEADER_INDEX_CACHE[key] = idx
+    return idx
+
+
+def _calls_in(node: TSNode, source: bytes) -> list[tuple[str, int]]:
+    """``(callee_name, line)`` for each direct call (``foo(...)``) under ``node``."""
+    out: list[tuple[str, int]] = []
+    stack = list(node.named_children)
+    while stack:
+        n = stack.pop()
+        if n.type == "call_expression":
+            fn = n.child_by_field_name("function")
+            if fn is not None and fn.type == "identifier":
+                out.append((_text(fn, source), n.start_point[0] + 1))
+        stack.extend(n.named_children)
+    return out
+
+
+def _function_declarator(node: TSNode | None) -> TSNode | None:
+    """Descend pointer/parenthesized declarators to the ``function_declarator``."""
+    while node is not None:
+        if node.type == "function_declarator":
+            return node
+        if node.type in ("pointer_declarator", "parenthesized_declarator"):
+            node = node.child_by_field_name("declarator")
+        else:
+            return None
+    return None
+
+
+def _declarator_name(node: TSNode | None, source: bytes) -> str:
+    """The identifier name inside a (possibly wrapped) declarator."""
+    while node is not None:
+        if node.type in ("identifier", "field_identifier", "type_identifier"):
+            return _text(node, source)
+        nxt = node.child_by_field_name("declarator")
+        if nxt is None:
+            # function_declarator's name is its `declarator` child; fall back to first id.
+            ids = [c for c in node.named_children if c.type in ("identifier", "field_identifier")]
+            return _text(ids[0], source) if ids else ""
+        node = nxt
+    return ""
+
+
+def _declared_names(field: TSNode, source: bytes) -> list[str]:
+    """Member names declared in a ``field_declaration`` (handles ``int x, y;``)."""
+    names: list[str] = []
+    for child in field.named_children:
+        if child.type in ("field_identifier", "identifier"):
+            names.append(_text(child, source))
+        elif child.type in _DECLARATOR_WRAPPERS:
+            nm = _declarator_name(child, source)
+            if nm:
+                names.append(nm)
+    return [n for n in names if n]
+
+
+def _member_type_name(field: TSNode, source: bytes) -> str | None:
+    """The struct/union type a member refers to (for REFERENCES), or ``None`` for a
+    primitive / non-aggregate type."""
+    ty = field.child_by_field_name("type")
+    if ty is None:
+        return None
+    if ty.type == "type_identifier":
+        return _text(ty, source)
+    if ty.type in ("struct_specifier", "union_specifier"):
+        nm = _field_text(ty, "name", source)
+        return nm or None
+    return None
+
+
+def _last_type_identifier(node: TSNode, source: bytes) -> str:
+    """The typedef alias — the last top-level ``type_identifier`` child."""
+    names = [c for c in node.named_children if c.type == "type_identifier"]
+    return _text(names[-1], source) if names else ""
+
+
+def _has_body(spec: TSNode) -> bool:
+    return spec.child_by_field_name("body") is not None
+
+
+def _is_static(node: TSNode, source: bytes) -> bool:
+    return _has_storage(node, source, "static")
+
+
+def _has_storage(node: TSNode, source: bytes, keyword: str) -> bool:
+    return any(
+        c.type == "storage_class_specifier" and _text(c, source) == keyword for c in node.named_children
+    )
+
+
+def _string_content(node: TSNode, source: bytes) -> str:
+    for child in node.named_children:
+        if child.type == "string_content":
+            return _text(child, source)
+    return _text(node, source).strip('"')
+
+
+def _field_text(node: TSNode, field: str, source: bytes) -> str:
+    child = node.child_by_field_name(field)
+    return _text(child, source) if child is not None else ""
+
+
+def _text(node: TSNode | None, source: bytes) -> str:
+    if node is None:
+        return ""
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace").strip()
+
+
+def _c_parser() -> Any:
+    try:
+        import tree_sitter_c
+        from tree_sitter import Language, Parser
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise RuntimeError(
+            "C extraction needs tree-sitter; install the extra: "
+            "uv pip install 'tree-sitter>=0.21' 'tree-sitter-c>=0.21'"
+        ) from exc
+    language = Language(tree_sitter_c.language())
+    try:
+        return Parser(language)
+    except TypeError:  # older tree-sitter API
+        parser = Parser()
+        parser.language = language
+        return parser
+
+
+__all__ = ["CExtractor"]

--- a/src/orchestrator/pkg/extractor.py
+++ b/src/orchestrator/pkg/extractor.py
@@ -432,9 +432,9 @@ class PythonExtractor:
 def default_extractors() -> list[LanguageExtractor]:
     """The language front-ends used when none are passed explicitly.
 
-    Always Python (stdlib ``ast``). Java, TypeScript, and C# are added **only when
+    Always Python (stdlib ``ast``). Java, TypeScript, C#, and C are added **only when
     their tree-sitter grammar is importable** (the ``java`` / ``typescript`` /
-    ``csharp`` extras) so the base install stays stdlib-only — this is what makes
+    ``csharp`` / ``c`` extras) so the base install stays stdlib-only — this is what makes
     ``understand`` / grounding / ``pkg extract`` multi-language without forcing
     the parser dependency on everyone.
     """
@@ -454,6 +454,10 @@ def default_extractors() -> list[LanguageExtractor]:
         from orchestrator.pkg.csharp_extractor import CSharpExtractor
 
         extractors.append(CSharpExtractor())
+    if has_tree_sitter and importlib.util.find_spec("tree_sitter_c"):
+        from orchestrator.pkg.c_extractor import CExtractor
+
+        extractors.append(CExtractor())
     return extractors
 
 

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -466,6 +466,48 @@ _REFINE_SYSTEM_CSHARP = (
     "the build green. Same path rules — relative, no '..'."
 )
 
+# C (CMake/ctest) variants — selected when the layout's language is "c".
+_IMPLEMENT_SYSTEM_C = (
+    "You are a senior engineer. Implement the feature described by the SPEC as "
+    "runnable C inside the given CMake project (the worktree).\n\n"
+    "Output ONE JSON object, no prose, no code fences:\n"
+    f"{_FILE_FORMS}\n"
+    "Rules: paths are relative to the worktree root — no leading slash, no '..'. "
+    "Write source files only (NO test files here). Put implementation `.c` files "
+    "under the source dir shown in the layout and DECLARE the public functions in a "
+    "header (`.h`) there, guarded with `#ifndef`/`#define`. Write portable C11 using "
+    "only the standard library. Follow the build-file guidance in the LAYOUT block "
+    "(CMake globs new files; Meson needs them registered in `meson.build`). Every "
+    "file must be complete and compile with no warnings-as-errors."
+)
+
+_TESTS_SYSTEM_C = (
+    "You write C unit tests for an already-implemented feature. You are given the "
+    "SPEC and the CURRENT SOURCE FILES.\n\n"
+    "Output ONE JSON object, no prose, no code fences:\n"
+    f"{_FILE_FORMS}\n"
+    "Rules: write test files only, under the tests dir shown in the layout, named "
+    "`test_<name>.c`. Each test file is a standalone program with an `int main(void)` "
+    "that exercises the feature and returns 0 on success, non-zero on failure (use "
+    "`assert.h` or explicit `if (...) return 1;` checks). `#include` the public "
+    "header from the source dir. Register the test as the LAYOUT describes (CMake "
+    "auto-discovers `tests/*.c`; Meson needs an `executable()`+`test()` in `meson.build`). "
+    "Each acceptance criterion maps to at least "
+    "one assertion; tests must pass against the given source."
+)
+
+_REFINE_SYSTEM_C = (
+    "You are fixing a failing build / test run (a configure error, a compiler "
+    "error, or a failing assertion). You are given the SPEC, the CURRENT FILES, and "
+    "the FAILURE OUTPUT.\n\n"
+    "Output ONE JSON object, no prose, no code fences:\n"
+    f"{_FILE_FORMS}\n"
+    "Rules: files you created earlier this session may be resent in full via "
+    "`content`; any other existing file must be changed via `edits` (including "
+    "the build file — `CMakeLists.txt` or `meson.build`). Make the smallest change that turns the "
+    "build + tests green. Same path rules — relative, no '..'."
+)
+
 # Phase system prompts keyed by language (default: Python). Adding a language is a
 # new column here, not another boolean branch at each call site.
 _IMPLEMENT_SYSTEMS = {
@@ -473,18 +515,21 @@ _IMPLEMENT_SYSTEMS = {
     "java": _IMPLEMENT_SYSTEM_JAVA,
     "typescript": _IMPLEMENT_SYSTEM_TS,
     "csharp": _IMPLEMENT_SYSTEM_CSHARP,
+    "c": _IMPLEMENT_SYSTEM_C,
 }
 _TESTS_SYSTEMS = {
     "python": _TESTS_SYSTEM,
     "java": _TESTS_SYSTEM_JAVA,
     "typescript": _TESTS_SYSTEM_TS,
     "csharp": _TESTS_SYSTEM_CSHARP,
+    "c": _TESTS_SYSTEM_C,
 }
 _REFINE_SYSTEMS = {
     "python": _REFINE_SYSTEM,
     "java": _REFINE_SYSTEM_JAVA,
     "typescript": _REFINE_SYSTEM_TS,
     "csharp": _REFINE_SYSTEM_CSHARP,
+    "c": _REFINE_SYSTEM_C,
 }
 
 
@@ -670,6 +715,30 @@ class LLMCodegenAdapter:
                 "project already references the source project).\n"
                 f"- Declare any new dependency as a `<PackageReference>` in the source "
                 "`.csproj` (edit it); don't invent unrelated paths.\n\n"
+            )
+        if layout.language == "c":
+            if layout.build_tool == "meson":
+                build_line = (
+                    "- This project uses **Meson** (`meson.build`), which does NOT glob: "
+                    "register every new file — add new `.c` sources to the library/target "
+                    "source list, and add an `executable(...)` + `test(...)` for each new "
+                    f"`{layout.tests_dir}/test_<name>.c`. Edit `meson.build` to do so. "
+                    "Prefer extending existing files (no `meson.build` change needed) when you can."
+                )
+            else:
+                build_line = (
+                    "- New `src/*.c` and `tests/*.c` are auto-discovered by CMake's glob; "
+                    "edit `CMakeLists.txt` only to add an external dependency."
+                )
+            return (
+                "PROJECT LAYOUT (authoritative — overrides any default path guidance):\n"
+                f"- Put implementation at `{layout.source_dir}/<name>.c` and DECLARE its "
+                f"public functions in a header `{layout.source_dir}/<name>.h` (with an "
+                "`#ifndef`/`#define` guard); C11, standard library only.\n"
+                f"- Put tests at `{layout.tests_dir}/test_<name>.c` — each a standalone "
+                "`int main(void)` returning non-zero on failure, `#include`-ing the "
+                f"header from `{layout.source_dir}/`.\n"
+                f"{build_line} Don't invent unrelated paths.\n\n"
             )
         return (
             "PROJECT LAYOUT (authoritative — overrides any default path guidance):\n"

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -122,6 +122,8 @@ def _resolve_language(path: Path, requested: str) -> str:
             return "typescript"
         if "csharp" in langs:
             return "csharp"
+        if "c" in langs:
+            return "c"
     return "python"
 
 
@@ -160,11 +162,13 @@ async def run_feature(
     from orchestrator.sdlc.layout import is_effectively_empty, resolve_layout
     from orchestrator.sdlc.scaffold import scaffold
     from orchestrator.sdlc.testenv import (
+        c_toolchain_available,
         detect_dotnet_tfm,
         dotnet_toolchain_available,
         java_toolchain_available,
         make_test_environment,
         make_test_runner,
+        meson_toolchain_available,
         node_toolchain_available,
         run_with_autoheal,
     )
@@ -286,6 +290,35 @@ async def run_feature(
             "C# codegen needs the .NET SDK (`dotnet`) on PATH (install it, then retry).",
             code=2,
         )
+    elif lang == "c":
+        # Greenfield always scaffolds a CMake project; brownfield uses the repo's own
+        # build system (CMake or Meson). Preflight the matching toolchain and fail
+        # fast with a clear message rather than a cryptic build error in refine.
+        build_tool = layout.build_tool if layout.mode == "existing" else "cmake"
+        if build_tool == "meson":
+            if not meson_toolchain_available():
+                raise FeatureRunError(
+                    "Meson C codegen needs meson + ninja + a C compiler (cc/gcc/clang) on PATH "
+                    "(install them, then retry).",
+                    code=2,
+                )
+        elif build_tool in ("cmake", ""):
+            if not c_toolchain_available():
+                raise FeatureRunError(
+                    "C codegen needs CMake + a C compiler (cc/gcc/clang) on PATH (install both, then retry).",
+                    code=2,
+                )
+            if layout.mode == "existing" and not (path / "CMakeLists.txt").is_file():
+                raise FeatureRunError(
+                    "C codegen builds with CMake or Meson, but this repo has neither a "
+                    "CMakeLists.txt nor a recognized meson.build.",
+                    code=2,
+                )
+        else:  # make or another unrecognized build system
+            raise FeatureRunError(
+                f"C codegen builds with CMake or Meson, but this repo uses {build_tool} (not supported yet).",
+                code=2,
+            )
     # ``ensure`` may install deps (Node ``<pm> install``); run it after the
     # toolchain preflight so a missing toolchain fails fast with a clear message.
     await testenv.ensure(path)

--- a/src/orchestrator/sdlc/layout.py
+++ b/src/orchestrator/sdlc/layout.py
@@ -31,7 +31,7 @@ _FALLBACK_PACKAGE = "app"
 _JAVA_GROUP = "org.example"  # default reverse-DNS group for greenfield Java
 
 # Source-file extension per language (Python is the default).
-_SOURCE_EXT = {"java": "java", "typescript": "ts", "csharp": "cs"}
+_SOURCE_EXT = {"java": "java", "typescript": "ts", "csharp": "cs", "c": "c"}
 
 
 @dataclass(frozen=True)
@@ -310,6 +310,58 @@ def _resolve_csharp_layout(
     return TargetLayout(derived, src, tst, True, "new", language="csharp", build_tool="dotnet")
 
 
+def _detect_c_build_tool(root: Path) -> str:
+    if (root / "CMakeLists.txt").is_file():
+        return "cmake"
+    if (root / "meson.build").is_file():
+        return "meson"
+    if (root / "Makefile").is_file() or (root / "makefile").is_file():
+        return "make"
+    return ""
+
+
+def detect_c_layout(root: Path) -> tuple[str, str, str] | None:
+    """If the repo is a recognizable C project (CMake or Make), return
+    ``(package, source_dir, tests_dir)``. The package is the CMake ``project()`` name
+    when parseable, else derived; ``source_dir`` is ``src`` when it holds ``.c`` files,
+    else the repo root."""
+    if _detect_c_build_tool(root) == "":
+        return None
+    package = _read_cmake_project_name(root) or derive_package_name(str(root))
+    src = root / "src"
+    source_dir = "src" if src.is_dir() and any(src.glob("*.c")) else "."
+    tests_dir = "tests" if (root / "tests").is_dir() else source_dir
+    return package, source_dir, tests_dir
+
+
+def _read_cmake_project_name(root: Path) -> str | None:
+    cmake = root / "CMakeLists.txt"
+    if not cmake.is_file():
+        return None
+    m = re.search(r"project\s*\(\s*([A-Za-z_][\w-]*)", cmake.read_text(encoding="utf-8", errors="replace"))
+    return m.group(1) if m else None
+
+
+def _resolve_c_layout(root: Path, *, mode: str, package_name: str | None, repo: str | None) -> TargetLayout:
+    existing = detect_c_layout(root)
+    derived = package_name or derive_package_name(repo or str(root))
+    build_tool = _detect_c_build_tool(root) or "cmake"
+    if mode == "existing" or (mode == "auto" and existing is not None):
+        if existing is not None:
+            pkg, source_dir, tests_dir = existing
+            return TargetLayout(
+                package_name=package_name or pkg,
+                source_dir=source_dir,
+                tests_dir=tests_dir,
+                src_layout=source_dir.startswith("src"),
+                mode="existing",
+                language="c",
+                build_tool=build_tool,
+            )
+        return TargetLayout(derived, "src", "tests", True, "existing", language="c", build_tool=build_tool)
+    return TargetLayout(derived, "src", "tests", True, "new", language="c", build_tool="cmake")
+
+
 def is_effectively_empty(root: Path) -> bool:
     """True when the worktree holds no source the model could extend (a fresh
     clone of an empty repo is just ``.git`` + maybe a README/LICENSE). Used to
@@ -350,6 +402,8 @@ def resolve_layout(
         return _resolve_typescript_layout(root_path, mode=mode, package_name=package_name, repo=repo)
     if language == "csharp":
         return _resolve_csharp_layout(root_path, mode=mode, package_name=package_name, repo=repo)
+    if language == "c":
+        return _resolve_c_layout(root_path, mode=mode, package_name=package_name, repo=repo)
     existing = detect_existing_package(root_path)
     derived = package_name or derive_package_name(repo or str(root_path))
 
@@ -378,6 +432,7 @@ __all__ = [
     "derive_java_package",
     "derive_npm_package",
     "derive_package_name",
+    "detect_c_layout",
     "detect_csharp_layout",
     "detect_existing_package",
     "detect_java_layout",

--- a/src/orchestrator/sdlc/scaffold.py
+++ b/src/orchestrator/sdlc/scaffold.py
@@ -83,6 +83,8 @@ def scaffold(root: Path | str, layout: TargetLayout, *, profile: ProjectProfile 
         files = _typescript_files(layout)
     elif layout.language == "csharp":
         files = _csharp_files(layout)
+    elif layout.language == "c":
+        files = _c_files(layout)
     else:
         files = _python_files(layout)
 
@@ -95,28 +97,31 @@ def scaffold(root: Path | str, layout: TargetLayout, *, profile: ProjectProfile 
         path.write_text(content, encoding="utf-8")
         created.append(rel)
     if layout.language == "csharp":
-        created += _ensure_dotnet_gitignore(root_path)
+        created += _ensure_build_ignores(root_path, ("bin", "obj"))
+    elif layout.language == "c":
+        created += _ensure_build_ignores(root_path, ("build",))
     return created
 
 
-def _ensure_dotnet_gitignore(root: Path) -> list[str]:
-    """Guarantee ``bin/`` and ``obj/`` are ignored so ``dotnet`` build output never
-    lands in a commit/PR. The scaffold's own ``.gitignore`` covers them, but a
-    brownfield or scratch worktree with a pre-existing ``.gitignore`` (never
-    clobbered) may not — append the missing rules rather than overwrite."""
+def _ensure_build_ignores(root: Path, dirs: tuple[str, ...]) -> list[str]:
+    """Guarantee ``dirs`` (compiled output like ``bin``/``obj`` or CMake ``build``) are
+    gitignored so build output never lands in a commit/PR. The scaffold's own
+    ``.gitignore`` covers them, but a brownfield or scratch worktree with a pre-existing
+    ``.gitignore`` (never clobbered) may not — append the missing rules rather than
+    overwrite."""
     gi = root / ".gitignore"
     if not gi.exists():
-        return []  # the scaffold just wrote its .gitignore (already has bin/ obj/)
+        return []  # the scaffold just wrote its .gitignore (already has these)
     existing = gi.read_text(encoding="utf-8")
     have = {ln.strip().rstrip("/") for ln in existing.splitlines()}
-    missing = [d for d in ("bin", "obj") if d not in have]
+    missing = [d for d in dirs if d not in have]
     if not missing:
         return []
     sep = "" if existing.endswith("\n") else "\n"
     gi.write_text(
         existing
         + sep
-        + "\n# .NET build output (appended by the SDLC scaffold)\n"
+        + "\n# build output (appended by the SDLC scaffold)\n"
         + "".join(f"{d}/\n" for d in missing),
         encoding="utf-8",
     )
@@ -311,6 +316,72 @@ obj/
 .vs/
 [Dd]ebug/
 [Rr]elease/
+"""
+
+
+def _c_files(layout: TargetLayout) -> dict[str, str]:
+    # A CMake project that globs src/*.c into a library and turns each tests/*.c into a
+    # ctest executable linked against it. A stub source + header give CMake something to
+    # configure before codegen; tests run via `ctest` with plain assert()-based mains
+    # (no external framework needed — buildable offline).
+    name = layout.package_name
+    guard = f"{name.upper()}_H"
+    cmake = _CMAKELISTS.replace("__name__", name)
+    header = _C_HEADER.replace("__guard__", guard).replace("__name__", name)
+    return {
+        "CMakeLists.txt": cmake,
+        f"{layout.source_dir}/{name}.h": header,
+        f"{layout.source_dir}/{name}.c": f'#include "{name}.h"\n',
+        f"{layout.tests_dir}/.gitkeep": "",
+        "README.md": _README_TEMPLATE.format(
+            package=layout.package_name,
+            source_dir=layout.source_dir,
+            tests_dir=layout.tests_dir,
+        ),
+        ".gitignore": _C_GITIGNORE,
+    }
+
+
+_CMAKELISTS = """\
+cmake_minimum_required(VERSION 3.15)
+project(__name__ C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Library built from everything under src/.
+file(GLOB __name___SOURCES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/src/*.c")
+add_library(__name__ ${__name___SOURCES})
+target_include_directories(__name__ PUBLIC "${CMAKE_SOURCE_DIR}/src")
+
+# Tests: each tests/*.c is a ctest executable linked against the library.
+enable_testing()
+file(GLOB __name___TESTS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/tests/*.c")
+foreach(test_file ${__name___TESTS})
+    get_filename_component(test_name ${test_file} NAME_WE)
+    add_executable(${test_name} ${test_file})
+    target_link_libraries(${test_name} __name__)
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()
+"""
+
+_C_HEADER = """\
+#ifndef __guard__
+#define __guard__
+
+/* Public API for __name__. Declare functions here; define them in __name__.c. */
+
+#endif /* __guard__ */
+"""
+
+_C_GITIGNORE = """\
+build/
+*.o
+*.a
+*.so
+*.dylib
+compile_commands.json
 """
 
 

--- a/src/orchestrator/sdlc/testenv.py
+++ b/src/orchestrator/sdlc/testenv.py
@@ -237,9 +237,48 @@ def java_toolchain_available() -> bool:
     return shutil.which("mvn") is not None and shutil.which("java") is not None
 
 
+class CToolEnvironment:
+    """C build toolchain (CMake or Meson + a C compiler). Dependencies come from the
+    system / build files, not pip — so ``install`` (auto-heal) is a no-op and
+    ``ensure`` does nothing (the build configures on the test run). ``build_tool``
+    (``cmake``/``meson``) selects the runner. ``python`` is unavailable by design."""
+
+    declared: set[str] = set()
+
+    def __init__(self, build_tool: str = "cmake") -> None:
+        self.build_tool = build_tool or "cmake"
+
+    @property
+    def python(self) -> str:
+        raise RuntimeError("CToolEnvironment has no Python interpreter")
+
+    async def ensure(self, worktree: Path | str) -> None:
+        return None
+
+    async def install(self, packages: list[str]) -> bool:
+        return False  # C deps are system / CMake-resolved, not pip-installed
+
+    def describe(self) -> str:
+        return f"c toolchain ({self.build_tool} + system compiler)"
+
+
 def dotnet_toolchain_available() -> bool:
     """True if the ``dotnet`` CLI is on PATH (C# codegen prerequisite)."""
     return shutil.which("dotnet") is not None
+
+
+def _c_compiler_available() -> bool:
+    return any(shutil.which(cc) is not None for cc in ("cc", "gcc", "clang"))
+
+
+def c_toolchain_available() -> bool:
+    """True if CMake and a C compiler are on PATH (CMake C codegen prerequisite)."""
+    return shutil.which("cmake") is not None and _c_compiler_available()
+
+
+def meson_toolchain_available() -> bool:
+    """True if Meson, Ninja and a C compiler are on PATH (Meson C codegen prereq)."""
+    return shutil.which("meson") is not None and shutil.which("ninja") is not None and _c_compiler_available()
 
 
 def detect_dotnet_tfm(default: str = "net8.0") -> str:
@@ -278,6 +317,8 @@ def make_test_environment(language: str = "python", *, build_tool: str = "") -> 
         return NodeToolEnvironment(build_tool or "npm")
     if language == "csharp":
         return DotnetToolEnvironment()
+    if language == "c":
+        return CToolEnvironment(build_tool or "cmake")
     if os.getenv("SDLC_TEST_ISOLATION", "venv").lower() == "local":
         return LocalTestEnvironment()
     return VenvTestEnvironment()
@@ -287,8 +328,10 @@ def make_test_runner(language: str, env: TestEnvironment) -> TestRunner:
     """The runner for ``language``: Maven for Java, the package manager's ``test``
     script for TypeScript, pytest (on the env's interpreter) for Python."""
     from orchestrator.sdlc.testrunner import (
+        CTestRunner,
         DotnetTestRunner,
         MavenTestRunner,
+        MesonTestRunner,
         NodeTestRunner,
         SubprocessTestRunner,
     )
@@ -299,6 +342,9 @@ def make_test_runner(language: str, env: TestEnvironment) -> TestRunner:
         return NodeTestRunner(package_manager=getattr(env, "package_manager", "npm"))
     if language == "csharp":
         return DotnetTestRunner()
+    if language == "c":
+        # The build tool (cmake/meson) is carried on the C tool environment.
+        return MesonTestRunner() if getattr(env, "build_tool", "cmake") == "meson" else CTestRunner()
     return SubprocessTestRunner(python=env.python)
 
 
@@ -417,6 +463,7 @@ def _project_dependencies(root: Path) -> list[str]:
 
 
 __all__ = [
+    "CToolEnvironment",
     "DotnetToolEnvironment",
     "JavaToolEnvironment",
     "LocalTestEnvironment",
@@ -424,9 +471,11 @@ __all__ = [
     "NodeToolEnvironment",
     "TestEnvironment",
     "VenvTestEnvironment",
+    "c_toolchain_available",
     "detect_dotnet_tfm",
     "dotnet_toolchain_available",
     "java_toolchain_available",
+    "meson_toolchain_available",
     "make_test_environment",
     "make_test_runner",
     "node_toolchain_available",

--- a/src/orchestrator/sdlc/testrunner.py
+++ b/src/orchestrator/sdlc/testrunner.py
@@ -248,6 +248,85 @@ class NodeTestRunner:
         return TestRunResult(passed=rc == 0, returncode=rc, output=output)
 
 
+class CTestRunner:
+    """Configures, builds, and tests a CMake project via ``cmake`` + ``ctest``.
+
+    Runs, in order: ``cmake -S <root> -B <root>/build``, ``cmake --build <root>/build``,
+    then ``ctest --test-dir <root>/build --output-on-failure``. The first non-zero step
+    fails the run (``passed`` is rc == 0) and its output — a configure error, a
+    compiler error, or a failing assertion — is what the refine prompt needs. The
+    greenfield scaffold's ``CMakeLists.txt`` globs ``src/*.c`` into a library and each
+    ``tests/*.c`` into a ctest executable, so no build argument is needed."""
+
+    def __init__(self, cmake: str = "cmake", ctest: str = "ctest", *, timeout: float = 600.0) -> None:
+        self._cmake = cmake
+        self._ctest = ctest
+        self._timeout = timeout
+
+    async def run(self, *, path: str) -> TestRunResult:
+        build = str(Path(path) / "build")
+        steps = (
+            (self._cmake, "-S", path, "-B", build),
+            (self._cmake, "--build", build),
+            (self._ctest, "--test-dir", build, "--output-on-failure"),
+        )
+        captured: list[str] = []
+        for argv in steps:
+            rc, out = await _exec_capture(argv, cwd=path, timeout=self._timeout)
+            captured.append(out)
+            if rc != 0:
+                return TestRunResult(passed=False, returncode=rc, output=_clip("\n".join(captured)))
+        return TestRunResult(passed=True, returncode=0, output=_clip("\n".join(captured)))
+
+
+class MesonTestRunner:
+    """Configures, builds, and tests a Meson project via ``meson`` + ``ninja``.
+
+    Runs ``meson setup build`` once (configure), then ``meson test -C build
+    --print-errorlogs`` — which rebuilds changed targets and re-configures on a
+    ``meson.build`` edit before running the tests. The first non-zero step fails the
+    run (``passed`` is rc == 0); its output is the configure/compiler/test-log error
+    the refine prompt needs. Used for brownfield C repos whose build system is
+    Meson; greenfield still scaffolds CMake."""
+
+    def __init__(self, meson: str = "meson", *, timeout: float = 600.0) -> None:
+        self._meson = meson
+        self._timeout = timeout
+
+    async def run(self, *, path: str) -> TestRunResult:
+        captured: list[str] = []
+        if not (Path(path) / "build").exists():
+            rc, out = await _exec_capture((self._meson, "setup", "build"), cwd=path, timeout=self._timeout)
+            captured.append(out)
+            if rc != 0:
+                return TestRunResult(passed=False, returncode=rc, output=_clip("\n".join(captured)))
+        rc, out = await _exec_capture(
+            (self._meson, "test", "-C", "build", "--print-errorlogs"), cwd=path, timeout=self._timeout
+        )
+        captured.append(out)
+        return TestRunResult(passed=rc == 0, returncode=rc, output=_clip("\n".join(captured)))
+
+
+def _clip(output: str) -> str:
+    return output[-_MAX_OUTPUT_CHARS:] if len(output) > _MAX_OUTPUT_CHARS else output
+
+
+async def _exec_capture(argv: tuple[str, ...], *, cwd: str, timeout: float) -> tuple[int, str]:
+    """Run ``argv`` (no shell), returning ``(returncode, combined_output)``."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith(_SECRET_ENV_PREFIXES)}
+    proc = await asyncio.create_subprocess_exec(
+        *argv, cwd=cwd, env=env, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT
+    )
+    try:
+        stdout_bytes, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return -1, f"timed out: {' '.join(argv)}"
+    rc = proc.returncode if proc.returncode is not None else -1
+    return rc, stdout_bytes.decode("utf-8", "replace")
+
+
 _DOTNET_SKIP_DIRS = {"bin", "obj", "node_modules", ".git", ".vs"}
 
 
@@ -289,8 +368,10 @@ class StubTestRunner:
 
 
 __all__ = [
+    "CTestRunner",
     "DotnetTestRunner",
     "MavenTestRunner",
+    "MesonTestRunner",
     "NodeTestRunner",
     "StubTestRunner",
     "SubprocessTestRunner",

--- a/tests/knowledge/test_current_state.py
+++ b/tests/knowledge/test_current_state.py
@@ -75,8 +75,41 @@ def test_developer_lens_renders_sections() -> None:
     assert "# Current State" in md
     assert "## Architecture — layers" in md
     assert "## Recommendations" in md
-    assert "```mermaid" in md  # coupling diagram
+    # System-architecture diagram: a mermaid flowchart with zone subgraphs + a
+    # component-dependency table.
+    assert "## System architecture" in md
+    assert "```mermaid" in md and "subgraph" in md
+    assert "### Component dependencies" in md
     assert "UserController" in md
+
+
+def test_area_groups_by_directory_for_path_modules() -> None:
+    # C/C++ modules are slash-paths: areas must be the directory, not the whole file
+    # (so the architecture diagram shows components, not one node per file).
+    from orchestrator.knowledge.current_state import _area, _zone
+
+    assert _area("src/smf/smf-sm.c") == "src/smf"
+    assert _area("lib/sbi/openapi/model/x.c") == "lib/sbi"
+    assert _zone("src/smf") == "src"
+    # dotted namespaces (C#/Java/Python) keep the first-two-segments behavior
+    assert _area("App.Api.Controllers") == "App.Api"
+
+
+def test_call_graph_hotspots_rendered() -> None:
+    # Functions with the most incoming CALLS edges surface as "most-depended-upon".
+    b = FactBatch()
+    mod = _node("c:src/util.c", NodeKind.MODULE, "src/util.c", "src/util.c")
+    helper = _node("c:helper", NodeKind.FUNCTION, "helper", "src/util.c")
+    b.add_node(mod)
+    b.add_node(helper)
+    for i in range(3):
+        caller = _node(f"c:caller{i}", NodeKind.FUNCTION, f"caller{i}", "src/util.c")
+        b.add_node(caller)
+        b.add_edge(Edge(caller.id, helper.id, EdgeKind.CALLS, Provenance("src/util.c", i)))
+    s = compute_current_state(b, _PROFILE)
+    assert s.call_hotspots and s.call_hotspots[0] == ("helper", 3)
+    md = render_current_state(s, lens="developer")
+    assert "## Call graph — most-depended-upon functions" in md and "`helper`" in md
 
 
 def test_stakeholder_lens_is_plain_language() -> None:
@@ -104,3 +137,22 @@ def test_build_current_state_end_to_end_python(tmp_path: Path) -> None:
     )
     md = build_current_state(tmp_path, lens="developer", refresh=True)
     assert "# Current State" in md and "## At a glance" in md
+
+
+def test_vendored_and_generated_paths_excluded() -> None:
+    # Live-proving on a large real C repo showed vendored/generated trees skew the
+    # "what is THIS project" metrics. _is_generated now catches common conventions
+    # (path substrings), language-agnostically — not just the C# markers.
+    from orchestrator.knowledge.current_state import _is_generated
+
+    def n(file: str) -> Node:
+        return Node("c:x", NodeKind.TYPE, "x", "c", Provenance(file, 1))
+
+    assert _is_generated(n("lib/sbi/openapi/external/cJSON.c"))  # /external/
+    assert _is_generated(n("lib/sbi/contrib/multipart_parser.c"))  # /contrib/
+    assert _is_generated(n("lib/ipfw/objs/include/ip_fw.h"))  # /objs/
+    assert _is_generated(n("subprojects/freediameter/foo.c"))  # /subprojects/
+    assert _is_generated(n("third_party/x/y.c"))  # /third_party/
+    # the project's own code is NOT flagged
+    assert not _is_generated(n("src/amf/amf-context.c"))
+    assert not _is_generated(n("lib/core/ogs-hash.c"))

--- a/tests/pkg/test_c_extractor.py
+++ b/tests/pkg/test_c_extractor.py
@@ -1,0 +1,154 @@
+"""PKG: the C front-end maps C source onto the universal facts (Track 2).
+
+The new model: the translation unit (file) is the module; free functions, types and
+globals hang off it. tree-sitter-c is an optional extra, so these skip when absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestrator.pkg.c_extractor import CExtractor
+from orchestrator.pkg.facts import EdgeKind, FactBatch, NodeKind
+
+pytest.importorskip("tree_sitter_c", reason="install the 'c' extra")
+
+
+def _extract(root: Path, *rels: str) -> FactBatch:
+    """Extract each file under ``root`` and merge (as RepoCodeExtractor would)."""
+    ex = CExtractor()
+    batch = FactBatch()
+    for rel in rels:
+        f = root / rel
+        batch.merge(ex.extract(path=f, module=ex.module_name(f, root), rel=rel))
+    return batch
+
+
+def _write(root: Path, rel: str, src: str) -> None:
+    (root / rel).parent.mkdir(parents=True, exist_ok=True)
+    (root / rel).write_text(src, encoding="utf-8")
+
+
+GEOMETRY_H = """\
+#ifndef GEOMETRY_H
+#define GEOMETRY_H
+typedef struct Point { int x; int y; } Point;
+struct Line { Point start; Point *end; };
+enum Axis { X, Y };
+int add(int a, int b);
+double distance(Point p);
+#endif
+"""
+
+GEOMETRY_C = """\
+#include <math.h>
+#include "geometry.h"
+
+int origin_count;
+
+int add(int a, int b) { return a + b; }
+
+static int square(int n) { return n * n; }
+
+double distance(Point p) {
+    int s = square(p.x);
+    return add(s, p.y);
+}
+"""
+
+
+def _geometry(tmp_path: Path, order: tuple[str, ...] = ("geometry.h", "geometry.c")) -> FactBatch:
+    _write(tmp_path, "geometry.h", GEOMETRY_H)
+    _write(tmp_path, "geometry.c", GEOMETRY_C)
+    return _extract(tmp_path, *order)
+
+
+def test_module_name_is_the_relative_path(tmp_path: Path) -> None:
+    _write(tmp_path, "src/util.c", "int f(void) { return 0; }\n")
+    ex = CExtractor()
+    assert ex.module_name(tmp_path / "src/util.c", tmp_path) == "src/util.c"
+
+
+def test_types_and_members(tmp_path: Path) -> None:
+    by_id = {n.id: n for n in _geometry(tmp_path).nodes}
+    # struct (via typedef), struct (tag), and enum are all Types
+    assert by_id["c:Point"].kind is NodeKind.TYPE
+    assert by_id["c:Line"].kind is NodeKind.TYPE
+    assert by_id["c:Axis"].kind is NodeKind.TYPE
+    # struct members + enum constants are Fields
+    assert by_id["c:Point.x"].kind is NodeKind.FIELD
+    assert by_id["c:Point.y"].kind is NodeKind.FIELD
+    assert by_id["c:Axis.X"].kind is NodeKind.FIELD
+
+
+def test_free_functions_contained_by_module(tmp_path: Path) -> None:
+    batch = _geometry(tmp_path)
+    by_id = {n.id: n for n in batch.nodes}
+    assert by_id["c:add"].kind is NodeKind.FUNCTION
+    contains = {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.CONTAINS}
+    # declared in the header, defined in the source → contained by BOTH translation units
+    assert ("c:geometry.c", "c:add") in contains
+    assert ("c:geometry.h", "c:add") in contains
+
+
+@pytest.mark.parametrize("order", [("geometry.h", "geometry.c"), ("geometry.c", "geometry.h")])
+def test_header_source_merge_prefers_definition(tmp_path: Path, order: tuple[str, ...]) -> None:
+    # The .h prototype and the .c definition collapse to ONE node whose provenance is
+    # the definition — regardless of which file is parsed first.
+    by_id = {n.id: n for n in _geometry(tmp_path, order).nodes}
+    add = by_id["c:add"]
+    assert add.grounded is True
+    assert add.provenance is not None and add.provenance.file == "geometry.c"
+
+
+def test_static_function_is_file_scoped(tmp_path: Path) -> None:
+    by_id = {n.id: n for n in _geometry(tmp_path).nodes}
+    # internal linkage → keyed by file so same-named statics in other files don't merge
+    assert "c:geometry.c::square" in by_id
+    assert by_id["c:geometry.c::square"].kind is NodeKind.FUNCTION
+    assert "c:square" not in by_id
+
+
+def test_global_variable_is_a_field(tmp_path: Path) -> None:
+    by_id = {n.id: n for n in _geometry(tmp_path).nodes}
+    assert by_id["c:origin_count"].kind is NodeKind.FIELD
+
+
+def test_include_resolution(tmp_path: Path) -> None:
+    batch = _geometry(tmp_path)
+    by_id = {n.id: n for n in batch.nodes}
+    imports = {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.IMPORTS}
+    assert ("c:geometry.c", "c:geometry.h") in imports
+    assert ("c:geometry.c", "c:math.h") in imports
+    # a "local.h" that exists in-repo is grounded; a <system.h> is external
+    assert by_id["c:geometry.h"].grounded is True
+    assert by_id["c:math.h"].external is True
+
+
+def test_missing_quoted_include_is_external(tmp_path: Path) -> None:
+    _write(tmp_path, "a.c", '#include "nowhere.h"\nint f(void){return 0;}\n')
+    by_id = {n.id: n for n in _extract(tmp_path, "a.c").nodes}
+    assert by_id["c:nowhere.h"].external is True  # not found in-repo → external
+
+
+def test_calls_resolve_global_and_local_static(tmp_path: Path) -> None:
+    calls = {(e.src, e.dst) for e in _geometry(tmp_path).edges if e.kind is EdgeKind.CALLS}
+    assert ("c:distance", "c:add") in calls  # global (external linkage)
+    assert ("c:distance", "c:geometry.c::square") in calls  # local static → file-scoped id
+
+
+def test_references_struct_member_type(tmp_path: Path) -> None:
+    refs = {(e.src, e.dst) for e in _geometry(tmp_path).edges if e.kind is EdgeKind.REFERENCES}
+    # `struct Line { Point start; Point *end; }` references Point (value and pointer)
+    assert ("c:Line", "c:Point") in refs
+
+
+def test_union_and_anonymous_typedef(tmp_path: Path) -> None:
+    src = "typedef union { int i; float f; } Value;\ntypedef struct { int w; } Widget;\n"
+    _write(tmp_path, "u.c", src)
+    by_id = {n.id: n for n in _extract(tmp_path, "u.c").nodes}
+    assert by_id["c:Value"].kind is NodeKind.TYPE  # typedef of anonymous union
+    assert by_id["c:Value.i"].kind is NodeKind.FIELD
+    assert by_id["c:Widget"].kind is NodeKind.TYPE  # typedef of anonymous struct

--- a/tests/pkg/test_default_extractors.py
+++ b/tests/pkg/test_default_extractors.py
@@ -34,6 +34,12 @@ def test_default_includes_csharp_when_available() -> None:
     assert ("csharp" in langs) == have_csharp
 
 
+def test_default_includes_c_when_available() -> None:
+    have_c = importlib.util.find_spec("tree_sitter_c") is not None
+    langs = {e.language for e in default_extractors()}
+    assert ("c" in langs) == have_c
+
+
 def test_repo_extractor_default_handles_java(tmp_path: Path) -> None:
     pytest.importorskip("tree_sitter_java", reason="install the 'java' extra")
     src = tmp_path / "src" / "main" / "java" / "com" / "demo"
@@ -69,3 +75,15 @@ def test_repo_extractor_default_handles_csharp(tmp_path: Path) -> None:
     batch = RepoCodeExtractor().extract(tmp_path)
     types = {n.name for n in batch.nodes if n.kind is NodeKind.TYPE and n.language == "csharp"}
     assert "Widget" in types
+
+
+def test_repo_extractor_default_handles_c(tmp_path: Path) -> None:
+    pytest.importorskip("tree_sitter_c", reason="install the 'c' extra")
+    (tmp_path / "widget.c").write_text(
+        "struct Widget { int id; };\nint widget_score(struct Widget *w) { return w->id; }\n"
+    )
+    # Default RepoCodeExtractor (no explicit extractors) must now pick up .c.
+    batch = RepoCodeExtractor().extract(tmp_path)
+    types = {n.name for n in batch.nodes if n.kind is NodeKind.TYPE and n.language == "c"}
+    funcs = {n.name for n in batch.nodes if n.kind is NodeKind.FUNCTION and n.language == "c"}
+    assert "Widget" in types and "widget_score" in funcs

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -358,6 +358,31 @@ async def test_csharp_layout_selects_csharp_prompts(tmp_path: Path) -> None:
     assert "<TypeName>Tests.cs" in llm.calls[0][-1].content  # xUnit test path hint
 
 
+async def test_c_layout_selects_c_prompts(tmp_path: Path) -> None:
+    """A C layout switches implement/author_tests/refine to the CMake/ctest prompts and
+    pins the header/source + tests-dir conventions in the layout block."""
+    from orchestrator.sdlc.layout import TargetLayout
+
+    layout = TargetLayout("calc_lib", "src", "tests", True, "new", language="c", build_tool="cmake")
+    llm = _ScriptedLLM(
+        [
+            _files_response({"src/calc.c": '#include "calc.h"\nint add(int a,int b){return a+b;}\n'}),
+            _files_response({"tests/test_calc.c": '#include "calc.h"\nint main(void){return 0;}\n'}),
+            _files_response({"src/calc.c": '#include "calc.h"\nint add(int a,int b){return a+b;}\n'}),
+        ]
+    )
+    adapter = LLMCodegenAdapter(llm, layout=layout)
+    await adapter.implement(spec=_SPEC, path=str(tmp_path), issue_key="C-1")
+    await adapter.author_tests(spec=_SPEC, path=str(tmp_path), issue_key="C-1")
+    await adapter.refine(spec=_SPEC, path=str(tmp_path), issue_key="C-1", failures="error: expected ';'")
+
+    assert "runnable C inside" in llm.calls[0][0].content  # implement system prompt
+    assert "C unit tests" in llm.calls[1][0].content  # author_tests system prompt
+    assert "CMakeLists.txt" in llm.calls[2][0].content  # refine system prompt
+    assert "test_<name>.c" in llm.calls[0][-1].content  # layout block (user)
+    assert "#ifndef" in llm.calls[0][-1].content  # header-guard hint
+
+
 async def test_no_layout_block_when_layout_unset(tmp_path: Path) -> None:
     """Backward compatible: without a layout, the prompt carries no layout block."""
     llm = _ScriptedLLM([_files_response({"m.py": "x = 1\n"})])

--- a/tests/sdlc/test_layout.py
+++ b/tests/sdlc/test_layout.py
@@ -214,3 +214,40 @@ class TestCSharpLayout:
         assert layout.package_name == "Shop" and layout.build_tool == "dotnet"
         # no test project present → tests dir is derived from the source project name.
         assert layout.tests_dir == "tests/Shop.Tests"
+
+
+class TestCLayout:
+    def test_new_c_cmake_layout(self, tmp_path: Path) -> None:
+        layout = resolve_layout(tmp_path, mode="new", language="c", repo="https://x/Calc-Lib")
+        assert layout.language == "c" and layout.build_tool == "cmake" and layout.mode == "new"
+        assert layout.package_name == "calc_lib"
+        assert layout.source_dir == "src" and layout.tests_dir == "tests"
+        assert layout.module_rel_path("vector") == "src/vector.c"
+
+    def test_detect_existing_cmake_project(self, tmp_path: Path) -> None:
+        from orchestrator.sdlc.layout import detect_c_layout
+
+        (tmp_path / "CMakeLists.txt").write_text("cmake_minimum_required(VERSION 3.15)\nproject(mylib C)\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "a.c").write_text("int x;\n")
+        (tmp_path / "tests").mkdir()
+        # package comes from the CMake project() name; src/ holds .c so it's the source dir.
+        assert detect_c_layout(tmp_path) == ("mylib", "src", "tests")
+
+    def test_auto_existing_make_project(self, tmp_path: Path) -> None:
+        (tmp_path / "Makefile").write_text("all:\n\tcc -o app main.c\n")
+        layout = resolve_layout(tmp_path, mode="auto", language="c")
+        assert layout.mode == "existing" and layout.build_tool == "make"
+
+    def test_detects_meson_build_tool(self, tmp_path: Path) -> None:
+        # Meson projects are recognized as C with build_tool=meson, so
+        # the runner can fail fast with a clear "CMake-only" message (not a cryptic
+        # cmake error). CMake remains the supported brownfield build path.
+        from orchestrator.sdlc.layout import detect_c_layout
+
+        (tmp_path / "meson.build").write_text("project('demo', 'c')\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "a.c").write_text("int x;\n")
+        assert detect_c_layout(tmp_path) is not None
+        layout = resolve_layout(tmp_path, mode="existing", language="c")
+        assert layout.build_tool == "meson"

--- a/tests/sdlc/test_scaffold.py
+++ b/tests/sdlc/test_scaffold.py
@@ -162,6 +162,44 @@ def test_scaffold_csharp_appends_dotnet_ignores_to_existing_gitignore(tmp_path: 
     assert "bin/" in gi and "obj/" in gi  # .NET build output now ignored
 
 
+_C_LAYOUT = TargetLayout(
+    package_name="calc_lib",
+    source_dir="src",
+    tests_dir="tests",
+    src_layout=True,
+    mode="new",
+    language="c",
+    build_tool="cmake",
+)
+
+
+def test_scaffold_c_cmake_project(tmp_path: Path) -> None:
+    created = scaffold(tmp_path, _C_LAYOUT)
+    assert "CMakeLists.txt" in created
+    assert "src/calc_lib.c" in created and "src/calc_lib.h" in created
+    cmake = (tmp_path / "CMakeLists.txt").read_text()
+    assert "project(calc_lib C)" in cmake
+    assert "enable_testing()" in cmake and "add_test(" in cmake
+    assert "${CMAKE_SOURCE_DIR}/src/*.c" in cmake  # cmake vars preserved (not .format-mangled)
+    header = (tmp_path / "src" / "calc_lib.h").read_text()
+    assert "#ifndef CALC_LIB_H" in header  # include guard
+    assert "build/" in (tmp_path / ".gitignore").read_text()  # C .gitignore
+    assert not (tmp_path / "pyproject.toml").exists()
+
+
+def test_scaffold_c_appends_build_ignore_to_existing_gitignore(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    created = scaffold(tmp_path, _C_LAYOUT)
+    assert ".gitignore" in created
+    gi = (tmp_path / ".gitignore").read_text()
+    assert ".venv/" in gi and "build/" in gi  # pre-existing preserved + build/ appended
+
+
+def test_scaffold_c_is_idempotent(tmp_path: Path) -> None:
+    scaffold(tmp_path, _C_LAYOUT)
+    assert scaffold(tmp_path, _C_LAYOUT) == []
+
+
 def test_scaffold_csharp_honors_target_framework(tmp_path: Path) -> None:
     from dataclasses import replace
 

--- a/tests/sdlc/test_testenv.py
+++ b/tests/sdlc/test_testenv.py
@@ -407,3 +407,142 @@ async def test_dotnet_runner_no_target_runs_at_root(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr("orchestrator.sdlc.testrunner.asyncio.create_subprocess_exec", fake_exec)
     await DotnetTestRunner().run(path=str(tmp_path))
     assert captured[0] == ("dotnet", "test", "--nologo")
+
+
+# --- C (2.2) -----------------------------------------------------------------
+
+
+def test_make_test_environment_c() -> None:
+    from orchestrator.sdlc.testenv import CToolEnvironment, make_test_environment
+
+    assert isinstance(make_test_environment("c"), CToolEnvironment)
+
+
+def test_make_test_runner_picks_ctest_for_c() -> None:
+    from orchestrator.sdlc.testenv import CToolEnvironment, make_test_runner
+    from orchestrator.sdlc.testrunner import CTestRunner
+
+    assert isinstance(make_test_runner("c", CToolEnvironment()), CTestRunner)
+
+
+def test_c_env_install_is_noop_and_python_unavailable() -> None:
+    import asyncio
+
+    from orchestrator.sdlc.testenv import CToolEnvironment
+
+    env = CToolEnvironment()
+    assert asyncio.run(env.install(["cmocka"])) is False  # C deps are system/CMake
+    with pytest.raises(RuntimeError):
+        _ = env.python
+
+
+def test_c_toolchain_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.sdlc import testenv
+
+    monkeypatch.setattr(
+        "orchestrator.sdlc.testenv.shutil.which",
+        lambda name: f"/usr/bin/{name}" if name in {"cmake", "clang"} else None,
+    )
+    assert testenv.c_toolchain_available() is True  # cmake + a compiler
+    monkeypatch.setattr(
+        "orchestrator.sdlc.testenv.shutil.which",
+        lambda name: "/usr/bin/cmake" if name == "cmake" else None,  # no compiler
+    )
+    assert testenv.c_toolchain_available() is False
+
+
+async def test_ctest_runner_passes_when_all_steps_succeed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.sdlc.testrunner import CTestRunner
+
+    calls: list[tuple[object, ...]] = []
+
+    async def fake_exec(*a: object, **k: object) -> _FakeProc:
+        calls.append(a)
+        return _FakeProc(0, b"100% tests passed")
+
+    monkeypatch.setattr("orchestrator.sdlc.testrunner.asyncio.create_subprocess_exec", fake_exec)
+    result = await CTestRunner().run(path="/wt")
+    assert result.passed and result.returncode == 0
+    # configure → build → test (three steps), starting with cmake -S/-B.
+    assert len(calls) == 3 and calls[0][:2] == ("cmake", "-S")
+
+
+async def test_ctest_runner_short_circuits_on_compile_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.sdlc.testrunner import CTestRunner
+
+    calls: list[tuple[object, ...]] = []
+
+    async def fake_exec(*a: object, **k: object) -> _FakeProc:
+        calls.append(a)
+        rc = 0 if a[:2] == ("cmake", "-S") else 1  # configure ok, build fails
+        return _FakeProc(rc, b"error: expected ';'")
+
+    monkeypatch.setattr("orchestrator.sdlc.testrunner.asyncio.create_subprocess_exec", fake_exec)
+    result = await CTestRunner().run(path="/wt")
+    assert not result.passed and "error:" in result.output
+    assert len(calls) == 2  # stopped after the failing build; ctest skipped
+
+
+# --- C with Meson (2.4) ------------------------------------------------------
+
+
+def test_make_test_environment_c_carries_build_tool() -> None:
+    from orchestrator.sdlc.testenv import CToolEnvironment, make_test_environment
+
+    env = make_test_environment("c", build_tool="meson")
+    assert isinstance(env, CToolEnvironment) and env.build_tool == "meson"
+    default = make_test_environment("c")
+    assert isinstance(default, CToolEnvironment) and default.build_tool == "cmake"  # default
+
+
+def test_make_test_runner_picks_meson_when_build_tool_is_meson() -> None:
+    from orchestrator.sdlc.testenv import CToolEnvironment, make_test_runner
+    from orchestrator.sdlc.testrunner import CTestRunner, MesonTestRunner
+
+    assert isinstance(make_test_runner("c", CToolEnvironment("meson")), MesonTestRunner)
+    assert isinstance(make_test_runner("c", CToolEnvironment("cmake")), CTestRunner)
+
+
+def test_meson_toolchain_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.sdlc import testenv
+
+    monkeypatch.setattr(
+        "orchestrator.sdlc.testenv.shutil.which",
+        lambda name: f"/usr/bin/{name}" if name in {"meson", "ninja", "clang"} else None,
+    )
+    assert testenv.meson_toolchain_available() is True
+    monkeypatch.setattr(
+        "orchestrator.sdlc.testenv.shutil.which",
+        lambda name: f"/usr/bin/{name}" if name in {"meson", "clang"} else None,  # no ninja
+    )
+    assert testenv.meson_toolchain_available() is False
+
+
+async def test_meson_runner_configures_then_tests(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from orchestrator.sdlc.testrunner import MesonTestRunner
+
+    calls: list[tuple[object, ...]] = []
+
+    async def fake_exec(*a: object, **k: object) -> _FakeProc:
+        calls.append(a)
+        return _FakeProc(0, b"Ok: 1")
+
+    monkeypatch.setattr("orchestrator.sdlc.testrunner.asyncio.create_subprocess_exec", fake_exec)
+    result = await MesonTestRunner().run(path=str(tmp_path))  # no build/ → setup + test
+    assert result.passed
+    assert calls[0][:2] == ("meson", "setup") and calls[1][:2] == ("meson", "test")
+
+
+async def test_meson_runner_fails_on_setup(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from orchestrator.sdlc.testrunner import MesonTestRunner
+
+    calls: list[tuple[object, ...]] = []
+
+    async def fake_exec(*a: object, **k: object) -> _FakeProc:
+        calls.append(a)
+        return _FakeProc(1, b"meson.build:3: ERROR: Unknown function")
+
+    monkeypatch.setattr("orchestrator.sdlc.testrunner.asyncio.create_subprocess_exec", fake_exec)
+    result = await MesonTestRunner().run(path=str(tmp_path))
+    assert not result.passed and "ERROR" in result.output
+    assert len(calls) == 1  # setup failed → test skipped

--- a/uv.lock
+++ b/uv.lock
@@ -3066,7 +3066,7 @@ wheels = [
 
 [[package]]
 name = "synaptixs-spine"
-version = "2.0.1"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -3093,6 +3093,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+c = [
+    { name = "tree-sitter" },
+    { name = "tree-sitter-c" },
+]
 csharp = [
     { name = "tree-sitter" },
     { name = "tree-sitter-c-sharp" },
@@ -3169,9 +3173,11 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "temporalio", specifier = ">=1.7" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.50" },
+    { name = "tree-sitter", marker = "extra == 'c'", specifier = ">=0.21" },
     { name = "tree-sitter", marker = "extra == 'csharp'", specifier = ">=0.21" },
     { name = "tree-sitter", marker = "extra == 'java'", specifier = ">=0.21" },
     { name = "tree-sitter", marker = "extra == 'typescript'", specifier = ">=0.21" },
+    { name = "tree-sitter-c", marker = "extra == 'c'", specifier = ">=0.21" },
     { name = "tree-sitter-c-sharp", marker = "extra == 'csharp'", specifier = ">=0.21" },
     { name = "tree-sitter-java", marker = "extra == 'java'", specifier = ">=0.21" },
     { name = "tree-sitter-typescript", marker = "extra == 'typescript'", specifier = ">=0.21" },
@@ -3180,7 +3186,7 @@ requires-dist = [
     { name = "types-pyyaml", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
-provides-extras = ["security", "java", "typescript", "csharp", "mcp", "sdlc", "tui", "otel", "dev"]
+provides-extras = ["security", "java", "typescript", "csharp", "c", "mcp", "sdlc", "tui", "otel", "dev"]
 
 [[package]]
 name = "temporalio"
@@ -3385,6 +3391,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
     { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/c9/3834f3d9278251aea7312274971bc4c45b17aec2490fd4b884d93bd7019a/tree_sitter_c-0.24.2.tar.gz", hash = "sha256:1628584df0299b5a340aa63f8e67b6c97c91517f52fa7e7a4c557e40adb330a9", size = 228397, upload-time = "2026-04-22T08:06:14.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/c1/26ed17730ec2c17bedc1b673349e5e0a466c578e3eb0327c3b73cf52bf97/tree_sitter_c-0.24.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4d4579a8b54f0a442f903d88d3304cab77cd5c2031d4015baa4f2f8e15d6dcb7", size = 81016, upload-time = "2026-04-22T08:06:07.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1c/1140db75e7e375cda3c68792a33826c4fd40b5b98c3259d93c75f6c8368f/tree_sitter_c-0.24.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:97bc80a224d48215d4e6e6376bf30d114f4c317b8145ff1b02afe785d4ba7bdd", size = 86213, upload-time = "2026-04-22T08:06:08.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/8c/0dfb88d726f8821d1c4c36042f092be974a800afd734307a595b8604190c/tree_sitter_c-0.24.2-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5041ef67eb68ce6bc8bb0b1f8ef3a5585ce523dae0c7eec109ab0627dd75aede", size = 94264, upload-time = "2026-04-22T08:06:08.918Z" },
+    { url = "https://files.pythonhosted.org/packages/87/78/47dc570e7aee6b0a1ecc2520b30639cc2b06003154c9ab0672d86bf720d5/tree_sitter_c-0.24.2-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c098bedcd5ac86ff93fa734d51d1dd86aed40fd5ed7d634c7af11380a0469969", size = 94560, upload-time = "2026-04-22T08:06:09.852Z" },
+    { url = "https://files.pythonhosted.org/packages/29/37/75d59d3f74f4cfc00f04472917e933d8a9c9fdc6eff980ef9552e010e6aa/tree_sitter_c-0.24.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:82842c5a5f2acd93f4de10038c33ac179c8979defc39376f990348d6289e933b", size = 94023, upload-time = "2026-04-22T08:06:10.682Z" },
+    { url = "https://files.pythonhosted.org/packages/64/57/8fc655d5a446a70a637e92b98bd2fdaab88bf5bb5b36076ac4add544808d/tree_sitter_c-0.24.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e2b42e8e22202c251f8629306f9321233542e07a6e01611b5fe83489272143eb", size = 94160, upload-time = "2026-04-22T08:06:11.497Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f7/72a1d6b42dd31fd37e03ff67e7dc5ee572301499e6b216002b8dd42a1714/tree_sitter_c-0.24.2-cp310-abi3-win_amd64.whl", hash = "sha256:abb549225091f7b25df2dd3a0143ece6e208f7055d8bcb4700b41ee79b9ef1e1", size = 84669, upload-time = "2026-04-22T08:06:12.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9d/7475d9ae8ef679aa36c7dfe6c903ab78e573651c68b6ef9862d6a3f994db/tree_sitter_c-0.24.2-cp310-abi3-win_arm64.whl", hash = "sha256:4a2f4371cd816cc3153458f69062135ebb2ea5f275ddd90494e5c823d778204a", size = 82956, upload-time = "2026-04-22T08:06:13.364Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated sync from the private repo @ e54ee4c (v2.2.0).

## What's in this release
- chore: genericize live-proving comments — no private validation-repo names in published files
- docs: document orchestrator state (current-state report + diagrams) for 2.2.0
- feat(c): Meson build runner — brownfield Meson C codegen end-to-end; close Track 2.4 (2.2.0)
- feat(c): detect Meson + fast-fail clear message for non-CMake brownfield (2.4 validate, 2.1.3)
- feat(current-state): system-architecture + component + call-graph diagrams (2.1.2)
- fix(current-state): language-agnostic vendored/generated exclusion + C churn (2.1.1)
- feat(c): Track 2 — C as the 5th language (2.1–2.3), 2.1.0

Merge to release.