### PR TITLE
Publish v3.6.1 (4659993)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## 3.6.1 — Shareable codebase-intelligence report
+
+`orchestrator state . --out report.html` now emits a single **self-contained HTML file** you
+open in a browser and forward to your team — the engineering-decision counterpart to a
+concept-map `graph.html`. Deterministic, no LLM, nothing fetched. It packages the analysis
+`state` already computes, so this is rendering, not new comprehension.
+
+### Added
+
+- **Shareable HTML report** — `orchestrator state . --out report.html` writes one
+  self-contained, theme-aware (light/dark) file with a provenance header, plain-language
+  overview, architecture diagram, blast-radius hotspots, risk & health, test-coverage gaps,
+  security surface, recent activity, and prioritized recommendations. `--out *.html` selects
+  HTML; any other extension keeps today's markdown. `--no-timestamp` gives byte-stable output
+  for CI diffs. The `--lens stakeholder` view drops the jargon-heavy sections.
+- **Deterministic architecture diagram** — an inline SVG (components grouped into zones,
+  weighted dependency arrows) laid out seeded-in-Python, so the same commit renders the same
+  picture; it grid-wraps large zones to stay legible and themes with the page (no mermaid, no
+  external assets).
+- **Graph-quantified blast radius** — the spotlight quantifies the cross-layer impact of the
+  top hotspot via `impact_across` ("changing X → N dependents across M files") and lists
+  blast-radius symbols with no covering test via the regression plan (`build_regression_plan`).
+- **In-browser filter** — a client-side search box hides non-matching rows, dims non-matching
+  architecture components, and collapses emptied sections; vanilla JS, no build step, still one
+  self-contained file.
+
 ## 3.6.0 — Knowledge-graph-grounded design & RCA
 
 A suite of new, deterministic-first CLI commands that ground engineering work — design,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.6.0"
+version = "3.6.1"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -22,6 +22,7 @@ import json
 import os
 import sys
 from collections.abc import Iterator
+from datetime import UTC
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -1397,6 +1398,10 @@ def state(
         str | None,
         typer.Option("--dialect", help="SQL dialect (postgres|mysql|tsql|oracle|…); default: auto-detect."),
     ] = None,
+    no_timestamp: Annotated[
+        bool,
+        typer.Option("--no-timestamp", help="Omit the generated-at time (byte-stable HTML for CI diffs)."),
+    ] = False,
 ) -> None:
     """Current State — a team-facing snapshot of what a repo is today and how healthy it looks.
 
@@ -1404,19 +1409,56 @@ def state(
     layered on top of `understand`. `--lens developer` gives the technical view;
     `--lens stakeholder` gives plain language. A report is a *view* of the code — re-run to
     refresh; nothing is written unless `--out` is given.
-    """
-    from orchestrator.knowledge.current_state import build_current_state
 
