### PR TITLE
Publish v2.6.0 (304d0fe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,12 @@ JIRA_DRY_RUN=true                      # false to write real issues
 # --- Notion (optional source) ----------------------------------------------
 # NOTION_API_TOKEN=secret_...
 
+# --- OpenSpec (optional, spec-driven source; https://openspec.dev) ----------
+# Read change proposals from openspec/changes/ as deterministic, intent-shaped
+# specs (no creds, no LLM extraction). Default root is ./openspec — override:
+# ORCHESTRATOR_OPENSPEC_ROOT=./openspec
+# Use with: orchestrator ingest --source openspec://<change-id>   (or openspec:// for all)
+
 
 # ============================================================================
 # 3. Target repo + GitHub auth — for `sdlc feature`/`run` that push & open PRs

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -19,6 +19,7 @@ tests, get them green, open a PR — with **two human gates** (before building, 
 | Capability | Status | How to use |
 |---|---|---|
 | Intake — Confluence / Notion / Markdown → specs → backlog | ✅ | `orchestrator ingest --source <uri>`, `orchestrator backlog` |
+| Spec-driven intake — [OpenSpec](https://openspec.dev) changes → deterministic intents (no LLM guessing); write-back drafts OpenSpec from a wiki for review | ✅ | `--source openspec://<change-id>`, `orchestrator openspec draft --source <uri>` |
 | Single feature build (local & safe by default) | ✅ | `orchestrator sdlc feature --source file://./spec.md --safe` |
 | Full orchestrated run (backlog → many features) | ✅ | `orchestrator sdlc run --source <uri>` |
 | Open / complete a PR (live) | ✅ | `orchestrator sdlc feature … --live`, `orchestrator sdlc complete` |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ reviewed, tested pull requests, with a human in control.
 > package and its command is **`orchestrator`** — those names stay in install lines
 > and commands throughout the docs.
 
-Spine reads a requirement (from Confluence, Notion, or a Markdown file), understands
+Spine reads a requirement (from Confluence, Notion, a Markdown file, or an
+[OpenSpec](https://openspec.dev) spec-driven change), understands
 your target repo, generates code grounded in that repo's own conventions, writes and
 runs tests, and opens a **pull request for you to review**. It pauses for your
 approval before it starts and before anything merges. Nothing is pushed, merged, or

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -211,7 +211,14 @@ a **local branch + diff** to inspect. No pushes, no PRs, nothing external.
 orchestrator sdlc feature --source confluence://<page_id> --safe
 ```
 
-- `--source` also accepts `notion://<page_id>` or `file://./spec.md`.
+- `--source` also accepts `notion://<page_id>`, `file://./spec.md`, or
+  **`openspec://<change-id>`** (spec-driven: reads an [OpenSpec](https://openspec.dev)
+  change under `openspec/changes/` and maps its `### Requirement:`/`#### Scenario:`
+  blocks straight to acceptance criteria — **deterministic, no LLM extraction**, so
+  intents are exactly what the spec states; `openspec://` alone runs every change).
+  To go the other way — **bootstrap** an OpenSpec change *from* a wiki page for a human
+  to polish — run `orchestrator openspec draft --source confluence://<id> --out ./openspec`,
+  edit the generated `openspec/changes/<id>/`, then `sdlc feature --source openspec://<id>`.
 - `--safe` is the safe default: dry-run tracker, local commit, **no push**.
 - Pin one requirement with `--intent <intent-id>` if a page has several.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "2.5.0"
+version = "2.6.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -35,12 +35,14 @@ mcp_app = typer.Typer(help="Onboard external MCP servers (DBs, Atlassian, …)."
 catalog_app = typer.Typer(
     help="Capability catalog — inspect what the orchestrator can assemble.", no_args_is_help=True
 )
+openspec_app = typer.Typer(help="Spec-driven development with OpenSpec (openspec.dev).", no_args_is_help=True)
 app.add_typer(template_app, name="template")
 app.add_typer(contract_app, name="contract")
 app.add_typer(task_app, name="task")
 app.add_typer(sdlc_app, name="sdlc")
 app.add_typer(mcp_app, name="mcp")
 app.add_typer(catalog_app, name="catalog")
+app.add_typer(openspec_app, name="openspec")
 
 
 def _client() -> httpx.Client:
@@ -204,7 +206,8 @@ def ingest(
         str,
         typer.Option(
             "--source",
-            help="Source root, e.g. confluence://<page_id>, notion://<page_id>, or file://./spec.md.",
+            help="Source root, e.g. confluence://<page_id>, notion://<page_id>, "
+            "openspec://<change-id> (spec-driven), or file://./spec.md.",
         ),
     ],
     create: Annotated[
@@ -293,6 +296,83 @@ async def _run_ingest(
     _print({"created": [{"key": i.key, "url": i.url} for i in issues]})
 
 
+@openspec_app.command("draft")
+def openspec_draft(
+    source: Annotated[
+        str,
+        typer.Option("--source", help="Unstructured source to bootstrap FROM, e.g. confluence://<id>."),
+    ],
+    out: Annotated[
+        str,
+        typer.Option("--out", help="OpenSpec root to write into (changes/<id>/ is created under it)."),
+    ] = "openspec",
+    refresh: Annotated[
+        bool,
+        typer.Option("--refresh", help="Re-extract from the source (default: reuse the cached backlog)."),
+    ] = False,
+    overwrite: Annotated[
+        bool,
+        typer.Option("--overwrite", help="Overwrite existing change files (default: never clobber)."),
+    ] = False,
+) -> None:
+    """Bootstrap OpenSpec change proposals FROM an unstructured source (the write-back).
+
+    Runs the LLM intake once (source → intents → specs), then renders each as a
+    structured `openspec/changes/<id>/` proposal (proposal.md + specs delta + tasks).
+    A human polishes the draft, then implements deterministically:
+
+        orchestrator openspec draft --source confluence://<id> --out ./openspec
+        # …review/edit openspec/changes/<id>/…
+        orchestrator sdlc feature --source openspec://<id> --safe
+    """
+    import asyncio
+
+    asyncio.run(_run_openspec_draft(source, out=out, refresh=refresh, overwrite=overwrite))
+
+
+async def _run_openspec_draft(source: str, *, out: str, refresh: bool, overwrite: bool) -> None:
+    from pathlib import Path
+
+    from orchestrator.core.env import load_local_env
+
+    load_local_env()
+    from orchestrator.intake.cache import analyze_cached
+    from orchestrator.intake.factory import IntakeNotConfiguredError, build_service_for
+    from orchestrator.intake.openspec_writer import change_id_for, render_change, write_change
+    from orchestrator.intake.service import parse_source_uri
+
+    parse_source_uri(source)  # validate early
+    try:
+        service = build_service_for(source, dry_run=True, rules_path=None)
+    except IntakeNotConfiguredError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
+
+    plan = await analyze_cached(service, source, refresh=refresh, log=lambda m: typer.echo(m, err=True))
+    root = Path(out)
+    intents_by_id = {i.id: i for i in plan.intents}
+    drafted: list[dict[str, object]] = []
+    for spec in plan.specs:
+        intent = intents_by_id.get(spec.intent_id)
+        if intent is None:
+            continue
+        written = write_change(root, intent, render_change(spec, intent), overwrite=overwrite)
+        drafted.append(
+            {
+                "change_id": change_id_for(intent),
+                "source": f"openspec://{change_id_for(intent)}",
+                "files": [str(p) for p in written],
+                "skipped_existing": not written,
+            }
+        )
+    _print({"root": str(root), "drafted": drafted})
+    typer.echo(
+        f"\nDrafted {sum(1 for d in drafted if d['files'])} OpenSpec change(s) under {root}/changes/. "
+        "Review + polish them, then: orchestrator sdlc feature --source openspec://<change-id> --safe",
+        err=True,
+    )
+
+
 @app.command("backlog")
 def backlog(
     source: Annotated[
@@ -333,7 +413,8 @@ def sdlc_run(
         str,
         typer.Option(
             "--source",
-            help="Source root, e.g. confluence://<page_id>, notion://<page_id>, or file://./spec.md.",
+            help="Source root, e.g. confluence://<page_id>, notion://<page_id>, "
+            "openspec://<change-id> (spec-driven), or file://./spec.md.",
         ),
     ],
     actor: Annotated[
@@ -537,7 +618,8 @@ def sdlc_feature(
         str,
         typer.Option(
             "--source",
-            help="Source root, e.g. confluence://<page_id>, notion://<page_id>, or file://./spec.md.",
+            help="Source root, e.g. confluence://<page_id>, notion://<page_id>, "
+            "openspec://<change-id> (spec-driven), or file://./spec.md.",
         ),
     ],
     intent: Annotated[

--- a/src/orchestrator/intake/factory.py
+++ b/src/orchestrator/intake/factory.py
@@ -85,6 +85,19 @@ def build_file_service(*, dry_run: bool, rules_path: str | None = None) -> Backl
     return _build_service(FileSourceAdapter(FileSourceConfig()), dry_run=dry_run, rules_path=rules_path)
 
 
+def build_openspec_service(*, dry_run: bool, rules_path: str | None = None) -> BacklogService:
+    """Wire an OpenSpec-backed ``BacklogService`` (spec-driven intake).
+
+    Like ``file``, it needs no credentials — the change lives on disk under
+    ``openspec/`` (``$ORCHESTRATOR_OPENSPEC_ROOT``). The adapter is a
+    ``StructuredIntentSource``, so ``analyze`` parses changes → intents
+    deterministically and skips the LLM extractor.
+    """
+    from orchestrator.intake.openspec_source import OpenSpecSourceAdapter
+
+    return _build_service(OpenSpecSourceAdapter(), dry_run=dry_run, rules_path=rules_path)
+
+
 def build_mcp_confluence_service(*, dry_run: bool, rules_path: str | None = None) -> BacklogService:
     """Wire a Confluence source backed by an onboarded MCP server (Phase 3).
 
@@ -109,6 +122,7 @@ _BUILDERS = {
     "confluence": build_confluence_service,
     "notion": build_notion_service,
     "file": build_file_service,
+    "openspec": build_openspec_service,
     "mcp-confluence": build_mcp_confluence_service,
 }
 

--- a/src/orchestrator/intake/intents.py
+++ b/src/orchestrator/intake/intents.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -92,6 +92,21 @@ class Intent(BaseModel):
     nfrs: list[str] = Field(default_factory=list)
     open_questions: list[str] = Field(default_factory=list)
     source_doc_ids: list[str] = Field(default_factory=list)
+
+
+@runtime_checkable
+class StructuredIntentSource(Protocol):
+    """A source that yields fully-formed ``Intent``s **deterministically** (no LLM).
+
+    Most sources hand the extractor unstructured prose (Confluence/Notion/markdown)
+    and an LLM guesses intents out of it. A source whose format is already
+    intent-shaped — e.g. OpenSpec change proposals, where each change is one
+    capability with `### Requirement:`/`#### Scenario:` acceptance criteria — should
+    parse straight to ``Intent``s instead. ``BacklogService.analyze`` prefers this
+    path when the source implements it, skipping the LLM extraction entirely (cheaper,
+    deterministic, and lossless on the stated criteria)."""
+
+    def structured_intents(self, documents: list[SourceDocument]) -> list[Intent]: ...
 
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")

--- a/src/orchestrator/intake/openspec_source.py
+++ b/src/orchestrator/intake/openspec_source.py
@@ -1,0 +1,258 @@
+"""OpenSpec source adapter — spec-driven intake (https://openspec.dev).
+
+Reads OpenSpec **change proposals** (``openspec/changes/<id>/``) as fully-formed
+``Intent``s, **deterministically — no LLM**. Because an OpenSpec change is already
+intent-shaped (one capability, with ``### Requirement:`` SHALL statements and
+``#### Scenario:`` Given/When/Then acceptance tests), we parse it straight to an
+``Intent`` and populate ``acceptance_criteria`` **verbatim** from the requirements +
+scenarios — the exact contract codegen must hit. This bypasses the LLM intent
+extractor (via the ``StructuredIntentSource`` seam), which removes the "guess intents
+out of prose" step that makes wiki-sourced intents crude.
+
+Directory layout (openspec.dev)::
+
+    openspec/
+      changes/<change-id>/
+        proposal.md          ## Why | ## What Changes | ## Impact
+                             (older variant: ## Intent | ## Scope | ## Approach)
+        design.md            (optional)
+        tasks.md             ## N. Group  +  - [ ] N.M task
+        specs/<cap>/spec.md   ## ADDED/MODIFIED/REMOVED Requirements
+                                → ### Requirement: <text> (SHALL/MUST)
+                                  → #### Scenario: <text>
+                                    - GIVEN/WHEN/THEN/AND …
+      specs/<cap>/spec.md     current truth (not a change)
+
+``openspec://<change-id>`` → that one change; ``openspec://`` → every change (excluding
+``changes/archive/``). The root dir comes from ``ORCHESTRATOR_OPENSPEC_ROOT`` (default
+``./openspec``); ``openspec:///abs/path/openspec`` can point at an absolute dir.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from orchestrator.intake.intents import Intent, _slug
+from orchestrator.intake.source import FetchTreeResult, SourceDocument, SourceRef
+
+_ARCHIVE = "archive"
+_DEFAULT_ROOT = "openspec"
+
+# `## Heading` section splitter (level-2). Everything up to the next `## ` (or EOF).
+_H2 = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+# `### Requirement: <text>` and `#### Scenario: <text>` markers. (Delta section
+# headers — `## ADDED/MODIFIED/REMOVED Requirements` — are just `## ` sections; we
+# read every requirement regardless of which delta bucket it sits under.)
+_REQ = re.compile(r"^###\s+Requirement:\s*(.+?)\s*$", re.MULTILINE)
+_SCENARIO = re.compile(r"^####\s+Scenario:\s*(.+?)\s*$", re.MULTILINE)
+
+
+# --- markdown parsing (pure, unit-testable) --------------------------------
+
+
+def _h2_sections(md: str) -> dict[str, str]:
+    """Map each ``## Heading`` (lowercased) → its body text, in document order."""
+    out: dict[str, str] = {}
+    matches = list(_H2.finditer(md))
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(md)
+        out[m.group(1).strip().lower()] = md[m.end() : end].strip()
+    return out
+
+
+def _first_section(sections: dict[str, str], *names: str) -> str:
+    """First non-empty body among the given (lowercased) heading names."""
+    for n in names:
+        if sections.get(n):
+            return sections[n]
+    return ""
+
+
+def _title(proposal_md: str, change_id: str) -> str:
+    """The change title: the H1 (minus a ``Proposal:``/``Change:`` prefix), else the id humanized."""
+    for line in proposal_md.splitlines():
+        s = line.strip()
+        if s.startswith("# "):
+            t = s[2:].strip()
+            t = re.sub(r"^(proposal|change)\s*:\s*", "", t, flags=re.IGNORECASE).strip()
+            return t or _humanize(change_id)
+    return _humanize(change_id)
+
+
+def _humanize(change_id: str) -> str:
+    return change_id.replace("-", " ").replace("_", " ").strip().capitalize()
+
+
+def _scenario_lines(body: str) -> list[str]:
+    """The GIVEN/WHEN/THEN/AND bullet lines of a scenario, normalized to one string."""
+    steps: list[str] = []
+    for line in body.splitlines():
+        s = line.strip().lstrip("-*").strip()
+        if re.match(r"^(GIVEN|WHEN|THEN|AND|BUT)\b", s, re.IGNORECASE):
+            steps.append(" ".join(s.split()))
+    return steps
+
+
+def _requirements(spec_md: str) -> list[tuple[str, list[str]]]:
+    """Parse a (delta) spec file into ``(requirement_statement, [scenario_lines...])``.
+
+    The requirement statement is the ``### Requirement: <name>`` heading plus its
+    normative body up to the first scenario (the SHALL/MUST sentence). Each
+    ``#### Scenario:`` becomes a rendered ``"Scenario: <name> — GIVEN … WHEN … THEN …"``.
+    """
+    out: list[tuple[str, list[str]]] = []
+    reqs = list(_REQ.finditer(spec_md))
+    for i, rm in enumerate(reqs):
+        end = reqs[i + 1].start() if i + 1 < len(reqs) else len(spec_md)
+        block = spec_md[rm.end() : end]
+        name = rm.group(1).strip()
+        scen = list(_SCENARIO.finditer(block))
+        # requirement body = text before the first scenario (the SHALL statement)
+        body_end = scen[0].start() if scen else len(block)
+        statement = " ".join(block[:body_end].split()).strip()
+        req_text = f"{name}: {statement}" if statement else name
+        rendered: list[str] = []
+        for j, sm in enumerate(scen):
+            s_end = scen[j + 1].start() if j + 1 < len(scen) else len(block)
+            steps = _scenario_lines(block[sm.end() : s_end])
+            label = sm.group(1).strip()
+            rendered.append(f"Scenario: {label} — {' '.join(steps)}".strip(" —"))
+        out.append((req_text, rendered))
+    return out
+
+
+def change_to_intent(
+    change_id: str, *, proposal_md: str = "", spec_texts: tuple[str, ...] = (), tasks_md: str = ""
+) -> Intent:
+    """Map one OpenSpec change to an ``Intent`` (deterministic; scenarios → criteria)."""
+    sections = _h2_sections(proposal_md)
+    description = _first_section(sections, "why", "intent", "purpose", "what changes")
+    scope = _first_section(sections, "scope", "what changes", "impact")
+    approach = _first_section(sections, "approach")
+    if approach and approach not in scope:
+        scope = f"{scope}\n\nApproach: {approach}".strip()
+
+    criteria: list[str] = []
+    for spec_md in spec_texts:
+        for req_text, scenarios in _requirements(spec_md):
+            criteria.append(req_text)
+            criteria.extend(scenarios)
+
+    # Open questions: a proposal may carry them explicitly; keep them verbatim.
+    open_q = [
+        ln.strip().lstrip("-*").strip()
+        for ln in _first_section(sections, "open questions", "questions").splitlines()
+        if ln.strip().lstrip("-*").strip()
+    ]
+
+    return Intent(
+        id=f"intent-{_slug(change_id)}",
+        title=_title(proposal_md, change_id),
+        description=description or _humanize(change_id),
+        scope=scope,
+        acceptance_criteria=criteria,
+        open_questions=open_q,
+        source_doc_ids=[f"openspec:{change_id}"],
+    )
+
+
+# --- the adapter -----------------------------------------------------------
+
+
+@dataclass
+class OpenSpecSourceConfig:
+    """Where the ``openspec/`` tree lives. Default: ``$ORCHESTRATOR_OPENSPEC_ROOT`` or ``./openspec``."""
+
+    root: Path = field(default_factory=lambda: Path(os.getenv("ORCHESTRATOR_OPENSPEC_ROOT", _DEFAULT_ROOT)))
+
+
+class OpenSpecSourceAdapter:
+    """Reads ``openspec/changes/`` as deterministic, intent-shaped documents.
+
+    Implements ``SourceAdapter`` (so it drops into the intake pipeline) **and**
+    ``StructuredIntentSource`` (so ``analyze`` skips the LLM extractor and uses the
+    parsed intents directly)."""
+
+    source_kind = "openspec"
+
+    def __init__(self, config: OpenSpecSourceConfig | None = None) -> None:
+        self._config = config or OpenSpecSourceConfig()
+        self._intents: dict[str, Intent] = {}  # doc_id → parsed Intent, filled by fetch_tree
+
+    # location helpers
+    @property
+    def _changes_dir(self) -> Path:
+        return self._config.root / "changes"
+
+    def _change_dir(self, change_id: str) -> Path:
+        return self._changes_dir / change_id
+
+    def _list_change_ids(self) -> list[str]:
+        if not self._changes_dir.is_dir():
+            return []
+        return sorted(
+            p.name
+            for p in self._changes_dir.iterdir()
+            if p.is_dir() and p.name != _ARCHIVE and (p / "proposal.md").is_file()
+        )
+
+    def _read(self, change_id: str) -> tuple[SourceDocument, Intent]:
+        d = self._change_dir(change_id)
+        proposal = _read_text(d / "proposal.md")
+        tasks = _read_text(d / "tasks.md")
+        specs_dir = d / "specs"
+        spec_texts = tuple(_read_text(p) for p in sorted(specs_dir.rglob("spec.md")) if p.is_file())
+        intent = change_to_intent(change_id, proposal_md=proposal, spec_texts=spec_texts, tasks_md=tasks)
+        body = "\n\n".join(t for t in (proposal, *spec_texts) if t.strip())
+        doc = SourceDocument(
+            id=change_id,
+            title=intent.title,
+            body=body,
+            url=str(d),
+            space="openspec",
+            labels=("openspec", "change"),
+        )
+        return doc, intent
+
+    async def fetch_document(self, doc_id: str) -> SourceDocument:
+        doc, intent = self._read(doc_id)
+        self._intents[doc.id] = intent
+        return doc
+
+    async def list_children(self, doc_id: str) -> list[SourceRef]:
+        # The root ("") lists every change; a change has no children.
+        if doc_id and doc_id != _DEFAULT_ROOT:
+            return []
+        return [SourceRef(id=cid, title=_humanize(cid), kind="change") for cid in self._list_change_ids()]
+
+    async def fetch_tree(self, root_id: str, *, max_depth: int = 3, max_docs: int = 100) -> FetchTreeResult:
+        ids = [root_id] if root_id and root_id != _DEFAULT_ROOT else self._list_change_ids()
+        docs: list[SourceDocument] = []
+        truncated = False
+        for cid in ids:
+            if len(docs) >= max_docs:
+                truncated = True
+                break
+            if not self._change_dir(cid).is_dir():
+                continue
+            doc, intent = self._read(cid)
+            self._intents[doc.id] = intent
+            docs.append(doc)
+        return FetchTreeResult(documents=docs, truncated=truncated)
+
+    def structured_intents(self, documents: list[SourceDocument]) -> list[Intent]:
+        """The parsed intents for these documents (populated during ``fetch_tree``)."""
+        return [self._intents[d.id] for d in documents if d.id in self._intents]
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+__all__ = ["OpenSpecSourceAdapter", "OpenSpecSourceConfig", "change_to_intent"]

--- a/src/orchestrator/intake/openspec_writer.py
+++ b/src/orchestrator/intake/openspec_writer.py
@@ -1,0 +1,141 @@
+"""Write-back: render derived specs as OpenSpec change proposals.
+
+The inverse of ``openspec_source``. Given the ``Intent``/``FeatureSpec`` that the LLM
+extractor derived from an **unstructured** source (a Confluence page, a Notion doc), emit
+a structured, reviewable **OpenSpec change** (``openspec/changes/<id>/``). A human then
+polishes the draft — sharpening requirements into ``SHALL`` statements and criteria into
+Given/When/Then scenarios — and Spine implements from the polished ``openspec://`` change
+**deterministically** (no more LLM guessing).
+
+This closes the loop: keep "point Spine at a wiki", but land in a durable, versioned,
+human-owned spec instead of an ephemeral guess. The rendered files round-trip — reading
+one back with ``openspec_source.change_to_intent`` recovers the same acceptance criteria.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from orchestrator.intake.intents import Intent, _slug
+from orchestrator.intake.specs import FeatureSpec
+
+_DRAFT_NOTE = (
+    "> ⚠️ **Auto-drafted by Spine** from an unstructured source — review before use: "
+    "sharpen each requirement into a SHALL/MUST statement and each scenario into "
+    "Given/When/Then, then run `orchestrator sdlc feature --source openspec://{change_id}`.\n"
+)
+
+_GWT = re.compile(r"\b(GIVEN|WHEN|THEN|AND|BUT)\b", re.IGNORECASE)
+# BDD keywords for *splitting* a criterion into bullets are UPPERCASE by convention —
+# case-sensitive so a mid-sentence prose "and"/"then" isn't mistaken for a step keyword.
+_BDD_UPPER = re.compile(r"\b(GIVEN|WHEN|THEN|AND|BUT)\b")
+
+
+def change_id_for(intent: Intent) -> str:
+    """The OpenSpec change id for an intent (``intent-foo`` → ``foo``; else slug the title)."""
+    cid = intent.id[len("intent-") :] if intent.id.startswith("intent-") else _slug(intent.title)
+    return cid or "change"
+
+
+def _scenario_bullets(criterion: str) -> list[str]:
+    """Render one acceptance criterion as scenario bullet lines.
+
+    A criterion already phrased Given/When/Then is split onto one bullet per keyword;
+    a plain criterion becomes a single ``- THEN <criterion>`` for the human to expand.
+    """
+    text = " ".join(criterion.split())
+    if _BDD_UPPER.search(text):
+        # start a new bullet at each UPPERCASE BDD keyword (prose "and" is left alone)
+        chunks = re.split(r"(?=\b(?:GIVEN|WHEN|THEN|AND|BUT)\b)", text)
+        bullets = [f"- {c.strip()}" for c in chunks if c.strip()]
+        return bullets or [f"- THEN {text}"]
+    return [f"- THEN {text}"]
+
+
+def _spec_md(spec: FeatureSpec) -> str:
+    """The delta spec: one ``### Requirement`` with each acceptance criterion as a scenario."""
+    lines = [f"# Delta for {spec.title}", "", "## ADDED Requirements", "", f"### Requirement: {spec.title}"]
+    statement = (spec.summary or spec.user_story or f"The system SHALL support {spec.title}.").strip()
+    lines += [statement, ""]
+    criteria = spec.acceptance_criteria or ["The behavior described in the proposal holds."]
+    for i, crit in enumerate(criteria, 1):
+        label = _short_label(crit) or f"Criterion {i}"
+        lines.append(f"#### Scenario: {label}")
+        lines += _scenario_bullets(crit)
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _short_label(criterion: str) -> str:
+    """A concise scenario label from a criterion (its lead clause, before a G/W/T keyword)."""
+    text = " ".join(criterion.split())
+    head = _GWT.split(text)[0].strip(" :.-—")
+    head = head.split(".")[0]
+    return head[:60].strip()
+
+
+def _proposal_md(spec: FeatureSpec, intent: Intent, change_id: str) -> str:
+    why = (intent.description or spec.summary or "").strip()
+    what = (intent.scope or spec.user_story or "").strip()
+    impact = spec.technical_notes.strip()
+    parts = [
+        f"# Proposal: {spec.title}",
+        "",
+        _DRAFT_NOTE.format(change_id=change_id),
+        "## Why",
+        why or "TODO",
+    ]
+    parts += ["", "## What Changes", what or "TODO"]
+    if impact:
+        parts += ["", "## Impact", impact]
+    if intent.open_questions:
+        parts += ["", "## Open Questions"] + [f"- {q}" for q in intent.open_questions]
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def _tasks_md(spec: FeatureSpec) -> str:
+    lines = [
+        "# Tasks",
+        "",
+        "## 1. Implementation",
+        "- [ ] 1.1 Implement the requirement",
+        "- [ ] 1.2 Add tests",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_change(spec: FeatureSpec, intent: Intent) -> dict[str, str]:
+    """Render one derived spec into OpenSpec change files: ``{relpath: content}``.
+
+    Keys are paths **relative to the change dir** (``proposal.md``, ``tasks.md``,
+    ``specs/<cap>/spec.md``). ``write_change`` places them under ``<root>/changes/<id>/``.
+    """
+    change_id = change_id_for(intent)
+    cap = _slug(spec.title) or change_id
+    return {
+        "proposal.md": _proposal_md(spec, intent, change_id),
+        "tasks.md": _tasks_md(spec),
+        f"specs/{cap}/spec.md": _spec_md(spec),
+    }
+
+
+def write_change(root: Path, intent: Intent, files: dict[str, str], *, overwrite: bool = False) -> list[Path]:
+    """Write rendered change files under ``<root>/changes/<change-id>/``.
+
+    Skips files that already exist unless ``overwrite`` — so re-running a draft never
+    clobbers a change a human has since polished. Returns the paths written.
+    """
+    change_dir = root / "changes" / change_id_for(intent)
+    written: list[Path] = []
+    for rel, content in files.items():
+        path = change_dir / rel
+        if path.exists() and not overwrite:
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        written.append(path)
+    return written
+
+
+__all__ = ["change_id_for", "render_change", "write_change"]

--- a/src/orchestrator/intake/service.py
+++ b/src/orchestrator/intake/service.py
@@ -23,7 +23,7 @@ import logging
 from dataclasses import dataclass, field
 
 from orchestrator.intake.gaps import GapAnalyzer, GapFinding, blocks_approval
-from orchestrator.intake.intents import Intent, IntentExtractor
+from orchestrator.intake.intents import Intent, IntentExtractor, StructuredIntentSource
 from orchestrator.intake.jira import CreatedIssue, IssueLink, IssueRequest, IssueTrackerAdapter
 from orchestrator.intake.source import SourceAdapter, SourceDocument
 from orchestrator.intake.specs import FeatureSpec, SpecWriter
@@ -57,6 +57,9 @@ def parse_source_uri(uri: str) -> tuple[str, str]:
         if not root:
             raise SourceUriError(f"file source needs a path: {uri!r}")
         return kind, root
+    if kind == "openspec":
+        # openspec://<change-id> selects one change; openspec:// (empty root) = every change.
+        return kind, rest.strip("/")
     rest = rest.strip("/")
     if rest.startswith("page/"):
         rest = rest[len("page/") :]
@@ -144,7 +147,13 @@ class BacklogService:
 
     async def analyze(self, root_id: str) -> BacklogPlan:
         tree = await self._source.fetch_tree(root_id)
-        intents = await self._extractor.extract(tree.documents)
+        # A structured source (e.g. OpenSpec) is already intent-shaped — parse it
+        # deterministically and skip the LLM extractor (cheaper + lossless on the
+        # stated acceptance criteria). Unstructured sources take the LLM path.
+        if isinstance(self._source, StructuredIntentSource):
+            intents = self._source.structured_intents(tree.documents)
+        else:
+            intents = await self._extractor.extract(tree.documents)
         gaps = self._analyzer.analyze(intents)
         specs = await self._spec_writer.write_all(intents)
         return BacklogPlan(

--- a/tests/intake/test_factory.py
+++ b/tests/intake/test_factory.py
@@ -29,7 +29,13 @@ from orchestrator.intake.service import SourceUriError
 def test_supported_kinds_match_registry() -> None:
     # The validate-only callers (e.g. `sdlc run`) trust this set; keep it
     # exactly the keys the dispatcher can actually build.
-    assert set(SUPPORTED_SOURCE_KINDS) == {"confluence", "notion", "file", "mcp-confluence"}
+    assert set(SUPPORTED_SOURCE_KINDS) == {
+        "confluence",
+        "notion",
+        "file",
+        "openspec",
+        "mcp-confluence",
+    }
 
 
 def test_dispatch_routes_to_kind_builder(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/intake/test_openspec_source.py
+++ b/tests/intake/test_openspec_source.py
@@ -1,0 +1,168 @@
+"""OpenSpec source adapter — spec-driven intake (deterministic, no LLM)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from orchestrator.core.llm import CompletionResult, MockLLMClient
+from orchestrator.intake.factory import SUPPORTED_SOURCE_KINDS, build_service_for
+from orchestrator.intake.gaps import GapAnalyzer
+from orchestrator.intake.intents import IntentExtractor, StructuredIntentSource
+from orchestrator.intake.jira import JiraAdapter, JiraConfig
+from orchestrator.intake.openspec_source import (
+    OpenSpecSourceAdapter,
+    OpenSpecSourceConfig,
+    change_to_intent,
+)
+from orchestrator.intake.service import BacklogService, parse_source_uri
+from orchestrator.intake.specs import SpecWriter
+
+_PROPOSAL = """\
+# Proposal: Add single-URL input
+
+## Why
+Users need to submit one page URL to assess. The MVP entry point.
+
+## What Changes
+Add a `parse_url(raw: str) -> Url` helper and a CLI flag `--url`.
+
+## Impact
+New module src/aeo/input.py; no breaking changes.
+"""
+
+_SPEC = """\
+# Delta for Input
+
+## ADDED Requirements
+
+### Requirement: Single URL input
+The system SHALL accept exactly one absolute http(s) URL via `--url`.
+
+#### Scenario: Valid https URL
+- GIVEN the CLI is invoked
+- WHEN the user passes --url https://example.com/page
+- THEN parse_url returns a Url with host "example.com"
+
+#### Scenario: Rejects non-http scheme
+- GIVEN the CLI is invoked
+- WHEN the user passes --url ftp://x
+- THEN a ValueError is raised
+"""
+
+
+def _write_change(
+    root: Path, change_id: str, proposal: str, *, cap: str = "input", spec: str = _SPEC
+) -> None:
+    d = root / "changes" / change_id
+    (d / "specs" / cap).mkdir(parents=True, exist_ok=True)
+    (d / "proposal.md").write_text(proposal, encoding="utf-8")
+    (d / "specs" / cap / "spec.md").write_text(spec, encoding="utf-8")
+
+
+def _reply(text: str) -> CompletionResult:
+    return CompletionResult(
+        text=text, model="mock", prompt_tokens=0, completion_tokens=0, cost_usd=0.0, latency_ms=0.0
+    )
+
+
+# --- parser (pure) ---------------------------------------------------------
+
+
+def test_change_to_intent_maps_requirements_and_scenarios_to_criteria() -> None:
+    intent = change_to_intent("add-url-input", proposal_md=_PROPOSAL, spec_texts=(_SPEC,))
+    assert intent.id == "intent-add-url-input"
+    assert intent.title == "Add single-URL input"  # H1 with the "Proposal:" prefix stripped
+    assert "submit one page URL" in intent.description  # ## Why
+    assert "parse_url" in intent.scope  # ## What Changes
+    # the SHALL statement + each scenario land as VERBATIM acceptance criteria
+    assert any("SHALL accept exactly one absolute http(s) URL" in c for c in intent.acceptance_criteria)
+    assert any("Scenario: Valid https URL" in c and "example.com" in c for c in intent.acceptance_criteria)
+    assert any("Rejects non-http scheme" in c and "ValueError" in c for c in intent.acceptance_criteria)
+
+
+def test_change_to_intent_tolerates_section_name_variants() -> None:
+    # older OpenSpec proposals use ## Intent / ## Scope / ## Approach
+    proposal = "# Change: Foo\n\n## Intent\nWhy foo.\n\n## Scope\nIn scope: foo.\n\n## Approach\nUse bar.\n"
+    intent = change_to_intent("foo", proposal_md=proposal, spec_texts=())
+    assert intent.title == "Foo"
+    assert intent.description == "Why foo."
+    assert "In scope: foo." in intent.scope and "Approach: Use bar." in intent.scope
+
+
+def test_change_to_intent_no_specs_yields_no_criteria() -> None:
+    intent = change_to_intent("bare", proposal_md="# Proposal: Bare\n\n## Why\nx\n")
+    assert intent.acceptance_criteria == [] and intent.title == "Bare"
+
+
+# --- adapter ---------------------------------------------------------------
+
+
+def _adapter(tmp_path: Path) -> OpenSpecSourceAdapter:
+    return OpenSpecSourceAdapter(OpenSpecSourceConfig(root=tmp_path / "openspec"))
+
+
+async def test_fetch_tree_all_changes_excludes_archive(tmp_path: Path) -> None:
+    root = tmp_path / "openspec"
+    _write_change(root, "add-url-input", _PROPOSAL)
+    _write_change(root, "add-crawler", "# Proposal: Add crawler\n\n## Why\nfetch pages\n")
+    (root / "changes" / "archive" / "old").mkdir(parents=True)
+    (root / "changes" / "archive" / "old" / "proposal.md").write_text("# archived\n")
+
+    res = await _adapter(tmp_path).fetch_tree("")  # empty root → every change
+    ids = sorted(d.id for d in res.documents)
+    assert ids == ["add-crawler", "add-url-input"]  # archive excluded
+
+
+async def test_fetch_tree_single_change(tmp_path: Path) -> None:
+    root = tmp_path / "openspec"
+    _write_change(root, "add-url-input", _PROPOSAL)
+    res = await _adapter(tmp_path).fetch_tree("add-url-input")
+    assert [d.id for d in res.documents] == ["add-url-input"]
+    assert res.documents[0].labels == ("openspec", "change")
+
+
+async def test_structured_intents_and_seam(tmp_path: Path) -> None:
+    root = tmp_path / "openspec"
+    _write_change(root, "add-url-input", _PROPOSAL)
+    ad = _adapter(tmp_path)
+    assert isinstance(ad, StructuredIntentSource)  # the seam analyze() branches on
+    res = await ad.fetch_tree("")
+    intents = ad.structured_intents(res.documents)
+    assert [i.id for i in intents] == ["intent-add-url-input"]
+    assert intents[0].acceptance_criteria  # criteria parsed, not LLM-guessed
+
+
+# --- wiring ----------------------------------------------------------------
+
+
+def test_parse_source_uri_openspec() -> None:
+    assert parse_source_uri("openspec://") == ("openspec", "")  # all changes
+    assert parse_source_uri("openspec://add-url-input") == ("openspec", "add-url-input")
+
+
+def test_openspec_is_a_supported_kind() -> None:
+    assert "openspec" in SUPPORTED_SOURCE_KINDS
+    assert isinstance(build_service_for("openspec://", dry_run=True), BacklogService)  # no creds needed
+
+
+# --- analyze uses the structured path (skips the LLM extractor) ------------
+
+
+async def test_analyze_skips_llm_extractor_for_openspec(tmp_path: Path) -> None:
+    root = tmp_path / "openspec"
+    _write_change(root, "add-url-input", _PROPOSAL)
+    # A boom-extractor: an empty script raises if ever invoked, proving the structured
+    # path bypasses the LLM extractor. The spec writer still runs (enrich) — its mock
+    # returns trivial JSON, and the OpenSpec criteria still flow through verbatim.
+    service = BacklogService(
+        source=_adapter(tmp_path),
+        extractor=IntentExtractor(MockLLMClient(script=[])),  # would raise if called
+        analyzer=GapAnalyzer(),
+        spec_writer=SpecWriter(MockLLMClient(script=[_reply("{}")])),
+        tracker=JiraAdapter(JiraConfig(dry_run=True)),
+    )
+    plan = await service.analyze("")  # no MissingFixtureError ⇒ extractor never called
+    assert [i.id for i in plan.intents] == ["intent-add-url-input"]
+    assert plan.specs and any(
+        "SHALL accept exactly one" in c for c in plan.specs[0].acceptance_criteria
+    )  # criteria survived intent → spec, no LLM extraction

--- a/tests/intake/test_openspec_writer.py
+++ b/tests/intake/test_openspec_writer.py
@@ -1,0 +1,87 @@
+"""OpenSpec write-back — render derived specs as reviewable OpenSpec changes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from orchestrator.intake.intents import Intent
+from orchestrator.intake.openspec_source import change_to_intent
+from orchestrator.intake.openspec_writer import change_id_for, render_change, write_change
+from orchestrator.intake.specs import FeatureSpec
+
+
+def _intent() -> Intent:
+    return Intent(
+        id="intent-create-page-object",
+        title="Create Page object",
+        description="A typed record of a fetched page.",
+        scope="Add src/aeo/page.py with url, status_code, is_ok.",
+        acceptance_criteria=[
+            "The system SHALL provide a Page with url, status_code, html fields.",
+            "GIVEN a Page with status_code 200 THEN page.is_ok is True",
+        ],
+        open_questions=["Should redirects be followed?"],
+    )
+
+
+def _spec(intent: Intent) -> FeatureSpec:
+    return FeatureSpec(
+        intent_id=intent.id,
+        title=intent.title,
+        summary=intent.description,
+        acceptance_criteria=intent.acceptance_criteria,
+    )
+
+
+def test_change_id_strips_intent_prefix() -> None:
+    assert change_id_for(_intent()) == "create-page-object"
+    assert change_id_for(Intent(id="x", title="My Feature")) == "my-feature"  # no prefix → slug
+
+
+def test_render_change_produces_openspec_structure() -> None:
+    intent = _intent()
+    files = render_change(_spec(intent), intent)
+    assert set(files) == {"proposal.md", "tasks.md", "specs/create-page-object/spec.md"}
+    proposal = files["proposal.md"]
+    assert proposal.startswith("# Proposal: Create Page object")
+    assert "Auto-drafted by Spine" in proposal  # the review banner
+    assert "## Why" in proposal and "## What Changes" in proposal
+    assert "## Open Questions" in proposal and "redirects" in proposal
+    spec_md = files["specs/create-page-object/spec.md"]
+    assert "## ADDED Requirements" in spec_md
+    assert "### Requirement: Create Page object" in spec_md
+    assert spec_md.count("#### Scenario:") == 2  # one per criterion
+    # a Given/When/Then criterion is split onto BDD bullet lines
+    assert "- GIVEN a Page with status_code 200" in spec_md and "- THEN page.is_ok is True" in spec_md
+
+
+def test_render_roundtrips_through_the_reader() -> None:
+    # render → read back with change_to_intent recovers the criteria (scenarios survive)
+    intent = _intent()
+    files = render_change(_spec(intent), intent)
+    back = change_to_intent(
+        "create-page-object",
+        proposal_md=files["proposal.md"],
+        spec_texts=(files["specs/create-page-object/spec.md"],),
+    )
+    assert back.title == "Create Page object"
+    joined = " ".join(back.acceptance_criteria)
+    assert "url, status_code, html" in joined  # requirement statement survived
+    assert "status_code 200" in joined and "is_ok is True" in joined  # scenario survived
+
+
+def test_write_change_never_clobbers_by_default(tmp_path: Path) -> None:
+    intent = _intent()
+    files = render_change(_spec(intent), intent)
+    first = write_change(tmp_path / "openspec", intent, files)
+    assert first  # wrote the 3 files
+    assert (tmp_path / "openspec" / "changes" / "create-page-object" / "proposal.md").is_file()
+    # a human edits the draft; re-running must NOT clobber it
+    edited = tmp_path / "openspec" / "changes" / "create-page-object" / "proposal.md"
+    edited.write_text("# polished by a human\n", encoding="utf-8")
+    second = write_change(tmp_path / "openspec", intent, files)
+    assert second == []  # nothing overwritten
+    assert edited.read_text() == "# polished by a human\n"
+    # explicit overwrite restores the draft
+    write_change(tmp_path / "openspec", intent, files, overwrite=True)
+    assert "Auto-drafted by Spine" in edited.read_text()


### PR DESCRIPTION
Automated sync from the private repo @ 304d0fe (v2.6.0).

## What's in this release
- chore(release): 2.6.0 — OpenSpec spec-driven intake (source + write-back)
- feat(intake): OpenSpec write-back — bootstrap structured specs from a wiki (`openspec draft`)
- feat(intake): OpenSpec source — spec-driven, deterministic intents (no LLM extraction)
- docs(spec): add complete-automation section to the SDLC tracking blueprint
- docs(spec): blueprint for SDLC tracking — tokens/cost/impact per work item (greenfield+brownfield)

Merge to release.