### PR TITLE
Publish v3.5.0 (52121e2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,10 @@ updates:
     target-branch: "develop"
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      # ONE PR for all action bumps. Without this, Dependabot splits related actions
+      # into separate PRs — notably codeql-action/init and codeql-action/analyze, which
+      # MUST move together (an init on vN emits a config a vN-1 analyze rejects,
+      # failing CI). Grouping keeps interdependent actions in lockstep.
+      github-actions:
+        patterns: ["*"]

--- a/src/orchestrator/registry/api/capabilities.py
+++ b/src/orchestrator/registry/api/capabilities.py
@@ -220,7 +220,12 @@ async def understand(body: UnderstandRequest, request: Request, principal: Princ
 
         with materialize_repo_source(source, log=log) as repo:
             result = build_memory_bank(repo, refresh=body.refresh, sql_dialect=body.dialect, log=log)
-            summary = {k: result.get(k) for k in ("files", "greenfield", "summary") if k in result}
+            # Annotate explicitly: the comprehension otherwise infers a Literal-keyed
+            # dict, which mypy rejects against CapabilityResult's dict[str, Any] under
+            # stricter type-stub versions (surfaced by a dependency bump, not our code).
+            summary: dict[str, Any] = {
+                k: result.get(k) for k in ("files", "greenfield", "summary") if k in result
+            }
             body_bytes = json.dumps(result, default=str, ensure_ascii=False).encode("utf-8")
             return CapabilityResult(body_bytes, "application/json", "understand.json", summary)
 


### PR DESCRIPTION
Automated sync from the private repo @ 52121e2 (v3.5.0).

## What's in this release
- ci(security): group Dependabot action bumps; fix dep-bump-exposed type

Merge to release.