+    Output format follows `--out`'s extension: `--out report.html` emits a single
+    self-contained, shareable HTML report; any other extension (or stdout) emits markdown.
+    """
     if lens not in ("developer", "stakeholder"):
         typer.echo("ERROR: --lens must be 'developer' or 'stakeholder'.", err=True)
         raise typer.Exit(code=2)
+
+    want_html = out is not None and out.suffix.lower() in (".html", ".htm")
     with _repo_arg(path) as (repo, _):
-        markdown = build_current_state(repo, lens=lens, refresh=refresh, sql_dialect=dialect)
+        if want_html:
+            content = _render_state_html(
+                repo, lens=lens, refresh=refresh, dialect=dialect, no_timestamp=no_timestamp
+            )
+        else:
+            from orchestrator.knowledge.current_state import build_current_state
+
+            content = build_current_state(repo, lens=lens, refresh=refresh, sql_dialect=dialect)
     if out is not None:
-        out.write_text(markdown, encoding="utf-8")
+        out.write_text(content, encoding="utf-8")
         typer.echo(f"wrote {out}")
     else:
-        typer.echo(markdown)
+        typer.echo(content)
+
+
+def _render_state_html(
+    repo: Path, *, lens: str, refresh: bool, dialect: str | None, no_timestamp: bool
+) -> str:
+    """Build a `CurrentState` and render the self-contained shareable HTML report."""
+    from datetime import datetime
+
+    from orchestrator.knowledge.current_state import load_current_state
+    from orchestrator.knowledge.report_html import render_report_html
+    from orchestrator.pkg.persistence import repo_state
+    from orchestrator.pkg.store import FactStore
+
+    state, batch = load_current_state(repo, refresh=refresh, sql_dialect=dialect)
+    sha, _dirty = repo_state(repo)
+    grounded = sum(1 for n in batch.nodes if n.grounded)
+    timestamp = None if no_timestamp else datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    return render_report_html(
+        state,
+        repo_name=repo.resolve().name or "repository",
+        sha=sha,
+        timestamp=timestamp,
+        lens=lens,
+        grounded=grounded,
+        edges=len(batch.edges),
+        store=FactStore(batch),
+    )
 
 
 @app.command("design")

--- a/src/orchestrator/knowledge/current_state.py
+++ b/src/orchestrator/knowledge/current_state.py
@@ -402,11 +402,15 @@ def _zone_label(zone: str) -> str:
     return _ZONE_LABELS.get(zone, zone)
 
 
-def _architecture_mermaid(s: CurrentState) -> list[str]:
-    """A system-architecture flowchart: the top components grouped into zone
-    subgraphs, with the strongest cross-component dependency edges (from the
-    `#include` / import graph). Bounded so it stays readable."""
-    from collections import defaultdict
+def architecture_graph(s: CurrentState) -> tuple[list[str], list[tuple[tuple[str, str], int]]]:
+    """The bounded ``(components, weighted_edges)`` behind the architecture diagram.
+
+    The strongest cross-component dependency edges (from the import / ``#include`` graph)
+    plus the biggest components, capped so any visual stays legible (invariant #7). Shared
+    by the mermaid block and the SVG renderer so the two never draw different architectures
+    for the same commit. ``components`` is the draw order; each edge is ``((from, to), weight)``
+    over that node set.
+    """
 
     def _is_test_area(a: str) -> bool:
         return _zone(a) in ("tests", "test")
@@ -431,6 +435,17 @@ def _architecture_mermaid(s: CurrentState) -> list[str]:
     nodes = nodes[:18]
     nodeset = set(nodes)
     edges = [(ab, c) for ab, c in edges if ab[0] in nodeset and ab[1] in nodeset]
+    return nodes, edges
+
+
+def _architecture_mermaid(s: CurrentState) -> list[str]:
+    """A system-architecture flowchart: the top components grouped into zone
+    subgraphs, with the strongest cross-component dependency edges (from the
+    `#include` / import graph). Bounded so it stays readable."""
+    from collections import defaultdict
+
+    nodes, edges = architecture_graph(s)
+    nodeset = set(nodes)
 
     by_zone: dict[str, list[str]] = defaultdict(list)
     for a in nodes:
@@ -688,10 +703,15 @@ def _render_developer(s: CurrentState) -> str:
     return "\n".join(o) + "\n"
 
 
-def build_current_state(
-    root: Path | str, *, lens: str = "developer", refresh: bool = False, sql_dialect: str | None = None
-) -> str:
-    """Extract the PKG + profile for ``root`` and render the current-state markdown."""
+def load_current_state(
+    root: Path | str, *, refresh: bool = False, sql_dialect: str | None = None
+) -> tuple[CurrentState, FactBatch]:
+    """Extract the PKG + profile for ``root`` and return the structured ``CurrentState``.
+
+    The raw ``FactBatch`` is returned alongside so callers that need graph-level
+    provenance (grounded/edge counts, the HTML report's blast-radius spotlight) can
+    reuse it without a second extraction. Rendering (markdown, HTML) is a separate step.
+    """
     from orchestrator.catalog.profile import ProjectProfile
     from orchestrator.pkg.data_layer_link import link_data_layer
     from orchestrator.pkg.extractor import RepoCodeExtractor
@@ -710,7 +730,22 @@ def build_current_state(
     batch = link_data_layer(batch)
     profile = ProjectProfile.from_repo(root_path)
     state = compute_current_state(batch, profile, root=root_path)
+    return state, batch
+
+
+def build_current_state(
+    root: Path | str, *, lens: str = "developer", refresh: bool = False, sql_dialect: str | None = None
+) -> str:
+    """Extract the PKG + profile for ``root`` and render the current-state markdown."""
+    state, _batch = load_current_state(root, refresh=refresh, sql_dialect=sql_dialect)
     return render_current_state(state, lens=lens)
 
 
-__all__ = ["CurrentState", "build_current_state", "compute_current_state", "render_current_state"]
+__all__ = [
+    "CurrentState",
+    "architecture_graph",
+    "build_current_state",
+    "compute_current_state",
+    "load_current_state",
+    "render_current_state",
+]

--- a/src/orchestrator/knowledge/report_html.py
+++ b/src/orchestrator/knowledge/report_html.py
@@ -1,0 +1,506 @@
+"""Shareable report — one self-contained HTML file rendered from a ``CurrentState``.
+
+The engineering-grade counterpart to a comprehension tool's ``graph.html``: a single
+file a team lead opens in a browser and forwards, with **no platform install**. It packages
+the analysis ``current_state`` already computes (blast-radius hotspots, coupling,
+god-components, test-coverage gaps, security surface, churn, recommendations) into a
+skim-then-drill document.
+
+Design constraints (see ``docs/specs/shareable-report-spec.md``):
+
+- **Self-contained** — all CSS inline in a ``<style>``; zero external requests (invariant #5).
+  A saved copy keeps its styling and fetches nothing.
+- **Deterministic, no LLM** — same ``CurrentState`` in → same document out (invariant #2). The
+  commit SHA is the report's identity; the timestamp is metadata and can be omitted for
+  byte-stable diffs.
+- **Theme-aware** — light/dark via ``prefers-color-scheme``; it's a page people open.
+- **Pure** — ``render_report_html`` does no I/O and is unit-testable on a synthetic state.
+
+Phase 1 (this module) renders every ``CurrentState`` section as tables/prose with a
+module-list stand-in for the architecture diagram. Phase 2 replaces that stand-in with a
+deterministic inline-SVG layout (``report_svg.py``) and the ``impact_across`` blast-radius
+spotlight.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import TYPE_CHECKING
+
+from orchestrator.knowledge.current_state import _app_type, _overview, architecture_graph
+from orchestrator.knowledge.report_svg import architecture_svg
+from orchestrator.pkg.facts import NodeKind
+
+if TYPE_CHECKING:
+    from orchestrator.knowledge.current_state import CurrentState
+    from orchestrator.pkg.store import FactStore
+
+# Sections §4–§7 (blast radius, risk/health, coverage, security) carry developer jargon; the
+# stakeholder lens keeps only §1–§3 and §8–§9, in plain language — mirrors the markdown split.
+_STAKEHOLDER_LENS = "stakeholder"
+
+
+def _e(text: object) -> str:
+    """HTML-escape any value for safe interpolation into the document."""
+    return html.escape(str(text), quote=True)
+
+
+def _prose(text: str) -> str:
+    """Escape, then render the only inline markdown the shared prose uses: ``**bold**``.
+    `html.escape` leaves ``*`` untouched, so the conversion is safe after escaping."""
+    return re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", _e(text))
+
+
+def _node_count(state: CurrentState) -> int:
+    return sum(state.counts.values())
+
+
+# --- sections -------------------------------------------------------------------------
+
+
+def _header(
+    state: CurrentState, repo_name: str, sha: str | None, timestamp: str | None, grounded: int, edges: int
+) -> str:
+    """Provenance banner — establishes 'this is your real code, at this commit'."""
+    langs = ", ".join(state.languages) or "—"
+    chips = [
+        ("languages", langs),
+        ("nodes", f"{_node_count(state):,}"),
+        ("grounded", f"{grounded:,}"),
+        ("edges", f"{edges:,}"),
+        ("files", f"{state.modules:,}"),
+    ]
+    if sha:
+        chips.insert(0, ("commit", sha[:12]))
+    chip_html = "".join(
+        f'<span class="chip"><span class="chip-k">{_e(k)}</span><span class="chip-v">{_e(v)}</span></span>'
+        for k, v in chips
+    )
+    meta = f'<p class="generated">Generated {_e(timestamp)}</p>' if timestamp else ""
+    return (
+        '<header class="report-header">'
+        f"<h1>{_e(repo_name)}</h1>"
+        f'<p class="subtitle">Codebase intelligence report · {_e(_app_type(state))}</p>'
+        f'<div class="chips">{chip_html}</div>'
+        f"{meta}"
+        "</header>"
+    )
+
+
+def _section(title: str, subtitle: str, body: str) -> str:
+    sub = f'<p class="section-sub">{_e(subtitle)}</p>' if subtitle else ""
+    return f"<section><h2>{_e(title)}</h2>{sub}{body}</section>"
+
+
+def _overview_section(state: CurrentState) -> str:
+    return _section("Overview", "", f'<p class="lede">{_prose(_overview(state))}</p>')
+
+
+def _architecture_section(state: CurrentState) -> str:
+    """The deterministic inline-SVG architecture diagram (zones → components, weighted
+    arrows), plus the strongest dependency edges as a table beneath it."""
+    if not (state.area_types or state.area_funcs):
+        return ""
+    svg = architecture_svg(state)
+    shown = len(architecture_graph(state)[0])
+    total = len(set(state.area_types) | set(state.area_funcs))
+    body = f'<div class="arch-wrap">{svg}</div>' if svg else ""
+    if total > shown:
+        body += f'<p class="section-sub">Showing the top {shown} of {total} components.</p>'
+    if state.coupling:
+        rows = "".join(
+            f"<tr><td><code>{_e(a)}</code></td><td>→</td>"
+            f'<td><code>{_e(b)}</code></td><td class="num">{c}</td></tr>'
+            for (a, b), c in state.coupling.most_common(10)
+        )
+        body += (
+            '<h3 class="sub">Component dependencies (strongest)</h3>'
+            "<table><thead><tr><th>From</th><th></th><th>To</th>"
+            f'<th class="num">Strength</th></tr></thead><tbody>{rows}</tbody></table>'
+        )
+    return _section(
+        "Architecture",
+        "Components grouped by zone; arrows are dependency strength (import / #include count).",
+        body,
+    )
+
+
+def _top_hotspot_id(state: CurrentState, store: FactStore | None) -> str | None:
+    """The node id of the top call-hotspot, for graph queries.
+
+    ``call_hotspots`` keeps only names, so several distinct functions can share the top
+    name; resolve to the *same* node the hotspot metric ranked — the same-named function
+    with the most callers — not just the first match, so the spotlight and the hotspot
+    table describe one node."""
+    if store is None or not state.call_hotspots:
+        return None
+    candidates = [n for n in store.find(state.call_hotspots[0][0]) if n.kind is NodeKind.FUNCTION]
+    if not candidates:
+        return None
+    # Rank by caller count (the hotspot metric); id as a deterministic tiebreak.
+    return max(candidates, key=lambda n: (len(store.callers_of(n.id)), n.id)).id
+
+
+def _spotlight(state: CurrentState, store: FactStore | None) -> str:
+    """The differentiator sentence. With a graph, quantify the *cross-layer* blast radius
+    (dependents + files touched) via ``impact_across``; without one, fall back to the raw
+    call-site count. Deterministic either way — no target-picking beyond the top hotspot."""
+    top_name, top_calls = state.call_hotspots[0]
+    tid = _top_hotspot_id(state, store)
+    if store is not None and tid is not None:
+        impacted = store.impact_across(tid)
+        if impacted:
+            files = {n.provenance.file for n, _ in impacted if n.provenance}
+            return (
+                f'<p class="spotlight">Changing <code>{_e(top_name)}</code> ripples out to '
+                f"<strong>{len(impacted)}</strong> dependents across <strong>{len(files)}</strong> "
+                "files — the widest blast radius in the graph.</p>"
+            )
+    return (
+        f'<p class="spotlight">Changing <code>{_e(top_name)}</code> ripples out to '
+        f"<strong>{top_calls}</strong> call sites — the most-depended-upon code in the graph.</p>"
+    )
+
+
+def _blast_radius_section(state: CurrentState, store: FactStore | None) -> str:
+    if not state.call_hotspots:
+        return ""
+    rows = "".join(
+        f'<tr><td><code>{_e(n)}</code></td><td class="num">{c}</td></tr>' for n, c in state.call_hotspots
+    )
+    body = (
+        _spotlight(state, store) + "<table><thead><tr><th>Function</th>"
+        '<th class="num">Called from (sites)</th></tr></thead>'
+        f"<tbody>{rows}</tbody></table>"
+    )
+    return _section(
+        "Blast-radius hotspots",
+        "The functions most other code relies on — where a change reaches furthest.",
+        body,
+    )
+
+
+def _risk_section(state: CurrentState) -> str:
+    parts: list[str] = []
+    if state.layers:
+        rows = "".join(
+            f'<tr><td>{_e(lyr)}</td><td class="num">{c}</td></tr>' for lyr, c in state.layers.most_common()
+        )
+        parts.append(
+            '<h3 class="sub">Layers</h3>'
+            '<table><thead><tr><th>Layer</th><th class="num">Components</th></tr></thead>'
+            f"<tbody>{rows}</tbody></table>"
+        )
+    if state.hotspots:
+        rows = "".join(
+            f'<tr><td><code>{_e(n)}</code></td><td class="num">{c}</td><td>{_e(loc)}</td></tr>'
+            for n, c, loc in state.hotspots
+        )
+        dist = " · ".join(f"{_e(k)}: {v}" for k, v in state.size_dist.most_common())
+        parts.append(
+            f'<h3 class="sub">God-components &amp; complexity</h3>'
+            f'<p class="section-sub">Size distribution — {dist}</p>'
+            '<table><thead><tr><th>Largest component</th><th class="num">Members</th>'
+            f"<th>Location</th></tr></thead><tbody>{rows}</tbody></table>"
+        )
+    if state.external_deps:
+        chips = "".join(
+            f'<span class="dep">{_e(d)} <span class="dep-c">{c}</span></span>'
+            for d, c in state.external_deps.most_common(12)
+        )
+        parts.append(f'<h3 class="sub">External-dependency surface</h3><div class="deps">{chips}</div>')
+    if not parts:
+        return ""
+    return _section(
+        "Risk & health", "Coupling, oversized components, and the third-party surface.", "".join(parts)
+    )
+
+
+def _blast_coverage(state: CurrentState, store: FactStore | None) -> str:
+    """Symbols in the *top hotspot's* blast radius that no test reaches — the "what's
+    untested where it matters most" a concept map can't show. Reuses C8's regression plan
+    (``build_regression_plan``) at the top call-hotspot; empty without a call graph."""
+    tid = _top_hotspot_id(state, store)
+    if store is None or tid is None:
+        return ""
+    from orchestrator.sdlc.coverage import build_regression_plan
+
+    plan = build_regression_plan(store, tid)
+    if not plan.call_graph_available or not plan.impacted:
+        return ""
+    target = f"<code>{_e(plan.target)}</code>"
+    uncovered = [it for it in plan.impacted if not it.covered]
+    if not uncovered:
+        return (
+            f'<p class="section-sub">✅ All {len(plan.impacted)} symbols in the blast radius of '
+            f"{target} are reached by a test.</p>"
+        )
+    shown = uncovered[:12]
+    items = "".join(
+        f'<li><span class="area"><code>{_e(it.name)}</code></span>'
+        f'<span class="area-m">{_e(it.where)}</span></li>'
+        for it in shown
+    )
+    more = (
+        f'<p class="section-sub">…and {len(uncovered) - len(shown)} more.</p>'
+        if len(uncovered) > len(shown)
+        else ""
+    )
+    return (
+        f'<h3 class="sub">Untested in the blast radius of {target}</h3>'
+        f'<p class="section-sub">{len(uncovered)} of {len(plan.impacted)} impacted symbols have no '
+        f'covering test — a change here could break them silently.</p><ul class="gaps">{items}</ul>{more}'
+    )
+
+
+def _coverage_section(state: CurrentState, store: FactStore | None) -> str:
+    tested = f"<strong>{state.tested_areas} of {state.areas} areas</strong> have any test type."
+    untested = ""
+    if state.untested_top:
+        items = "".join(
+            f'<li><span class="area">{_e(a)}</span>'
+            f'<span class="area-m">{c} types, no covering test</span></li>'
+            for a, c in state.untested_top
+        )
+        untested = f'<p class="section-sub">Largest untested areas:</p><ul class="gaps">{items}</ul>'
+    return _section(
+        "Test-coverage gaps",
+        "What a change could break silently — areas with no covering test.",
+        f"<p>{tested}</p>{untested}{_blast_coverage(state, store)}",
+    )
+
+
+def _security_section(state: CurrentState) -> str:
+    if not state.auth_surface:
+        return ""
+    chips = "".join(f'<span class="dep">{_e(n)}</span>' for n in state.auth_surface)
+    note = (
+        '<p class="section-sub">⚠️ Attribute-level auth ([Authorize]/decorators) isn\'t extracted '
+        "yet — endpoint access rules can't be confirmed from the graph alone.</p>"
+    )
+    return _section(
+        "Security surface",
+        f"{len(state.auth_surface)} auth/security-related types (by name).",
+        f'<div class="deps">{chips}</div>{note}',
+    )
+
+
+def _activity_section(state: CurrentState) -> str:
+    if not state.recent_areas:
+        return ""
+    items = "".join(
+        f'<li><span class="area">{_e(a)}</span><span class="area-m">{c} changes</span></li>'
+        for a, c in state.recent_areas
+    )
+    return _section(
+        "Recent activity",
+        "Where change concentrates (last ~60 commits).",
+        f'<ul class="gaps">{items}</ul>',
+    )
+
+
+def _recommendations_section(state: CurrentState) -> str:
+    if not state.recommendations:
+        return ""
+    items = "".join(
+        f'<li><span class="pri pri-{_e(pri).lower()}">{_e(pri)}</span>{_e(text)}</li>'
+        for pri, text in state.recommendations
+    )
+    return _section(
+        "Recommendations",
+        "Prioritized, deterministic next actions.",
+        f'<ol class="recs">{items}</ol>',
+    )
+
+
+def _toolbar() -> str:
+    """A sticky search box. Filtering is done entirely client-side by ``_SCRIPT`` over the
+    already-inlined data — the layout stays precomputed; JS only shows/hides (invariant #3,
+    #4: no build step, nothing fetched). Degrades to a plain (inert) box with JS disabled."""
+    return (
+        '<div class="toolbar">'
+        '<input id="report-search" type="search" autocomplete="off" spellcheck="false" '
+        'placeholder="Filter components, functions, dependencies…" '
+        'aria-label="Filter the report">'
+        '<span class="toolbar-count" id="report-count" aria-live="polite"></span>'
+        "</div>"
+    )
+
+
+def _footer(state: CurrentState) -> str:
+    caveat = "Heuristic synthesis from naming + structure. "
+    if not state.has_calls:
+        caveat += "Call graph not yet available for this language. "
+    caveat += f"{state.generated} generated types flagged and excluded from hotspots."
+    return (
+        "<footer><p>Deterministic snapshot rendered from the Program Knowledge Graph — no LLM, "
+        f"nothing fetched. {_e(caveat)}</p></footer>"
+    )
+
+
+# --- document -------------------------------------------------------------------------
+
+
+def render_report_html(
+    state: CurrentState,
+    *,
+    repo_name: str = "repository",
+    sha: str | None = None,
+    timestamp: str | None = None,
+    lens: str = "developer",
+    grounded: int = 0,
+    edges: int = 0,
+    store: FactStore | None = None,
+) -> str:
+    """Render a ``CurrentState`` as one self-contained, theme-aware HTML document.
+
+    Pure: no I/O, deterministic for a given ``state`` (the ``timestamp`` is the only
+    non-reproducible input — omit it for byte-stable diffs). When a ``store`` is supplied the
+    blast-radius spotlight and coverage gaps are quantified from the graph (``impact_across`` /
+    ``build_regression_plan``); without one they degrade to the ``state``-only signals. The
+    stakeholder ``lens`` drops the jargon-heavy sections (blast radius, risk/health, coverage,
+    security).
+    """
+    body = [_header(state, repo_name, sha, timestamp, grounded, edges), _toolbar(), _overview_section(state)]
+    body.append(_architecture_section(state))
+    if lens != _STAKEHOLDER_LENS:
+        body.append(_blast_radius_section(state, store))
+        body.append(_risk_section(state))
+        body.append(_coverage_section(state, store))
+        body.append(_security_section(state))
+    body.append(_activity_section(state))
+    body.append(_recommendations_section(state))
+    body.append(_footer(state))
+    main = "\n".join(part for part in body if part)
+    title = f"{_e(repo_name)} — codebase report"
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        f"<title>{title}</title>\n<style>{_CSS}</style>\n</head>\n"
+        f'<body><main class="report">{main}</main>\n<script>{_SCRIPT}</script>\n</body>\n</html>\n'
+    )
+
+
+_CSS = """
+:root{
+  --bg:#f7f8fa;--card:#fff;--fg:#1a1d24;--muted:#5c6370;
+  --line:#e3e6eb;--accent:#3b6ef5;--chip:#eef1f6;--code:#f0f2f5;
+  --hi:#8a4b00;--hi-bg:#fff5e6;--pri-p0:#c0362c;--pri-p1:#b06a00;--pri-p2:#2f7d4f;
+}
+@media (prefers-color-scheme:dark){
+  :root{
+    --bg:#0f1115;--card:#171a21;--fg:#e6e9ef;--muted:#9aa2b1;--line:#262b35;
+    --accent:#6d97ff;--chip:#20252f;--code:#1c212b;--hi:#ffcf8a;--hi-bg:#2a2013;
+    --pri-p0:#ff6b5e;--pri-p1:#e0a144;--pri-p2:#5fce8f;
+  }
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);
+  font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+.report{max-width:960px;margin:0 auto;padding:2rem 1.25rem 4rem}
+code{background:var(--code);padding:.1em .35em;border-radius:4px;
+  font:.86em/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+h1{font-size:1.9rem;margin:0 0 .2rem}
+h2{font-size:1.3rem;margin:0 0 .3rem;padding-bottom:.35rem;border-bottom:2px solid var(--line)}
+h3{font-size:1rem;margin:1.2rem 0 .5rem}
+h3.sub{color:var(--muted);text-transform:uppercase;letter-spacing:.04em;font-size:.78rem}
+section{background:var(--card);border:1px solid var(--line);border-radius:12px;
+  padding:1.25rem 1.4rem;margin:1rem 0}
+.report-header{background:var(--card);border:1px solid var(--line);border-radius:12px;
+  padding:1.5rem 1.4rem;margin-bottom:1rem}
+.subtitle{color:var(--muted);margin:.1rem 0 1rem}
+.section-sub{color:var(--muted);font-size:.9rem;margin:.1rem 0 .8rem}
+.lede{font-size:1.05rem;line-height:1.6}
+.chips{display:flex;flex-wrap:wrap;gap:.5rem}
+.chip{display:inline-flex;flex-direction:column;background:var(--chip);
+  border-radius:8px;padding:.4rem .7rem;min-width:64px}
+.chip-k{font-size:.68rem;text-transform:uppercase;letter-spacing:.05em;color:var(--muted)}
+.chip-v{font-weight:600;font-size:.95rem}
+.generated{color:var(--muted);font-size:.8rem;margin:1rem 0 0}
+table{width:100%;border-collapse:collapse;margin:.5rem 0;font-size:.9rem}
+th,td{text-align:left;padding:.45rem .6rem;border-bottom:1px solid var(--line)}
+th{color:var(--muted);font-weight:600;font-size:.8rem;text-transform:uppercase;letter-spacing:.03em}
+td.num,th.num{text-align:right;font-variant-numeric:tabular-nums}
+.zones{display:grid;grid-template-columns:repeat(auto-fill,minmax(230px,1fr));gap:.8rem}
+.zone{background:var(--bg);border:1px solid var(--line);border-radius:10px;padding:.8rem .9rem}
+.zone h3{margin:0 0 .5rem;font-size:.95rem}
+.zone ul,.gaps{list-style:none;margin:0;padding:0}
+.zone li,.gaps li{display:flex;justify-content:space-between;gap:.5rem;
+  padding:.25rem 0;border-bottom:1px solid var(--line)}
+.zone li:last-child,.gaps li:last-child{border-bottom:0}
+.area{font-weight:500}.area-m{color:var(--muted);font-size:.82rem;white-space:nowrap}
+.spotlight{background:var(--hi-bg);color:var(--hi);border-radius:10px;
+  padding:.8rem 1rem;margin:.2rem 0 1rem;font-size:1rem}
+.spotlight code{background:rgba(0,0,0,.08)}
+.deps{display:flex;flex-wrap:wrap;gap:.4rem;margin:.3rem 0}
+.dep{background:var(--chip);border-radius:6px;padding:.25rem .55rem;font-size:.85rem}
+.dep-c{color:var(--muted);font-size:.78rem}
+.recs{margin:.3rem 0;padding-left:0;list-style:none;counter-reset:r}
+.recs li{padding:.5rem 0;border-bottom:1px solid var(--line);display:flex;gap:.6rem;align-items:baseline}
+.recs li:last-child{border-bottom:0}
+.pri{font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.04em;
+  padding:.15rem .45rem;border-radius:5px;background:var(--chip);white-space:nowrap}
+.pri-p0{color:var(--pri-p0)}.pri-p1{color:var(--pri-p1)}.pri-p2{color:var(--pri-p2)}
+.arch-wrap{overflow-x:auto;margin:.3rem 0 1rem;padding-bottom:.3rem}
+svg.arch{display:block;min-width:520px;max-width:100%;height:auto}
+.arch-zone{fill:var(--bg);stroke:var(--line);stroke-width:1}
+.arch-zone-label{fill:var(--muted);font-size:12px;font-weight:600;
+  text-transform:uppercase;letter-spacing:.04em}
+.arch-node rect{fill:var(--card);stroke:var(--line);stroke-width:1.5}
+.arch-name{fill:var(--fg);font-size:12.5px;font-weight:600}
+.arch-meta{fill:var(--muted);font-size:10.5px}
+.arch-edge{stroke:var(--accent);stroke-width:1.5;fill:none;opacity:.55}
+.arch-head{fill:var(--accent);opacity:.7}
+.arch-weight{fill:var(--muted);font-size:10px;font-variant-numeric:tabular-nums}
+.arch-node{transition:opacity .12s}
+.arch-node.dim{opacity:.16}
+.toolbar{position:sticky;top:0;z-index:5;display:flex;align-items:center;gap:.7rem;
+  background:var(--bg);padding:.7rem 0;margin:.2rem 0 .4rem}
+#report-search{flex:1;font:15px/1.4 inherit;color:var(--fg);background:var(--card);
+  border:1px solid var(--line);border-radius:9px;padding:.55rem .8rem}
+#report-search:focus{outline:2px solid var(--accent);outline-offset:1px}
+.toolbar-count{color:var(--muted);font-size:.82rem;white-space:nowrap}
+tr[hidden],li[hidden],.dep[hidden]{display:none!important}
+section.dim{display:none}
+footer{color:var(--muted);font-size:.82rem;margin-top:1.5rem;text-align:center}
+"""
+
+# Client-side filter. Reads the already-rendered text (no data duplicated), hides
+# non-matching rows / list items / dep chips, dims non-matching SVG components, and hides a
+# section once all its filter targets are hidden. Layout is untouched — this only toggles
+# visibility (invariant #3). Vanilla JS, no deps, no build step (invariant #4).
+_SCRIPT = """
+(function(){
+  var q=document.getElementById('report-search'),c=document.getElementById('report-count');
+  if(!q)return;
+  var ROW='table tbody tr, .gaps li, .recs li, .deps .dep';
+  var rows=[].slice.call(document.querySelectorAll(ROW.replace(/(^|,)/g,'$1.report ')));
+  var nodes=[].slice.call(document.querySelectorAll('.report svg.arch .arch-node'));
+  var secs=[].slice.call(document.querySelectorAll('.report section'));
+  function nodeName(g){var t=g.querySelector('.arch-name');return t?t.textContent.toLowerCase():'';}
+  function apply(){
+    var term=q.value.trim().toLowerCase(),shown=0;
+    rows.forEach(function(r){
+      var hit=!term||r.textContent.toLowerCase().indexOf(term)>=0;
+      r.hidden=!hit; if(hit)shown++;
+    });
+    nodes.forEach(function(g){
+      g.classList.toggle('dim',!!term&&nodeName(g).indexOf(term)<0);
+    });
+    secs.forEach(function(s){
+      var t=s.querySelectorAll(ROW);
+      if(!t.length){return;}
+      var vis=0;
+      for(var i=0;i<t.length;i++){if(!t[i].hidden)vis++;}
+      s.classList.toggle('dim',!vis);
+    });
+    c.textContent=term?(shown+' match'+(shown===1?'':'es')):'';
+  }
+  q.addEventListener('input',apply);
+  q.addEventListener('keydown',function(e){if(e.key==='Escape'){q.value='';apply();}});
+})();
+"""
+
+__all__ = ["render_report_html"]

--- a/src/orchestrator/knowledge/report_svg.py
+++ b/src/orchestrator/knowledge/report_svg.py
@@ -1,0 +1,171 @@
+"""Deterministic inline-SVG architecture diagram for the shareable report.
+
+Spine draws no random/force layout: positions are **computed, seeded, in Python** so the
+same commit yields the same picture and two reports diff cleanly (invariant #3). This module
+turns the bounded ``(components, edges)`` from ``architecture_graph`` into a layered SVG —
+one column per zone, components stacked by weight, weighted dependency arrows between them.
+
+Self-contained: emits plain ``<svg>`` with class hooks; all colour comes from the report's
+inline ``<style>`` via CSS variables, so it themes light/dark with the rest of the page and
+fetches nothing (invariant #5). No ``<script>``, no external marker refs.
+"""
+
+from __future__ import annotations
+
+import html
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from orchestrator.knowledge.areas import zone_of
+from orchestrator.knowledge.current_state import architecture_graph
+
+if TYPE_CHECKING:
+    from orchestrator.knowledge.current_state import CurrentState
+
+# Layout constants (px). Fixed geometry keeps the picture reproducible and bounded.
+_BOX_W = 168
+_BOX_H = 48
+_VGAP = 18  # vertical gap between stacked components
+_HGAP = 72  # horizontal gap between zone columns (room for cross-zone arrows)
+_PAD = 20  # outer padding
+_ZONE_HEAD = 30  # zone label band height
+_LABEL_MAX = 22  # component-name truncation
+_MAX_ROWS = 6  # a zone taller than this wraps into extra sub-columns (keeps it legible)
+
+
+def _e(text: object) -> str:
+    return html.escape(str(text), quote=True)
+
+
+def _truncate(name: str) -> str:
+    return name if len(name) <= _LABEL_MAX else name[: _LABEL_MAX - 1] + "…"
+
+
+def _zone_label(zone: str) -> str:
+    return {"src": "src — apps / services", "lib": "lib — libraries", "app": "app"}.get(zone, zone)
+
+
+def _border_point(cx: float, cy: float, tx: float, ty: float) -> tuple[float, float]:
+    """Where the ray from box-center (cx,cy) toward (tx,ty) exits the box border.
+    Straight AABB clip — keeps arrowheads on the box edge, not buried inside it."""
+    dx, dy = tx - cx, ty - cy
+    if dx == 0 and dy == 0:
+        return cx, cy
+    hw, hh = _BOX_W / 2, _BOX_H / 2
+    sx = hw / abs(dx) if dx else float("inf")
+    sy = hh / abs(dy) if dy else float("inf")
+    s = min(sx, sy)
+    return cx + dx * s, cy + dy * s
+
+
+def architecture_svg(state: CurrentState) -> str:
+    """Render the architecture as one deterministic, theme-aware inline ``<svg>`` string.
+
+    Returns ``""`` when there's nothing to draw. Layout is a pure function of ``state`` —
+    no randomness, no clock — so the diagram is byte-identical for an identical commit.
+    """
+    nodes, edges = architecture_graph(state)
+    if not nodes:
+        return ""
+
+    def _weight(a: str) -> int:
+        return state.area_types.get(a, 0) * 3 + state.area_funcs.get(a, 0)
+
+    by_zone: dict[str, list[str]] = defaultdict(list)
+    for a in nodes:
+        by_zone[zone_of(a)].append(a)
+    zones = sorted(by_zone)
+    # Deterministic stacking within a column: weight desc, name asc (the name tiebreak is
+    # what makes equal-weight rows reproducible rather than input-order dependent).
+    for z in zones:
+        by_zone[z].sort(key=lambda a: (-_weight(a), a))
+
+    # Position every box. Each zone is a block of one-or-more sub-columns: components
+    # stack down a column up to _MAX_ROWS, then wrap into the next sub-column of the same
+    # zone — so a single-zone repo (everything under one namespace) grids out instead of
+    # forming one absurdly tall column. Placement is column-major and fully determined by
+    # the sorted order, so the layout stays reproducible (invariant #3).
+    pos: dict[str, tuple[float, float]] = {}  # area -> (top-left x, y)
+    blocks: list[tuple[str, int, int]] = []  # (zone, start_col, ncols)
+    col_cursor = 0
+    for z in zones:
+        members = by_zone[z]
+        ncols = (len(members) + _MAX_ROWS - 1) // _MAX_ROWS
+        for idx, a in enumerate(members):
+            col = col_cursor + idx // _MAX_ROWS
+            row = idx % _MAX_ROWS
+            x = _PAD + col * (_BOX_W + _HGAP)
+            y = _PAD + _ZONE_HEAD + row * (_BOX_H + _VGAP)
+            pos[a] = (x, y)
+        blocks.append((z, col_cursor, ncols))
+        col_cursor += ncols
+
+    total_cols = col_cursor
+    max_rows = max(min(len(by_zone[z]), _MAX_ROWS) for z in zones)
+    width = _PAD * 2 + total_cols * _BOX_W + (total_cols - 1) * _HGAP
+    height = _PAD * 2 + _ZONE_HEAD + max_rows * (_BOX_H + _VGAP) - _VGAP + 12
+
+    parts: list[str] = [
+        # Inline in HTML5 — no xmlns needed, and omitting it keeps the report free of any
+        # http(s) URL so "self-contained, nothing fetched" stays trivially checkable.
+        f'<svg class="arch" viewBox="0 0 {width} {height}" width="100%" '
+        f'preserveAspectRatio="xMidYMin meet" role="img" '
+        f'aria-label="Architecture: {len(nodes)} components across {len(zones)} zones">',
+        # A closed arrowhead marker, styled via CSS (fill:currentColor on the edge group).
+        '<defs><marker id="ah" markerWidth="9" markerHeight="9" refX="7.5" refY="4" '
+        'orient="auto" markerUnits="userSpaceOnUse">'
+        '<path d="M0,0 L8,4 L0,8 Z" class="arch-head"/></marker></defs>',
+    ]
+
+    # Zone bands (behind the boxes) + labels. A band spans all of its zone's sub-columns
+    # and is as tall as its fullest column.
+    for z, start_col, ncols in blocks:
+        rows = min(len(by_zone[z]), _MAX_ROWS)
+        zx = _PAD + start_col * (_BOX_W + _HGAP) - 8
+        zw = ncols * _BOX_W + (ncols - 1) * _HGAP + 16
+        zh = _ZONE_HEAD + rows * (_BOX_H + _VGAP) - _VGAP + 12
+        parts.append(f'<rect class="arch-zone" x="{zx}" y="{_PAD}" width="{zw}" height="{zh}" rx="10"/>')
+        parts.append(
+            f'<text class="arch-zone-label" x="{zx + zw / 2}" y="{_PAD + 19}" '
+            f'text-anchor="middle">{_e(_zone_label(z))}</text>'
+        )
+
+    # Edges first, so boxes paint over the line ends.
+    for (a, b), c in edges:
+        if a not in pos or b not in pos:
+            continue
+        ax, ay = pos[a]
+        bx, by = pos[b]
+        acx, acy = ax + _BOX_W / 2, ay + _BOX_H / 2
+        bcx, bcy = bx + _BOX_W / 2, by + _BOX_H / 2
+        x1, y1 = _border_point(acx, acy, bcx, bcy)
+        x2, y2 = _border_point(bcx, bcy, acx, acy)
+        mx, my = (x1 + x2) / 2, (y1 + y2) / 2
+        parts.append(
+            f'<line class="arch-edge" x1="{x1:.1f}" y1="{y1:.1f}" x2="{x2:.1f}" y2="{y2:.1f}" '
+            'marker-end="url(#ah)"/>'
+        )
+        parts.append(
+            f'<text class="arch-weight" x="{mx:.1f}" y="{my - 3:.1f}" text-anchor="middle">{c}</text>'
+        )
+
+    # Boxes with the component name + "T types · F fns".
+    for a, (nx, ny) in pos.items():
+        t, f = state.area_types.get(a, 0), state.area_funcs.get(a, 0)
+        parts.append(
+            f'<g class="arch-node"><rect x="{nx}" y="{ny}" width="{_BOX_W}" height="{_BOX_H}" rx="8"/>'
+        )
+        parts.append(
+            f'<text class="arch-name" x="{nx + _BOX_W / 2}" y="{ny + 20}" text-anchor="middle">'
+            f"{_e(_truncate(a))}</text>"
+        )
+        parts.append(
+            f'<text class="arch-meta" x="{nx + _BOX_W / 2}" y="{ny + 36}" text-anchor="middle">'
+            f"{t} types · {f} fns</text></g>"
+        )
+
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+__all__ = ["architecture_svg"]

--- a/src/orchestrator/sdlc/activities.py
+++ b/src/orchestrator/sdlc/activities.py
@@ -307,6 +307,8 @@ class SDLCActivities:
         Reuses the commit-keyed PKG cache that comprehension just populated for
         this commit, so re-extraction is cheap; any failure returns ``None`` and
         the design falls back to the overview-only grounding."""
+        import asyncio
+
         try:
             base = await self._deps.workspace.ensure_base_repo()
 

--- a/src/orchestrator/sdlc/activities.py
+++ b/src/orchestrator/sdlc/activities.py
@@ -307,7 +307,6 @@ class SDLCActivities:
         Reuses the commit-keyed PKG cache that comprehension just populated for
         this commit, so re-extraction is cheap; any failure returns ``None`` and
         the design falls back to the overview-only grounding."""
-        import asyncio
 
         try:
             base = await self._deps.workspace.ensure_base_repo()

--- a/tests/knowledge/test_report_html.py
+++ b/tests/knowledge/test_report_html.py
@@ -1,0 +1,179 @@
+"""Shareable HTML report — self-contained, deterministic, theme-aware, two lenses."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from orchestrator.catalog.profile import ProjectProfile
+from orchestrator.knowledge.current_state import CurrentState, compute_current_state
+from orchestrator.knowledge.report_html import render_report_html
+from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+
+
+def _node(nid: str, kind: NodeKind, name: str, file: str = "f.cs") -> Node:
+    return Node(nid, kind, name, "csharp", Provenance(file, 1))
+
+
+def _batch() -> FactBatch:
+    b = FactBatch()
+    api = _node("c:App.Api", NodeKind.MODULE, "App.Api")
+    biz = _node("c:App.Biz", NodeKind.MODULE, "App.Biz")
+    ctrl = _node("c:App.Api.UserController", NodeKind.TYPE, "UserController", "UserController.cs")
+    svc = _node("c:App.Biz.UserService", NodeKind.TYPE, "UserService", "UserService.cs")
+    for n in (api, biz, ctrl, svc):
+        b.add_node(n)
+    b.add_edge(Edge(api.id, ctrl.id, EdgeKind.CONTAINS, Provenance("UserController.cs", 1)))
+    b.add_edge(Edge(biz.id, svc.id, EdgeKind.CONTAINS, Provenance("UserService.cs", 1)))
+    b.add_edge(Edge(api.id, biz.id, EdgeKind.IMPORTS, Provenance("UserController.cs", 1)))
+    # A hot function: `Validate` called from several sites → a blast-radius hotspot.
+    hot = _node("c:App.Biz.UserService.Validate", NodeKind.FUNCTION, "Validate", "UserService.cs")
+    b.add_node(hot)
+    b.add_edge(Edge(svc.id, hot.id, EdgeKind.CONTAINS, Provenance("UserService.cs", 5)))
+    for i in range(4):
+        caller = _node(f"c:App.Api.UserController.M{i}", NodeKind.FUNCTION, f"M{i}", "UserController.cs")
+        b.add_node(caller)
+        b.add_edge(Edge(ctrl.id, caller.id, EdgeKind.CONTAINS, Provenance("UserController.cs", i)))
+        b.add_edge(Edge(caller.id, hot.id, EdgeKind.CALLS, Provenance("UserController.cs", i)))
+    return b
+
+
+_PROFILE = ProjectProfile(
+    languages=frozenset({"csharp"}),
+    framework="aspnet",
+    has_db=False,
+    has_migrations=False,
+    test_runner=None,
+    task_type="feature",
+)
+
+
+def _state() -> CurrentState:
+    return compute_current_state(_batch(), _PROFILE)
+
+
+def test_self_contained_document() -> None:
+    html = render_report_html(_state(), repo_name="myrepo", sha="abc123def456789", edges=3, grounded=4)
+    assert html.startswith("<!doctype html>")
+    assert "<style>" in html and "</style>" in html  # inline CSS
+    # Nothing fetched: no external links, scripts, or remote images (invariant #5). An
+    # *inline* <script> is fine (Phase 3 filtering) — `src=` catches any external one.
+    for needle in ("http://", "https://", "src=", "<link"):
+        assert needle not in html, f"report must be self-contained; found {needle!r}"
+    assert "myrepo" in html
+    assert "abc123def456" in html  # sha truncated to 12 chars
+
+
+def test_theme_aware() -> None:
+    html = render_report_html(_state())
+    assert "prefers-color-scheme:dark" in html
+
+
+def test_timestamp_optional_and_deterministic() -> None:
+    a = render_report_html(_state(), timestamp=None)
+    b = render_report_html(_state(), timestamp=None)
+    assert a == b  # same state in → same bytes out (no LLM, no clock)
+    assert "Generated" not in a
+    assert "Generated 2026" in render_report_html(_state(), timestamp="2026-07-21 10:00 UTC")
+
+
+def test_stakeholder_lens_drops_jargon_sections() -> None:
+    dev = render_report_html(_state(), lens="developer")
+    stake = render_report_html(_state(), lens="stakeholder")
+    assert "Blast-radius hotspots" in dev
+    assert "Blast-radius hotspots" not in stake
+    assert "Risk &amp; health" not in stake
+    # Overview + architecture survive both lenses.
+    assert "Overview" in stake and "Architecture" in stake
+
+
+def test_html_escaping() -> None:
+    s = _state()
+    s.auth_surface = ["<script>Evil</script>"]
+    html = render_report_html(s)
+    assert "<script>Evil" not in html
+    assert "&lt;script&gt;Evil" in html
+
+
+def test_empty_sections_omitted() -> None:
+    s = _state()
+    s.auth_surface = []
+    s.recent_areas = []
+    s.recommendations = []
+    html = render_report_html(s)
+    assert "Security surface" not in html
+    assert "Recent activity" not in html
+    assert "Recommendations" not in html
+
+
+def test_architecture_order_is_name_tiebroken() -> None:
+    # Equal-weight areas must order by name so the layout diffs cleanly (invariant #3) —
+    # not by set-iteration order, which varies across processes.
+    s = _state()
+    s.area_types = Counter({"src.zzz": 2, "src.aaa": 2})
+    s.area_funcs = Counter()
+    html = render_report_html(s)
+    assert html.index("src.aaa") < html.index("src.zzz")
+
+
+def test_svg_diagram_replaces_placeholder() -> None:
+    # Phase 2: the architecture section renders an inline SVG, not the old zone-card list.
+    html = render_report_html(_state())
+    assert '<svg class="arch"' in html
+    assert 'class="zones"' not in html
+
+
+def _coverage_batch() -> FactBatch:
+    """A hotspot H called by two uncovered production functions and one test."""
+    b = FactBatch()
+    mod = _node("py:app", NodeKind.MODULE, "app", "app.py")
+    b.add_node(mod)
+    hot = _node("py:app.validate", NodeKind.FUNCTION, "validate", "app.py")
+    b.add_node(hot)
+    b.add_edge(Edge(mod.id, hot.id, EdgeKind.CONTAINS, Provenance("app.py", 1)))
+    for name in ("handle_a", "handle_b"):  # production callers, no test reaches them
+        p = _node(f"py:app.{name}", NodeKind.FUNCTION, name, "app.py")
+        b.add_node(p)
+        b.add_edge(Edge(mod.id, p.id, EdgeKind.CONTAINS, Provenance("app.py", 2)))
+        b.add_edge(Edge(p.id, hot.id, EdgeKind.CALLS, Provenance("app.py", 3)))
+    t = _node("py:tests.test_it", NodeKind.FUNCTION, "test_it", "tests/test_it.py")
+    b.add_node(t)
+    b.add_edge(Edge(t.id, hot.id, EdgeKind.CALLS, Provenance("tests/test_it.py", 4)))
+    return b
+
+
+def test_spotlight_uses_graph_when_store_given() -> None:
+    from orchestrator.pkg.store import FactStore
+
+    s = compute_current_state(_coverage_batch(), _PROFILE)
+    with_store = render_report_html(s, store=FactStore(_coverage_batch()))
+    without = render_report_html(s)
+    assert "dependents across" in with_store  # impact_across quantified
+    assert "call sites" in without  # graph-free fallback
+
+
+def test_blast_radius_coverage_gaps() -> None:
+    from orchestrator.pkg.store import FactStore
+
+    s = compute_current_state(_coverage_batch(), _PROFILE)
+    html = render_report_html(s, store=FactStore(_coverage_batch()))
+    assert "Untested in the blast radius" in html
+    # The two production callers have no covering test and must be listed.
+    assert "handle_a" in html and "handle_b" in html
+
+
+def test_filter_toolbar_and_inline_script() -> None:
+    html = render_report_html(_state())
+    assert 'id="report-search"' in html  # the filter box
+    assert "<script>" in html and "</script>" in html  # inline, no src
+    assert "addEventListener('input'" in html  # wires the live filter
+    # Filter targets the rendered data (table rows / list items), not a duplicated copy.
+    assert "table tbody tr" in html and "querySelectorAll" in html
+
+
+def test_header_counts_rendered() -> None:
+    s = _state()
+    s.counts = {"Type": 12, "Function": 40, "Module": 3}
+    html = render_report_html(s, grounded=50, edges=99)
+    assert "55" in html  # node count = sum of counts
+    assert "99" in html  # edges
+    assert Counter(s.counts).total() == 55

--- a/tests/knowledge/test_report_svg.py
+++ b/tests/knowledge/test_report_svg.py
@@ -1,0 +1,83 @@
+"""Deterministic architecture SVG — bounded, non-overlapping, theme-agnostic, no fetches."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+from orchestrator.catalog.profile import ProjectProfile
+from orchestrator.knowledge.current_state import CurrentState, compute_current_state
+from orchestrator.knowledge.report_svg import _BOX_H, _BOX_W, _MAX_ROWS, architecture_svg
+from orchestrator.pkg.facts import FactBatch
+
+_PROFILE_AREAS = 30
+_PROFILE = ProjectProfile(
+    languages=frozenset({"python"}),
+    framework=None,
+    has_db=False,
+    has_migrations=False,
+    test_runner=None,
+    task_type="feature",
+)
+
+
+def _many_area_state() -> CurrentState:
+    """A state with more components than fit one column, to exercise grid-wrapping."""
+    s = compute_current_state(FactBatch(), _PROFILE)
+    # One zone ("pkg") with many equal-ish components → must wrap into sub-columns.
+    s.area_types = Counter({f"pkg.mod{i:02d}": 10 - (i % 5) for i in range(_PROFILE_AREAS)})
+    s.area_funcs = Counter({f"pkg.mod{i:02d}": 3 for i in range(_PROFILE_AREAS)})
+    s.coupling = Counter({("pkg.mod00", "pkg.mod01"): 5, ("pkg.mod02", "pkg.mod03"): 3})
+    return s
+
+
+def _boxes(svg: str) -> list[tuple[float, float]]:
+    return [
+        (float(x), float(y))
+        for x, y in re.findall(r'<g class="arch-node"><rect x="([\d.]+)" y="([\d.]+)"', svg)
+    ]
+
+
+def test_empty_state_draws_nothing() -> None:
+    s = _many_area_state()
+    s.area_types = Counter()
+    s.area_funcs = Counter()
+    s.coupling = Counter()
+    assert architecture_svg(s) == ""
+
+
+def test_deterministic() -> None:
+    s = _many_area_state()
+    assert architecture_svg(s) == architecture_svg(s)
+
+
+def test_self_contained_svg() -> None:
+    svg = architecture_svg(_many_area_state())
+    assert svg.startswith("<svg")
+    for needle in ("http://", "https://", "<script", "<image", "xlink"):
+        assert needle not in svg
+
+
+def test_boxes_in_bounds_and_non_overlapping() -> None:
+    svg = architecture_svg(_many_area_state())
+    m = re.search(r'viewBox="0 0 ([\d.]+) ([\d.]+)"', svg)
+    assert m
+    w, h = float(m.group(1)), float(m.group(2))
+    boxes = _boxes(svg)
+    assert boxes
+    for x, y in boxes:
+        assert x >= 0 and y >= 0 and x + _BOX_W <= w and y + _BOX_H <= h
+    for i in range(len(boxes)):
+        for j in range(i + 1, len(boxes)):
+            ax, ay = boxes[i]
+            bx, by = boxes[j]
+            assert not (abs(ax - bx) < _BOX_W and abs(ay - by) < _BOX_H), "boxes overlap"
+
+
+def test_single_zone_wraps_into_grid() -> None:
+    # 30 components in one zone must not stack into one column taller than _MAX_ROWS.
+    svg = architecture_svg(_many_area_state())
+    ys = {y for _x, y in _boxes(svg)}
+    xs = {x for x, _y in _boxes(svg)}
+    assert len(ys) <= _MAX_ROWS  # at most _MAX_ROWS distinct rows
+    assert len(xs) > 1  # wrapped into multiple sub-columns


### PR DESCRIPTION
Automated sync from the private repo @ 4659993 (v3.6.1).

## What's in this release
- chore(release): 3.6.1 — shareable codebase-intelligence report
- docs(spec): mark shareable-report Phase 3 shipped
- feat(report): client-side filter/search over the inlined data (Phase 3)
- docs(spec): mark shareable-report Phases 1–2 shipped
- feat(report): deterministic architecture SVG + graph-quantified blast radius (Phase 2)
- feat(report): shareable self-contained HTML report — `state --out report.html` (Phase 1)

Merge to release.