### PR TITLE
Publish v2.4.0 (19d1d76)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -31,7 +31,7 @@ radius) and grounds new code in what already exists. Full guide:
 
 | Capability | Status | How to use |
 |---|---|---|
-| Multi-language comprehension + codegen — Python, Java, TypeScript, C#, C | ✅ | automatic per repo |
+| Multi-language comprehension + codegen — Python, Java, TypeScript, C#, C, C++ | ✅ | automatic per repo |
 | Framework-aware edges — ASP.NET Core endpoints, EF Core entities (C#) | ✅ | emitted into the PKG on `pkg extract` / `understand` |
 | C `#include` graph + header/source merge; codegen on **CMake or Meson** | ✅ | `.c`/`.h` per repo; `sdlc feature --language c` |
 | Committed `memory-bank/` for humans + any AI tool | ✅ | `orchestrator understand --out memory-bank` |

--- a/KNOWLEDGE_GRAPH.md
+++ b/KNOWLEDGE_GRAPH.md
@@ -134,6 +134,7 @@ flowchart LR
   | TypeScript / TSX | ✅ | `pip install 'synaptixs-spine[typescript]'` |
   | C# | ✅ + framework edges | `pip install 'synaptixs-spine[csharp]'` |
   | C | ✅ + `#include` graph | `pip install 'synaptixs-spine[c]'` |
+  | C++ | ✅ classes/namespaces/inheritance | `pip install 'synaptixs-spine[cpp]'` |
 
   C# additionally lifts **framework edges** into the graph: ASP.NET Core controllers
   and Minimal-API routes become `Endpoint` nodes with `EXPOSES` edges to their
@@ -144,6 +145,13 @@ flowchart LR
   graph** (`IMPORTS`); a function prototype in a `.h` and its definition in a `.c`
   **merge onto one node** (the definition wins), `CALLS` resolve across files by name,
   and a struct member whose type is another struct becomes a `REFERENCES` data edge.
+
+  C++ is a **superset of the C front-end** — it reuses the include graph and the
+  header/source merge, then adds the object model: `class`/`struct`/`union`/`enum`
+  become namespace-qualified `Type` nodes, base classes become `IMPLEMENTS` edges
+  (multiple inheritance → multiple edges), member functions merge an in-class
+  declaration with an out-of-line `Class::method` definition, templates emit their
+  `Type`/`Function`, and `CALLS`/`REFERENCES` carry over.
 - **Cached per commit.** Re-running on an unchanged tree reuses the cache; `--refresh`
   forces a re-extract. So `understand` is cheap to re-run as the code evolves.
 
@@ -302,7 +310,7 @@ reviews honest.
 
 - **Static, not runtime.** The PKG is built from source structure; it doesn't capture
   runtime behavior, dynamic dispatch it can't see, or values only known at execution.
-- **Parser coverage.** Python/Java/TypeScript/C#/C today. Other languages aren't
+- **Parser coverage.** Python/Java/TypeScript/C#/C/C++ today. Other languages aren't
   extracted yet (their files are simply not represented). For C, parsing is
   pre-preprocessor — heavy macro use yields partial facts (we never run `cpp`).
 - **Heuristic edges.** Some edges (e.g. data-layer foreign keys) are inferred and improve

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ writes) so you can inspect everything first.
 **Code-grounded understanding.** Before generating, it builds a **Product Knowledge
 Graph** of your repo — modules, types, functions, call sites, blast radius — and
 grounds new code in what already exists, so output reads like your team wrote it.
-Works across **Python, Java, TypeScript, C#, and C**. `orchestrator understand` writes a
+Works across **Python, Java, TypeScript, C#, C, and C++**. `orchestrator understand` writes a
 committed, code-true `memory-bank/` your whole team (and any AI tool) can read.
 
 **Governed autonomy.** The workflow itself is a typed, validated artifact. A planner
@@ -124,9 +124,11 @@ The autonomous multi-feature pipeline + web dashboard needs Temporal + Postgres 
 see the [Setup guide](SETUP.md).
 
 **Which languages and models?**
-Code generation and comprehension cover **Python, Java, TypeScript, C#, and C**
+Code generation and comprehension cover **Python, Java, TypeScript, C#, C, and C++**
 (C# also extracts ASP.NET Core endpoints and EF Core entities; C builds the
-`#include` graph and merges header declarations with their source definitions). Any
+`#include` graph and merges header declarations with their source definitions; C++ is
+a superset of the C front-end that adds classes, namespaces, inheritance, member
+functions, and templates, and shares C's CMake/Meson + `ctest` codegen). Any
 LiteLLM-supported provider (Anthropic, OpenAI, Bedrock) or a local Ollama model;
 you can set a different model per stage.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -64,10 +64,10 @@ orchestrator --help
 Optional extras, added when you need them:
 - `pip install 'synaptixs-spine[sdlc]'` — run the generated tests (the `sdlc feature`/`run` path)
 - `pip install 'synaptixs-spine[tui]'` — the `orchestrator tui` terminal UI (Step 7)
-- `[java]`, `[typescript]`, `[csharp]`, `[c]` — language parsers for comprehension +
+- `[java]`, `[typescript]`, `[csharp]`, `[c]`, `[cpp]` — language parsers for comprehension +
   grounding (Python needs no extra). C# codegen also needs the **.NET SDK** (`dotnet`)
