### PR TITLE
fix(codegen): instruct refine loop to fix implementation not tests

### DIFF
--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -1165,6 +1165,9 @@ class LLMCodegenAdapter:
             self._condition_system(self._refine_system(), self._skills, phase="refine"),
             f"{self._layout_block()}{self._grounding(spec, root)}Issue: {issue_key}\n\n"
             f"SPEC:\n{_spec_text(spec)}\n\n"
+            "IMPORTANT: Fix the IMPLEMENTATION files only. Do NOT modify test files to "
+            "make them match a broken implementation — fix the source code so the tests "
+            "pass as written.\n\n"
             f"CURRENT FILES:\n{self._session_files(root, include_tests=True)}"
             f"{_named_existing_files(spec, root)}{self._convention_block(root)}\n\n"
             f"FAILURE OUTPUT:\n{_truncate(failures, _MAX_CONTEXT_BYTES)}",


### PR DESCRIPTION
What:
Added an explicit instruction to the refine loop's user prompt directing the model to fix implementation files only, not test files.

Why:
When a test fails due to a bug in the generated implementation, the refine loop was incorrectly patching the test file to match the broken implementation instead of fixing the source code. This caused the pipeline to exhaust its refine attempts and exit with a FAILED verdict despite the fix being straightforward.

Root cause:
The refine prompt provided no guidance on repair target selection. With both implementation and test files in context, the model defaulted to the easier fix — adjusting the test assertion — rather than correcting the underlying logic.
Fix
Added the following instruction to the refine user prompt in LLMCodegenAdapter.refine():

"IMPORTANT: Fix the IMPLEMENTATION files only. Do NOT modify test files to make them match a broken implementation — fix the source code so the tests pass as written."

Tested against:
Intent intent-create-crawl-result-object — CrawlResult.from_json() was generated with json.loads() outside the try block. The refine loop previously patched the test 3 times before failing. With this fix the loop targets the correct file.
Closes #[your issue number here]

Closes Issue #30