### PR TITLE
Publish v3.3.0 (e3061c4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ build/
 *.local.md
 *.local.json
 *.local.txt
+
+# Disk-backed artifact store written by `orchestrator up` (fs mode)
+.orchestrator-artifacts/

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -148,6 +148,15 @@ table, **call-graph hotspots**, complexity/god-components, test-coverage and rec
 signals, a name-based security surface, and prioritized recommendations. A report is a
 *view* — re-run to refresh; nothing is written unless `--out` is given.
 
+> **Local path _or_ git URL.** `understand`, `state`, `profile`, `catalog plan`, and
+> `pkg extract`/`export`/`docs` accept either — `orchestrator state https://github.com/org/repo`
+> shallow-clones it to a temp dir, analyses it, and cleans up (for `understand` on a URL the
+> memory bank lands in `./memory-bank`, since the clone is transient). Public providers
+> (github.com / bitbucket.org / gitlab.com) work out of the box; add an enterprise host with
+> `ORCHESTRATOR_REPO_ALLOWED_HOSTS=git.acme.com`. `file://`, plaintext `http://`, and
+> private/loopback hosts are always refused (SSRF guard). The web UI exposes the same on every
+> Understand page — a **Browse…** button to pick a local folder, or paste a URL.
+
 **Where it's stored.** `memory-bank/` is the one artifact you **commit** — the durable,
 versioned, code-true doc your team and any AI tool reads. The graph it renders from is a
 regenerable cache at `~/.cache/orchestrator/pkg/` (rebuilt from code on every commit, so it
@@ -387,13 +396,33 @@ authenticates every page). Start a run from the **Inbox** (paste a source, click
 **Delegate**), or from the terminal:
 ```bash
 orchestrator sdlc run --source confluence://<page_id> --max-features 1
-# prints the sdlc_id and two gate ids: sdlc-<id>-0 (intents), sdlc-<id>-1 (merge)
+# prints the sdlc_id and the gate ids: sdlc-<id>-0 (intents), sdlc-<id>-1 (merge),
+# plus sdlc-<id>-2 (designs) when the design gate is enabled — see 7.3a
 ```
 
 Approve a gate by clicking **Approve / Reject** in the Inbox or Console — or via the API:
 ```bash
 curl -X POST -H "x-api-key: dev-key" http://localhost:8000/v1/approvals/sdlc-<id>-0/approve
 ```
+
+**7.3a — What a run does before it writes code.** The pipeline **comprehends the repo**
+first — it builds the same knowledge graph + `memory-bank/` as `understand`, and folds a
+one-line summary into the intents gate, so you approve the extracted intents *and* see that
+Spine read the codebase. After you approve intents and it creates issues, a **design wave**
+produces a grounded, per-issue **design** (approach, files-to-touch, interfaces, risks, test
+strategy — anchored to the repo's real modules) that each feature then builds to. Both the
+comprehension and the designs are saved as **run artifacts**: expand the run in the **Console**
+to download `knowledge-graph.db`, the memory-bank docs, and each issue's
+`design.md` / `design.json`.
+
+Three pipeline flags control this (comprehension + design are **on** by default; the extra
+design *gate* is **off** so runs don't gain a mandatory pause unless you want one):
+
+| Env var | Default | Effect |
+|---|---|---|
+| `SDLC_COMPREHEND` | on | Comprehend the repo before the intents gate. |
+| `SDLC_DESIGN` | on | Produce a grounded design per issue before codegen. |
+| `SDLC_DESIGN_GATE` | **off** | Add a human **“approve designs”** gate (Gate 1.5, id `sdlc-<id>-2`) after the design wave, before any code is written. |
 
 **7.4 — The web UI (sign in at `/login` first):** one app, one nav, one login. The
 left sidebar groups every surface into sections:
@@ -404,9 +433,9 @@ left sidebar groups every surface into sections:
 | `/app/inbox` | **Inbox** — delegate a run, watch it progress **live** (server-sent events), approve/reject gates **inline**. The front door. |
 | `/app/intake` | **Intake studio** — preview any source (Confluence / Notion / file / OpenSpec) as a backlog, then delegate a gated run (dry-run by default). |
 | `/app/backlog` | **Backlog preview** — a source rendered as a derived backlog (read-only). |
-| `/console` | **Console** — the approval queue + runs dashboard (state filter, inline trace, export a run's timeline). |
+| `/console` | **Console** — the approval queue + runs dashboard (state filter, inline trace, export a run's timeline). Expand a run to download its **comprehension + design artifacts** (knowledge graph, memory bank, per-issue designs). |
 
-**Understand** — repo intelligence. Point at a **local path _or_ a git URL** (GitHub / Bitbucket / GitLab / enterprise); URLs are cloned on demand.
+**Understand** — repo intelligence. Point at a **local path _or_ a git URL** (GitHub / Bitbucket / GitLab / enterprise) — **Browse…** picks a local folder, or paste a URL (cloned on demand).
 | URL | What you see |
 |---|---|
 | `/app/understand` | Build the code-true **memory bank** for a repo (runs as a job, with live progress). |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.2.0"
+version = "3.3.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -17,9 +17,11 @@ Configuration via environment variables:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -65,6 +67,36 @@ def _load_payload(path: Path) -> dict[str, Any]:
 
 def _print(data: Any) -> None:
     typer.echo(json.dumps(data, indent=2, default=str))
+
+
+@contextlib.contextmanager
+def _repo_arg(spec: str) -> Iterator[tuple[Path, bool]]:
+    """Resolve a repo argument to an on-disk path, yielding ``(path, is_remote)``.
+
+    ``spec`` is a **local path** (used as-is — the CLI is a trusted, single-user
+    context) or a **git URL** (``https://``/``ssh://``/``git@host:…`` for
+    github/bitbucket/gitlab, or a host in ``ORCHESTRATOR_REPO_ALLOWED_HOSTS``),
+    which is shallow-cloned on demand and removed on exit. This mirrors the web
+    ``/v1/capabilities/*`` resolution exactly (same SSRF guard + host allow-list),
+    so ``understand``/``state``/``pkg``/``profile``/``catalog plan`` reach remote
+    repos the way the UI does. ``is_remote`` lets a caller pick a sensible output
+    location (a clone's files vanish on exit)."""
+    from orchestrator.registry.api.config import Settings
+    from orchestrator.registry.api.workspace import (
+        RepoPathError,
+        RepoSourceError,
+        materialize_repo_source,
+        resolve_repo_source,
+    )
+
+    try:
+        # repo_allow_any_local: a local CLI path isn't sandboxed to a workspace root.
+        source = resolve_repo_source(spec, Settings(repo_allow_any_local=True))
+    except (RepoSourceError, RepoPathError) as exc:
+        typer.echo(f"ERROR: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    with materialize_repo_source(source, log=lambda m: typer.echo(m, err=True)) as path:
+        yield path, source.kind == "git"
 
 
 def _check(resp: httpx.Response) -> dict[str, Any]:
@@ -1282,16 +1314,21 @@ def audit(
 
 @app.command("profile")
 def profile(
-    path: Annotated[Path, typer.Argument(help="Repo or directory to profile.")] = Path("."),
+    path: Annotated[str, typer.Argument(help="Repo path or git URL to profile.")] = ".",
     intent: Annotated[
         str | None, typer.Option("--intent", help="Intent title, to classify the task type.")
     ] = None,
     as_json: Annotated[bool, typer.Option("--json", help="Emit the profile as JSON.")] = False,
 ) -> None:
-    """Profile a project (languages, framework, DB, tests, task type) — read-only."""
+    """Profile a project (languages, framework, DB, tests, task type) — read-only.
+
+    ``path`` is a local path or a git URL (github/bitbucket/gitlab/enterprise),
+    cloned on demand.
+    """
     from orchestrator.catalog import ProjectProfile
 
-    prof = ProjectProfile.from_repo(path, intent_title=intent)
+    with _repo_arg(path) as (repo, _):
+        prof = ProjectProfile.from_repo(repo, intent_title=intent)
     if as_json:
         _print(prof.to_dict())
         return
@@ -1306,10 +1343,10 @@ def profile(
 
 @app.command("understand")
 def understand(
-    path: Annotated[Path, typer.Argument(help="Repo or directory to comprehend.")] = Path("."),
+    path: Annotated[str, typer.Argument(help="Repo path or git URL to comprehend.")] = ".",
     out: Annotated[
         Path | None,
-        typer.Option("--out", help="Memory-bank dir (default: <repo>/memory-bank)."),
+        typer.Option("--out", help="Memory-bank dir (default: <repo>/memory-bank; ./memory-bank for a URL)."),
     ] = None,
     refresh: Annotated[
         bool, typer.Option("--refresh", help="Re-extract the PKG instead of using the commit cache.")
@@ -1324,10 +1361,16 @@ def understand(
     Phase 0: extracts the Product Knowledge Graph + project profile and renders
     architecture / domain-model / tech-context / conventions / glossary as
     markdown in the target repo. Deterministic (no LLM); re-run to refresh.
+    ``path`` may be a local path or a git URL cloned on demand — for a URL the
+    clone is transient, so the memory bank defaults to ``./memory-bank``.
     """
     from orchestrator.knowledge import build_memory_bank
 
-    result = build_memory_bank(path, out_dir=out, refresh=refresh, sql_dialect=dialect, log=typer.echo)
+    with _repo_arg(path) as (repo, is_remote):
+        out_dir = out or (Path("memory-bank") if is_remote else repo / "memory-bank")
+        result = build_memory_bank(
+            repo, out_dir=out_dir, refresh=refresh, sql_dialect=dialect, log=typer.echo
+        )
     _print(
         {
             "dir": result["dir"],
@@ -1340,7 +1383,7 @@ def understand(
 
 @app.command("state")
 def state(
-    path: Annotated[Path, typer.Argument(help="Repo or directory to summarize.")] = Path("."),
+    path: Annotated[str, typer.Argument(help="Repo path or git URL to summarize.")] = ".",
     lens: Annotated[str, typer.Option("--lens", help="Audience: developer | stakeholder.")] = "developer",
     out: Annotated[
         Path | None,
@@ -1366,7 +1409,8 @@ def state(
     if lens not in ("developer", "stakeholder"):
         typer.echo("ERROR: --lens must be 'developer' or 'stakeholder'.", err=True)
         raise typer.Exit(code=2)
-    markdown = build_current_state(path, lens=lens, refresh=refresh, sql_dialect=dialect)
+    with _repo_arg(path) as (repo, _):
+        markdown = build_current_state(repo, lens=lens, refresh=refresh, sql_dialect=dialect)
     if out is not None:
         out.write_text(markdown, encoding="utf-8")
         typer.echo(f"wrote {out}")
@@ -1405,7 +1449,7 @@ def catalog_list(
 
 @catalog_app.command("plan")
 def catalog_plan(
-    path: Annotated[Path, typer.Argument(help="Repo or directory to plan for.")] = Path("."),
+    path: Annotated[str, typer.Argument(help="Repo path or git URL to plan for.")] = ".",
     intent: Annotated[
         str | None, typer.Option("--intent", help="Intent title, to classify the task type.")
     ] = None,
@@ -1414,7 +1458,8 @@ def catalog_plan(
     """Show the capability plan the orchestrator would assemble for a project."""
     from orchestrator.catalog import ProjectProfile, plan_capabilities
 
-    prof = ProjectProfile.from_repo(path, intent_title=intent)
+    with _repo_arg(path) as (repo, _):
+        prof = ProjectProfile.from_repo(repo, intent_title=intent)
     plan = plan_capabilities(prof)
     if as_json:
         _print(plan.to_dict())
@@ -1429,7 +1474,7 @@ def catalog_plan(
 
 @pkg_app.command("extract")
 def pkg_extract(
-    path: Annotated[Path, typer.Argument(help="Repo or directory to scan.")] = Path("."),
+    path: Annotated[str, typer.Argument(help="Repo path or git URL to scan.")] = ".",
     query: Annotated[
         str | None, typer.Option("--query", "-q", help="Show callers + blast radius of a symbol name.")
     ] = None,
@@ -1443,7 +1488,8 @@ def pkg_extract(
     from orchestrator.pkg import FactStore, RepoCodeExtractor
 
     extractor = RepoCodeExtractor(sql_dialect=dialect)
-    store = FactStore(extractor.extract(path))
+    with _repo_arg(path) as (repo, _):
+        store = FactStore(extractor.extract(repo))
 
     if as_json:
         _print(
@@ -1490,13 +1536,14 @@ def pkg_extract(
 
 @pkg_app.command("export")
 def pkg_export(
-    path: Annotated[Path, typer.Argument(help="Repo or directory to scan.")] = Path("."),
+    path: Annotated[str, typer.Argument(help="Repo path or git URL to scan.")] = ".",
     db: Annotated[Path, typer.Option("--db", help="SQLite file to write.")] = Path("pkg-facts.db"),
 ) -> None:
     """Extract facts and export the ontomesh-ready kind-per-table SQLite projection."""
     from orchestrator.pkg import RepoCodeExtractor, export_sqlite
 
-    batch = RepoCodeExtractor().extract(path)
+    with _repo_arg(path) as (repo, _):
+        batch = RepoCodeExtractor().extract(repo)
     counts = export_sqlite(batch, db)
     typer.echo(f"Exported {path} → {db}")
     for table, n in counts.items():
@@ -1505,7 +1552,7 @@ def pkg_export(
 
 @pkg_app.command("docs")
 def pkg_docs(
-    repo: Annotated[Path, typer.Argument(help="Repo to extract facts from.")] = Path("."),
+    repo: Annotated[str, typer.Argument(help="Repo path or git URL to extract facts from.")] = ".",
     docs: Annotated[list[Path], typer.Option("--doc", "-d", help="Markdown/text doc(s) to reconcile.")] = [],  # noqa: B006
 ) -> None:
     """Reconcile documentation claims against the code's fact graph (read-only)."""
@@ -1515,7 +1562,6 @@ def pkg_docs(
         typer.echo("No docs given — pass one or more --doc <file>.")
         raise typer.Exit(code=2)
 
-    batch = load_or_extract(repo)
     pages = [
         DocPage(
             title=str(p),
@@ -1524,7 +1570,9 @@ def pkg_docs(
         )
         for p in docs
     ]
-    bindings, drift = DocReconciler(batch, repo_root=repo).reconcile(pages)
+    with _repo_arg(repo) as (repo_path, _):
+        batch = load_or_extract(repo_path)
+        bindings, drift = DocReconciler(batch, repo_root=repo_path).reconcile(pages)
 
     bound = sum(1 for b in bindings if b.bound)
     typer.echo(

--- a/src/orchestrator/launch.py
+++ b/src/orchestrator/launch.py
@@ -156,9 +156,10 @@ def build_child_env(config: LaunchConfig) -> dict[str, str]:
     child = dict(config.env)
     child.setdefault("ORCHESTRATOR_API_KEY", config.api_key)
     child.setdefault("ORCHESTRATOR_SESSION_SECRET", config.session_secret)
-    # No MinIO in the minimal stack — keep artifacts in-memory so the worker
-    # doesn't block on an object store the user didn't start.
-    child.setdefault("ORCHESTRATOR_ARTIFACT_STORE", "memory")
+    # No MinIO in the minimal stack — use the disk-backed store so run artifacts
+    # (comprehension/design) the worker writes are visible to the web UI process,
+    # without an object store the user didn't start.
+    child.setdefault("ORCHESTRATOR_ARTIFACT_STORE", "fs")
     # Real codegen by default (the SDLC worker falls back to a stub otherwise),
     # so a delegated feature actually produces code. Needs an LLM key — run_up
     # warns if none is set.

--- a/src/orchestrator/registry/api/runs.py
+++ b/src/orchestrator/registry/api/runs.py
@@ -11,14 +11,25 @@ writes exactly one): merged / failed / denied / cancelled, else running.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, status
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, Response, status
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from orchestrator.registry.api.deps import PrincipalDep, SessionDep
 from orchestrator.registry.db.models import AuditLogRow
 
 router = APIRouter(prefix="/v1/runs", tags=["runs"])
+
+# Audit actions whose after_json carries an ``artifacts`` map (name → store key).
+_ARTIFACT_ACTIONS = {"sdlc_repo_comprehended": "comprehension", "feature_designed": "design"}
+_CONTENT_TYPES = {
+    ".db": "application/vnd.sqlite3",
+    ".json": "application/json",
+    ".md": "text/markdown",
+    ".txt": "text/plain",
+}
 
 # Terminal audit actions → run state. First match (latest-first scan) wins.
 _TERMINAL_STATE = {
@@ -139,3 +150,76 @@ def _summarize(run_id: str, events_newest_first: list[AuditLogRow]) -> RunSummar
 
 def _iso(row: AuditLogRow) -> str:
     return row.timestamp.isoformat() if row.timestamp else ""
+
+
+# --------------------------------------------------------------------------- #
+# Run artifacts — the architectural artifacts the pipeline persists (M1/M2)
+# --------------------------------------------------------------------------- #
+class RunArtifact(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str  # comprehension | design
+    name: str  # e.g. current-state.md, memory-bank/architecture.md
+    key: str  # artifact-store key (download via /artifacts/download?key=)
+    resource_id: str  # the run or feature the artifact belongs to
+
+
+class RunArtifactsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[RunArtifact]
+
+
+@router.get("/{run_id}/artifacts", response_model=RunArtifactsResponse)
+async def run_artifacts(run_id: str, session: SessionDep, principal: PrincipalDep) -> RunArtifactsResponse:
+    """List the architectural artifacts a run persisted (comprehension + design),
+    derived from the audit manifests (which live in the shared DB)."""
+    stmt = (
+        select(AuditLogRow)
+        .where(
+            AuditLogRow.tenant_id == principal.tenant_id,
+            or_(AuditLogRow.resource_id == run_id, AuditLogRow.trace_id == run_id),
+            AuditLogRow.action.in_(list(_ARTIFACT_ACTIONS)),
+        )
+        .order_by(AuditLogRow.timestamp)
+        .limit(_MAX_SCAN)
+    )
+    rows = list((await session.execute(stmt)).scalars().all())
+    items: list[RunArtifact] = []
+    for r in rows:
+        after = r.after_json or {}
+        artifacts = after.get("artifacts")
+        if not isinstance(artifacts, dict):
+            continue
+        kind = _ARTIFACT_ACTIONS[r.action]
+        for name, key in artifacts.items():
+            items.append(RunArtifact(kind=kind, name=str(name), key=str(key), resource_id=r.resource_id))
+    return RunArtifactsResponse(items=items)
+
+
+@router.get("/{run_id}/artifacts/download")
+async def download_run_artifact(
+    run_id: str, request: Request, _principal: PrincipalDep, key: str
+) -> Response:
+    """Download one run artifact by its store key. The key must belong to this
+    run (``run/<run_id>/…``), and the store must be shared with the writer (the
+    disk-backed store under local ``up``; the object store in production)."""
+    if not key.startswith(f"run/{run_id}/"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="key does not belong to this run")
+    store: Any = getattr(request.app.state, "artifact_store", None)
+    if store is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="no artifact store")
+    try:
+        body = await store.get_bytes(key)
+    except LookupError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"{exc} (run artifacts need a shared store — set ORCHESTRATOR_ARTIFACT_STORE=fs)",
+        ) from exc
+    ext = key[key.rfind(".") :] if "." in key else ""
+    filename = key.rsplit("/", 1)[-1]
+    return Response(
+        content=body,
+        media_type=_CONTENT_TYPES.get(ext, "application/octet-stream"),
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/src/orchestrator/registry/api/web/intelligence.py
+++ b/src/orchestrator/registry/api/web/intelligence.py
@@ -34,11 +34,14 @@ def _repo_bar(button_id: str, button_label: str, *, extra: str = "") -> str:
         '<div class="repo-bar">'
         '<label>repo <input id="repo" value="." '
         'placeholder="local path or git URL (https://github.com/org/repo)" size="40"></label>'
+        '<button id="repo-browse" type="button">Browse…</button>'
         f"{extra}"
         f'<button id="{button_id}" class="primary">{button_label}</button>'
         "</div>"
-        '<p class="repo-hint muted">A path under the workspace root, or a git URL to clone '
-        "(github.com / bitbucket.org / gitlab.com, or a configured enterprise host).</p>"
+        '<p class="repo-hint muted">A local path (use <strong>Browse…</strong> to pick a folder on '
+        "this machine), or a git URL to clone — github.com / bitbucket.org / gitlab.com, or a "
+        "configured enterprise host.</p>"
+        '<div id="fsmodal"></div>'
         '<div id="status" class="muted"></div>'
     )
 
@@ -50,7 +53,9 @@ def _page(*, title: str, active: str, intro: str, body: str, script: str) -> HTM
             active=active,
             body=f"<h1>{title}</h1><p class='lead'>{intro}</p>{body}",
             head='<link rel="stylesheet" href="/static/intelligence.css">',
-            scripts=script,
+            # repobrowse.js powers the shared "Browse…" repo-folder picker on
+            # every intelligence page; the page-specific script follows it.
+            scripts='<script src="/static/repobrowse.js"></script>' + script,
         )
     )
 

--- a/src/orchestrator/registry/api/web/static/console.css
+++ b/src/orchestrator/registry/api/web/static/console.css
@@ -85,3 +85,8 @@ tr.clickable:hover { background: var(--surface); cursor: pointer; }
 }
 tr.clickable td:first-child { cursor: pointer; }
 .run-actions { white-space: nowrap; }
+
+/* Run artifacts (M1 comprehension / M2 design) in the run detail */
+.artifacts { margin: 0.4rem 0; font-size: 0.85rem; }
+.artifacts a { color: var(--accent); text-decoration: none; margin-right: 0.2rem; }
+.artifacts strong { margin-right: 0.4rem; }

--- a/src/orchestrator/registry/api/web/static/console.js
+++ b/src/orchestrator/registry/api/web/static/console.js
@@ -121,10 +121,30 @@ async function toggleRunDetail(id){
     const rows = (t.audit||[]).map(e =>
       `<tr><td class='muted'>${esc((e.timestamp||"").slice(0,19))}</td><td>${esc(e.action)}</td><td class='muted'>${esc(e.actor)}</td></tr>`).join("");
     cell.innerHTML = `<div class='detail'><div class='muted'>${(t.audit||[]).length} event(s) · <a href='/trace/${esc(id)}' target='_blank'>full trace →</a></div>`
+      + `<div id='ra-${esc(id)}'></div>`
       + `<table class='mini'><tbody>${rows || "<tr><td class='muted'>no events</td></tr>"}</tbody></table></div>`;
+    loadRunArtifacts(id);
   } catch(e){
     cell.innerHTML = "<div class='detail muted'>No trace available for this run.</div>";
   }
+}
+
+// Architectural artifacts the pipeline persisted (M1 comprehension / M2 design).
+async function loadRunArtifacts(id){
+  const box = $("ra-"+id);
+  if(!box) return;
+  try {
+    const items = (await api("/v1/runs/" + encodeURIComponent(id) + "/artifacts")).items || [];
+    if(!items.length) return;
+    const byKind = {};
+    for(const a of items){ (byKind[a.kind] = byKind[a.kind] || []).push(a); }
+    box.innerHTML = Object.keys(byKind).map(kind =>
+      `<div class='artifacts'><strong>${esc(kind)} artifacts</strong> `
+      + byKind[kind].map(a =>
+          `<a href='/v1/runs/${esc(id)}/artifacts/download?key=${encodeURIComponent(a.key)}'>${esc(a.name)}</a>`
+        ).join(" · ")
+      + `</div>`).join("");
+  } catch(e){ /* none / store not shared */ }
 }
 
 async function exportRun(id){

--- a/src/orchestrator/registry/api/web/static/intelligence.css
+++ b/src/orchestrator/registry/api/web/static/intelligence.css
@@ -27,10 +27,16 @@
 .fs-bar { padding: 0.5rem 1rem; border-bottom: 1px solid var(--border); font-size: 0.85rem; }
 .fs-bar a { color: var(--accent); text-decoration: none; }
 .fs-path { margin-top: 0.35rem; color: var(--muted); overflow-x: auto; white-space: nowrap; }
-.fs-list { overflow-y: auto; padding: 0.35rem; }
+.fs-list { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 0.35rem; }
 .fs-entry { padding: 0.35rem 0.6rem; border-radius: var(--radius); cursor: pointer; font-size: 0.9rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .fs-entry:hover { background: var(--accent-soft); }
 .fs-entry.fs-match { color: var(--accent); font-weight: 600; }
+/* Folder picker (repobrowse.js): files are shown but inert; a footer confirms the pick. */
+.fs-entry.fs-file { color: var(--muted); cursor: default; }
+.fs-entry.fs-file:hover { background: transparent; }
+.fs-git { margin-left: 0.4rem; padding: 0.05rem 0.4rem; border-radius: 999px; background: var(--accent-soft); color: var(--accent); font-size: 0.72rem; font-weight: 600; }
+.fs-foot { display: flex; align-items: center; gap: 0.75rem; padding: 0.6rem 1rem; border-top: 1px solid var(--border); }
+.fs-foot .muted { overflow-x: auto; white-space: nowrap; font-size: 0.8rem; }
 #status { min-height: 1.2rem; font-size: 0.88rem; margin-bottom: 0.5rem; }
 #status .ok { color: var(--ok); }
 #status .err { color: var(--fail); }

--- a/src/orchestrator/registry/api/web/static/repobrowse.js
+++ b/src/orchestrator/registry/api/web/static/repobrowse.js
@@ -1,0 +1,87 @@
+// Shared repo-folder picker for the Understand section.
+//
+// Adds a native-feel "Browse…" button next to the repo input on every
+// intelligence page (understand / state / memory-bank / graph / catalog) so a
+// user can pick a local repo *directory* off the server's disk without typing
+// the path — the same exposure the Connections page has for picking an
+// mcp.json file. Git URLs (github/bitbucket/gitlab/enterprise) are still typed
+// straight into the input; this only helps with local paths.
+//
+// Wrapped in an IIFE: the page-specific script (understand.js, state.js, …)
+// declares its own top-level `const $` / `const esc`, so ours must stay local
+// or the classic-script global scope would collide.
+(function () {
+  const $ = (id) => document.getElementById(id);
+  const esc = (s) => {
+    const d = document.createElement("div");
+    d.textContent = s == null ? "" : String(s);
+    return d.innerHTML;
+  };
+  const modal = () => $("fsmodal");
+  function close() {
+    if (modal()) modal().innerHTML = "";
+  }
+
+  // Directories navigate on click; files are shown greyed and inert (this is a
+  // folder picker). A `.git` entry marks the folder as a git repo.
+  function row(e) {
+    if (!e.is_dir) return `<div class="fs-entry fs-file">📄 ${esc(e.name)}</div>`;
+    const git = e.name === ".git" ? " fs-match" : "";
+    return `<div class="fs-entry${git}" data-path="${esc(e.path)}" data-dir="true">📁 ${esc(e.name)}</div>`;
+  }
+
+  async function list(path) {
+    let d;
+    try {
+      d = await window.spine.apiJSON("/v1/fs/list" + (path ? "?path=" + encodeURIComponent(path) : ""));
+    } catch (e) {
+      if (String(e.message) !== "session expired") window.alert("Cannot list directory: " + e.message);
+      return;
+    }
+    const isRepo = d.entries.some((e) => e.is_dir && e.name === ".git");
+    const up = d.parent ? '<a href="#" id="fs-up">↑ up</a>' : '<span class="muted">↑ up</span>';
+    const rows = d.entries.map(row).join("") || "<p class='muted'>Empty.</p>";
+    const badge = isRepo ? " <span class='fs-git'>git repo</span>" : "";
+    modal().innerHTML = `<div class="fs-backdrop"><div class="fs-modal">
+      <div class="fs-head"><strong>Select a repo folder</strong><a href="#" id="fs-close">✕</a></div>
+      <div class="fs-bar">${up} · <a href="#" id="fs-home">~ home</a> · <a href="#" id="fs-ws">workspace</a>
+        <div class="fs-path"><code>${esc(d.path)}</code>${badge}</div></div>
+      <div class="fs-list">${rows}${d.truncated ? "<p class='muted'>…truncated.</p>" : ""}</div>
+      <div class="fs-foot"><button id="fs-use" type="button" class="primary">Use this folder</button>
+        <span class="muted">${esc(d.path)}</span></div>
+    </div></div>`;
+    $("fs-close").onclick = (e) => {
+      e.preventDefault();
+      close();
+    };
+    if (d.parent)
+      $("fs-up").onclick = (e) => {
+        e.preventDefault();
+        list(d.parent);
+      };
+    $("fs-home").onclick = (e) => {
+      e.preventDefault();
+      list("~");
+    };
+    $("fs-ws").onclick = (e) => {
+      e.preventDefault();
+      list("");
+    };
+    $("fs-use").onclick = () => {
+      $("repo").value = d.path;
+      close();
+      $("status").textContent = "Repo set to " + d.path;
+    };
+    modal().querySelector(".fs-backdrop").onclick = (ev) => {
+      if (ev.target.classList.contains("fs-backdrop")) close();
+    };
+    modal()
+      .querySelectorAll(".fs-entry[data-dir='true']")
+      .forEach((el) => {
+        el.onclick = () => list(el.dataset.path);
+      });
+  }
+
+  const btn = $("repo-browse");
+  if (btn) btn.onclick = () => list("");
+})();

--- a/src/orchestrator/runtime/__init__.py
+++ b/src/orchestrator/runtime/__init__.py
@@ -9,6 +9,7 @@ slot in when a ``chain_factory`` is supplied.
 from orchestrator.runtime.agent_node import SingleAgentNode
 from orchestrator.runtime.artifacts import (
     ArtifactStore,
+    FilesystemArtifactStore,
     InMemoryArtifactStore,
     ObjectStoreArtifactStore,
     artifact_store_from_env,
@@ -59,6 +60,7 @@ __all__ = [
     "ContextBudget",
     "FailurePolicy",
     "Handoff",
+    "FilesystemArtifactStore",
     "InMemoryArtifactStore",
     "ManagerSpec",
     "MemorySaver",

--- a/src/orchestrator/runtime/artifacts.py
+++ b/src/orchestrator/runtime/artifacts.py
@@ -14,6 +14,7 @@ the runtime can call directly without an HTTP hop, plus an
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any, Protocol
 
 from orchestrator.storage import ArtifactNotFoundError, ObjectStoreClient
@@ -109,6 +110,57 @@ class InMemoryArtifactStore:
         return list(self._blobs) + list(self._byte_blobs)
 
 
+class FilesystemArtifactStore:
+    """Disk-backed store — **shared across processes** (the SDLC worker writes,
+    the API reads). Artifacts live under ``ORCHESTRATOR_ARTIFACT_DIR`` (default
+    ``.orchestrator-artifacts``); the ``artifact_id`` is the relative path. The
+    local-``up`` default so run artifacts are visible to the web UI without MinIO.
+    """
+
+    def __init__(self, root: str | None = None) -> None:
+        import os
+
+        raw = root or os.getenv("ORCHESTRATOR_ARTIFACT_DIR") or ".orchestrator-artifacts"
+        self._root = Path(raw).expanduser().resolve()
+
+    def _path(self, artifact_id: str) -> Path:
+        p = (self._root / artifact_id).resolve()
+        if p != self._root and self._root not in p.parents:
+            raise ValueError(f"artifact id {artifact_id!r} escapes the artifact root")
+        return p
+
+    async def put_bytes(
+        self, artifact_id: str, body: bytes, content_type: str = "application/octet-stream"
+    ) -> None:
+        p = self._path(artifact_id)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(body)
+
+    async def get_bytes(self, artifact_id: str) -> bytes:
+        p = self._path(artifact_id)
+        if not p.is_file():
+            raise LookupError(f"artifact {artifact_id!r} not found")
+        return p.read_bytes()
+
+    async def put_json(self, artifact_id: str, body: dict[str, Any]) -> None:
+        payload = json.dumps(body, default=str, ensure_ascii=False).encode("utf-8")
+        await self.put_bytes(artifact_id, payload, "application/json")
+
+    async def get_json(self, artifact_id: str) -> dict[str, Any]:
+        raw = await self.get_bytes(artifact_id)
+        loaded = json.loads(raw.decode("utf-8"))
+        if not isinstance(loaded, dict):
+            raise ValueError(f"artifact {artifact_id!r} did not deserialise to a JSON object")
+        return dict(loaded)
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        """Relative keys of every file under ``prefix`` (for run-artifact listing)."""
+        base = self._path(prefix)
+        if not base.is_dir():
+            return []
+        return sorted(str(p.relative_to(self._root)) for p in base.rglob("*") if p.is_file())
+
+
 def make_artifact_id(*, task_id: str, node_id: str, suffix: str = "output") -> str:
     """Stable key for a specialist's terminal output.
 
@@ -130,12 +182,16 @@ def make_job_artifact_id(*, job_id: str, filename: str) -> str:
 
 
 def artifact_store_from_env() -> ArtifactStore:
-    """Pick the artifact store from the environment: in-memory when
-    ``ORCHESTRATOR_ARTIFACT_STORE=memory`` (the local ``up`` default and CI),
-    else the S3/MinIO-backed object store. Shared by the Temporal worker and the
-    in-process capability job runner so both honour the same hint."""
+    """Pick the artifact store from ``ORCHESTRATOR_ARTIFACT_STORE``:
+    ``memory`` (in-process, tests/CI), ``fs`` (disk-backed, shared across the
+    worker + API — the local ``up`` default so run artifacts reach the web UI),
+    else the S3/MinIO object store (production). Shared by the Temporal worker
+    and the in-process capability job runner so both honour the same hint."""
     import os
 
-    if os.getenv("ORCHESTRATOR_ARTIFACT_STORE", "").lower() == "memory":
+    kind = os.getenv("ORCHESTRATOR_ARTIFACT_STORE", "").lower()
+    if kind == "memory":
         return InMemoryArtifactStore()
+    if kind == "fs":
+        return FilesystemArtifactStore()
     return ObjectStoreArtifactStore()

--- a/src/orchestrator/sdlc/activities.py
+++ b/src/orchestrator/sdlc/activities.py
@@ -244,6 +244,61 @@ class SDLCActivities:
         plan = plan_capabilities(profile)
         return {"profile": profile.to_dict(), "plan": plan.to_dict()}
 
+    @activity.defn(name="sdlc_comprehend_repo")
+    async def comprehend_repo(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """M1: understand the repo → persist architectural artifacts (knowledge
+        graph, memory bank, current-state), summarised at the intent gate.
+
+        Deterministic, no LLM, best-effort: gated by ``SDLC_COMPREHEND`` (on by
+        default) and never fails the run — a missing repo or extraction error
+        degrades to a ``skipped`` result the gate simply notes."""
+        import os
+
+        if (os.getenv("SDLC_COMPREHEND", "1") or "1").strip().lower() in ("0", "false", "no"):
+            return {"skipped": True, "reason": "disabled"}
+        try:
+            base = await self._deps.workspace.ensure_base_repo()
+        except Exception as exc:  # noqa: BLE001 — no reachable repo → skip, don't block the run
+            logger.warning("sdlc.comprehend.no_repo", extra={"error": str(exc)[:200]})
+            return {"skipped": True, "reason": "no base repo reachable"}
+        try:
+            from orchestrator.sdlc.comprehension import run_comprehension
+
+            return await run_comprehension(
+                base,
+                artifact_store=self._deps.artifact_store,
+                run_id=str(payload["sdlc_id"]),
+                sql_dialect=payload.get("sql_dialect"),
+            )
+        except Exception as exc:  # noqa: BLE001 — comprehension is best-effort
+            logger.warning("sdlc.comprehend.failed", extra={"error": str(exc)[:200]})
+            return {"skipped": True, "reason": f"failed: {str(exc)[:150]}"}
+
+    @activity.defn(name="sdlc_design_feature")
+    async def design_feature(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """M2: spec × knowledge graph → a grounded design for one issue, persisted
+        as an artifact. Best-effort + flag-gated (``SDLC_DESIGN``, on by default);
+        an LLM writes it when configured, else a deterministic heuristic design."""
+        import os
+
+        issue_key = str(payload.get("issue_key") or "")
+        if (os.getenv("SDLC_DESIGN", "1") or "1").strip().lower() in ("0", "false", "no"):
+            return {"issue_key": issue_key, "skipped": True, "reason": "disabled"}
+        try:
+            from orchestrator.sdlc.design import design_feature as _design
+
+            return await _design(
+                dict(payload.get("spec") or {}),
+                comprehension=payload.get("comprehension") or {},
+                artifact_store=self._deps.artifact_store,
+                run_id=str(payload["sdlc_id"]),
+                issue_key=issue_key,
+                llm=self._deps.llm,
+            )
+        except Exception as exc:  # noqa: BLE001 — design is best-effort
+            logger.warning("sdlc.design.failed", extra={"issue": issue_key, "error": str(exc)[:200]})
+            return {"issue_key": issue_key, "skipped": True, "reason": f"failed: {str(exc)[:150]}"}
+
     @activity.defn(name="sdlc_create_jira_issues")
     async def create_jira_issues(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Pair each spec with an issue key for the fan-out.
@@ -372,11 +427,41 @@ class SDLCActivities:
 
     @activity.defn(name="sdlc_create_workspace")
     async def create_workspace(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Create a per-issue git worktree, returning its path."""
+        """Create a per-issue git worktree, returning its path.
+
+        Also seeds the worktree with the run's comprehension **memory bank** (M1b)
+        so codegen grounds every feature on the run's code-true knowledge (domain
+        model, conventions) via the existing memory-bank grounding path."""
         sdlc_id = str(payload["sdlc_id"])
         issue_key = str(payload["issue_key"])
         path = await self._deps.workspace.create(sdlc_id, issue_key)
-        return {"path": str(path)}
+        seeded = await self._seed_memory_bank(path, payload.get("comprehension") or {})
+        return {"path": str(path), "memory_bank_seeded": seeded}
+
+    async def _seed_memory_bank(self, path: Any, comprehension: dict[str, Any]) -> int:
+        """Fetch the comprehension memory-bank artifacts and write them into the
+        worktree's ``memory-bank/`` (best-effort — never fails workspace setup)."""
+        from pathlib import Path
+
+        artifacts = comprehension.get("artifacts")
+        if not isinstance(artifacts, dict):
+            return 0
+        mb_keys = {n: k for n, k in artifacts.items() if str(n).startswith("memory-bank/")}
+        if not mb_keys:
+            return 0
+        mb_dir = Path(path) / "memory-bank"
+        seeded = 0
+        for name, key in mb_keys.items():
+            try:
+                data = await self._deps.artifact_store.get_bytes(str(key))
+            except Exception as exc:  # noqa: BLE001 — a missing artifact must not block the run
+                logger.warning("sdlc.seed_memory_bank.miss", extra={"key": str(key), "error": str(exc)[:120]})
+                continue
+            dest = mb_dir / str(name).split("/", 1)[1]
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(data)
+            seeded += 1
+        return seeded
 
     @contextlib.asynccontextmanager
     async def _budget_scope(self, payload: dict[str, Any], stage: str) -> AsyncIterator[None]:

--- a/src/orchestrator/sdlc/comprehension.py
+++ b/src/orchestrator/sdlc/comprehension.py
@@ -1,0 +1,111 @@
+"""Repo comprehension milestone (M1): understand the repo → persisted artifacts.
+
+Runs once per SDLC run, before the intent gate, on the base checkout (the same
+one ``sdlc_profile_and_plan`` already ensures). Produces durable **architectural
+artifacts** — the Product Knowledge Graph (a SQLite export + a bounded module
+overview), the memory bank, and a current-state report — stored in the
+``ArtifactStore`` under ``run/<sdlc_id>/comprehension/`` and summarised at Gate 1.
+
+Deterministic, no LLM; the commit-SHA-keyed PKG cache makes re-runs on the same
+commit cheap. The heavy extraction runs off the event loop so it never blocks the
+activity worker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from orchestrator.runtime import ArtifactStore
+
+_KIND = "comprehension"
+
+
+def _key(run_id: str, name: str) -> str:
+    return f"run/{run_id}/{_KIND}/{name}"
+
+
+def _compute(root: Path, sql_dialect: str | None) -> dict[str, Any]:
+    """The deterministic, CPU-bound work (PKG + memory bank + current state).
+    Returns raw bytes/strings; the async caller persists them."""
+    from orchestrator.knowledge import build_memory_bank
+    from orchestrator.knowledge.current_state import build_current_state
+    from orchestrator.pkg import RepoCodeExtractor, export_sqlite
+    from orchestrator.pkg.overview import build_overview
+
+    batch = RepoCodeExtractor(sql_dialect=sql_dialect).extract(root)
+    overview = build_overview(batch)
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "knowledge-graph.db"
+        export_sqlite(batch, db_path)
+        db_bytes = db_path.read_bytes()
+
+    # Write the memory bank to a throwaway dir (never touch the checkout), read it back.
+    mb_files: dict[str, str] = {}
+    with tempfile.TemporaryDirectory() as tmp:
+        mb = build_memory_bank(root, out_dir=tmp, sql_dialect=sql_dialect)
+        for p in sorted(Path(tmp).glob("*.md")):
+            mb_files[p.name] = p.read_text(encoding="utf-8")
+
+    current_state = build_current_state(root, lens="developer", sql_dialect=sql_dialect)
+    return {
+        "overview": overview,
+        "db_bytes": db_bytes,
+        "memory_bank": mb_files,
+        "current_state": current_state,
+        "greenfield": bool(mb.get("greenfield")),
+        "summary": str(mb.get("summary") or ""),
+    }
+
+
+async def run_comprehension(
+    root: Path | str,
+    *,
+    artifact_store: ArtifactStore,
+    run_id: str,
+    sql_dialect: str | None = None,
+) -> dict[str, Any]:
+    """Comprehend ``root``, persist the artifacts, and return a manifest.
+
+    The manifest (JSON-safe) carries the headline counts + the artifact keys so
+    the workflow can audit it and fold a summary into the intent gate."""
+    computed = await asyncio.to_thread(_compute, Path(root), sql_dialect)
+
+    artifacts: dict[str, str] = {}
+
+    async def _put(name: str, data: bytes, content_type: str) -> None:
+        key = _key(run_id, name)
+        await artifact_store.put_bytes(key, data, content_type)
+        artifacts[name] = key
+
+    await _put("knowledge-graph.db", computed["db_bytes"], "application/vnd.sqlite3")
+    await _put(
+        "graph-overview.json",
+        json.dumps(computed["overview"], default=str, ensure_ascii=False).encode("utf-8"),
+        "application/json",
+    )
+    for name, content in computed["memory_bank"].items():
+        await _put(f"memory-bank/{name}", content.encode("utf-8"), "text/markdown")
+    await _put("current-state.md", computed["current_state"].encode("utf-8"), "text/markdown")
+
+    manifest: dict[str, Any] = {
+        "run_id": run_id,
+        "greenfield": computed["greenfield"],
+        "summary": computed["summary"],
+        "counts": computed["overview"]["summary"],  # {nodes, grounded_nodes, external_nodes, edges}
+        "kinds": computed["overview"].get("kinds", {}),
+        "memory_bank_files": sorted(computed["memory_bank"]),
+        "artifacts": dict(artifacts),
+    }
+    await _put(
+        "comprehension.json",
+        json.dumps(manifest, default=str, ensure_ascii=False).encode("utf-8"),
+        "application/json",
+    )
+    return manifest
+
+
+__all__ = ["run_comprehension"]

--- a/src/orchestrator/sdlc/deps.py
+++ b/src/orchestrator/sdlc/deps.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from orchestrator.core.llm import LLMClient, RunBudget
 from orchestrator.intake.service import BacklogService
+from orchestrator.runtime import ArtifactStore, InMemoryArtifactStore
 from orchestrator.sdlc.ci import CIAdapter, StubCIAdapter
 from orchestrator.sdlc.codegen import CodegenAdapter, StubCodegenAdapter
 from orchestrator.sdlc.escalation import EscalationPolicy
@@ -66,3 +67,7 @@ class SDLCDeps:
     # The LLM client for post-merge memory consolidation (Phase 2b). None when no
     # LLM is configured (stub codegen) — the consolidate activity then no-ops.
     llm: LLMClient | None = None
+    # Where the repo-comprehension milestone (M1) persists its architectural
+    # artifacts (knowledge graph, memory bank, current-state). Defaults to an
+    # in-memory store for tests; the worker wires the env-selected store.
+    artifact_store: ArtifactStore = field(default_factory=InMemoryArtifactStore)

--- a/src/orchestrator/sdlc/design.py
+++ b/src/orchestrator/sdlc/design.py
@@ -1,0 +1,192 @@
+"""Feature/Issue design milestone (M2): spec × knowledge graph → a grounded design.
+
+For each issue, consumes the M1 comprehension artifacts (the module-level
+knowledge-graph overview + the memory bank) and the spec, and produces a
+**design** — approach, files to touch, interfaces, data changes, risks, test
+strategy — anchored to the repo's real structure. An LLM writes it when one is
+configured; otherwise a deterministic heuristic design is produced from the graph
++ acceptance criteria. Persisted under ``run/<sdlc_id>/feature/<issue_key>/``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import Any
+
+from orchestrator.runtime import ArtifactStore
+
+_FIELDS = ("approach", "files_to_touch", "interfaces", "data_changes", "risks", "test_strategy")
+_LIST_FIELDS = ("files_to_touch", "interfaces", "data_changes", "risks")
+
+
+def _key(run_id: str, issue_key: str, name: str) -> str:
+    return f"run/{run_id}/feature/{issue_key}/{name}"
+
+
+async def _load_context(comprehension: dict[str, Any], store: ArtifactStore) -> dict[str, Any]:
+    """The structural + conventional context from the M1 comprehension artifacts."""
+    arts = (comprehension or {}).get("artifacts")
+    ctx: dict[str, Any] = {"overview": None, "memory_bank": {}}
+    if not isinstance(arts, dict):
+        return ctx
+    ov_key = arts.get("graph-overview.json")
+    if ov_key:
+        with contextlib.suppress(Exception):  # best-effort; design degrades without it
+            ctx["overview"] = json.loads((await store.get_bytes(str(ov_key))).decode("utf-8"))
+    for name in ("domain-model.md", "tech-context.md", "conventions.md"):
+        k = arts.get(f"memory-bank/{name}")
+        if k:
+            with contextlib.suppress(Exception):
+                ctx["memory_bank"][name] = (await store.get_bytes(str(k))).decode("utf-8")
+    return ctx
+
+
+def _structure_lines(overview: dict[str, Any] | None) -> list[str]:
+    if not overview:
+        return []
+    lines: list[str] = []
+    mods = overview.get("modules") or []
+    if mods:
+        lines.append("Top modules: " + ", ".join(f"{m['module']} ({m['nodes']})" for m in mods[:8]))
+    edges = overview.get("module_edges") or []
+    if edges:
+        lines.append(
+            "Key dependencies: " + "; ".join(f"{e['src']}→{e['dst']} ({e['kind']})" for e in edges[:6])
+        )
+    syms = overview.get("top_symbols") or []
+    if syms:
+        lines.append(
+            "Most-connected symbols: " + ", ".join(f"{s['name']} in {s.get('module', '?')}" for s in syms[:8])
+        )
+    return lines
+
+
+def _fallback_design(spec: dict[str, Any], overview: dict[str, Any] | None) -> dict[str, Any]:
+    mods = [str(m["module"]) for m in (overview or {}).get("modules", [])[:5]]
+    ac = [str(a) for a in (spec.get("acceptance_criteria") or [])]
+    return {
+        "approach": (
+            f"Implement '{spec.get('title', 'the feature')}' following the repo's existing "
+            "structure and conventions."
+        ),
+        "files_to_touch": mods,
+        "interfaces": [],
+        "data_changes": [],
+        "risks": (
+            ["Heuristic design (no LLM) — confirm the affected modules before building."] if mods else []
+        ),
+        "test_strategy": "Add tests covering each acceptance criterion: " + "; ".join(ac[:6]),
+        "grounded": bool(overview),
+        "llm": False,
+    }
+
+
+def _normalise(design: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for f in _FIELDS:
+        v = design.get(f)
+        if f in _LIST_FIELDS:
+            out[f] = [str(x) for x in v] if isinstance(v, list) else ([str(v)] if v else [])
+        else:
+            out[f] = str(v) if v is not None else ""
+    out["grounded"] = bool(design.get("grounded", True))
+    out["llm"] = bool(design.get("llm", False))
+    return out
+
+
+async def _llm_design(spec: dict[str, Any], ctx: dict[str, Any], llm: Any) -> dict[str, Any]:
+    from orchestrator.core.llm.client import Message
+    from orchestrator.sdlc.codegen import resolve_codegen_model
+
+    structure = "\n".join(_structure_lines(ctx.get("overview"))) or "(no structure available)"
+    conventions = "\n\n".join(f"## {n}\n{c[:1500]}" for n, c in (ctx.get("memory_bank") or {}).items())
+    ac = "\n".join(f"- {a}" for a in (spec.get("acceptance_criteria") or []))
+    prompt = (
+        "Design how to implement this feature in THIS repository. Ground every decision in the "
+        "structure + conventions below; reference REAL modules/symbols. Respond with a JSON object "
+        "with keys: approach (string), files_to_touch (list of paths), interfaces (list of "
+        "signatures/types to add or change), data_changes (list), risks (list), test_strategy (string).\n\n"
+        f"FEATURE: {spec.get('title', '')}\n{spec.get('summary', '')}\n"
+        f"Acceptance criteria:\n{ac}\n\n"
+        f"REPO STRUCTURE (knowledge graph):\n{structure}\n\n"
+        f"CONVENTIONS / DOMAIN (memory bank):\n{conventions[:4000]}"
+    )
+    result = await llm.complete(
+        [
+            Message(
+                role="system",
+                content="You are a senior engineer designing a change grounded in an existing codebase.",
+            ),
+            Message(role="user", content=prompt),
+        ],
+        model=resolve_codegen_model(),
+        json_object=True,
+        temperature=0.2,
+    )
+    data = json.loads(result.text)
+    data["grounded"] = bool(ctx.get("overview"))
+    data["llm"] = True
+    return _normalise(data)
+
+
+def render_design_md(spec: dict[str, Any], design: dict[str, Any]) -> str:
+    def _list(title: str, items: list[str]) -> str:
+        if not items:
+            return ""
+        body = "\n".join(f"- {i}" for i in items)
+        return f"\n## {title}\n{body}\n"
+
+    origin = "LLM-generated" if design.get("llm") else "heuristic (no LLM)"
+    return (
+        f"# Design — {spec.get('title', 'feature')}\n\n"
+        f"_{origin}, grounded in the knowledge graph: {design.get('grounded')}_\n\n"
+        f"## Approach\n{design.get('approach', '')}\n"
+        + _list("Files to touch", design.get("files_to_touch") or [])
+        + _list("Interfaces", design.get("interfaces") or [])
+        + _list("Data changes", design.get("data_changes") or [])
+        + _list("Risks", design.get("risks") or [])
+        + f"\n## Test strategy\n{design.get('test_strategy', '')}\n"
+    )
+
+
+async def design_feature(
+    spec: dict[str, Any],
+    *,
+    comprehension: dict[str, Any],
+    artifact_store: ArtifactStore,
+    run_id: str,
+    issue_key: str,
+    llm: Any = None,
+) -> dict[str, Any]:
+    """Produce + persist a grounded design for one issue; return a summary + refs."""
+    ctx = await _load_context(comprehension, artifact_store)
+    try:
+        design = (
+            await _llm_design(spec, ctx, llm) if llm is not None else _fallback_design(spec, ctx["overview"])
+        )
+    except Exception:  # noqa: BLE001 — LLM/parse failure → deterministic design, never blocks
+        design = _fallback_design(spec, ctx["overview"])
+
+    artifacts: dict[str, str] = {}
+
+    async def _put(name: str, data: bytes, content_type: str) -> None:
+        k = _key(run_id, issue_key, name)
+        await artifact_store.put_bytes(k, data, content_type)
+        artifacts[name] = k
+
+    await _put(
+        "design.json", json.dumps(design, default=str, ensure_ascii=False).encode("utf-8"), "application/json"
+    )
+    await _put("design.md", render_design_md(spec, design).encode("utf-8"), "text/markdown")
+    return {
+        "issue_key": issue_key,
+        "summary": design.get("approach", ""),
+        "files_to_touch": design.get("files_to_touch") or [],
+        "llm": design.get("llm", False),
+        "design": design,
+        "artifacts": artifacts,
+    }
+
+
+__all__ = ["design_feature", "render_design_md"]

--- a/src/orchestrator/sdlc/run_control.py
+++ b/src/orchestrator/sdlc/run_control.py
@@ -86,6 +86,7 @@ async def start_run(
             dry_run_jira=not create_jira,
             max_features=max_features,
             max_parallel_features=max_parallel,
+            design_gate=(os.getenv("SDLC_DESIGN_GATE", "0") or "0").strip().lower() in ("1", "true", "yes"),
         ),
         id=f"task-{sdlc_id}",
         task_queue=queue,

--- a/src/orchestrator/sdlc/types.py
+++ b/src/orchestrator/sdlc/types.py
@@ -50,6 +50,11 @@ class SDLCWorkflowInput:
     # Children run in batches of this size — a full fan-out of LLM codegen
     # bursts past provider rate tiers (run #6's lesson).
     max_parallel_features: int = 2
+    # M2: raise the design gate (Gate 1.5) after the design wave, so a human
+    # signs off the per-issue designs before implementation. Captured at start
+    # from ``SDLC_DESIGN_GATE`` (off by default). Designs are always produced
+    # (the activity self-gates on ``SDLC_DESIGN``); this only controls the gate.
+    design_gate: bool = False
 
 
 @dataclass
@@ -98,6 +103,13 @@ class FeatureWorkflowInput:
     # to condition the agentic codegen loop. Run-level (same for every feature).
     skills: list[str] = field(default_factory=list)
     mcp_servers: list[str] = field(default_factory=list)
+    # Repo comprehension manifest (M1): the artifact keys for the shared memory
+    # bank, so a feature's worktree can be seeded with it before codegen and
+    # grounds on the run's code-true knowledge. Run-level; ``{}`` when skipped.
+    comprehension: dict[str, Any] = field(default_factory=dict)
+    # This issue's approved design (M2): folded into the spec before codegen so
+    # implementation follows the grounded approach. ``{}`` when design skipped.
+    design: dict[str, Any] = field(default_factory=dict)
 
 
 # Child verdicts. ``passed`` is the only one that opens a PR and lets the parent

--- a/src/orchestrator/sdlc/worker.py
+++ b/src/orchestrator/sdlc/worker.py
@@ -30,6 +30,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from temporalio.worker import Worker
 
 from orchestrator.core.llm import BudgetedLLMClient, LLMClient, RunBudget
+from orchestrator.runtime import artifact_store_from_env
 from orchestrator.sdlc.activities import SDLCActivities
 from orchestrator.sdlc.ci import CIAdapter, GHACIAdapter, StubCIAdapter
 from orchestrator.sdlc.codegen import (
@@ -212,6 +213,7 @@ def build_deps() -> SDLCDeps:
         preflight=SubprocessPreflightRunner(),
         budget=budget,
         llm=llm() if codegen_is_llm else None,
+        artifact_store=artifact_store_from_env(),
     )
 
 
@@ -232,6 +234,8 @@ def sdlc_activity_methods(instance: SDLCActivities) -> list[Any]:
         instance.raise_approval_request,
         instance.intake_analyze,
         instance.profile_and_plan,
+        instance.comprehend_repo,
+        instance.design_feature,
         instance.create_jira_issues,
         instance.integration_test,
         instance.merge_prs,

--- a/src/orchestrator/sdlc/workflows.py
+++ b/src/orchestrator/sdlc/workflows.py
@@ -49,6 +49,9 @@ _STAGE_TIMEOUT = timedelta(minutes=2)
 _CODEGEN_TIMEOUT = timedelta(minutes=15)
 _INTAKE_TIMEOUT = timedelta(minutes=5)
 _WORKSPACE_TIMEOUT = timedelta(minutes=2)
+# Comprehension (M1) extracts the PKG + memory bank + current-state; generous for
+# a large repo (SHA-cached, so re-runs on the same commit are fast).
+_COMPREHEND_TIMEOUT = timedelta(minutes=10)
 # Human approval can take a while but abandoned runs should self-clean.
 _DEFAULT_APPROVAL_WAIT = timedelta(hours=24)
 
@@ -107,9 +110,16 @@ class FeatureImplementationWorkflow:
 
     @workflow.run
     async def run(self, payload: FeatureWorkflowInput) -> FeatureWorkflowResult:
+        # M2: fold this issue's approved design into the spec so every codegen
+        # stage (plan / implement / refine) builds to the grounded approach.
+        payload.spec = _spec_with_design(payload.spec, payload.design)
         ws = await workflow.execute_activity(
             "sdlc_create_workspace",
-            {"sdlc_id": payload.sdlc_id, "issue_key": payload.issue_key},
+            {
+                "sdlc_id": payload.sdlc_id,
+                "issue_key": payload.issue_key,
+                "comprehension": payload.comprehension,
+            },
             schedule_to_close_timeout=_WORKSPACE_TIMEOUT,
             retry_policy=_STAGE_RETRY,
         )
@@ -540,6 +550,19 @@ class SDLCWorkflow:
             payload, "sdlc_capability_plan", {"profile": plan_out["profile"], "plan": capability_plan}
         )
 
+        # ---- 1c. comprehend the repo → architectural artifacts (M1) --------
+        # Deterministic, best-effort: extract the knowledge graph + memory bank +
+        # current-state on the base checkout, persist them as run artifacts, and
+        # summarise "what Spine understood" at the intent gate below.
+        comprehension = await workflow.execute_activity(
+            "sdlc_comprehend_repo",
+            {"sdlc_id": payload.sdlc_id, "trace_id": payload.trace_id},
+            schedule_to_close_timeout=_COMPREHEND_TIMEOUT,
+            retry_policy=_STAGE_RETRY,
+        )
+        result.stage_outcomes["comprehension"] = comprehension
+        await self._audit(payload, "sdlc_repo_comprehended", comprehension)
+
         # ---- 2. GATE 1: approve intents (and answer any open questions) ----
         # Surface the extractor's open questions to the approver so ambiguity
         # is resolved here — by a human — rather than guessed at by codegen.
@@ -551,7 +574,9 @@ class SDLCWorkflow:
             before_node="intents",
             title="approve intents",
             risk="medium",
-            description=_intents_gate_description(intake["intent_count"], open_questions, capability_plan),
+            description=_intents_gate_description(
+                intake["intent_count"], open_questions, capability_plan, comprehension
+            ),
         )
         result.gate_decisions.append(gate1)
         if gate1["action"] in ("deny", "cancel"):
@@ -601,6 +626,67 @@ class SDLCWorkflow:
         result.issue_keys = [p["issue_key"] for p in issue_plans]
         await self._audit(payload, "sdlc_issues_created", {"issue_keys": result.issue_keys})
 
+        # ---- 3b. DESIGN wave (M2) — one grounded design per issue -----------
+        # Fan out design activities (each self-gates on SDLC_DESIGN, best-effort)
+        # so every design is anchored to the comprehension knowledge graph BEFORE
+        # any code is written. Optionally gate the whole set (Gate 1.5).
+        designs_by_issue: dict[str, dict[str, Any]] = {}
+        if issue_plans:
+            design_results = await asyncio.gather(
+                *[
+                    workflow.execute_activity(
+                        "sdlc_design_feature",
+                        {
+                            "sdlc_id": payload.sdlc_id,
+                            "issue_key": plan["issue_key"],
+                            "spec": plan["spec"],
+                            "comprehension": comprehension if isinstance(comprehension, dict) else {},
+                            "trace_id": payload.trace_id,
+                        },
+                        schedule_to_close_timeout=_CODEGEN_TIMEOUT,
+                        retry_policy=_STAGE_RETRY,
+                    )
+                    for plan in issue_plans
+                ]
+            )
+            designs_by_issue = {d["issue_key"]: d for d in design_results if d.get("issue_key")}
+            produced = [d for d in design_results if not d.get("skipped")]
+            if produced:
+                # One audit per design carrying its artifact manifest, so the
+                # run-artifacts API (keyed on ``feature_designed`` + ``artifacts``)
+                # surfaces design.json/design.md for download in the console —
+                # the same way ``sdlc_repo_comprehended`` surfaces M1's artifacts.
+                for d in produced:
+                    if isinstance(d.get("artifacts"), dict) and d["artifacts"]:
+                        await self._audit(
+                            payload,
+                            "feature_designed",
+                            {
+                                "issue_key": d.get("issue_key"),
+                                "summary": d.get("summary"),
+                                "files_to_touch": d.get("files_to_touch") or [],
+                                "artifacts": d["artifacts"],
+                            },
+                        )
+                await self._audit(payload, "sdlc_designs_ready", {"count": len(produced)})
+                if payload.design_gate:
+                    gate15, decisions_consumed = await self._gate(
+                        payload,
+                        decisions_consumed,
+                        gate_index=2,
+                        before_node="designs",
+                        title="approve designs",
+                        risk="medium",
+                        description=_designs_gate_description(produced),
+                    )
+                    result.gate_decisions.append(gate15)
+                    if gate15["action"] in ("deny", "cancel"):
+                        reason = "cancelled" if gate15["action"] == "cancel" else "designs_denied"
+                        await self._audit(payload, f"sdlc_{reason}", {"gate": "designs"})
+                        result.terminated = True
+                        result.termination_reason = reason
+                        return result
+
         # ---- 4. fan-out: one child workflow per issue, run concurrently ----
         # Each child gets a deterministic id (feat-{sdlc_id}-{issue_key}) for
         # idempotency on replay. asyncio.gather starts them concurrently and
@@ -624,6 +710,8 @@ class SDLCWorkflow:
                         max_review_iterations=eff_max_review,
                         skills=list(capability_plan.get("skills") or []),
                         mcp_servers=list(capability_plan.get("mcp_servers") or []),
+                        comprehension=comprehension if isinstance(comprehension, dict) else {},
+                        design=designs_by_issue.get(plan["issue_key"], {}),
                     ),
                     # ``task-`` prefix so the child can receive REST approval
                     # signals for in-loop gates (the API signals task-{task_id}).
@@ -848,10 +936,67 @@ def _to_loop_decision(decision: dict[str, Any]) -> dict[str, Any]:
     return {"action": "reject", "rationale": "human denied the tool call"}
 
 
+def _designs_gate_description(designs: list[dict[str, Any]]) -> str:
+    """Gate 1.5 prompt: the per-issue designs to approve before implementation."""
+    lines = []
+    for d in designs:
+        files = d.get("files_to_touch") or []
+        files_note = f" — touches {', '.join(str(f) for f in files[:4])}" if files else ""
+        lines.append(f"  - {d.get('issue_key')}: {str(d.get('summary') or '')[:160]}{files_note}")
+    body = "\n".join(lines)
+    return (
+        f"Gate 1.5: approve {len(designs)} feature design(s) before implementation. Each is grounded "
+        f"in the repo's knowledge graph (see the run's design artifacts):\n{body}"
+    )
+
+
+def _spec_with_design(spec: dict[str, Any], design: dict[str, Any]) -> dict[str, Any]:
+    """Fold an approved design into the spec's technical notes so codegen builds
+    to the grounded approach (no codegen-adapter change needed)."""
+    d = (design or {}).get("design") or {}
+    if not d:
+        return spec
+    parts = [f"APPROVED DESIGN — approach: {d.get('approach', '')}"]
+    if d.get("files_to_touch"):
+        parts.append("Files to touch: " + ", ".join(str(f) for f in d["files_to_touch"]))
+    if d.get("interfaces"):
+        parts.append("Interfaces: " + "; ".join(str(i) for i in d["interfaces"]))
+    if d.get("data_changes"):
+        parts.append("Data changes: " + "; ".join(str(x) for x in d["data_changes"]))
+    if d.get("test_strategy"):
+        parts.append("Test strategy: " + str(d["test_strategy"]))
+    design_block = "\n".join(parts)
+    merged = dict(spec)
+    existing = str(merged.get("technical_notes") or "")
+    merged["technical_notes"] = f"{existing}\n\n{design_block}".strip() if existing else design_block
+    return merged
+
+
+def _comprehension_summary_line(comprehension: dict[str, Any] | None) -> str | None:
+    """A one-line "what Spine understood" summary for the intent gate (M1)."""
+    if not comprehension:
+        return None
+    if comprehension.get("skipped"):
+        return f"Repo comprehension skipped ({comprehension.get('reason', 'n/a')})."
+    counts = comprehension.get("counts") or {}
+    if comprehension.get("greenfield"):
+        return "Greenfield repo — no existing code to map."
+    nodes = counts.get("nodes")
+    edges = counts.get("edges")
+    if nodes is None:
+        return None
+    files = len(comprehension.get("memory_bank_files") or [])
+    return (
+        f"Understood the repo: {nodes} code entities, {edges} relationships; "
+        f"knowledge graph + {files} memory-bank docs + current-state saved (see the run's artifacts)."
+    )
+
+
 def _intents_gate_description(
     intent_count: int,
     open_questions: list[str],
     capability_plan: dict[str, Any] | None = None,
+    comprehension: dict[str, Any] | None = None,
 ) -> str:
     """Gate-1 prompt: intents, open questions, and the assembled capability plan.
 
@@ -869,6 +1014,9 @@ def _intents_gate_description(
             "`clarifications` patch (string or list), or approve to proceed as "
             f"specified:\n{lines}"
         )
+    comprehension_line = _comprehension_summary_line(comprehension)
+    if comprehension_line:
+        parts.append(comprehension_line)
     plan_lines = _plan_summary_lines(capability_plan)
     if plan_lines:
         body = "\n".join(f"  - {line}" for line in plan_lines)

--- a/tests/registry/test_phase_b.py
+++ b/tests/registry/test_phase_b.py
@@ -110,6 +110,9 @@ async def test_intelligence_pages_render_and_are_navigable() -> None:
             r = await client.get(path)
             assert r.status_code == 200 and title in r.text and script in r.text
             assert 'id="repo"' in r.text  # the repo bar
+            # the shared "Browse…" repo-folder picker (local path exposure)
+            assert 'id="repo-browse"' in r.text and 'id="fsmodal"' in r.text
+            assert "/static/repobrowse.js" in r.text
         home = await client.get("/app")
         for href in ("/app/understand", "/app/state", "/app/graph"):
             assert f'href="{href}"' in home.text  # nav section + home cards

--- a/tests/registry/test_run_artifacts.py
+++ b/tests/registry/test_run_artifacts.py
@@ -1,0 +1,120 @@
+"""Run artifacts: the filesystem store (shared across processes) + /v1/runs/*/artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import Table
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from orchestrator.registry.api.app import create_app
+from orchestrator.registry.api.config import Settings
+from orchestrator.registry.db.models import AuditLogRow
+from orchestrator.registry.repositories import AuditLogRepo
+from orchestrator.runtime.artifacts import FilesystemArtifactStore
+
+_AUTH = {"X-API-Key": "dev-key"}
+RUN = "RUN-A"
+
+
+# --------------------------------------------------------------------------- #
+# Filesystem store
+# --------------------------------------------------------------------------- #
+async def test_fs_store_round_trip_and_prefix(tmp_path: Path) -> None:
+    store = FilesystemArtifactStore(root=str(tmp_path))
+    await store.put_bytes("run/R/comprehension/current-state.md", b"# hi\n", "text/markdown")
+    await store.put_json("run/R/comprehension/comprehension.json", {"nodes": 3})
+    assert await store.get_bytes("run/R/comprehension/current-state.md") == b"# hi\n"
+    assert (await store.get_json("run/R/comprehension/comprehension.json"))["nodes"] == 3
+    keys = store.list_prefix("run/R/comprehension")
+    assert "run/R/comprehension/current-state.md" in keys
+    with pytest.raises(LookupError):
+        await store.get_bytes("run/R/missing.md")
+
+
+async def test_fs_store_rejects_escape(tmp_path: Path) -> None:
+    store = FilesystemArtifactStore(root=str(tmp_path / "root"))
+    with pytest.raises(ValueError, match="escapes"):
+        await store.put_bytes("../evil.txt", b"x")
+
+
+# --------------------------------------------------------------------------- #
+# Endpoint
+# --------------------------------------------------------------------------- #
+@pytest_asyncio.fixture
+async def app_ctx(tmp_path: Path) -> AsyncIterator[SimpleNamespace]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(cast(Table, AuditLogRow.__table__).create)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    store = FilesystemArtifactStore(root=str(tmp_path / "artifacts"))
+    # A comprehension artifact the worker "wrote", + the audit manifest that lists it.
+    key = f"run/{RUN}/comprehension/current-state.md"
+    await store.put_bytes(key, b"# Current State\n", "text/markdown")
+    async with factory() as s:
+        await AuditLogRepo(s).write(
+            actor="worker",
+            action="sdlc_repo_comprehended",
+            resource_type="sdlc",
+            resource_id=RUN,
+            trace_id=RUN,
+            after={"counts": {"nodes": 5}, "artifacts": {"current-state.md": key}},
+        )
+        # A design artifact the design wave "wrote", + its per-issue manifest.
+        design_key = f"run/{RUN}/feature/SDLC-1/design.md"
+        await store.put_bytes(design_key, b"# Design\n", "text/markdown")
+        await AuditLogRepo(s).write(
+            actor="worker",
+            action="feature_designed",
+            resource_type="sdlc",
+            resource_id=RUN,
+            trace_id=RUN,
+            after={"issue_key": "SDLC-1", "artifacts": {"design.md": design_key}},
+        )
+        await s.commit()
+
+    app = create_app(Settings())
+    app.router.lifespan_context = None  # type: ignore[assignment]
+    app.state.session_factory = factory
+    app.state.artifact_store = store
+    yield SimpleNamespace(app=app, key=key)
+    await engine.dispose()
+
+
+def _client(app: object) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test", headers=_AUTH)  # type: ignore[arg-type]
+
+
+async def test_lists_run_artifacts_from_manifest(app_ctx: SimpleNamespace) -> None:
+    async with _client(app_ctx.app) as c:
+        items = (await c.get(f"/v1/runs/{RUN}/artifacts")).json()["items"]
+    by_kind = {i["kind"]: i for i in items}
+    # both milestones surface: M1 comprehension + M2 design
+    assert by_kind["comprehension"]["name"] == "current-state.md"
+    assert by_kind["comprehension"]["key"] == app_ctx.key
+    assert by_kind["design"]["name"] == "design.md"
+    assert by_kind["design"]["key"].endswith("feature/SDLC-1/design.md")
+
+
+async def test_downloads_run_artifact(app_ctx: SimpleNamespace) -> None:
+    async with _client(app_ctx.app) as c:
+        r = await c.get(f"/v1/runs/{RUN}/artifacts/download", params={"key": app_ctx.key})
+    assert r.status_code == 200
+    assert r.content == b"# Current State\n"
+    assert r.headers["content-type"].startswith("text/markdown")
+    assert "current-state.md" in r.headers["content-disposition"]
+
+
+async def test_download_rejects_key_outside_run(app_ctx: SimpleNamespace) -> None:
+    async with _client(app_ctx.app) as c:
+        r = await c.get(f"/v1/runs/{RUN}/artifacts/download", params={"key": "run/OTHER/x.md"})
+    assert r.status_code == 400

--- a/tests/sdlc/test_comprehension.py
+++ b/tests/sdlc/test_comprehension.py
@@ -1,0 +1,162 @@
+"""M1 — repo comprehension: the service, the activity, and the intent-gate fold."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.runtime.artifacts import InMemoryArtifactStore
+from orchestrator.sdlc.activities import SDLCActivities
+from orchestrator.sdlc.comprehension import run_comprehension
+from orchestrator.sdlc.deps import SDLCDeps
+from orchestrator.sdlc.workflows import _comprehension_summary_line, _intents_gate_description
+
+
+def _small_repo(tmp_path: Path) -> Path:
+    (tmp_path / "app.py").write_text(
+        "def greet(name):\n    return f'hi {name}'\n\n\ndef main():\n    return greet('x')\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+# --------------------------------------------------------------------------- #
+# Service
+# --------------------------------------------------------------------------- #
+async def test_run_comprehension_persists_artifacts_and_manifest(tmp_path: Path) -> None:
+    store = InMemoryArtifactStore()
+    manifest = await run_comprehension(_small_repo(tmp_path), artifact_store=store, run_id="R1")
+
+    assert manifest["counts"]["nodes"] > 0
+    arts = manifest["artifacts"]
+    assert {"knowledge-graph.db", "graph-overview.json", "current-state.md"} <= set(arts)
+    assert any(k.startswith("memory-bank/") for k in arts)
+
+    # Artifacts are really stored under the run-scoped namespace.
+    assert await store.get_bytes("run/R1/comprehension/knowledge-graph.db")  # non-empty
+    md = (await store.get_bytes(arts["current-state.md"])).decode("utf-8")
+    assert "#" in md  # a markdown report
+    overview = json.loads((await store.get_bytes(arts["graph-overview.json"])).decode("utf-8"))
+    assert overview["summary"]["nodes"] == manifest["counts"]["nodes"]
+
+
+# --------------------------------------------------------------------------- #
+# Activity
+# --------------------------------------------------------------------------- #
+class _StubSession:
+    async def __aenter__(self) -> _StubSession:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def commit(self) -> None:
+        return None
+
+
+def _session_factory() -> Any:
+    return lambda: _StubSession()
+
+
+class _FakeWorkspace:
+    def __init__(self, base: Path) -> None:
+        self._base = base
+
+    async def ensure_base_repo(self) -> Path:
+        return self._base
+
+
+def _acts(workspace: Any) -> SDLCActivities:
+    deps = SDLCDeps(
+        session_factory=_session_factory(),
+        workspace=workspace,
+        artifact_store=InMemoryArtifactStore(),
+    )
+    return SDLCActivities(deps)
+
+
+async def test_activity_runs_and_returns_manifest(tmp_path: Path) -> None:
+    out = await _acts(_FakeWorkspace(_small_repo(tmp_path))).comprehend_repo({"sdlc_id": "R2"})
+    assert not out.get("skipped") and out["counts"]["nodes"] > 0
+    assert out["artifacts"]["current-state.md"] == "run/R2/comprehension/current-state.md"
+
+
+async def test_activity_skipped_when_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SDLC_COMPREHEND", "0")
+    out = await _acts(_FakeWorkspace(_small_repo(tmp_path))).comprehend_repo({"sdlc_id": "R3"})
+    assert out == {"skipped": True, "reason": "disabled"}
+
+
+async def test_activity_skipped_when_no_repo() -> None:
+    class _BadWorkspace:
+        async def ensure_base_repo(self) -> Path:
+            raise RuntimeError("no repo url configured")
+
+    out = await _acts(_BadWorkspace()).comprehend_repo({"sdlc_id": "R4"})
+    assert out["skipped"] is True and "no base repo" in out["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# Intent-gate fold
+# --------------------------------------------------------------------------- #
+def test_gate_description_includes_comprehension() -> None:
+    d = _intents_gate_description(
+        2, [], None, {"counts": {"nodes": 50, "edges": 80}, "memory_bank_files": ["a.md", "b.md"]}
+    )
+    assert "Understood the repo: 50 code entities, 80 relationships" in d
+    assert "2 memory-bank docs" in d
+
+
+def test_comprehension_summary_line_variants() -> None:
+    assert _comprehension_summary_line(None) is None
+    assert "skipped" in (_comprehension_summary_line({"skipped": True, "reason": "disabled"}) or "")
+    assert "Greenfield" in (_comprehension_summary_line({"greenfield": True, "counts": {}}) or "")
+
+
+# --------------------------------------------------------------------------- #
+# M1b — a feature worktree is seeded with the run's memory bank
+# --------------------------------------------------------------------------- #
+class _SeedWorkspace:
+    def __init__(self, worktree: Path) -> None:
+        self._wt = worktree
+
+    async def create(self, sdlc_id: str, issue_key: str) -> Path:
+        return self._wt
+
+
+async def test_create_workspace_seeds_memory_bank(tmp_path: Path) -> None:
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    store = InMemoryArtifactStore()
+    await store.put_bytes("run/R/comprehension/memory-bank/domain-model.md", b"# Domain\n", "text/markdown")
+    await store.put_bytes("run/R/comprehension/memory-bank/glossary.md", b"# Glossary\n", "text/markdown")
+    deps = SDLCDeps(
+        session_factory=_session_factory(),
+        workspace=_SeedWorkspace(worktree),  # type: ignore[arg-type]
+        artifact_store=store,
+    )
+    comprehension = {
+        "artifacts": {
+            "current-state.md": "run/R/comprehension/current-state.md",  # not a memory-bank file → skipped
+            "memory-bank/domain-model.md": "run/R/comprehension/memory-bank/domain-model.md",
+            "memory-bank/glossary.md": "run/R/comprehension/memory-bank/glossary.md",
+        }
+    }
+    out = await SDLCActivities(deps).create_workspace(
+        {"sdlc_id": "R", "issue_key": "SDLC-1", "comprehension": comprehension}
+    )
+    assert out["memory_bank_seeded"] == 2
+    assert (worktree / "memory-bank" / "domain-model.md").read_text(encoding="utf-8") == "# Domain\n"
+    assert (worktree / "memory-bank" / "glossary.md").exists()
+
+
+async def test_create_workspace_without_comprehension_seeds_nothing(tmp_path: Path) -> None:
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    deps = SDLCDeps(session_factory=_session_factory(), workspace=_SeedWorkspace(worktree))  # type: ignore[arg-type]
+    out = await SDLCActivities(deps).create_workspace({"sdlc_id": "R", "issue_key": "SDLC-1"})
+    assert out["memory_bank_seeded"] == 0
+    assert not (worktree / "memory-bank").exists()

--- a/tests/sdlc/test_design.py
+++ b/tests/sdlc/test_design.py
@@ -1,0 +1,178 @@
+"""M2 — feature design: the service (heuristic + LLM), the activity, and the fold."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from orchestrator.runtime.artifacts import InMemoryArtifactStore
+from orchestrator.sdlc.activities import SDLCActivities
+from orchestrator.sdlc.deps import SDLCDeps
+from orchestrator.sdlc.design import design_feature, render_design_md
+from orchestrator.sdlc.workflows import _designs_gate_description, _spec_with_design
+
+_SPEC = {
+    "title": "Add CSV export",
+    "summary": "Export a report as CSV",
+    "acceptance_criteria": ["Downloads a .csv", "Includes a header row"],
+}
+_OVERVIEW = {
+    "summary": {"nodes": 10, "edges": 12},
+    "kinds": {"Function": 8},
+    "modules": [{"module": "report.py", "nodes": 6, "by_kind": {}}, {"module": "web.py", "nodes": 4}],
+    "module_edges": [{"src": "web.py", "dst": "report.py", "kind": "CALLS", "count": 3}],
+    "top_symbols": [{"name": "render", "module": "report.py", "degree": 5}],
+}
+
+
+async def _store_with_comprehension() -> tuple[InMemoryArtifactStore, dict[str, Any]]:
+    store = InMemoryArtifactStore()
+    ov_key = "run/R/comprehension/graph-overview.json"
+    dm_key = "run/R/comprehension/memory-bank/domain-model.md"
+    await store.put_bytes(ov_key, json.dumps(_OVERVIEW).encode(), "application/json")
+    await store.put_bytes(dm_key, b"# Domain\nA report is...\n", "text/markdown")
+    comprehension = {"artifacts": {"graph-overview.json": ov_key, "memory-bank/domain-model.md": dm_key}}
+    return store, comprehension
+
+
+# --------------------------------------------------------------------------- #
+# Service — heuristic (no LLM)
+# --------------------------------------------------------------------------- #
+async def test_heuristic_design_grounded_in_graph_and_persisted() -> None:
+    store, comprehension = await _store_with_comprehension()
+    out = await design_feature(
+        _SPEC, comprehension=comprehension, artifact_store=store, run_id="R", issue_key="SDLC-1", llm=None
+    )
+    assert out["issue_key"] == "SDLC-1" and out["llm"] is False
+    d = out["design"]
+    assert d["grounded"] is True
+    # files-to-touch come from the real modules in the graph overview
+    assert "report.py" in d["files_to_touch"] and "web.py" in d["files_to_touch"]
+    assert "Downloads a .csv" in d["test_strategy"]
+    # persisted under the per-feature namespace
+    assert out["artifacts"]["design.md"] == "run/R/feature/SDLC-1/design.md"
+    md = (await store.get_bytes(out["artifacts"]["design.md"])).decode()
+    assert "# Design — Add CSV export" in md and "report.py" in md
+
+
+# --------------------------------------------------------------------------- #
+# Service — LLM path
+# --------------------------------------------------------------------------- #
+class _FakeLLM:
+    async def complete(self, messages: Any, **kw: Any) -> Any:
+        from orchestrator.core.llm.client import CompletionResult
+
+        payload = {
+            "approach": "Add an export() to report.py",
+            "files_to_touch": ["report.py"],
+            "interfaces": ["def export(rows) -> bytes"],
+            "data_changes": [],
+            "risks": ["web.py calls report — check callers"],
+            "test_strategy": "Assert CSV bytes + header",
+        }
+        return CompletionResult(
+            text=json.dumps(payload),
+            model="m",
+            prompt_tokens=1,
+            completion_tokens=1,
+            cost_usd=0.0,
+            latency_ms=1.0,
+        )
+
+
+async def test_llm_design_used_when_client_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("orchestrator.sdlc.codegen.resolve_codegen_model", lambda: "test-model")
+    store, comprehension = await _store_with_comprehension()
+    out = await design_feature(
+        _SPEC,
+        comprehension=comprehension,
+        artifact_store=store,
+        run_id="R",
+        issue_key="SDLC-2",
+        llm=_FakeLLM(),
+    )
+    assert out["llm"] is True
+    assert out["design"]["approach"] == "Add an export() to report.py"
+    assert out["design"]["files_to_touch"] == ["report.py"]
+    assert out["design"]["interfaces"] == ["def export(rows) -> bytes"]
+
+
+async def test_llm_failure_falls_back_to_heuristic(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("orchestrator.sdlc.codegen.resolve_codegen_model", lambda: "test-model")
+
+    class _BadLLM:
+        async def complete(self, *a: Any, **k: Any) -> Any:
+            raise RuntimeError("provider down")
+
+    store, comprehension = await _store_with_comprehension()
+    out = await design_feature(
+        _SPEC,
+        comprehension=comprehension,
+        artifact_store=store,
+        run_id="R",
+        issue_key="SDLC-3",
+        llm=_BadLLM(),
+    )
+    assert out["llm"] is False and "report.py" in out["design"]["files_to_touch"]
+
+
+# --------------------------------------------------------------------------- #
+# Activity
+# --------------------------------------------------------------------------- #
+class _StubSession:
+    async def __aenter__(self) -> _StubSession:
+        return self
+
+    async def __aexit__(self, *e: object) -> None:
+        return None
+
+    async def commit(self) -> None:
+        return None
+
+
+def _acts(store: InMemoryArtifactStore) -> SDLCActivities:
+    deps = SDLCDeps(
+        session_factory=lambda: _StubSession(),  # type: ignore[arg-type]
+        workspace=object(),  # type: ignore[arg-type]
+        artifact_store=store,
+    )
+    return SDLCActivities(deps)
+
+
+async def test_activity_designs_and_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    store, comprehension = await _store_with_comprehension()
+    payload = {"sdlc_id": "R", "issue_key": "SDLC-9", "spec": _SPEC, "comprehension": comprehension}
+    out = await _acts(store).design_feature(payload)
+    assert not out.get("skipped") and out["issue_key"] == "SDLC-9"
+
+    monkeypatch.setenv("SDLC_DESIGN", "0")
+    off = await _acts(store).design_feature(payload)
+    assert off == {"issue_key": "SDLC-9", "skipped": True, "reason": "disabled"}
+
+
+# --------------------------------------------------------------------------- #
+# Workflow helpers
+# --------------------------------------------------------------------------- #
+def test_spec_with_design_folds_into_technical_notes() -> None:
+    design = {"design": {"approach": "Do X", "files_to_touch": ["a.py"], "interfaces": ["def f()"]}}
+    merged = _spec_with_design({"title": "t", "technical_notes": "existing"}, design)
+    assert "existing" in merged["technical_notes"]
+    assert "APPROVED DESIGN" in merged["technical_notes"] and "a.py" in merged["technical_notes"]
+    # no design → spec unchanged
+    assert _spec_with_design({"title": "t"}, {}) == {"title": "t"}
+
+
+def test_designs_gate_description() -> None:
+    d = _designs_gate_description(
+        [{"issue_key": "SDLC-1", "summary": "Add export", "files_to_touch": ["report.py"]}]
+    )
+    assert "Gate 1.5" in d and "SDLC-1" in d and "report.py" in d
+
+
+def test_render_design_md_sections() -> None:
+    md = render_design_md(
+        _SPEC, {"approach": "A", "files_to_touch": ["x.py"], "test_strategy": "T", "llm": True}
+    )
+    assert "## Approach" in md and "## Files to touch" in md and "x.py" in md and "## Test strategy" in md

--- a/tests/sdlc/test_workflows.py
+++ b/tests/sdlc/test_workflows.py
@@ -82,6 +82,23 @@ async def _stub_profile_and_plan(payload: dict[str, Any]) -> dict[str, Any]:
     return {"profile": {"languages": [], "task_type": "feature"}, "plan": _PLAN["value"]}
 
 
+@activity.defn(name="sdlc_comprehend_repo")
+async def _stub_comprehend_repo(payload: dict[str, Any]) -> dict[str, Any]:
+    _ = payload
+    return {"skipped": True, "reason": "stub"}
+
+
+@activity.defn(name="sdlc_design_feature")
+async def _stub_design_feature(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "issue_key": payload.get("issue_key"),
+        "summary": "stub design",
+        "files_to_touch": [],
+        "design": {"approach": "stub", "files_to_touch": []},
+        "artifacts": {},
+    }
+
+
 @activity.defn(name="sdlc_create_jira_issues")
 async def _stub_create_jira_issues(payload: dict[str, Any]) -> dict[str, Any]:
     specs = list(payload.get("specs") or [])
@@ -233,6 +250,8 @@ _ACTIVITIES = [
     _stub_raise_approval_request,
     _stub_intake_analyze,
     _stub_profile_and_plan,
+    _stub_comprehend_repo,
+    _stub_design_feature,
     _stub_create_jira_issues,
     _stub_integration_test,
     _stub_merge_prs,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -171,3 +171,29 @@ def test_register_loads_json_payload(
     result = runner.invoke(app, ["template", "register", str(f)])
     assert result.exit_code == 0
     assert "ok" in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# Repo-analysis commands accept a local path OR a git URL (parity with the UI).
+# --------------------------------------------------------------------------- #
+def test_analysis_commands_reject_disallowed_or_plaintext_url(runner: CliRunner) -> None:
+    """The SSRF guard + host allow-list fire before any clone is attempted."""
+    for spec in ("http://localhost:8000/x", "https://evil.example.test/r.git"):
+        result = runner.invoke(app, ["profile", spec])
+        assert result.exit_code == 2
+        assert "ERROR" in result.output
+
+
+def test_analysis_command_accepts_local_path(runner: CliRunner, tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text("x = 1\n", encoding="utf-8")
+    result = runner.invoke(app, ["profile", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "languages:" in result.output
+
+
+def test_repo_arg_classifies_local_vs_git(tmp_path: Path) -> None:
+    from orchestrator.cli import _repo_arg
+
+    with _repo_arg(str(tmp_path)) as (path, is_remote):
+        assert path == tmp_path.resolve()
+        assert is_remote is False

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -57,7 +57,8 @@ class TestBuildChildEnv:
         env = launch.build_child_env(cfg)
         assert env["ORCHESTRATOR_API_KEY"] == "k1"
         assert env["ORCHESTRATOR_SESSION_SECRET"] == "s1"
-        assert env["ORCHESTRATOR_ARTIFACT_STORE"] == "memory"
+        # Disk-backed by default so worker-written run artifacts reach the web UI.
+        assert env["ORCHESTRATOR_ARTIFACT_STORE"] == "fs"
         assert env["SDLC_CODEGEN"] == "llm"
 
     def test_existing_values_win(self) -> None:


### PR DESCRIPTION
Automated sync from the private repo @ e3061c4 (v3.3.0).

## What's in this release
- chore(release): 3.3.0 — repo comprehension + feature design milestones
- docs(user-guide): comprehension/design pipeline, run artifacts, CLI git URLs
- feat(cli): understand/state/pkg/profile/catalog accept a git URL
- feat(ui): repo-folder picker on the Understand section
- fix(sdlc): surface M2 design artifacts in the run-artifacts API
- feat(sdlc): M2 — feature/issue design milestone (spec × knowledge graph)
- feat(sdlc): M1b — features ground on the run's comprehension memory bank
- feat(ui): run artifacts visible + downloadable; disk-backed shared artifact store
- feat(sdlc): M1 — comprehend the repo as a pipeline milestone (architectural artifacts)

Merge to release.