-  on PATH; C codegen needs a C compiler plus **CMake** (greenfield) or **Meson + Ninja**
-  (matching the target repo's build system).
+  on PATH; C / C++ codegen needs a C / C++ compiler plus **CMake** (greenfield) or
+  **Meson + Ninja** (matching the target repo's build system).
 - `[mcp]` (MCP client), `[otel]` (live tracing)
 
 ### Upgrading
@@ -152,16 +152,19 @@ signals, a name-based security surface, and prioritized recommendations. A repor
 > uses it, and how it works for brownfield and greenfield projects.
 
 > **Multi-language.** Comprehension covers **Python** out of the box and **Java**,
-> **TypeScript**, **C#**, and **C** when the matching parser extra is installed
-> (`pip install 'synaptixs-spine[java]'` / `[typescript]` / `[csharp]` / `[c]`).
+> **TypeScript**, **C#**, **C**, and **C++** when the matching parser extra is installed
+> (`pip install 'synaptixs-spine[java]'` / `[typescript]` / `[csharp]` / `[c]` / `[cpp]`).
 > `understand`, codegen grounding, and `pkg extract` then process `.java` / `.ts` /
-> `.cs` / `.c` / `.h` too. For **C#**, the graph additionally captures ASP.NET Core
-> endpoints (`EXPOSES`) and EF Core entities (`REFERENCES`); codegen scaffolds a
+> `.cs` / `.c` / `.h` / `.cpp` / `.hpp` too. For **C#**, the graph additionally captures
+> ASP.NET Core endpoints (`EXPOSES`) and EF Core entities (`REFERENCES`); codegen scaffolds a
 > solution + xUnit project and runs `dotnet test` (needs the **.NET SDK**). For **C**,
 > it builds the `#include` graph and merges header declarations with their source
 > definitions; codegen scaffolds a **CMake** project (greenfield) or works in a brownfield
 > **Meson** repo, building + testing via `ctest` / `meson test` (needs a C compiler plus
-> CMake or Meson+Ninja).
+> CMake or Meson+Ninja). **C++** is a superset of the C front-end — it reuses the include
+> graph and header/source merge and adds classes, namespaces, inheritance (`IMPLEMENTS`),
+> member functions, and templates; codegen scaffolds a CMake **CXX** project and builds +
+> tests via `ctest` (needs a C++ compiler plus CMake).
 
 ### Working with existing repos (brownfield) — and how knowledge grows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "2.3.0"
+version = "2.4.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }
@@ -62,6 +62,11 @@ csharp = [
 c = [
     "tree-sitter>=0.21",
     "tree-sitter-c>=0.21",
+]
+# C++ PKG front-end (.cpp/.hpp/…). Same lazy-import contract as the `java` extra.
+cpp = [
+    "tree-sitter>=0.21",
+    "tree-sitter-cpp>=0.21",
 ]
 # Onboard external MCP servers (DBs, Atlassian, …) as orchestrator tools. The
 # MCP client lazy-imports this, so the base install stays MCP-free.
@@ -150,7 +155,7 @@ files = ["src", "tests"]
 # tree-sitter is an optional extra (the `java`/`typescript` PKG front-ends); not
 # installed in the default/CI env, so don't fail type-checking on its absence.
 [[tool.mypy.overrides]]
-module = ["tree_sitter", "tree_sitter.*", "tree_sitter_java", "tree_sitter_typescript", "tree_sitter_c_sharp", "tree_sitter_c"]
+module = ["tree_sitter", "tree_sitter.*", "tree_sitter_java", "tree_sitter_typescript", "tree_sitter_c_sharp", "tree_sitter_c", "tree_sitter_cpp"]
 ignore_missing_imports = true
 
 # `textual` is the optional `tui` extra; not installed in the default/CI env.

--- a/src/orchestrator/catalog/catalog.py
+++ b/src/orchestrator/catalog/catalog.py
@@ -48,6 +48,12 @@ _SEED: tuple[Capability, ...] = (
         CapabilitySelector(languages=frozenset({"c"}), task_types=frozenset({"feature"})),
     ),
     Capability(
+        "cpp-conventions",
+        CapabilityKind.SKILL,
+        "Match the repo's C++ conventions",
+        CapabilitySelector(languages=frozenset({"cpp"}), task_types=frozenset({"feature"})),
+    ),
+    Capability(
         "repo-pkg-grounding",
         CapabilityKind.SKILL,
         "Ground codegen on the repo's knowledge graph",

--- a/src/orchestrator/catalog/profile.py
+++ b/src/orchestrator/catalog/profile.py
@@ -25,6 +25,12 @@ _LANG_BY_SUFFIX = {
     ".cs": "csharp",
     ".c": "c",
     ".h": "c",
+    ".cpp": "cpp",
+    ".cc": "cpp",
+    ".cxx": "cpp",
+    ".hpp": "cpp",
+    ".hh": "cpp",
+    ".hxx": "cpp",
     ".go": "go",
     ".rb": "ruby",
 }

--- a/src/orchestrator/catalog/skills.py
+++ b/src/orchestrator/catalog/skills.py
@@ -134,6 +134,10 @@ NATIVE_SKILLS: tuple[Skill, ...] = (
         "Match the repo's C conventions — header/source split, include guards, naming.",
     ),
     Skill(
+        "cpp-conventions",
+        "Match the repo's C++ conventions — header/source split, RAII/ownership, namespaces.",
+    ),
+    Skill(
         "repo-pkg-grounding",
         "Reuse existing symbols — use the pkg_* tools to find them before writing code.",
     ),

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -589,7 +589,7 @@ def sdlc_feature(
         str,
         typer.Option(
             "--language",
-            help="Target language: auto (detect), python, java, typescript, csharp, or c.",
+            help="Target language: auto (detect), python, java, typescript, csharp, c, or cpp.",
         ),
     ] = "auto",
 ) -> None:

--- a/src/orchestrator/knowledge/current_state.py
+++ b/src/orchestrator/knowledge/current_state.py
@@ -203,9 +203,40 @@ def compute_current_state(
         s, d = by_id.get(e.src), by_id.get(e.dst)
         if s and s.kind is NodeKind.MODULE and d and d.kind is NodeKind.TYPE and not _is_generated(d):
             area_types[_area(s.name)] += 1
-    area_funcs: Counter[str] = Counter(
-        _area(n.id.split(":", 1)[-1]) for n in nodes if n.kind is NodeKind.FUNCTION and not _is_generated(n)
-    )
+    # A function's area is the component it *lives in* (its owning module's path or
+    # namespace), resolved by walking CONTAINS upward — not its bare symbol id. C/C++
+    # function ids are symbols (`cpp:HSL2RGB`, `cpp:A::A`, `c:widget_score`), so
+    # deriving the area from the id would make every function its own component (and,
+    # via `_zone`, its own zone) — flooding the layout with thousands of one-fn entries.
+    parent_of = {e.dst: e.src for e in contains}
+
+    def _owning_module_name(nid: str) -> str | None:
+        cur, seen = nid, set()
+        while cur in parent_of and cur not in seen:
+            seen.add(cur)
+            p = by_id.get(parent_of[cur])
+            if p is None:
+                break
+            if p.kind is NodeKind.MODULE:
+                return p.name
+            cur = p.id
+        return None
+
+    def _area_of(n: Node) -> str:
+        # The component a node lives in: its owning module's name (dotted namespace /
+        # file path). When that can't be resolved — e.g. a C++ method whose class is
+        # declared in a `.h` parsed as C, so no `cpp:` type node owns it — fall back to
+        # the source file it's defined in, never the bare symbol id (which for C/C++ is
+        # a symbol like `cpp:HSL2RGB`, not a location, so it'd be its own component).
+        mod = _owning_module_name(n.id)
+        if mod is None and n.provenance is not None:
+            mod = n.provenance.file
+        return _area(mod) if mod else _area(n.id.split(":", 1)[-1])
+
+    area_funcs: Counter[str] = Counter()
+    for n in nodes:
+        if n.kind is NodeKind.FUNCTION and not _is_generated(n):
+            area_funcs[_area_of(n)] += 1
 
     controllers = [n for n in types if n.name.endswith("Controller") and not _is_generated(n)]
     ctrl_ids = {c.id for c in controllers}
@@ -251,7 +282,7 @@ def compute_current_state(
         f = (n.provenance.file if n.provenance else "").lower()
         return "test" in n.name.lower() or ".tests" in n.id.lower() or "/test" in f
 
-    tested = {_area(n.id.split(":", 1)[-1]) for n in types if _is_test(n)}
+    tested = {_area_of(n) for n in types if _is_test(n)}
     untested_top = [(a, c) for a, c in area_types.most_common(5) if a not in tested]
 
     dup_names = [

--- a/src/orchestrator/pkg/cpp_extractor.py
+++ b/src/orchestrator/pkg/cpp_extractor.py
@@ -1,0 +1,423 @@
+"""C++ front-end for the PKG extractor (Track 3: a sixth language, a C superset).
+
+C++ reuses Track 2's machinery — the translation-unit model, the `#include` graph
+(with the same in-repo resolution + repo-wide header index), header/source merge,
+and the declarator/`call`/field helpers — and layers the object model on top:
+classes, namespaces, (multiple) inheritance, member functions, and templates.
+
+Emitted (precision-first):
+- ``Module`` — the file (``.cpp``/``.cc``/``.cxx``/``.hpp``/``.hh``/``.hxx``).
+- ``Type`` — ``class`` / ``struct`` / ``union`` / ``enum``, namespace-qualified
+  (``cpp:geo::Circle``); a ``template`` emits its ``Type``/``Function`` but
+  instantiations are not resolved.
+- ``Field`` — data members, enum constants, and file/global variables.
+- ``Function`` — free functions AND member functions. **Header/source merge:** an
+  in-class declaration is an ``external`` placeholder upgraded by the definition
+  (inline or the out-of-line ``ReturnType Class::method() {…}``), keyed by the
+  qualified name so the two collapse onto one node regardless of file order.
+- ``IMPORTS`` — ``#include`` (reuses the C resolver).
+- ``CONTAINS`` — module → free function / type / global, and type → member.
+- ``IMPLEMENTS`` — a class's ``base_class_clause`` (multiple bases → multiple edges).
+- ``CALLS`` — free-function and ``Namespace::func`` calls (name-keyed; overloads
+  collapse), plus an unqualified / ``this->`` call to a sibling method. Member
+  calls on other objects need type inference and are not resolved (documented).
+- ``REFERENCES`` — a data member whose type is another class/struct (the data edge).
+
+``.h`` headers stay with the C front-end (most are C-compatible); a C++ project that
+uses ``.h`` for class headers will have those parsed as C — classes there are not
+captured. Preprocessor caveat carries over: parsing is pre-expansion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from orchestrator.pkg.c_extractor import (
+    _PREPROC_CONTAINERS,
+    _declarator_name,
+    _declared_names,
+    _field_text,
+    _function_declarator,
+    _has_body,
+    _member_type_name,
+    _resolve_include,
+    _string_content,
+    _text,
+)
+from orchestrator.pkg.extractor import rel_module_name
+from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+
+if TYPE_CHECKING:
+    from tree_sitter import Node as TSNode
+
+_TYPE_SPECIFIERS = ("class_specifier", "struct_specifier", "union_specifier", "enum_specifier")
+
+
+class CppExtractor:
+    """C++ front-end (tree-sitter). Install the ``cpp`` extra to use it."""
+
+    language: str = "cpp"
+    suffixes: tuple[str, ...] = (".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx")
+
+    def module_name(self, path: Path, root: Path) -> str:
+        return rel_module_name(path, root)
+
+    def extract(self, *, path: Path, module: str, rel: str) -> FactBatch:
+        parser = _cpp_parser()
+        source = path.read_bytes()
+        tree = parser.parse(source)
+        batch = FactBatch()
+        module_id = f"cpp:{module}" if module else f"cpp:{rel}"
+        batch.add_node(Node(module_id, NodeKind.MODULE, module or rel, "cpp", Provenance(rel, 1)))
+
+        # Collected during the walk for the CALLS pass: every function/method body with
+        # its node id, plus each type's own method names (for sibling-call resolution).
+        funcs: list[tuple[str, str | None, TSNode]] = []  # (func_id, enclosing_type_id, body)
+        free_funcs: dict[str, str] = {}
+        type_methods: dict[str, set[str]] = {}
+        ctx = _Ctx(module_id, path, source, rel, batch, funcs, free_funcs, type_methods)
+
+        self._walk(tree.root_node.named_children, "", ctx)
+        for fid, type_id, body in funcs:
+            self._calls(fid, type_id, body, ctx)
+        return batch
+
+    # --- walk ----------------------------------------------------------------
+
+    def _walk(self, nodes: list[TSNode], ns: str, ctx: _Ctx, tparams: frozenset[str] = frozenset()) -> None:
+        for node in nodes:
+            t = node.type
+            if t in _PREPROC_CONTAINERS:
+                self._walk(node.named_children, ns, ctx, tparams)
+            elif t == "namespace_definition":
+                inner = _join(ns, _field_text(node, "name", ctx.source))
+                body = node.child_by_field_name("body")
+                if body is not None:
+                    self._walk(body.named_children, inner, ctx)
+            elif t == "template_declaration":
+                child = next(
+                    (
+                        c
+                        for c in node.named_children
+                        if c.type in (*_TYPE_SPECIFIERS, "function_definition", "declaration")
+                    ),
+                    None,
+                )
+                if child is not None:
+                    self._walk([child], ns, ctx, _template_params(node, ctx.source))
+            elif t == "preproc_include":
+                self._include(node, ctx)
+            elif t in _TYPE_SPECIFIERS:
+                name = _field_text(node, "name", ctx.source)
+                if name and _has_body(node):
+                    self._emit_type(node, ns, ctx, tparams)
+            elif t == "function_definition":
+                self._function_def(node, ns, ctx)
+            elif t == "declaration":
+                self._declaration(node, ns, ctx)
+
+    # --- includes (reuse the C resolver) -------------------------------------
+
+    def _include(self, node: TSNode, ctx: _Ctx) -> None:
+        target = node.child_by_field_name("path")
+        if target is None:
+            return
+        line = node.start_point[0] + 1
+        if target.type == "system_lib_string":
+            name = _text(target, ctx.source).strip("<>")
+            ctx.batch.add_node(Node(f"cpp:{name}", NodeKind.MODULE, name, "cpp", external=True))
+            ctx.batch.add_edge(
+                Edge(ctx.module_id, f"cpp:{name}", EdgeKind.IMPORTS, Provenance(ctx.rel, line))
+            )
+            return
+        raw = _string_content(target, ctx.source)
+        if not raw:
+            return
+        resolved = _resolve_include(ctx.path, ctx.rel, raw)
+        if resolved is not None:
+            tid = f"cpp:{resolved}"
+            ctx.batch.add_node(Node(tid, NodeKind.MODULE, resolved, "cpp", Provenance(resolved, 1)))
+        else:
+            tid = f"cpp:{raw}"
+            ctx.batch.add_node(Node(tid, NodeKind.MODULE, raw, "cpp", external=True))
+        ctx.batch.add_edge(Edge(ctx.module_id, tid, EdgeKind.IMPORTS, Provenance(ctx.rel, line)))
+
+    # --- types + members -----------------------------------------------------
+
+    def _emit_type(self, spec: TSNode, ns: str, ctx: _Ctx, tparams: frozenset[str] = frozenset()) -> None:
+        name = _field_text(spec, "name", ctx.source)
+        qualified = _join(ns, name)
+        type_id = f"cpp:{qualified}"
+        line = spec.start_point[0] + 1
+        ctx.batch.add_node(
+            Node(type_id, NodeKind.TYPE, name, "cpp", Provenance(ctx.rel, line, spec.end_point[0] + 1))
+        )
+        ctx.batch.add_edge(Edge(ctx.module_id, type_id, EdgeKind.CONTAINS, Provenance(ctx.rel, line)))
+        ctx.type_methods.setdefault(type_id, set())
+
+        for base in _base_types(spec, ctx.source):
+            target = base if "::" in base else _join(ns, base)
+            ctx.batch.add_edge(Edge(type_id, f"cpp:{target}", EdgeKind.IMPLEMENTS, Provenance(ctx.rel, line)))
+
+        body = spec.child_by_field_name("body")
+        if body is None:
+            return
+        if spec.type == "enum_specifier":
+            for e in body.named_children:
+                if e.type == "enumerator":
+                    en = _field_text(e, "name", ctx.source)
+                    if en:
+                        _member(type_id, en, NodeKind.FIELD, e.start_point[0] + 1, ctx)
+            return
+        for member in body.named_children:
+            mline = member.start_point[0] + 1
+            if member.type == "function_definition":  # inline method definition
+                self._member_function(member, type_id, ns, ctx, is_definition=True)
+            elif member.type == "field_declaration":
+                fdeclr = _function_declarator(member.child_by_field_name("declarator"))
+                if fdeclr is not None:  # a member-function declaration
+                    self._member_function(member, type_id, ns, ctx, is_definition=False)
+                else:  # data member(s)
+                    mtype = _member_type_name(member, ctx.source)
+                    for fname in _declared_names(member, ctx.source):
+                        _member(type_id, fname, NodeKind.FIELD, mline, ctx)
+                    if mtype is not None and mtype != _qual_name(type_id) and mtype not in tparams:
+                        tgt = mtype if "::" in mtype else _join(ns, mtype)
+                        ctx.batch.add_edge(
+                            Edge(type_id, f"cpp:{tgt}", EdgeKind.REFERENCES, Provenance(ctx.rel, mline))
+                        )
+            elif member.type in _TYPE_SPECIFIERS and _has_body(member):
+                self._emit_type(member, qualified, ctx, tparams)  # nested type
+
+    def _member_function(
+        self, node: TSNode, type_id: str, ns: str, ctx: _Ctx, *, is_definition: bool
+    ) -> None:
+        fdeclr = _function_declarator(node.child_by_field_name("declarator"))
+        name = _declarator_name(fdeclr, ctx.source) if fdeclr else ""
+        if not name:
+            return
+        mid = f"{type_id}::{name}"
+        line = node.start_point[0] + 1
+        ctx.batch.add_node(
+            Node(mid, NodeKind.FUNCTION, name, "cpp", Provenance(ctx.rel, line), external=not is_definition)
+        )
+        ctx.batch.add_edge(Edge(type_id, mid, EdgeKind.CONTAINS, Provenance(ctx.rel, line)))
+        ctx.type_methods.setdefault(type_id, set()).add(name)
+        if is_definition:
+            body = node.child_by_field_name("body")
+            if body is not None:
+                ctx.funcs.append((mid, type_id, body))
+
+    # --- free functions + out-of-line definitions + globals ------------------
+
+    def _function_def(self, node: TSNode, ns: str, ctx: _Ctx) -> None:
+        fdeclr = _function_declarator(node.child_by_field_name("declarator"))
+        if fdeclr is None:
+            return
+        name_node = fdeclr.child_by_field_name("declarator")
+        body = node.child_by_field_name("body")
+        if name_node is not None and name_node.type == "qualified_identifier":
+            # Out-of-line member definition: `RetType A::B::method() { … }`. Prefix the
+            # enclosing namespace so a partial qualifier inside `namespace geo {…}`
+            # (`Circle::area`) merges with the in-class declaration (`geo::Circle::area`).
+            full = _join(ns, _qualified_text(name_node, ctx.source))
+            type_q, _, method = full.rpartition("::")
+            type_id = f"cpp:{type_q}"
+            mid = f"{type_id}::{method}"
+            line = node.start_point[0] + 1
+            ctx.batch.add_node(Node(mid, NodeKind.FUNCTION, method, "cpp", Provenance(ctx.rel, line)))
+            ctx.batch.add_edge(Edge(type_id, mid, EdgeKind.CONTAINS, Provenance(ctx.rel, line)))
+            ctx.type_methods.setdefault(type_id, set()).add(method)
+            if body is not None:
+                ctx.funcs.append((mid, type_id, body))
+            return
+        # A free function definition.
+        name = _declarator_name(fdeclr, ctx.source)
+        if not name:
+            return
+        fid = f"cpp:{_join(ns, name)}"
+        line = node.start_point[0] + 1
+        ctx.batch.add_node(Node(fid, NodeKind.FUNCTION, name, "cpp", Provenance(ctx.rel, line)))
+        ctx.batch.add_edge(Edge(ctx.module_id, fid, EdgeKind.CONTAINS, Provenance(ctx.rel, line)))
+        ctx.free_funcs[name] = fid
+        if body is not None:
+            ctx.funcs.append((fid, None, body))
+
+    def _declaration(self, node: TSNode, ns: str, ctx: _Ctx) -> None:
+        type_node = node.child_by_field_name("type")
+        declarators = [
+            c
+            for c in node.named_children
+            if c.type
+            in (
+                "identifier",
+                "pointer_declarator",
+                "array_declarator",
+                "init_declarator",
+                "function_declarator",
+            )
+        ]
+        if not declarators and type_node is not None and type_node.type in _TYPE_SPECIFIERS:
+            if _field_text(type_node, "name", ctx.source) and _has_body(type_node):
+                self._emit_type(type_node, ns, ctx)
+            return
+        for d in declarators:
+            fdeclr = _function_declarator(d)
+            if fdeclr is not None:  # free-function prototype → placeholder
+                name = _declarator_name(fdeclr, ctx.source)
+                if name:
+                    fid = f"cpp:{_join(ns, name)}"
+                    line = node.start_point[0] + 1
+                    ctx.batch.add_node(
+                        Node(fid, NodeKind.FUNCTION, name, "cpp", Provenance(ctx.rel, line), external=True)
+                    )
+                    ctx.batch.add_edge(Edge(ctx.module_id, fid, EdgeKind.CONTAINS, Provenance(ctx.rel, line)))
+                    ctx.free_funcs.setdefault(name, fid)
+                continue
+            vname = _declarator_name(d, ctx.source)
+            if vname:
+                vid = f"cpp:{_join(ns, vname)}"
+                line = d.start_point[0] + 1
+                ctx.batch.add_node(Node(vid, NodeKind.FIELD, vname, "cpp", Provenance(ctx.rel, line)))
+                ctx.batch.add_edge(Edge(ctx.module_id, vid, EdgeKind.CONTAINS, Provenance(ctx.rel, line)))
+
+    # --- CALLS (3.3) ---------------------------------------------------------
+
+    def _calls(self, caller: str, type_id: str | None, body: TSNode, ctx: _Ctx) -> None:
+        siblings = ctx.type_methods.get(type_id or "", set())
+        stack = list(body.named_children)
+        while stack:
+            n = stack.pop()
+            if n.type == "call_expression":
+                fn = n.child_by_field_name("function")
+                target = _resolve_callee(fn, ctx.source, siblings, type_id, ctx.free_funcs)
+                if target is not None:
+                    ctx.batch.add_edge(
+                        Edge(caller, target, EdgeKind.CALLS, Provenance(ctx.rel, n.start_point[0] + 1))
+                    )
+            stack.extend(n.named_children)
+
+
+class _Ctx:
+    """Threaded extraction state (keeps method signatures short)."""
+
+    def __init__(
+        self,
+        module_id: str,
+        path: Path,
+        source: bytes,
+        rel: str,
+        batch: FactBatch,
+        funcs: list[tuple[str, str | None, Any]],
+        free_funcs: dict[str, str],
+        type_methods: dict[str, set[str]],
+    ) -> None:
+        self.module_id = module_id
+        self.path = path
+        self.source = source
+        self.rel = rel
+        self.batch = batch
+        self.funcs = funcs
+        self.free_funcs = free_funcs
+        self.type_methods = type_methods
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _member(type_id: str, name: str, kind: NodeKind, line: int, ctx: _Ctx) -> None:
+    mid = f"{type_id}::{name}"
+    ctx.batch.add_node(Node(mid, kind, name, "cpp", Provenance(ctx.rel, line)))
+    ctx.batch.add_edge(Edge(type_id, mid, EdgeKind.CONTAINS, Provenance(ctx.rel, line)))
+
+
+def _resolve_callee(
+    fn: TSNode | None, source: bytes, siblings: set[str], type_id: str | None, free_funcs: dict[str, str]
+) -> str | None:
+    """The called function's node id, or ``None`` when it can't be resolved precisely."""
+    if fn is None:
+        return None
+    if fn.type == "identifier":
+        name = _text(fn, source)
+        if type_id and name in siblings:
+            return f"{type_id}::{name}"  # unqualified sibling-method call
+        return free_funcs.get(name, f"cpp:{name}")  # free function (name-keyed)
+    if fn.type == "qualified_identifier":
+        return f"cpp:{_qualified_text(fn, source)}"  # Namespace::func or Class::method
+    if fn.type == "field_expression":
+        # obj.method() / this->method() — only resolvable to a sibling on `this`.
+        arg = fn.child_by_field_name("argument")
+        field = fn.child_by_field_name("field")
+        if arg is not None and arg.type == "this" and field is not None and type_id:
+            name = _text(field, source)
+            if name in siblings:
+                return f"{type_id}::{name}"
+    return None
+
+
+def _qualified_text(node: TSNode, source: bytes) -> str:
+    """A qualified identifier / type name with all whitespace removed. Out-of-line
+    definitions can wrap the line between `::` and the name (`connection::\\n  read`)
+    or around `<...>`; the raw source slice would carry that whitespace into the node
+    id/name, so collapse it (qualified ids have no semantic whitespace)."""
+    return "".join(_text(node, source).split())
+
+
+def _template_params(node: TSNode, source: bytes) -> frozenset[str]:
+    """The type-parameter names of a ``template_declaration`` (``T``, ``U``) — excluded
+    from REFERENCES so a member of template type isn't read as a concrete type."""
+    plist = node.child_by_field_name("parameters")
+    if plist is None:
+        plist = next((c for c in node.named_children if c.type == "template_parameter_list"), None)
+    if plist is None:
+        return frozenset()
+    names: set[str] = set()
+    for p in plist.named_children:
+        ident = next((c for c in p.named_children if c.type == "type_identifier"), None)
+        if ident is not None:
+            names.add(_text(ident, source))
+    return frozenset(names)
+
+
+def _base_types(spec: TSNode, source: bytes) -> list[str]:
+    """Base-class names from a ``base_class_clause`` (drops access specifiers/virtual)."""
+    clause = next((c for c in spec.named_children if c.type == "base_class_clause"), None)
+    if clause is None:
+        return []
+    out: list[str] = []
+    for c in clause.named_children:
+        if c.type in ("type_identifier", "qualified_identifier", "template_type"):
+            out.append(_qualified_text(c, source).split("<", 1)[0])
+    return out
+
+
+def _join(ns: str, name: str) -> str:
+    if ns and name:
+        return f"{ns}::{name}"
+    return name or ns
+
+
+def _qual_name(type_id: str) -> str:
+    return type_id.split(":", 1)[1] if ":" in type_id else type_id
+
+
+def _cpp_parser() -> Any:
+    try:
+        import tree_sitter_cpp
+        from tree_sitter import Language, Parser
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise RuntimeError(
+            "C++ extraction needs tree-sitter; install the extra: "
+            "uv pip install 'tree-sitter>=0.21' 'tree-sitter-cpp>=0.21'"
+        ) from exc
+    language = Language(tree_sitter_cpp.language())
+    try:
+        return Parser(language)
+    except TypeError:  # older tree-sitter API
+        parser = Parser()
+        parser.language = language
+        return parser
+
+
+__all__ = ["CppExtractor"]

--- a/src/orchestrator/pkg/extractor.py
+++ b/src/orchestrator/pkg/extractor.py
@@ -458,6 +458,10 @@ def default_extractors() -> list[LanguageExtractor]:
         from orchestrator.pkg.c_extractor import CExtractor
 
         extractors.append(CExtractor())
+    if has_tree_sitter and importlib.util.find_spec("tree_sitter_cpp"):
+        from orchestrator.pkg.cpp_extractor import CppExtractor
+
+        extractors.append(CppExtractor())
     return extractors
 
 

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -508,6 +508,46 @@ _REFINE_SYSTEM_C = (
     "build + tests green. Same path rules — relative, no '..'."
 )
 
+# C++ (CMake/ctest) variants — selected when the layout's language is "cpp".
+_IMPLEMENT_SYSTEM_CPP = (
+    "You are a senior engineer. Implement the feature described by the SPEC as "
+    "runnable C++ inside the given CMake project (the worktree).\n\n"
+    "Output ONE JSON object, no prose, no code fences:\n"
+    f"{_FILE_FORMS}\n"
+    "Rules: paths are relative to the worktree root — no leading slash, no '..'. "
+    "Write source files only (NO test files here). Declare classes/functions in a "
+    "header (`.hpp`) under the source dir with an include guard or `#pragma once`; "
+    "define them in a matching `.cpp`. Write modern C++17 with RAII/ownership "
+    "discipline (no raw owning pointers; prefer references / smart pointers), using "
+    "only the standard library. New `src/*.cpp` are picked up by CMake's glob — edit "
+    "`CMakeLists.txt` only to add an external dependency. Every file must compile."
+)
+
+_TESTS_SYSTEM_CPP = (
+    "You write C++ unit tests for an already-implemented feature. You are given the "
+    "SPEC and the CURRENT SOURCE FILES.\n\n"
+    "Output ONE JSON object, no prose, no code fences:\n"
+    f"{_FILE_FORMS}\n"
+    "Rules: write test files only, under the tests dir shown in the layout, named "
+    "`test_<name>.cpp`. Each is a standalone program with `int main()` that exercises "
+    "the feature and returns 0 on success, non-zero on failure (use `<cassert>` or "
+    "explicit `if (...) return 1;`). `#include` the public header from the source dir. "
+    "Each `tests/*.cpp` becomes a ctest executable linked against the library "
+    "automatically. Each acceptance criterion maps to at least one assertion."
+)
+
+_REFINE_SYSTEM_CPP = (
+    "You are fixing a failing CMake build / ctest run (a configure error, a C++ "
+    "compiler error, or a failing assertion). You are given the SPEC, the CURRENT "
+    "FILES, and the FAILURE OUTPUT.\n\n"
+    "Output ONE JSON object, no prose, no code fences:\n"
+    f"{_FILE_FORMS}\n"
+    "Rules: files you created earlier this session may be resent in full via "
+    "`content`; any other existing file must be changed via `edits` (including "
+    "`CMakeLists.txt`). Make the smallest change that turns the build + tests green. "
+    "Same path rules — relative, no '..'."
+)
+
 # Phase system prompts keyed by language (default: Python). Adding a language is a
 # new column here, not another boolean branch at each call site.
 _IMPLEMENT_SYSTEMS = {
@@ -516,6 +556,7 @@ _IMPLEMENT_SYSTEMS = {
     "typescript": _IMPLEMENT_SYSTEM_TS,
     "csharp": _IMPLEMENT_SYSTEM_CSHARP,
     "c": _IMPLEMENT_SYSTEM_C,
+    "cpp": _IMPLEMENT_SYSTEM_CPP,
 }
 _TESTS_SYSTEMS = {
     "python": _TESTS_SYSTEM,
@@ -523,6 +564,7 @@ _TESTS_SYSTEMS = {
     "typescript": _TESTS_SYSTEM_TS,
     "csharp": _TESTS_SYSTEM_CSHARP,
     "c": _TESTS_SYSTEM_C,
+    "cpp": _TESTS_SYSTEM_CPP,
 }
 _REFINE_SYSTEMS = {
     "python": _REFINE_SYSTEM,
@@ -530,6 +572,7 @@ _REFINE_SYSTEMS = {
     "typescript": _REFINE_SYSTEM_TS,
     "csharp": _REFINE_SYSTEM_CSHARP,
     "c": _REFINE_SYSTEM_C,
+    "cpp": _REFINE_SYSTEM_CPP,
 }
 
 
@@ -738,6 +781,25 @@ class LLMCodegenAdapter:
                 f"- Put tests at `{layout.tests_dir}/test_<name>.c` — each a standalone "
                 "`int main(void)` returning non-zero on failure, `#include`-ing the "
                 f"header from `{layout.source_dir}/`.\n"
+                f"{build_line} Don't invent unrelated paths.\n\n"
+            )
+        if layout.language == "cpp":
+            meson = layout.build_tool == "meson"
+            build_line = (
+                "- Meson (`meson.build`) does NOT glob: register new `.cpp` sources + an "
+                "`executable()`+`test()` per new `tests/*.cpp` in `meson.build`."
+                if meson
+                else "- New `src/*.cpp` and `tests/*.cpp` are auto-discovered by CMake's glob; "
+                "edit `CMakeLists.txt` only to add a dependency."
+            )
+            return (
+                "PROJECT LAYOUT (authoritative — overrides any default path guidance):\n"
+                f"- Declare classes/functions in `{layout.source_dir}/<name>.hpp` (include "
+                f"guard or `#pragma once`) and define them in `{layout.source_dir}/<name>.cpp`; "
+                "modern C++17, RAII, standard library only.\n"
+                f"- Put tests at `{layout.tests_dir}/test_<name>.cpp` — each a standalone "
+                "`int main()` returning non-zero on failure, `#include`-ing the header from "
+                f"`{layout.source_dir}/`.\n"
                 f"{build_line} Don't invent unrelated paths.\n\n"
             )
         return (

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -122,6 +122,8 @@ def _resolve_language(path: Path, requested: str) -> str:
             return "typescript"
         if "csharp" in langs:
             return "csharp"
+        if "cpp" in langs:
+            return "cpp"
         if "c" in langs:
             return "c"
     return "python"
@@ -163,6 +165,7 @@ async def run_feature(
     from orchestrator.sdlc.scaffold import scaffold
     from orchestrator.sdlc.testenv import (
         c_toolchain_available,
+        cpp_toolchain_available,
         detect_dotnet_tfm,
         dotnet_toolchain_available,
         java_toolchain_available,
@@ -290,33 +293,36 @@ async def run_feature(
             "C# codegen needs the .NET SDK (`dotnet`) on PATH (install it, then retry).",
             code=2,
         )
-    elif lang == "c":
+    elif lang in ("c", "cpp"):
         # Greenfield always scaffolds a CMake project; brownfield uses the repo's own
         # build system (CMake or Meson). Preflight the matching toolchain and fail
         # fast with a clear message rather than a cryptic build error in refine.
+        label = "C++" if lang == "cpp" else "C"
+        cmake_ok = cpp_toolchain_available if lang == "cpp" else c_toolchain_available
         build_tool = layout.build_tool if layout.mode == "existing" else "cmake"
         if build_tool == "meson":
             if not meson_toolchain_available():
                 raise FeatureRunError(
-                    "Meson C codegen needs meson + ninja + a C compiler (cc/gcc/clang) on PATH "
+                    f"Meson {label} codegen needs meson + ninja + a compiler on PATH "
                     "(install them, then retry).",
                     code=2,
                 )
         elif build_tool in ("cmake", ""):
-            if not c_toolchain_available():
+            if not cmake_ok():
                 raise FeatureRunError(
-                    "C codegen needs CMake + a C compiler (cc/gcc/clang) on PATH (install both, then retry).",
+                    f"{label} codegen needs CMake + a {label} compiler on PATH (install both, then retry).",
                     code=2,
                 )
             if layout.mode == "existing" and not (path / "CMakeLists.txt").is_file():
                 raise FeatureRunError(
-                    "C codegen builds with CMake or Meson, but this repo has neither a "
+                    f"{label} codegen builds with CMake or Meson, but this repo has neither a "
                     "CMakeLists.txt nor a recognized meson.build.",
                     code=2,
                 )
         else:  # make or another unrecognized build system
             raise FeatureRunError(
-                f"C codegen builds with CMake or Meson, but this repo uses {build_tool} (not supported yet).",
+                f"{label} codegen builds with CMake or Meson, but this repo uses "
+                f"{build_tool} (not supported yet).",
                 code=2,
             )
     # ``ensure`` may install deps (Node ``<pm> install``); run it after the

--- a/src/orchestrator/sdlc/layout.py
+++ b/src/orchestrator/sdlc/layout.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import keyword
 import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -31,7 +32,7 @@ _FALLBACK_PACKAGE = "app"
 _JAVA_GROUP = "org.example"  # default reverse-DNS group for greenfield Java
 
 # Source-file extension per language (Python is the default).
-_SOURCE_EXT = {"java": "java", "typescript": "ts", "csharp": "cs", "c": "c"}
+_SOURCE_EXT = {"java": "java", "typescript": "ts", "csharp": "cs", "c": "c", "cpp": "cpp"}
 
 
 @dataclass(frozen=True)
@@ -320,18 +321,32 @@ def _detect_c_build_tool(root: Path) -> str:
     return ""
 
 
-def detect_c_layout(root: Path) -> tuple[str, str, str] | None:
-    """If the repo is a recognizable C project (CMake or Make), return
-    ``(package, source_dir, tests_dir)``. The package is the CMake ``project()`` name
-    when parseable, else derived; ``source_dir`` is ``src`` when it holds ``.c`` files,
-    else the repo root."""
+# Source globs that mark a directory as a native (C / C++) source dir.
+_C_SRC_GLOBS = ("*.c",)
+_CPP_SRC_GLOBS = ("*.cpp", "*.cc", "*.cxx")
+
+
+def _detect_native_layout(root: Path, src_globs: tuple[str, ...]) -> tuple[str, str, str] | None:
+    """Shared C/C++ layout detection: a recognizable CMake/Meson/Make project →
+    ``(package, source_dir, tests_dir)``. ``source_dir`` is ``src`` when it holds
+    matching source files, else the repo root."""
     if _detect_c_build_tool(root) == "":
         return None
     package = _read_cmake_project_name(root) or derive_package_name(str(root))
     src = root / "src"
-    source_dir = "src" if src.is_dir() and any(src.glob("*.c")) else "."
+    source_dir = "src" if src.is_dir() and any(src.glob(g) for g in src_globs) else "."
     tests_dir = "tests" if (root / "tests").is_dir() else source_dir
     return package, source_dir, tests_dir
+
+
+def detect_c_layout(root: Path) -> tuple[str, str, str] | None:
+    """``(package, source_dir, tests_dir)`` for a recognizable C (CMake/Meson/Make) repo."""
+    return _detect_native_layout(root, _C_SRC_GLOBS)
+
+
+def detect_cpp_layout(root: Path) -> tuple[str, str, str] | None:
+    """``(package, source_dir, tests_dir)`` for a recognizable C++ (CMake/Meson) repo."""
+    return _detect_native_layout(root, _CPP_SRC_GLOBS)
 
 
 def _read_cmake_project_name(root: Path) -> str | None:
@@ -342,8 +357,16 @@ def _read_cmake_project_name(root: Path) -> str | None:
     return m.group(1) if m else None
 
 
-def _resolve_c_layout(root: Path, *, mode: str, package_name: str | None, repo: str | None) -> TargetLayout:
-    existing = detect_c_layout(root)
+def _resolve_native_layout(
+    root: Path,
+    *,
+    mode: str,
+    package_name: str | None,
+    repo: str | None,
+    language: str,
+    detect: Callable[[Path], tuple[str, str, str] | None],
+) -> TargetLayout:
+    existing = detect(root)
     derived = package_name or derive_package_name(repo or str(root))
     build_tool = _detect_c_build_tool(root) or "cmake"
     if mode == "existing" or (mode == "auto" and existing is not None):
@@ -355,11 +378,25 @@ def _resolve_c_layout(root: Path, *, mode: str, package_name: str | None, repo: 
                 tests_dir=tests_dir,
                 src_layout=source_dir.startswith("src"),
                 mode="existing",
-                language="c",
+                language=language,
                 build_tool=build_tool,
             )
-        return TargetLayout(derived, "src", "tests", True, "existing", language="c", build_tool=build_tool)
-    return TargetLayout(derived, "src", "tests", True, "new", language="c", build_tool="cmake")
+        return TargetLayout(
+            derived, "src", "tests", True, "existing", language=language, build_tool=build_tool
+        )
+    return TargetLayout(derived, "src", "tests", True, "new", language=language, build_tool="cmake")
+
+
+def _resolve_c_layout(root: Path, *, mode: str, package_name: str | None, repo: str | None) -> TargetLayout:
+    return _resolve_native_layout(
+        root, mode=mode, package_name=package_name, repo=repo, language="c", detect=detect_c_layout
+    )
+
+
+def _resolve_cpp_layout(root: Path, *, mode: str, package_name: str | None, repo: str | None) -> TargetLayout:
+    return _resolve_native_layout(
+        root, mode=mode, package_name=package_name, repo=repo, language="cpp", detect=detect_cpp_layout
+    )
 
 
 def is_effectively_empty(root: Path) -> bool:
@@ -404,6 +441,8 @@ def resolve_layout(
         return _resolve_csharp_layout(root_path, mode=mode, package_name=package_name, repo=repo)
     if language == "c":
         return _resolve_c_layout(root_path, mode=mode, package_name=package_name, repo=repo)
+    if language == "cpp":
+        return _resolve_cpp_layout(root_path, mode=mode, package_name=package_name, repo=repo)
     existing = detect_existing_package(root_path)
     derived = package_name or derive_package_name(repo or str(root_path))
 
@@ -433,6 +472,7 @@ __all__ = [
     "derive_npm_package",
     "derive_package_name",
     "detect_c_layout",
+    "detect_cpp_layout",
     "detect_csharp_layout",
     "detect_existing_package",
     "detect_java_layout",

--- a/src/orchestrator/sdlc/scaffold.py
+++ b/src/orchestrator/sdlc/scaffold.py
@@ -85,6 +85,8 @@ def scaffold(root: Path | str, layout: TargetLayout, *, profile: ProjectProfile 
         files = _csharp_files(layout)
     elif layout.language == "c":
         files = _c_files(layout)
+    elif layout.language == "cpp":
+        files = _cpp_files(layout)
     else:
         files = _python_files(layout)
 
@@ -98,7 +100,7 @@ def scaffold(root: Path | str, layout: TargetLayout, *, profile: ProjectProfile 
         created.append(rel)
     if layout.language == "csharp":
         created += _ensure_build_ignores(root_path, ("bin", "obj"))
-    elif layout.language == "c":
+    elif layout.language in ("c", "cpp"):
         created += _ensure_build_ignores(root_path, ("build",))
     return created
 
@@ -382,6 +384,61 @@ build/
 *.so
 *.dylib
 compile_commands.json
+"""
+
+
+def _cpp_files(layout: TargetLayout) -> dict[str, str]:
+    # A CMake (CXX) project: src/*.cpp glob into a library, each tests/*.cpp into a
+    # ctest executable (assert-based main, offline — no Catch2/GTest fetch needed).
+    name = layout.package_name
+    guard = f"{name.upper()}_HPP"
+    cmake = _CMAKELISTS_CPP.replace("__name__", name)
+    header = _CPP_HEADER.replace("__guard__", guard).replace("__name__", name)
+    return {
+        "CMakeLists.txt": cmake,
+        f"{layout.source_dir}/{name}.hpp": header,
+        f"{layout.source_dir}/{name}.cpp": f'#include "{name}.hpp"\n',
+        f"{layout.tests_dir}/.gitkeep": "",
+        "README.md": _README_TEMPLATE.format(
+            package=layout.package_name,
+            source_dir=layout.source_dir,
+            tests_dir=layout.tests_dir,
+        ),
+        ".gitignore": _C_GITIGNORE,
+    }
+
+
+_CMAKELISTS_CPP = """\
+cmake_minimum_required(VERSION 3.15)
+project(__name__ CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Library built from everything under src/.
+file(GLOB __name___SOURCES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/src/*.cpp")
+add_library(__name__ ${__name___SOURCES})
+target_include_directories(__name__ PUBLIC "${CMAKE_SOURCE_DIR}/src")
+
+# Tests: each tests/*.cpp is a ctest executable linked against the library.
+enable_testing()
+file(GLOB __name___TESTS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/tests/*.cpp")
+foreach(test_file ${__name___TESTS})
+    get_filename_component(test_name ${test_file} NAME_WE)
+    add_executable(${test_name} ${test_file})
+    target_link_libraries(${test_name} __name__)
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()
+"""
+
+_CPP_HEADER = """\
+#ifndef __guard__
+#define __guard__
+
+// Public API for __name__. Declare classes/functions here; define them in __name__.cpp.
+
+#endif  // __guard__
 """
 
 

--- a/src/orchestrator/sdlc/testenv.py
+++ b/src/orchestrator/sdlc/testenv.py
@@ -271,9 +271,18 @@ def _c_compiler_available() -> bool:
     return any(shutil.which(cc) is not None for cc in ("cc", "gcc", "clang"))
 
 
+def _cpp_compiler_available() -> bool:
+    return any(shutil.which(cc) is not None for cc in ("c++", "g++", "clang++"))
+
+
 def c_toolchain_available() -> bool:
     """True if CMake and a C compiler are on PATH (CMake C codegen prerequisite)."""
     return shutil.which("cmake") is not None and _c_compiler_available()
+
+
+def cpp_toolchain_available() -> bool:
+    """True if CMake and a C++ compiler are on PATH (CMake C++ codegen prerequisite)."""
+    return shutil.which("cmake") is not None and _cpp_compiler_available()
 
 
 def meson_toolchain_available() -> bool:
@@ -317,7 +326,7 @@ def make_test_environment(language: str = "python", *, build_tool: str = "") -> 
         return NodeToolEnvironment(build_tool or "npm")
     if language == "csharp":
         return DotnetToolEnvironment()
-    if language == "c":
+    if language in ("c", "cpp"):
         return CToolEnvironment(build_tool or "cmake")
     if os.getenv("SDLC_TEST_ISOLATION", "venv").lower() == "local":
         return LocalTestEnvironment()
@@ -342,8 +351,8 @@ def make_test_runner(language: str, env: TestEnvironment) -> TestRunner:
         return NodeTestRunner(package_manager=getattr(env, "package_manager", "npm"))
     if language == "csharp":
         return DotnetTestRunner()
-    if language == "c":
-        # The build tool (cmake/meson) is carried on the C tool environment.
+    if language in ("c", "cpp"):
+        # The build tool (cmake/meson) is carried on the C/C++ tool environment.
         return MesonTestRunner() if getattr(env, "build_tool", "cmake") == "meson" else CTestRunner()
     return SubprocessTestRunner(python=env.python)
 
@@ -472,6 +481,7 @@ __all__ = [
     "TestEnvironment",
     "VenvTestEnvironment",
     "c_toolchain_available",
+    "cpp_toolchain_available",
     "detect_dotnet_tfm",
     "dotnet_toolchain_available",
     "java_toolchain_available",

--- a/tests/knowledge/test_current_state.py
+++ b/tests/knowledge/test_current_state.py
@@ -112,6 +112,30 @@ def test_area_groups_by_directory_for_path_modules() -> None:
     assert _area("App.Api.Controllers") == "App.Api"
 
 
+def test_function_areas_group_by_owning_module_not_symbol_id() -> None:
+    # Regression: C/C++ function ids are symbols (`cpp:HSL2RGB`, `cpp:Conn::read`),
+    # not locations. Areas must come from the function's owning module / source file —
+    # otherwise every function becomes its own component (and its own zone), flooding
+    # the layout with thousands of one-fn entries on a real C++ repo.
+    b = FactBatch()
+    mod = _node("cpp:lib/svm/svm.cpp", NodeKind.MODULE, "lib/svm/svm.cpp", "lib/svm/svm.cpp")
+    b.add_node(mod)
+    # A free function contained directly by the module.
+    free = Node("cpp:HSL2RGB", NodeKind.FUNCTION, "HSL2RGB", "cpp", Provenance("lib/svm/svm.cpp", 5))
+    b.add_node(free)
+    b.add_edge(Edge(mod.id, free.id, EdgeKind.CONTAINS, Provenance("lib/svm/svm.cpp", 5)))
+    # A method whose class lives in a `.h` (no owning module node) — must fall back to
+    # the source file it's defined in, not its `Conn::read` symbol id.
+    meth = Node("cpp:Conn::read", NodeKind.FUNCTION, "read", "cpp", Provenance("lib/svm/svm.cpp", 9))
+    b.add_node(meth)
+    b.add_edge(Edge("cpp:Conn", meth.id, EdgeKind.CONTAINS, Provenance("lib/svm/svm.cpp", 9)))
+
+    s = compute_current_state(b, _PROFILE)
+    assert set(s.area_funcs) == {"lib/svm"}  # both collapse to the directory component
+    assert s.area_funcs["lib/svm"] == 2
+    assert "HSL2RGB" not in s.area_funcs and "Conn::read" not in s.area_funcs
+
+
 def test_call_graph_hotspots_rendered() -> None:
     # Functions with the most incoming CALLS edges surface as "most-depended-upon".
     b = FactBatch()

--- a/tests/pkg/test_cpp_extractor.py
+++ b/tests/pkg/test_cpp_extractor.py
@@ -1,0 +1,133 @@
+"""PKG: the C++ front-end — a C superset adding classes/namespaces/inheritance (Track 3).
+
+Reuses the C track's include graph + header-merge; adds the OO layer. tree-sitter-cpp
+is an optional extra, so these skip when it's absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestrator.pkg.cpp_extractor import CppExtractor
+from orchestrator.pkg.facts import EdgeKind, FactBatch, NodeKind
+
+pytest.importorskip("tree_sitter_cpp", reason="install the 'cpp' extra")
+
+
+def _extract(root: Path, *rels: str) -> FactBatch:
+    ex = CppExtractor()
+    batch = FactBatch()
+    for rel in rels:
+        f = root / rel
+        batch.merge(ex.extract(path=f, module=ex.module_name(f, root), rel=rel))
+    return batch
+
+
+def _write(root: Path, rel: str, src: str) -> None:
+    (root / rel).parent.mkdir(parents=True, exist_ok=True)
+    (root / rel).write_text(src, encoding="utf-8")
+
+
+SHAPE_HPP = """\
+#ifndef SHAPE_HPP
+#define SHAPE_HPP
+namespace geo {
+class Shape {
+public:
+    virtual double area() const = 0;
+    int id;
+};
+class Circle : public Shape {
+    double r;
+public:
+    Circle(double radius);
+    double area() const override;
+};
+struct Line { Shape* start; Shape* end; };
+enum Axis { X, Y };
+}
+template <typename T> class Box { T value; public: T get(); };
+int helper(int n);
+#endif
+"""
+
+SHAPES_CPP = """\
+#include "shape.hpp"
+namespace geo {
+double Circle::area() const { return helper(3) * 3.14; }
+}
+int helper(int n) { return n * 2; }
+int compute(int n) { return helper(n) + n; }
+"""
+
+
+def _shapes(tmp_path: Path, order: tuple[str, ...] = ("shape.hpp", "shapes.cpp")) -> FactBatch:
+    _write(tmp_path, "shape.hpp", SHAPE_HPP)
+    _write(tmp_path, "shapes.cpp", SHAPES_CPP)
+    return _extract(tmp_path, *order)
+
+
+def test_namespaced_classes_structs_enums(tmp_path: Path) -> None:
+    by_id = {n.id: n for n in _shapes(tmp_path).nodes}
+    assert by_id["cpp:geo::Shape"].kind is NodeKind.TYPE
+    assert by_id["cpp:geo::Circle"].kind is NodeKind.TYPE
+    assert by_id["cpp:geo::Line"].kind is NodeKind.TYPE
+    assert by_id["cpp:geo::Axis"].kind is NodeKind.TYPE
+    assert by_id["cpp:Box"].kind is NodeKind.TYPE  # template class
+    # members: a method, a field, an enum constant
+    assert by_id["cpp:geo::Circle::area"].kind is NodeKind.FUNCTION
+    assert by_id["cpp:geo::Circle::r"].kind is NodeKind.FIELD
+    assert by_id["cpp:geo::Axis::X"].kind is NodeKind.FIELD
+
+
+def test_inheritance_is_implements(tmp_path: Path) -> None:
+    edges = {(e.src, e.dst) for e in _shapes(tmp_path).edges if e.kind is EdgeKind.IMPLEMENTS}
+    assert ("cpp:geo::Circle", "cpp:geo::Shape") in edges  # base class, namespace-resolved
+
+
+@pytest.mark.parametrize("order", [("shape.hpp", "shapes.cpp"), ("shapes.cpp", "shape.hpp")])
+def test_out_of_line_method_merges_to_definition(tmp_path: Path, order: tuple[str, ...]) -> None:
+    # the in-class declaration and the out-of-line `Circle::area` definition collapse
+    # to one node whose provenance is the definition — regardless of file order.
+    area = {n.id: n for n in _shapes(tmp_path, order).nodes}["cpp:geo::Circle::area"]
+    assert area.grounded is True
+    assert area.provenance is not None and area.provenance.file == "shapes.cpp"
+
+
+def test_calls_free_and_member(tmp_path: Path) -> None:
+    calls = {(e.src, e.dst) for e in _shapes(tmp_path).edges if e.kind is EdgeKind.CALLS}
+    assert ("cpp:compute", "cpp:helper") in calls  # free → free
+    assert ("cpp:geo::Circle::area", "cpp:helper") in calls  # member → free
+
+
+def test_references_member_of_type_excludes_template_param(tmp_path: Path) -> None:
+    refs = {(e.src, e.dst) for e in _shapes(tmp_path).edges if e.kind is EdgeKind.REFERENCES}
+    assert ("cpp:geo::Line", "cpp:geo::Shape") in refs  # struct member of class type
+    assert ("cpp:Box", "cpp:T") not in refs  # T is a template parameter, not a type
+
+
+def test_include_resolution(tmp_path: Path) -> None:
+    batch = _shapes(tmp_path)
+    by_id = {n.id: n for n in batch.nodes}
+    imports = {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.IMPORTS}
+    assert ("cpp:shapes.cpp", "cpp:shape.hpp") in imports
+    assert by_id["cpp:shape.hpp"].grounded is True  # local header resolved in-repo
+
+
+def test_multiple_inheritance(tmp_path: Path) -> None:
+    src = "struct A {}; struct B {}; class C : public A, public B { int x; };\n"
+    _write(tmp_path, "multi.cpp", src)
+    edges = {(e.src, e.dst) for e in _extract(tmp_path, "multi.cpp").edges if e.kind is EdgeKind.IMPLEMENTS}
+    assert ("cpp:C", "cpp:A") in edges and ("cpp:C", "cpp:B") in edges
+
+
+def test_out_of_line_qualified_name_normalizes_whitespace(tmp_path: Path) -> None:
+    # Out-of-line definitions often wrap the line between `::` and the name; the node
+    # id/name must not carry that newline/indentation (`Conn::\n  read` → `Conn::read`).
+    _write(tmp_path, "conn.cpp", "struct Conn { int read(); };\nint Conn::\n    read() { return 0; }\n")
+    by_id = {n.id: n for n in _extract(tmp_path, "conn.cpp").nodes}
+    assert "cpp:Conn::read" in by_id
+    assert by_id["cpp:Conn::read"].name == "read"  # no embedded whitespace
+    assert not any("\n" in n.id or "\n" in n.name for n in by_id.values())

--- a/tests/pkg/test_default_extractors.py
+++ b/tests/pkg/test_default_extractors.py
@@ -40,6 +40,12 @@ def test_default_includes_c_when_available() -> None:
     assert ("c" in langs) == have_c
 
 
+def test_default_includes_cpp_when_available() -> None:
+    have_cpp = importlib.util.find_spec("tree_sitter_cpp") is not None
+    langs = {e.language for e in default_extractors()}
+    assert ("cpp" in langs) == have_cpp
+
+
 def test_repo_extractor_default_handles_java(tmp_path: Path) -> None:
     pytest.importorskip("tree_sitter_java", reason="install the 'java' extra")
     src = tmp_path / "src" / "main" / "java" / "com" / "demo"
@@ -87,3 +93,14 @@ def test_repo_extractor_default_handles_c(tmp_path: Path) -> None:
     types = {n.name for n in batch.nodes if n.kind is NodeKind.TYPE and n.language == "c"}
     funcs = {n.name for n in batch.nodes if n.kind is NodeKind.FUNCTION and n.language == "c"}
     assert "Widget" in types and "widget_score" in funcs
+
+
+def test_repo_extractor_default_handles_cpp(tmp_path: Path) -> None:
+    pytest.importorskip("tree_sitter_cpp", reason="install the 'cpp' extra")
+    (tmp_path / "widget.cpp").write_text(
+        "namespace app {\nclass Widget {\npublic:\n  int score() const;\n};\n}\n"
+        "int app::Widget::score() const { return 1; }\n"
+    )
+    batch = RepoCodeExtractor().extract(tmp_path)
+    types = {n.name for n in batch.nodes if n.kind is NodeKind.TYPE and n.language == "cpp"}
+    assert "Widget" in types

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -383,6 +383,31 @@ async def test_c_layout_selects_c_prompts(tmp_path: Path) -> None:
     assert "#ifndef" in llm.calls[0][-1].content  # header-guard hint
 
 
+async def test_cpp_layout_selects_cpp_prompts(tmp_path: Path) -> None:
+    """A C++ layout switches the phases to the CMake/ctest C++ prompts and pins the
+    header/source + RAII conventions in the layout block."""
+    from orchestrator.sdlc.layout import TargetLayout
+
+    layout = TargetLayout("vec", "src", "tests", True, "new", language="cpp", build_tool="cmake")
+    llm = _ScriptedLLM(
+        [
+            _files_response({"src/vec.cpp": '#include "vec.hpp"\n'}),
+            _files_response({"tests/test_vec.cpp": '#include "vec.hpp"\nint main(){return 0;}\n'}),
+            _files_response({"src/vec.cpp": '#include "vec.hpp"\n'}),
+        ]
+    )
+    adapter = LLMCodegenAdapter(llm, layout=layout)
+    await adapter.implement(spec=_SPEC, path=str(tmp_path), issue_key="P-1")
+    await adapter.author_tests(spec=_SPEC, path=str(tmp_path), issue_key="P-1")
+    await adapter.refine(spec=_SPEC, path=str(tmp_path), issue_key="P-1", failures="error: expected ';'")
+
+    assert "runnable C++" in llm.calls[0][0].content  # implement system prompt
+    assert "C++ unit tests" in llm.calls[1][0].content  # author_tests system prompt
+    assert "CMakeLists.txt" in llm.calls[2][0].content  # refine system prompt
+    assert "test_<name>.cpp" in llm.calls[0][-1].content  # layout block (user)
+    assert ".hpp" in llm.calls[0][-1].content  # header-discipline hint
+
+
 async def test_no_layout_block_when_layout_unset(tmp_path: Path) -> None:
     """Backward compatible: without a layout, the prompt carries no layout block."""
     llm = _ScriptedLLM([_files_response({"m.py": "x = 1\n"})])

--- a/tests/sdlc/test_layout.py
+++ b/tests/sdlc/test_layout.py
@@ -251,3 +251,22 @@ class TestCLayout:
         assert detect_c_layout(tmp_path) is not None
         layout = resolve_layout(tmp_path, mode="existing", language="c")
         assert layout.build_tool == "meson"
+
+
+class TestCppLayout:
+    def test_new_cpp_cmake_layout(self, tmp_path: Path) -> None:
+        layout = resolve_layout(tmp_path, mode="new", language="cpp", repo="https://x/Vec-Lib")
+        assert layout.language == "cpp" and layout.build_tool == "cmake" and layout.mode == "new"
+        assert layout.package_name == "vec_lib"
+        assert layout.source_dir == "src" and layout.tests_dir == "tests"
+        assert layout.module_rel_path("vector") == "src/vector.cpp"
+
+    def test_detect_existing_cpp_project(self, tmp_path: Path) -> None:
+        from orchestrator.sdlc.layout import detect_cpp_layout
+
+        (tmp_path / "CMakeLists.txt").write_text("project(engine CXX)\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "a.cpp").write_text("int x;\n")
+        (tmp_path / "tests").mkdir()
+        # src holds .cpp → it's the source dir; package from the CMake project() name.
+        assert detect_cpp_layout(tmp_path) == ("engine", "src", "tests")

--- a/tests/sdlc/test_scaffold.py
+++ b/tests/sdlc/test_scaffold.py
@@ -200,6 +200,35 @@ def test_scaffold_c_is_idempotent(tmp_path: Path) -> None:
     assert scaffold(tmp_path, _C_LAYOUT) == []
 
 
+_CPP_LAYOUT = TargetLayout(
+    package_name="vec_lib",
+    source_dir="src",
+    tests_dir="tests",
+    src_layout=True,
+    mode="new",
+    language="cpp",
+    build_tool="cmake",
+)
+
+
+def test_scaffold_cpp_cmake_project(tmp_path: Path) -> None:
+    created = scaffold(tmp_path, _CPP_LAYOUT)
+    assert "CMakeLists.txt" in created
+    assert "src/vec_lib.cpp" in created and "src/vec_lib.hpp" in created
+    cmake = (tmp_path / "CMakeLists.txt").read_text()
+    assert "project(vec_lib CXX)" in cmake and "CMAKE_CXX_STANDARD" in cmake
+    assert "${CMAKE_SOURCE_DIR}/src/*.cpp" in cmake and "add_test(" in cmake
+    header = (tmp_path / "src" / "vec_lib.hpp").read_text()
+    assert "#ifndef VEC_LIB_HPP" in header
+    assert "build/" in (tmp_path / ".gitignore").read_text()
+    assert not (tmp_path / "pyproject.toml").exists()
+
+
+def test_scaffold_cpp_is_idempotent(tmp_path: Path) -> None:
+    scaffold(tmp_path, _CPP_LAYOUT)
+    assert scaffold(tmp_path, _CPP_LAYOUT) == []
+
+
 def test_scaffold_csharp_honors_target_framework(tmp_path: Path) -> None:
     from dataclasses import replace
 

--- a/tests/sdlc/test_testenv.py
+++ b/tests/sdlc/test_testenv.py
@@ -546,3 +546,30 @@ async def test_meson_runner_fails_on_setup(monkeypatch: pytest.MonkeyPatch, tmp_
     result = await MesonTestRunner().run(path=str(tmp_path))
     assert not result.passed and "ERROR" in result.output
     assert len(calls) == 1  # setup failed → test skipped
+
+
+# --- C++ (3.2) ---------------------------------------------------------------
+
+
+def test_make_test_environment_and_runner_for_cpp() -> None:
+    from orchestrator.sdlc.testenv import CToolEnvironment, make_test_environment, make_test_runner
+    from orchestrator.sdlc.testrunner import CTestRunner, MesonTestRunner
+
+    assert isinstance(make_test_environment("cpp"), CToolEnvironment)
+    assert isinstance(make_test_runner("cpp", CToolEnvironment("cmake")), CTestRunner)
+    assert isinstance(make_test_runner("cpp", CToolEnvironment("meson")), MesonTestRunner)
+
+
+def test_cpp_toolchain_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.sdlc import testenv
+
+    monkeypatch.setattr(
+        "orchestrator.sdlc.testenv.shutil.which",
+        lambda name: f"/usr/bin/{name}" if name in {"cmake", "clang++"} else None,
+    )
+    assert testenv.cpp_toolchain_available() is True  # cmake + a C++ compiler
+    monkeypatch.setattr(
+        "orchestrator.sdlc.testenv.shutil.which",
+        lambda name: "/usr/bin/cmake" if name == "cmake" else None,  # no C++ compiler
+    )
+    assert testenv.cpp_toolchain_available() is False


### PR DESCRIPTION
Automated sync from the private repo @ 19d1d76 (v2.4.0).

## What's in this release
- docs(readme): note what the C++ front-end adds (superset of C; classes/namespaces/inheritance/templates)
- docs(roadmap): close Track 3.4 — C++ live-proven on a real CMake repo (dlib), PR opened
- fix(current-state,cpp): real components on large C/C++ repos — area grouping by location, not symbol id
- feat(cpp): Track 3 — C++ language support (comprehension + codegen), phases 3.1–3.3 (2.4.0)

Merge to release.