### PR TITLE
Publish v3.7.0 (788590c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## 3.7.0 — Go: the 8th PKG language
+
+Go is now a first-class language across the whole stack — comprehension, the call and
+interface graph, and greenfield **and** brownfield codegen — so `understand`, `state`,
+`design`, `investigate`, `localize`, `rca`, `regression`, grounding, and
+`sdlc feature --language go` all work on Go repos. Install with the `go` extra
+(`pip install 'synaptixs-spine[go]'`); codegen needs the `go` toolchain on PATH.
+
+### Added
+
+- **Go comprehension** (`go` extra, tree-sitter-go) — `Module`/`Type`/`Function`/`Field` +
+  `IMPORTS`/`CONTAINS`. Go's module unit is the **package = its directory**, so every `.go`
+  file in a dir merges into one component (the first front-end where that holds).
+- **Go call + data + interface graph** — `CALLS` (same-file package functions and
+  receiver-method calls), `REFERENCES` (same-package struct-field types), and the Go
+  highlight, **`IMPLEMENTS` by method-set matching**: because Go has no `implements` keyword,
+  a concrete type is linked to each in-repo interface it structurally satisfies (matched by
+  method name + arity over value **and** pointer receivers). So blast-radius, `design`,
+  `rca`, and `regression` light up on Go.
+- **Go codegen** (`sdlc feature --language go`) — scaffolds/extends a module and builds +
+  tests it with `go build ./...` / `go test ./...`, with co-located `_test.go` tests. It is
+  **multi-module aware**: the runner builds and tests the module(s) a change actually
+  touches (not just the repo root), so code generated into a sub-module is never a false
+  green.
+
+### Changed
+
+- **`sdlc feature --language` is now validated** against the supported set — an unknown value
+  errors instead of silently scaffolding a Python project.
+
 ## 3.6.1 — Shareable codebase-intelligence report
 
 `orchestrator state . --out report.html` now emits a single **self-contained HTML file** you

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -4,7 +4,7 @@
 engineer you delegate tickets to. From inside **Claude Code** you can ask it to read a
 requirement, ground new code in your repo's real structure, generate and test that code,
 and — when you say so — open a pull request. It works for **greenfield** (fresh) and
-**brownfield** (existing) repos across **Python, Java, TypeScript, C#, C, and C++**.
+**brownfield** (existing) repos across **Python, Java, TypeScript, C#, C, C++, and Go**.
 
 This guide takes you from zero to a delivered feature, entirely through Claude Code.
 
@@ -269,7 +269,7 @@ external writes). Parameters:
 | `intent_id` | Which derived intent to build (default: the first one). |
 | `repo` | Git URL or `owner/repo` to branch from. Omit for a throwaway scratch repo (pure demo). |
 | `layout` | `new` = **greenfield** (scaffold a fresh structure), `existing` = **brownfield** (follow the repo), `auto` = scaffold only if the repo is empty. |
-| `language` | `auto` (detect) or `python` / `java` / `typescript` / `csharp` / `c` / `cpp`. |
+| `language` | `auto` (detect) or `python` / `java` / `typescript` / `csharp` / `c` / `cpp` / `go` / `sql`. |
 | `package_name` | Override the scaffold package name (greenfield). |
 | `live` | `false` (default) = local branch + diff, no external writes. `true` = real Jira + push + PR. |
 | `confirm` | Must be `true` alongside `live=true` — the explicit authorization for writes. |
@@ -475,7 +475,7 @@ approval — Spine refuses a live write without it. `live=true` needs a reachabl
 
 ## 10. Language support & toolchains
 
-Comprehension + codegen cover six languages. Spine only needs a language's toolchain when
+Comprehension + codegen cover seven languages. Spine only needs a language's toolchain when
 it **builds/tests** generated code in that language:
 
 | Language | Build/test needs on PATH |
@@ -486,6 +486,7 @@ it **builds/tests** generated code in that language:
 | C# | the **.NET SDK** (`dotnet`) |
 | C | **CMake** (or **Meson + Ninja**) + a C compiler |
 | C++ | **CMake** (or **Meson + Ninja**) + a C++ compiler |
+| Go | the **`go`** toolchain (`go build` / `go test`) |
 
 `language=auto` detects from the repo. For C#, Spine additionally lifts ASP.NET Core
 endpoints and EF Core entities into the graph; for C/C++ it builds the `#include` graph and
@@ -503,7 +504,7 @@ merges header declarations with their definitions.
 | Codegen times out | Set a faster model: `ORCHESTRATOR_INTAKE_MODEL=...` (or `SDLC_CODEGEN_MODEL`). |
 | "live needs a repo to push to" | Pass `repo=...` or set `SDLC_REPO_URL`; ensure `GITHUB_TOKEN`/`GH_TOKEN` is set. |
 | A `live` call refuses to write | That's the gate — pass `confirm=true` together with `live=true`. |
-| Build fails for Java/TS/C#/C/C++ | The language toolchain isn't installed — see [§10](#10-language-support--toolchains). |
+| Build fails for Java/TS/C#/C/C++/Go | The language toolchain isn't installed — see [§10](#10-language-support--toolchains). |
 | Private repo clone fails | Set `GITHUB_TOKEN` (PAT) or configure the GitHub App. |
 
 For deeper diagnostics, ask Claude to run `doctor`, or run `orchestrator doctor` in a shell

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -32,11 +32,12 @@ radius) and grounds new code in what already exists. Full guide:
 
 | Capability | Status | How to use |
 |---|---|---|
-| Multi-language comprehension + codegen — Python, Java, TypeScript, C#, C, C++ | ✅ | automatic per repo |
+| Multi-language comprehension + codegen — Python, Java, TypeScript, C#, C, C++, Go | ✅ | automatic per repo |
 | SQL data-layer comprehension — schema, queries, stored procedures, migration folding | ✅ | `pip install 'synaptixs-spine[sql]'`; `.sql` per repo |
 | SQL greenfield codegen — generate a migration, validate on an ephemeral DB | ✅ | `sdlc feature --language sql` (in-memory SQLite; `SDLC_SQL_ENGINE=postgres` for real Postgres) |
 | Framework-aware edges — ASP.NET Core endpoints, EF Core entities (C#) | ✅ | emitted into the PKG on `pkg extract` / `understand` |
 | C `#include` graph + header/source merge; codegen on **CMake or Meson** | ✅ | `.c`/`.h` per repo; `sdlc feature --language c` |
+| Go — package-per-directory, call graph, **interface satisfaction** (`IMPLEMENTS` by method-set); codegen built + tested with `go build`/`go test`, multi-module aware | ✅ | `pip install 'synaptixs-spine[go]'`; `.go` per repo; `sdlc feature --language go` |
 | Committed `episteme/` for humans + any AI tool | ✅ | `orchestrator understand --out episteme` |
 | Current State report — overview, infrastructure/runtime, code structure, architecture diagrams (no LLM) | ✅ | `orchestrator state . --lens developer\|stakeholder` |
 | PKG extraction / export | ✅ | `orchestrator pkg extract`, `orchestrator pkg export` |

--- a/KNOWLEDGE_GRAPH.md
+++ b/KNOWLEDGE_GRAPH.md
@@ -116,7 +116,7 @@ walking edges, not by guessing.
 
 ```mermaid
 flowchart LR
-    src["Source files<br/>(.py · .java · .ts/.tsx · .cs · .c/.h · .sql)"] --> ext["Language extractor<br/>(tree-sitter / AST / sqlglot)"]
+    src["Source files<br/>(.py · .java · .ts/.tsx · .cs · .c/.h · .cpp · .go · .sql)"] --> ext["Language extractor<br/>(tree-sitter / AST / sqlglot)"]
     ext --> facts["Facts<br/>Nodes + Edges + Provenance"]
     facts --> cache["Per-commit cache"]
     facts --> store["Fact store<br/>(queryable)"]
@@ -135,6 +135,7 @@ flowchart LR
   | C# | ✅ + framework edges | `pip install 'synaptixs-spine[csharp]'` |
   | C | ✅ + `#include` graph | `pip install 'synaptixs-spine[c]'` |
   | C++ | ✅ classes/namespaces/inheritance | `pip install 'synaptixs-spine[cpp]'` |
+  | Go | ✅ + interface satisfaction (`IMPLEMENTS`) | `pip install 'synaptixs-spine[go]'` |
 
   C# additionally lifts **framework edges** into the graph: ASP.NET Core controllers
   and Minimal-API routes become `Endpoint` nodes with `EXPOSES` edges to their
@@ -152,6 +153,15 @@ flowchart LR
   (multiple inheritance → multiple edges), member functions merge an in-class
   declaration with an out-of-line `Class::method` definition, templates emit their
   `Type`/`Function`, and `CALLS`/`REFERENCES` carry over.
+
+  Go's module unit is the **package (its directory)** — every `.go` file in a dir merges
+  onto one `Module`. Structs/interfaces/aliases become `Type` nodes, funcs and receiver
+  methods become `Function`s, and struct fields become `Field`s. Its distinctive edge is
+  **interface satisfaction** (`IMPLEMENTS`): because Go has no `implements` keyword, a
+  concrete type is matched to each in-repo interface by **method set** — name + arity over
+  value **and** pointer receivers — so a type that structurally satisfies an interface is
+  linked to it. `CALLS` resolve same-package functions and receiver-method calls, and a
+  struct field whose type is another same-package type becomes a `REFERENCES` edge.
 - **Cached per commit.** Re-running on an unchanged tree reuses the cache; `--refresh`
   forces a re-extract. So `understand` is cheap to re-run as the code evolves.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ writes) so you can inspect everything first.
 **Code-grounded understanding.** Before generating, it builds a **Product Knowledge
 Graph** of your repo — modules, types, functions, call sites, blast radius — and
 grounds new code in what already exists, so output reads like your team wrote it.
-Works across **Python, Java, TypeScript, C#, C, and C++**, plus **SQL** data-layer
+Works across **Python, Java, TypeScript, C#, C, C++, and Go**, plus **SQL** data-layer
 comprehension (schema, queries, stored procedures, migration folding). `orchestrator
 understand` writes a committed, code-true `episteme/` your whole team (and any AI tool)
 can read — *epistēmē*, knowledge grounded in evidence, because every word of it is derived
@@ -149,11 +149,14 @@ The autonomous multi-feature pipeline + web dashboard needs Temporal + Postgres 
 see the [Setup guide](https://github.com/synaptixs/spine/blob/main/SETUP.md).
 
 **Which languages and models?**
-Code generation and comprehension cover **Python, Java, TypeScript, C#, C, and C++**
+Code generation and comprehension cover **Python, Java, TypeScript, C#, C, C++, and Go**
 (C# also extracts ASP.NET Core endpoints and EF Core entities; C builds the
 `#include` graph and merges header declarations with their source definitions; C++ is
 a superset of the C front-end that adds classes, namespaces, inheritance, member
-functions, and templates, and shares C's CMake/Meson + `ctest` codegen).
+functions, and templates, and shares C's CMake/Meson + `ctest` codegen; **Go** models a
+package as its directory, extracts calls and — via method-set matching — **interface
+satisfaction** (`IMPLEMENTS`), and generates code built + tested with `go build`/`go test`,
+multi-module aware).
 **SQL** (`[sql]` extra) adds data-layer *comprehension* — schema, foreign keys, views,
 queries, stored procedures, and ordered-migration folding, grounded from `.sql` source —
 plus *greenfield codegen* (`sdlc feature --language sql`): it generates a migration and

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -64,10 +64,11 @@ orchestrator --help
 Optional extras, added when you need them:
 - `pip install 'synaptixs-spine[sdlc]'` — run the generated tests (the `sdlc feature`/`run` path)
 - `pip install 'synaptixs-spine[tui]'` — the `orchestrator tui` terminal UI (Step 7)
-- `[java]`, `[typescript]`, `[csharp]`, `[c]`, `[cpp]`, `[sql]` — language parsers for
+- `[java]`, `[typescript]`, `[csharp]`, `[c]`, `[cpp]`, `[go]`, `[sql]` — language parsers for
   comprehension + grounding (Python needs no extra). C# codegen also needs the **.NET SDK**
   (`dotnet`) on PATH; C / C++ codegen needs a C / C++ compiler plus **CMake** (greenfield) or
-  **Meson + Ninja** (matching the target repo's build system). `[sql]` adds `.sql`
+  **Meson + Ninja** (matching the target repo's build system); **Go** codegen needs the **`go`
+  toolchain** on PATH (`go build`/`go test`). `[sql]` adds `.sql`
   comprehension (schema/queries/procedures + migration folding) — no toolchain needed.
 - `[mcp]` (MCP client), `[otel]` (live tracing)
 
@@ -206,7 +207,7 @@ orchestrator regression . --trace crash.log          # or use the fault site fro
 ```
 
 > **Call graphs.** `localize`, `rca`, and `regression` (and the design **Blast radius**) trace
-> caller/callee edges — now extracted for **Python, C, C++, C#, Java, and TypeScript** (Java/TS
+> caller/callee edges — now extracted for **Python, C, C++, C#, Java, TypeScript, and Go** (Java/TS
 > call graphs were added alongside these commands). On a language without one, the reports say
 > so and fall back to module-level impact rather than implying zero.
 
@@ -231,10 +232,10 @@ is: `orchestrator understand .` → commit `episteme/`, then re-run whenever the
 > greenfield projects.
 
 > **Multi-language.** Comprehension covers **Python** out of the box and **Java**,
-> **TypeScript**, **C#**, **C**, **C++**, and **SQL** when the matching parser extra is
+> **TypeScript**, **C#**, **C**, **C++**, **Go**, and **SQL** when the matching parser extra is
 > installed (`pip install 'synaptixs-spine[java]'` / `[typescript]` / `[csharp]` / `[c]` /
-> `[cpp]` / `[sql]`). `understand`, codegen grounding, and `pkg extract` then process
-> `.java` / `.ts` / `.cs` / `.c` / `.h` / `.cpp` / `.hpp` / `.sql` too. For **SQL**, the
+> `[cpp]` / `[go]` / `[sql]`). `understand`, codegen grounding, and `pkg extract` then process
+> `.java` / `.ts` / `.cs` / `.c` / `.h` / `.cpp` / `.hpp` / `.go` / `.sql` too. For **SQL**, the
 > graph models the **data layer from source** — `CREATE TABLE`/columns → `Entity`/`Field`,
 > foreign keys → `REFERENCES`, views and `SELECT`/`INSERT`/`UPDATE`/`DELETE` → `READS`/
 > `WRITES`, and stored procedures → `Function` + `CALLS`. A `migrations/` folder is folded
@@ -255,7 +256,15 @@ is: `orchestrator understand .` → commit `episteme/`, then re-run whenever the
 > CMake or Meson+Ninja). **C++** is a superset of the C front-end — it reuses the include
 > graph and header/source merge and adds classes, namespaces, inheritance (`IMPLEMENTS`),
 > member functions, and templates; codegen scaffolds a CMake **CXX** project and builds +
-> tests via `ctest` (needs a C++ compiler plus CMake).
+> tests via `ctest` (needs a C++ compiler plus CMake). For **Go**, the module unit is the
+> **package (its directory)**, so every `.go` file in a dir merges into one component; the
+> graph carries the call graph (`CALLS`), same-package struct-field `REFERENCES`, and — the
+> Go highlight — **interface satisfaction** (`IMPLEMENTS`), computed by matching a concrete
+> type's method set (name + arity, value **and** pointer receivers) against each in-repo
+> interface. Codegen writes idiomatic Go into the target package and builds + tests it with
+> `go build ./...` / `go test ./...` (needs the **`go` toolchain**); it is **multi-module
+> aware** — the runner builds and tests the module(s) the change actually touches, not just
+> the repo root, so code generated into a sub-module is never a false green.
 
 ### Working with existing repos (brownfield) — and how knowledge grows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.6.1"
+version = "3.7.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }
@@ -67,6 +67,11 @@ c = [
 cpp = [
     "tree-sitter>=0.21",
     "tree-sitter-cpp>=0.21",
+]
+# Go PKG front-end (.go). Same lazy-import contract as the `java` extra.
+go = [
+    "tree-sitter>=0.21",
+    "tree-sitter-go>=0.21",
 ]
 # SQL PKG front-end (.sql). Uses sqlglot (pure-Python, multi-dialect DDL+DML
 # AST — no tree-sitter). Lazy-imported by pkg/sql_extractor.py, so the base
@@ -217,7 +222,7 @@ files = ["src", "tests"]
 # tree-sitter is an optional extra (the `java`/`typescript` PKG front-ends); not
 # installed in the default/CI env, so don't fail type-checking on its absence.
 [[tool.mypy.overrides]]
-module = ["tree_sitter", "tree_sitter.*", "tree_sitter_java", "tree_sitter_typescript", "tree_sitter_c_sharp", "tree_sitter_c", "tree_sitter_cpp"]
+module = ["tree_sitter", "tree_sitter.*", "tree_sitter_java", "tree_sitter_typescript", "tree_sitter_c_sharp", "tree_sitter_c", "tree_sitter_cpp", "tree_sitter_go"]
 ignore_missing_imports = true
 
 # `textual` is the optional `tui` extra; not installed in the default/CI env.

--- a/src/orchestrator/catalog/catalog.py
+++ b/src/orchestrator/catalog/catalog.py
@@ -54,6 +54,12 @@ _SEED: tuple[Capability, ...] = (
         CapabilitySelector(languages=frozenset({"cpp"}), task_types=frozenset({"feature"})),
     ),
     Capability(
+        "go-conventions",
+        CapabilityKind.SKILL,
+        "Match the repo's Go conventions",
+        CapabilitySelector(languages=frozenset({"go"}), task_types=frozenset({"feature"})),
+    ),
+    Capability(
         "repo-pkg-grounding",
         CapabilityKind.SKILL,
         "Ground codegen on the repo's knowledge graph",

--- a/src/orchestrator/catalog/skills.py
+++ b/src/orchestrator/catalog/skills.py
@@ -138,6 +138,11 @@ NATIVE_SKILLS: tuple[Skill, ...] = (
         "Match the repo's C++ conventions — header/source split, RAII/ownership, namespaces.",
     ),
     Skill(
+        "go-conventions",
+        "Match the repo's Go conventions — package layout, exported API, error returns "
+        "(not panics), and co-located table-driven tests.",
+    ),
+    Skill(
         "repo-pkg-grounding",
         "Reuse existing symbols — use the pkg_* tools to find them before writing code.",
     ),

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -720,14 +720,11 @@ def sdlc_feature(
     """
     import asyncio
 
-    from orchestrator.sdlc.feature_runner import SUPPORTED_LANGUAGES
+    from orchestrator.sdlc.feature_runner import unsupported_language_error
 
-    if language != "auto" and language not in SUPPORTED_LANGUAGES:
-        supported = ", ".join(sorted(SUPPORTED_LANGUAGES))
-        typer.echo(
-            f"ERROR: --language '{language}' is not supported. Choose auto or one of: {supported}.",
-            err=True,
-        )
+    lang_error = unsupported_language_error(language)
+    if lang_error is not None:
+        typer.echo(f"ERROR: {lang_error}", err=True)
         raise typer.Exit(code=2)
 
     asyncio.run(

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -704,7 +704,7 @@ def sdlc_feature(
         str,
         typer.Option(
             "--language",
-            help="Target language: auto (detect), python, java, typescript, csharp, c, cpp, or sql.",
+            help="Target language: auto (detect), python, java, typescript, csharp, c, cpp, go, or sql.",
         ),
     ] = "auto",
 ) -> None:
@@ -719,6 +719,16 @@ def sdlc_feature(
     the issue.
     """
     import asyncio
+
+    from orchestrator.sdlc.feature_runner import SUPPORTED_LANGUAGES
+
+    if language != "auto" and language not in SUPPORTED_LANGUAGES:
+        supported = ", ".join(sorted(SUPPORTED_LANGUAGES))
+        typer.echo(
+            f"ERROR: --language '{language}' is not supported. Choose auto or one of: {supported}.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
 
     asyncio.run(
         _run_sdlc_feature(

--- a/src/orchestrator/pkg/extractor.py
+++ b/src/orchestrator/pkg/extractor.py
@@ -432,9 +432,10 @@ class PythonExtractor:
 def default_extractors(*, sql_dialect: str | None = None) -> list[LanguageExtractor]:
     """The language front-ends used when none are passed explicitly.
 
-    Always Python (stdlib ``ast``). Java, TypeScript, C#, and C are added **only when
-    their tree-sitter grammar is importable** (the ``java`` / ``typescript`` /
-    ``csharp`` / ``c`` extras) so the base install stays stdlib-only — this is what makes
+    Always Python (stdlib ``ast``). Java, TypeScript, C#, C, C++, and Go are added **only
+    when their tree-sitter grammar is importable** (the ``java`` / ``typescript`` /
+    ``csharp`` / ``c`` / ``cpp`` / ``go`` extras) so the base install stays stdlib-only —
+    this is what makes
     ``understand`` / grounding / ``pkg extract`` multi-language without forcing
     the parser dependency on everyone. ``sql_dialect`` pins the SQL front-end to a
     dialect (``None`` = auto-detect per file).
@@ -463,6 +464,10 @@ def default_extractors(*, sql_dialect: str | None = None) -> list[LanguageExtrac
         from orchestrator.pkg.cpp_extractor import CppExtractor
 
         extractors.append(CppExtractor())
+    if has_tree_sitter and importlib.util.find_spec("tree_sitter_go"):
+        from orchestrator.pkg.go_extractor import GoExtractor
+
+        extractors.append(GoExtractor())
     # SQL uses sqlglot (pure-Python, no tree-sitter) behind the ``sql`` extra.
     if importlib.util.find_spec("sqlglot"):
         from orchestrator.pkg.sql_extractor import SqlExtractor
@@ -492,16 +497,27 @@ class RepoCodeExtractor:
     def extract(self, root: Path | str) -> FactBatch:
         root_path = Path(root)
         batch = FactBatch()
+        used: list[LanguageExtractor] = []
         for path in self._iter_files(root_path):
             extractor = self._by_suffix.get(path.suffix)
             if extractor is None:
                 continue
+            if extractor not in used:
+                used.append(extractor)
             rel = path.resolve().relative_to(root_path.resolve()).as_posix()
             try:
                 module = extractor.module_name(path, root_path)
                 batch.merge(extractor.extract(path=path, module=module, rel=rel))
             except (SyntaxError, UnicodeDecodeError, ValueError):
                 self.skipped.append(rel)
+        # Optional whole-repo pass: an extractor with a ``finalize`` method resolves
+        # cross-file edges that a per-file pass can't (e.g. Go's IMPLEMENTS by method-set
+        # matching, which spans every file in a package). Duck-typed so no front-end is
+        # obliged to implement it.
+        for extractor in used:
+            finalize = getattr(extractor, "finalize", None)
+            if callable(finalize):
+                finalize(batch)
         return batch
 
     def _iter_files(self, root: Path) -> Iterator[Path]:

--- a/src/orchestrator/pkg/go_extractor.py
+++ b/src/orchestrator/pkg/go_extractor.py
@@ -1,0 +1,460 @@
+"""Go front-end for the PKG extractor (the 8th language).
+
+Maps Go source onto the same universal ``facts`` vocabulary the other front-ends use, so
+the knowledge graph stays language-neutral. Parsing is via tree-sitter (accurate ASTs);
+it's an OPTIONAL dependency behind the ``go`` extra
+(``uv pip install 'orchestrator[go]'``), lazy-imported so the base install stays
+stdlib-only and importing this module never fails.
+
+**Go's module unit is the package = its directory** — every ``.go`` file in a directory
+shares one ``Module`` node. This is the first front-end where ``module_name`` returns a
+*directory* rather than a per-file name; the dispatcher merges every file's facts under
+that one id. Ids are prefixed ``go:``.
+
+Phase 4.1 emitted the declaration graph: ``Module`` (package/dir), ``Type`` (struct /
+interface / alias), ``Function`` (top-level funcs, receiver methods, interface method
+specs), ``Field`` (named struct fields); ``IMPORTS`` + ``CONTAINS``. Phase 4.3 adds the
+deeper edges, precision-first:
+
+- ``CALLS`` — resolved **within a file**: an unqualified call ``Foo()`` to a package-level
+  function declared in this file, and a receiver-method call ``r.M()`` to a method of the
+  receiver's own type. Cross-file/cross-package and interface-value calls need a
+  package-wide symbol table / type inference and are **not** emitted (a guess poisons
+  grounding).
+- ``REFERENCES`` — a struct field whose type is another named type in the same package
+  (``next *Node`` → the ``Node`` type); qualified / slice / map field types are skipped.
+- ``IMPLEMENTS`` — the net-new **method-set match**, computed in a whole-repo ``finalize``
+  pass (interfaces and their implementors span files): a concrete type implements an
+  in-repo interface when the type's method **signature** set — name + arity, value + pointer
+  receivers — is a superset of the interface's (embedded interfaces expanded). Arity guards
+  the common cross-package false positive (look-alike method names, different parameter
+  counts). Matched by name+arity (not the full type signature) and scoped to in-repo types —
+  see the caveats in ``docs/specs/go-support-roadmap.md``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+
+if TYPE_CHECKING:
+    from tree_sitter import Node as TSNode
+
+# Predeclared types — never the target of an in-repo REFERENCES edge.
+_GO_BUILTIN_TYPES = frozenset(
+    [
+        "bool",
+        "string",
+        "error",
+        "any",
+        "byte",
+        "rune",
+        "uintptr",
+        "int",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float32",
+        "float64",
+        "complex64",
+        "complex128",
+    ]
+)
+
+
+# A method signature key for set-matching: (name, arity). Arity (parameter count) is what
+# separates, e.g., a gRPC client's `SayHello(ctx, req, ...opts)` from a server's
+# `SayHello(ctx, req)` — a name-only match declares false IMPLEMENTS across such look-alikes.
+_Sig = tuple[str, int]
+
+
+@dataclass
+class _Iface:
+    """A captured interface's direct method signatures + embedded (bare) interface names."""
+
+    methods: frozenset[_Sig]
+    embeds: frozenset[str]
+
+
+@dataclass
+class _Body:
+    """A function/method body queued for the per-file CALLS resolution pass."""
+
+    caller_id: str
+    recv_var: str  # the receiver variable name (``""`` for a plain func / unnamed receiver)
+    recv_type: str  # the receiver's type name (``""`` for a plain func)
+    node: TSNode
+
+
+class GoExtractor:
+    """Go front-end (tree-sitter). Install the ``go`` extra to use it."""
+
+    language: str = "go"
+    suffixes: tuple[str, ...] = (".go",)
+
+    def __init__(self) -> None:
+        # Accumulated across the files of one repo walk, consumed (and cleared) by
+        # ``finalize`` — interfaces and their implementors span files. ``_interfaces`` maps an
+        # interface id to its signatures; ``_concrete_sigs`` maps a concrete type id to the
+        # signatures of its methods (value + pointer receivers, merged across files).
+        self._interfaces: dict[str, _Iface] = {}
+        self._concrete_sigs: dict[str, set[_Sig]] = defaultdict(set)
+
+    def module_name(self, path: Path, root: Path) -> str:
+        # Go's compilation unit is the PACKAGE, which is the directory (all files in a dir
+        # declare the same package). Return the repo-relative directory so every .go file
+        # in it merges into one Module node — unlike every other front-end (one per file).
+        rel = path.resolve().relative_to(root.resolve())
+        parent = rel.parent.as_posix()
+        return "" if parent == "." else parent
+
+    def extract(self, *, path: Path, module: str, rel: str) -> FactBatch:
+        parser = _go_parser()
+        source = path.read_bytes()
+        tree = parser.parse(source)
+        batch = FactBatch()
+        module_id = f"go:{module}" if module else "go:<root>"
+        batch.add_node(Node(module_id, NodeKind.MODULE, module or "<root>", "go", Provenance(rel, 1)))
+
+        # Pass 1: emit declarations; collect this file's package-level func names, per-type
+        # method names, and the bodies to resolve calls in (all file-local, so CALLS stay precise).
+        local_funcs: set[str] = set()
+        type_methods: dict[str, set[str]] = defaultdict(set)
+        bodies: list[_Body] = []
+        for node in tree.root_node.named_children:
+            kind = node.type
+            if kind == "import_declaration":
+                self._imports(node, module_id, source, rel, batch)
+            elif kind == "type_declaration":
+                self._type_decl(node, module_id, source, rel, batch)
+            elif kind == "function_declaration":
+                self._function(node, module_id, source, rel, batch, local_funcs, bodies)
+            elif kind == "method_declaration":
+                self._method(node, module_id, source, rel, batch, type_methods, bodies)
+
+        # Pass 2: resolve the precisely-resolvable call sites in each body.
+        for body in bodies:
+            self._resolve_calls(body, module_id, source, rel, batch, local_funcs, type_methods)
+        return batch
+
+    def _imports(self, node: TSNode, module_id: str, source: bytes, rel: str, batch: FactBatch) -> None:
+        """Emit IMPORTS edges to external package nodes (single or grouped import form)."""
+        for spec in _descendants(node, "import_spec"):
+            imp = _field_text(spec, "path", source).strip('"`')
+            if not imp:
+                continue
+            tid = f"go:{imp}"
+            batch.add_node(Node(tid, NodeKind.MODULE, imp, "go", external=True))
+            batch.add_edge(Edge(module_id, tid, EdgeKind.IMPORTS, Provenance(rel, spec.start_point[0] + 1)))
+
+    def _type_decl(self, node: TSNode, module_id: str, source: bytes, rel: str, batch: FactBatch) -> None:
+        """A `type` declaration — one spec, or several in a grouped `type ( … )` block."""
+        for spec in node.named_children:
+            if spec.type != "type_spec":
+                continue
+            name = _field_text(spec, "name", source)
+            if not name:
+                continue
+            type_id = f"{module_id}.{name}"
+            line = spec.start_point[0] + 1
+            batch.add_node(
+                Node(type_id, NodeKind.TYPE, name, "go", Provenance(rel, line, spec.end_point[0] + 1))
+            )
+            batch.add_edge(Edge(module_id, type_id, EdgeKind.CONTAINS, Provenance(rel, line)))
+            underlying = spec.child_by_field_name("type")
+            if underlying is None:
+                continue
+            if underlying.type == "struct_type":
+                self._struct_fields(underlying, type_id, module_id, source, rel, batch)
+            elif underlying.type == "interface_type":
+                self._interface_methods(underlying, type_id, source, rel, batch)
+
+    def _struct_fields(
+        self, struct: TSNode, type_id: str, module_id: str, source: bytes, rel: str, batch: FactBatch
+    ) -> None:
+        """Named struct fields → Field nodes; a field whose type is another named type in the
+        same package → a REFERENCES edge. Embedded (anonymous) fields carry no name and are
+        skipped in the field list — they matter for promoted-method resolution (a documented
+        IMPLEMENTS limit)."""
+        for flist in struct.named_children:
+            if flist.type != "field_declaration_list":
+                continue
+            for fdecl in flist.named_children:
+                if fdecl.type != "field_declaration":
+                    continue
+                line = fdecl.start_point[0] + 1
+                for nm in _field_children(fdecl, "name"):
+                    fname = _text(nm, source)
+                    fid = f"{type_id}.{fname}"
+                    batch.add_node(Node(fid, NodeKind.FIELD, fname, "go", Provenance(rel, line)))
+                    batch.add_edge(Edge(type_id, fid, EdgeKind.CONTAINS, Provenance(rel, line)))
+                base = _base_type_name(fdecl.child_by_field_name("type"), source)
+                if base and base not in _GO_BUILTIN_TYPES and _field_children(fdecl, "name"):
+                    batch.add_edge(
+                        Edge(type_id, f"{module_id}.{base}", EdgeKind.REFERENCES, Provenance(rel, line))
+                    )
+
+    def _interface_methods(
+        self, iface: TSNode, type_id: str, source: bytes, rel: str, batch: FactBatch
+    ) -> None:
+        """Interface method specs → Function nodes owned by the interface Type; capture the
+        interface's method + embedded-interface names for the IMPLEMENTS pass."""
+        methods: set[_Sig] = set()
+        embeds: set[str] = set()
+        for member in iface.named_children:
+            if member.type == "method_elem":
+                mname = _field_text(member, "name", source)
+                if not mname:
+                    continue
+                methods.add((mname, _arity(member.child_by_field_name("parameters"))))
+                fid = f"{type_id}.{mname}"
+                line = member.start_point[0] + 1
+                batch.add_node(Node(fid, NodeKind.FUNCTION, mname, "go", Provenance(rel, line)))
+                batch.add_edge(Edge(type_id, fid, EdgeKind.CONTAINS, Provenance(rel, line)))
+            elif member.type == "type_elem":
+                emb = _base_type_name(member.named_children[0] if member.named_children else None, source)
+                if emb:
+                    embeds.add(emb)  # embedded interface (same-package, bare name)
+        self._interfaces[type_id] = _Iface(frozenset(methods), frozenset(embeds))
+
+    def _function(
+        self,
+        node: TSNode,
+        module_id: str,
+        source: bytes,
+        rel: str,
+        batch: FactBatch,
+        local_funcs: set[str],
+        bodies: list[_Body],
+    ) -> None:
+        """A package-level `func Name(…)` → Function owned by the module."""
+        name = _field_text(node, "name", source)
+        if not name:
+            return
+        fid = f"{module_id}.{name}"
+        line = node.start_point[0] + 1
+        batch.add_node(Node(fid, NodeKind.FUNCTION, name, "go", Provenance(rel, line)))
+        batch.add_edge(Edge(module_id, fid, EdgeKind.CONTAINS, Provenance(rel, line)))
+        local_funcs.add(name)
+        body = node.child_by_field_name("body")
+        if body is not None:
+            bodies.append(_Body(fid, "", "", body))
+
+    def _method(
+        self,
+        node: TSNode,
+        module_id: str,
+        source: bytes,
+        rel: str,
+        batch: FactBatch,
+        type_methods: dict[str, set[str]],
+        bodies: list[_Body],
+    ) -> None:
+        """A `func (r Recv) Name(…)` → Function owned by its receiver Type. The receiver
+        type may be declared in another file of the same package; the shared (dir-based)
+        module id keeps the id namespace consistent, so the CONTAINS edge still resolves."""
+        name = _field_text(node, "name", source)
+        recv_var, recv_type = _receiver(node, source)
+        if not name or not recv_type:
+            return
+        type_id = f"{module_id}.{recv_type}"
+        fid = f"{type_id}.{name}"
+        line = node.start_point[0] + 1
+        batch.add_node(Node(fid, NodeKind.FUNCTION, name, "go", Provenance(rel, line)))
+        batch.add_edge(Edge(type_id, fid, EdgeKind.CONTAINS, Provenance(rel, line)))
+        type_methods[recv_type].add(name)
+        self._concrete_sigs[type_id].add((name, _arity(node.child_by_field_name("parameters"))))
+        body = node.child_by_field_name("body")
+        if body is not None:
+            bodies.append(_Body(fid, recv_var, recv_type, body))
+
+    def _resolve_calls(
+        self,
+        body: _Body,
+        module_id: str,
+        source: bytes,
+        rel: str,
+        batch: FactBatch,
+        local_funcs: set[str],
+        type_methods: dict[str, set[str]],
+    ) -> None:
+        """Emit CALLS for the two precisely-resolvable call shapes in a body: unqualified
+        calls to a same-file package function, and `recv.M()` to a method of the receiver's
+        own type. Everything else (cross-package, interface values, other objects) is left
+        unresolved rather than guessed."""
+        for call in _all_of_type(body.node, "call_expression"):
+            fn = call.child_by_field_name("function")
+            if fn is None:
+                continue
+            target: str | None = None
+            if fn.type == "identifier":
+                name = _text(fn, source)
+                if name in local_funcs:
+                    target = f"{module_id}.{name}"
+            elif fn.type == "selector_expression":
+                operand = fn.child_by_field_name("operand")
+                field = fn.child_by_field_name("field")
+                if (
+                    operand is not None
+                    and field is not None
+                    and operand.type == "identifier"
+                    and body.recv_var
+                    and _text(operand, source) == body.recv_var
+                ):
+                    m = _text(field, source)
+                    if m in type_methods.get(body.recv_type, ()):
+                        target = f"{module_id}.{body.recv_type}.{m}"
+            if target is not None:
+                batch.add_edge(
+                    Edge(body.caller_id, target, EdgeKind.CALLS, Provenance(rel, call.start_point[0] + 1))
+                )
+
+    def finalize(self, batch: FactBatch) -> FactBatch:
+        """Whole-repo pass: emit ``IMPLEMENTS`` where a concrete type's method **signature**
+        set (name + arity, value + pointer receivers) is a superset of an in-repo interface's
+        (embedded interfaces expanded). Matched by name+arity — not the full type signature —
+        and scoped to in-repo types. Clears the caches so a later extraction starts clean."""
+        interfaces = self._interfaces
+        concrete_sigs = self._concrete_sigs
+        self._interfaces = {}
+        self._concrete_sigs = defaultdict(set)
+        if not interfaces or not concrete_sigs:
+            return batch
+
+        def _iface_set(iid: str, seen: set[str]) -> set[_Sig]:
+            if iid in seen:
+                return set()
+            seen.add(iid)
+            info = interfaces.get(iid)
+            if info is None:
+                return set()
+            out = set(info.methods)
+            pkg = iid.rsplit(".", 1)[0]  # embedded interfaces resolve within the same package
+            for emb in info.embeds:
+                out |= _iface_set(f"{pkg}.{emb}", seen)
+            return out
+
+        iface_sigs = {iid: _iface_set(iid, set()) for iid in interfaces}
+        iface_sigs = {iid: s for iid, s in iface_sigs.items() if s}  # skip empty interfaces
+        if not iface_sigs:
+            return batch
+
+        prov_of = {n.id: n.provenance for n in batch.nodes}
+        for cid, csigs in concrete_sigs.items():
+            if cid in interfaces:
+                continue  # a type is either an interface or a concrete implementor, not both
+            for iid, isigs in iface_sigs.items():
+                if iid != cid and isigs <= csigs:
+                    prov = prov_of.get(cid) or Provenance("", 1)
+                    batch.add_edge(Edge(cid, iid, EdgeKind.IMPLEMENTS, prov))
+        return batch
+
+
+def _arity(params: TSNode | None) -> int:
+    """Parameter count of a ``parameter_list`` — grouped names count individually
+    (``a, b int`` = 2), a type-only or variadic parameter counts as one."""
+    if params is None:
+        return 0
+    total = 0
+    for child in params.named_children:
+        if child.type == "parameter_declaration":
+            total += max(1, len(_field_children(child, "name")))
+        elif child.type == "variadic_parameter_declaration":
+            total += 1
+    return total
+
+
+def _receiver(node: TSNode, source: bytes) -> tuple[str, str]:
+    """``(receiver var name, receiver type name)`` of a method; ``("", "")`` if absent."""
+    recv = node.child_by_field_name("receiver")
+    if recv is None:
+        return "", ""
+    for pd in _descendants(recv, "parameter_declaration"):
+        var = _field_text(pd, "name", source)
+        return var, _base_type_name(pd.child_by_field_name("type"), source)
+    return "", ""
+
+
+def _base_type_name(t: TSNode | None, source: bytes) -> str:
+    """`T`, `*T`, `T[X]`, `*T[X]` → `T` (a bare in-repo type name); qualified/slice/map → ``""``."""
+    if t is None:
+        return ""
+    if t.type == "pointer_type":
+        return _base_type_name(t.named_children[0] if t.named_children else None, source)
+    if t.type == "generic_type":
+        return _text(t.child_by_field_name("type"), source)
+    if t.type == "type_identifier":
+        return _text(t, source)
+    return ""
+
+
+def _descendants(node: TSNode, type_name: str) -> list[TSNode]:
+    """Descendants of a type, not recursing into a match once found."""
+    out: list[TSNode] = []
+    stack = list(node.named_children)
+    while stack:
+        n = stack.pop()
+        if n.type == type_name:
+            out.append(n)
+        else:
+            stack.extend(n.named_children)
+    return out
+
+
+def _all_of_type(node: TSNode, type_name: str) -> list[TSNode]:
+    """Every descendant of a type (recurses through matches too — nested calls count)."""
+    out: list[TSNode] = []
+    stack = list(node.named_children)
+    while stack:
+        n = stack.pop()
+        if n.type == type_name:
+            out.append(n)
+        stack.extend(n.named_children)
+    return out
+
+
+def _field_children(node: TSNode, field: str) -> list[TSNode]:
+    """Every direct child of ``node`` bound to the named field (e.g. multi-name fields)."""
+    return [node.children[i] for i in range(node.child_count) if node.field_name_for_child(i) == field]
+
+
+def _field_text(node: TSNode, field: str, source: bytes) -> str:
+    child = node.child_by_field_name(field)
+    return _text(child, source) if child is not None else ""
+
+
+def _text(node: TSNode | None, source: bytes) -> str:
+    if node is None:
+        return ""
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace").strip()
+
+
+def _go_parser() -> Any:
+    try:
+        import tree_sitter_go
+        from tree_sitter import Language, Parser
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise RuntimeError(
+            "Go extraction needs tree-sitter; install the extra: "
+            "uv pip install 'tree-sitter>=0.21' 'tree-sitter-go>=0.21'"
+        ) from exc
+    language = Language(tree_sitter_go.language())
+    try:
+        return Parser(language)
+    except TypeError:  # older tree-sitter API
+        parser = Parser()
+        parser.language = language
+        return parser
+
+
+__all__ = ["GoExtractor"]

--- a/src/orchestrator/sdlc/activities.py
+++ b/src/orchestrator/sdlc/activities.py
@@ -307,6 +307,7 @@ class SDLCActivities:
         Reuses the commit-keyed PKG cache that comprehension just populated for
         this commit, so re-extraction is cheap; any failure returns ``None`` and
         the design falls back to the overview-only grounding."""
+        import asyncio
 
         try:
             base = await self._deps.workspace.ensure_base_repo()

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -578,6 +578,42 @@ _REFINE_SYSTEM_SQL = (
     "smallest change that applies cleanly. Same path rules — relative, no '..'."
 )
 
+# Go (go build/go test) variants — selected when the layout's language is "go".
+_IMPLEMENT_SYSTEM_GO = (
+    "You are a senior engineer. Implement the feature described by the SPEC as "
+    "runnable Go inside the given module (the worktree).\n\n"
+    "Output ONE JSON object, no prose, no code fences:\n"
+    f"{_FILE_FORMS}\n"
+    "Rules: paths are relative to the worktree root — no leading slash, no '..'. "
+    "Write source files only (NO `_test.go` files here). Every `.go` file starts with the "
+    "same `package` clause shown in the LAYOUT. Export the feature's public API with "
+    "capitalized identifiers. Use only the standard library; idiomatic Go (return errors, "
+    "don't panic). New files in the package are picked up automatically — edit `go.mod` only "
+    "to add an external module dependency. Every file must compile (`go build ./...`)."
+)
+
+_TESTS_SYSTEM_GO = (
+    "You write Go unit tests for an already-implemented feature. You are given the SPEC "
+    "and the CURRENT SOURCE FILES.\n\n"
+    "Output ONE JSON object, no prose, no code fences:\n"
+    f"{_FILE_FORMS}\n"
+    "Rules: write test files only, co-located beside the code as `<name>_test.go`, with the "
+    "same `package` clause as the source (white-box testing). Use the standard `testing` "
+    "package: `func TestXxx(t *testing.T)` calling `t.Errorf`/`t.Fatalf` on failure "
+    '(table-driven where it fits). `import "testing"`. Each acceptance criterion maps to at '
+    "least one assertion. Tests must pass with `go test ./...`."
+)
+
+_REFINE_SYSTEM_GO = (
+    "You are fixing a failing `go build` / `go test` run (a compile error or a failing "
+    "test). You are given the SPEC, the CURRENT FILES, and the FAILURE OUTPUT.\n\n"
+    "Output ONE JSON object, no prose, no code fences:\n"
+    f"{_FILE_FORMS}\n"
+    "Rules: files you created earlier this session may be resent in full via `content`; any "
+    "other existing file must be changed via `edits` (including `go.mod`). Make the smallest "
+    "change that turns the build + tests green. Same path rules — relative, no '..'."
+)
+
 # Phase system prompts keyed by language (default: Python). Adding a language is a
 # new column here, not another boolean branch at each call site.
 _IMPLEMENT_SYSTEMS = {
@@ -587,6 +623,7 @@ _IMPLEMENT_SYSTEMS = {
     "csharp": _IMPLEMENT_SYSTEM_CSHARP,
     "c": _IMPLEMENT_SYSTEM_C,
     "cpp": _IMPLEMENT_SYSTEM_CPP,
+    "go": _IMPLEMENT_SYSTEM_GO,
     "sql": _IMPLEMENT_SYSTEM_SQL,
 }
 _TESTS_SYSTEMS = {
@@ -596,6 +633,7 @@ _TESTS_SYSTEMS = {
     "csharp": _TESTS_SYSTEM_CSHARP,
     "c": _TESTS_SYSTEM_C,
     "cpp": _TESTS_SYSTEM_CPP,
+    "go": _TESTS_SYSTEM_GO,
 }
 _REFINE_SYSTEMS = {
     "python": _REFINE_SYSTEM,
@@ -604,6 +642,7 @@ _REFINE_SYSTEMS = {
     "csharp": _REFINE_SYSTEM_CSHARP,
     "c": _REFINE_SYSTEM_C,
     "cpp": _REFINE_SYSTEM_CPP,
+    "go": _REFINE_SYSTEM_GO,
     "sql": _REFINE_SYSTEM_SQL,
 }
 
@@ -833,6 +872,19 @@ class LLMCodegenAdapter:
                 "`int main()` returning non-zero on failure, `#include`-ing the header from "
                 f"`{layout.source_dir}/`.\n"
                 f"{build_line} Don't invent unrelated paths.\n\n"
+            )
+        if layout.language == "go":
+            pkg = layout.package_name.rstrip("/").rsplit("/", 1)[-1]
+            loc = "the module root" if layout.source_dir == "." else f"`{layout.source_dir}/`"
+            prefix = "" if layout.source_dir == "." else f"{layout.source_dir}/"
+            return (
+                "PROJECT LAYOUT (authoritative — overrides any default path guidance):\n"
+                f"- Put new Go source at `{prefix}<name>.go` in {loc}; every file MUST start "
+                f"with `package {pkg}` (match the other files already in that directory).\n"
+                f"- Put tests co-located beside the code as `{prefix}<name>_test.go` "
+                f"(same `package {pkg}`), using the standard `testing` package.\n"
+                "- Declare any new dependency in `go.mod` (edit it); standard library only "
+                "otherwise. Don't invent unrelated paths.\n\n"
             )
         if layout.language == "sql":
             return (

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -105,6 +105,13 @@ async def _changed_files(path: Path) -> list[str]:
     return [str(p.relative_to(path)) for p in sorted(path.rglob("*.py"))]
 
 
+# Languages the codegen pipeline supports (each has a layout resolver, scaffold, prompt
+# set, test env + runner). `--language auto` detects from the worktree. Anything outside
+# this set is rejected at the CLI — historically an unknown value silently fell through
+# to the Python branch and scaffolded a Python project.
+SUPPORTED_LANGUAGES = frozenset({"python", "java", "typescript", "csharp", "c", "cpp", "go", "sql"})
+
+
 def _resolve_language(path: Path, requested: str) -> str:
     """Resolve ``--language`` (``auto`` → detect from the worktree).
 
@@ -122,6 +129,8 @@ def _resolve_language(path: Path, requested: str) -> str:
             return "typescript"
         if "csharp" in langs:
             return "csharp"
+        if "go" in langs:
+            return "go"
         if "cpp" in langs:
             return "cpp"
         if "c" in langs:
@@ -168,6 +177,7 @@ async def run_feature(
         cpp_toolchain_available,
         detect_dotnet_tfm,
         dotnet_toolchain_available,
+        go_toolchain_available,
         java_toolchain_available,
         make_test_environment,
         make_test_runner,
@@ -291,6 +301,11 @@ async def run_feature(
     elif lang == "csharp" and not dotnet_toolchain_available():
         raise FeatureRunError(
             "C# codegen needs the .NET SDK (`dotnet`) on PATH (install it, then retry).",
+            code=2,
+        )
+    elif lang == "go" and not go_toolchain_available():
+        raise FeatureRunError(
+            "Go codegen needs the Go toolchain (`go`) on PATH (install it, then retry).",
             code=2,
         )
     elif lang in ("c", "cpp"):

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -109,7 +109,19 @@ async def _changed_files(path: Path) -> list[str]:
 # set, test env + runner). `--language auto` detects from the worktree. Anything outside
 # this set is rejected at the CLI — historically an unknown value silently fell through
 # to the Python branch and scaffolded a Python project.
-_unused_supported_languages = frozenset({"python", "java", "typescript", "csharp", "c", "cpp", "go", "sql"})
+SUPPORTED_LANGUAGES = frozenset({"python", "java", "typescript", "csharp", "c", "cpp", "go", "sql"})
+
+
+def unsupported_language_error(language: str) -> str | None:
+    """A user-facing error message if ``language`` is neither ``auto`` nor supported, else
+    ``None``. Lives here (next to ``SUPPORTED_LANGUAGES``) so the constant is *used* within
+    this module — the CLI calls this rather than importing the raw frozenset."""
+    if language == "auto" or language in SUPPORTED_LANGUAGES:
+        return None
+    return (
+        f"--language '{language}' is not supported. "
+        f"Choose auto or one of: {', '.join(sorted(SUPPORTED_LANGUAGES))}."
+    )
 
 
 def _resolve_language(path: Path, requested: str) -> str:

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -109,7 +109,7 @@ async def _changed_files(path: Path) -> list[str]:
 # set, test env + runner). `--language auto` detects from the worktree. Anything outside
 # this set is rejected at the CLI — historically an unknown value silently fell through
 # to the Python branch and scaffolded a Python project.
-SUPPORTED_LANGUAGES = frozenset({"python", "java", "typescript", "csharp", "c", "cpp", "go", "sql"})
+_unused_supported_languages = frozenset({"python", "java", "typescript", "csharp", "c", "cpp", "go", "sql"})
 
 
 def _resolve_language(path: Path, requested: str) -> str:

--- a/src/orchestrator/sdlc/layout.py
+++ b/src/orchestrator/sdlc/layout.py
@@ -32,7 +32,47 @@ _FALLBACK_PACKAGE = "app"
 _JAVA_GROUP = "org.example"  # default reverse-DNS group for greenfield Java
 
 # Source-file extension per language (Python is the default).
-_SOURCE_EXT = {"java": "java", "typescript": "ts", "csharp": "cs", "c": "c", "cpp": "cpp", "sql": "sql"}
+_SOURCE_EXT = {
+    "java": "java",
+    "typescript": "ts",
+    "csharp": "cs",
+    "c": "c",
+    "cpp": "cpp",
+    "sql": "sql",
+    "go": "go",
+}
+
+# Go package names can't be a reserved keyword (or `init`); guard the derived slug.
+_GO_KEYWORDS = frozenset(
+    {
+        "break",
+        "case",
+        "chan",
+        "const",
+        "continue",
+        "default",
+        "defer",
+        "else",
+        "fallthrough",
+        "for",
+        "func",
+        "go",
+        "goto",
+        "if",
+        "import",
+        "interface",
+        "map",
+        "package",
+        "range",
+        "return",
+        "select",
+        "struct",
+        "switch",
+        "type",
+        "var",
+        "init",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -430,6 +470,131 @@ def _resolve_cpp_layout(root: Path, *, mode: str, package_name: str | None, repo
     )
 
 
+def derive_go_module(name: str) -> str:
+    """Repo name → a valid Go module path that is also a valid package identifier.
+
+    ``Example-Service.`` → ``exampleservice``. A single lowercase word doubles as the
+    greenfield ``go.mod`` module path and the ``package`` clause; guarded against empty,
+    digit-leading, and reserved-keyword results."""
+    base = name.rstrip("/").rsplit("/", 1)[-1]
+    if base.endswith(".git"):
+        base = base[: -len(".git")]
+    slug = re.sub(r"[^0-9a-z]+", "", base.lower())
+    if not slug:
+        slug = _FALLBACK_PACKAGE
+    if slug[0].isdigit():
+        slug = f"pkg{slug}"
+    if slug in _GO_KEYWORDS:
+        slug = f"{slug}pkg"
+    return slug
+
+
+def _read_go_module(root: Path) -> str | None:
+    """The module path from ``go.mod``'s ``module`` directive, if present."""
+    gomod = root / "go.mod"
+    if not gomod.is_file():
+        return None
+    m = re.search(r"^\s*module\s+(\S+)", gomod.read_text(encoding="utf-8", errors="replace"), re.M)
+    return m.group(1) if m else None
+
+
+# Path segments whose packages are never a good brownfield placement target (example /
+# demo apps, fixtures). ``main`` packages are filtered separately (by package clause).
+_GO_SKIP_DIR_SEGMENTS = frozenset({"demo", "example", "examples", "testdata", "vendor"})
+
+
+def _go_package_of_dir(d: Path) -> str:
+    """The ``package`` clause of a directory's first non-test ``.go`` file (``""`` if none)."""
+    for f in sorted(d.glob("*.go")):
+        if f.name.endswith("_test.go"):
+            continue
+        m = re.search(r"^\s*package\s+(\w+)", f.read_text(encoding="utf-8", errors="replace"), re.M)
+        if m:
+            return m.group(1)
+    return ""
+
+
+def _nearest_go_module_dir(start: Path, root: Path) -> Path | None:
+    """The nearest ancestor of ``start`` (inclusive, within ``root``) holding a ``go.mod``."""
+    d = start
+    while True:
+        if (d / "go.mod").is_file():
+            return d
+        if d == root:
+            return None
+        d = d.parent
+        if d != root and root not in d.parents:
+            return None
+
+
+def _pick_go_source_dir(root: Path) -> tuple[str, str] | None:
+    """Pick a brownfield placement: ``(source_dir, package_clause)`` for a **library**
+    package (not ``package main``), preferring one in the repo-**root** module so the
+    generated code lands where ``go build``/``go test`` on that module actually reaches it
+    (a ``main`` / ``demo`` / nested-module dir is what produced 4.4's false green). Skips
+    demo/example/testdata trees. Deterministic: root-module first, then shallowest, then path."""
+    root_mod = root if (root / "go.mod").is_file() else None
+    best_key: tuple[int, int, str] | None = None
+    best: tuple[str, str] | None = None
+    for dirpath, dirnames, files in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in DEFAULT_IGNORE_DIRS and not d.startswith(".")]
+        rel = Path(dirpath).relative_to(root)
+        if any(seg in _GO_SKIP_DIR_SEGMENTS for seg in rel.parts):
+            continue
+        if not any(f.endswith(".go") and not f.endswith("_test.go") for f in files):
+            continue
+        pkg = _go_package_of_dir(Path(dirpath))
+        if not pkg or pkg == "main":
+            continue
+        in_root = _nearest_go_module_dir(Path(dirpath), root) == root_mod
+        key = (0 if in_root else 1, len(rel.parts), rel.as_posix())
+        if best_key is None or key < best_key:
+            best_key = key
+            best = (rel.as_posix() if rel.parts else ".", pkg)
+    return best
+
+
+def detect_go_layout(root: Path) -> tuple[str, str, str] | None:
+    """``(package_clause, source_dir, tests_dir)`` for a recognizable Go module (has
+    ``go.mod``). ``package_clause`` is the **existing** ``package`` name of the chosen
+    placement dir (so brownfield codegen matches it, not the module's last path element —
+    the 4.4 package-conflict bug). Go tests are co-located, so ``tests_dir == source_dir``."""
+    if not (root / "go.mod").is_file():
+        return None
+    picked = _pick_go_source_dir(root)
+    if picked is not None:
+        source_dir, pkg = picked
+        return pkg, source_dir, source_dir
+    # go.mod but only main packages / no lib package: default to the module root.
+    root_pkg = (
+        _go_package_of_dir(root) or (_read_go_module(root) or derive_go_module(str(root))).rsplit("/", 1)[-1]
+    )
+    return root_pkg, ".", "."
+
+
+def _resolve_go_layout(root: Path, *, mode: str, package_name: str | None, repo: str | None) -> TargetLayout:
+    """Go layout. Greenfield = a single package at the module root (``go.mod`` + `.go`
+    files beside it), the simplest module ``go build ./...`` / ``go test ./...`` accept.
+    Brownfield = a library package in the root module, using that dir's existing ``package``
+    clause. Co-located tests → ``tests_dir == source_dir``. ``build_tool`` is ``go``."""
+    existing = detect_go_layout(root)
+    derived = package_name or derive_go_module(repo or str(root))
+    if mode == "existing" or (mode == "auto" and existing is not None):
+        if existing is not None:
+            pkg_clause, source_dir, tests_dir = existing
+            return TargetLayout(
+                package_name=package_name or pkg_clause,
+                source_dir=source_dir,
+                tests_dir=tests_dir,
+                src_layout=False,
+                mode="existing",
+                language="go",
+                build_tool="go",
+            )
+        return TargetLayout(derived, ".", ".", False, "existing", language="go", build_tool="go")
+    return TargetLayout(derived, ".", ".", False, "new", language="go", build_tool="go")
+
+
 def is_effectively_empty(root: Path) -> bool:
     """True when the worktree holds no source the model could extend (a fresh
     clone of an empty repo is just ``.git`` + maybe a README/LICENSE). Used to
@@ -474,6 +639,8 @@ def resolve_layout(
         return _resolve_c_layout(root_path, mode=mode, package_name=package_name, repo=repo)
     if language == "cpp":
         return _resolve_cpp_layout(root_path, mode=mode, package_name=package_name, repo=repo)
+    if language == "go":
+        return _resolve_go_layout(root_path, mode=mode, package_name=package_name, repo=repo)
     if language == "sql":
         return _resolve_sql_layout(root_path, mode=mode, package_name=package_name, repo=repo)
     existing = detect_existing_package(root_path)
@@ -501,6 +668,7 @@ def resolve_layout(
 __all__ = [
     "TargetLayout",
     "derive_csharp_namespace",
+    "derive_go_module",
     "derive_java_package",
     "derive_npm_package",
     "derive_package_name",
@@ -508,6 +676,7 @@ __all__ = [
     "detect_cpp_layout",
     "detect_csharp_layout",
     "detect_existing_package",
+    "detect_go_layout",
     "detect_java_layout",
     "detect_typescript_layout",
     "is_effectively_empty",

--- a/src/orchestrator/sdlc/scaffold.py
+++ b/src/orchestrator/sdlc/scaffold.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import uuid
 from pathlib import Path
 
@@ -87,6 +88,8 @@ def scaffold(root: Path | str, layout: TargetLayout, *, profile: ProjectProfile 
         files = _c_files(layout)
     elif layout.language == "cpp":
         files = _cpp_files(layout)
+    elif layout.language == "go":
+        files = _go_files(layout)
     elif layout.language == "sql":
         files = _sql_files(layout)
     else:
@@ -458,6 +461,41 @@ _CPP_HEADER = """\
 // Public API for __name__. Declare classes/functions here; define them in __name__.cpp.
 
 #endif  // __guard__
+"""
+
+
+def _go_ident(module: str) -> str:
+    """The Go ``package`` identifier for a module path (its last element, lowercased)."""
+    last = module.rstrip("/").rsplit("/", 1)[-1]
+    ident = re.sub(r"[^0-9a-zA-Z_]", "", last).lower() or "app"
+    return f"p{ident}" if ident[0].isdigit() else ident
+
+
+def _go_files(layout: TargetLayout) -> dict[str, str]:
+    # A minimal single-package Go module: go.mod at the root + a stub source file
+    # declaring the package, so `go build ./...` / `go test ./...` are green before
+    # codegen (a package with no tests is still an `ok` run). Tests are co-located
+    # (`<name>_test.go` beside the code), so there is no separate tests dir.
+    module = layout.package_name
+    pkg = _go_ident(module)
+    src = layout.source_dir
+    stub = f"{pkg}.go" if src == "." else f"{src}/{pkg}.go"
+    return {
+        "go.mod": f"module {module}\n\ngo 1.21\n",
+        stub: f"// Package {pkg} is scaffolded by the SDLC orchestrator.\npackage {pkg}\n",
+        "README.md": _README_TEMPLATE.format(package=module, source_dir=src, tests_dir=layout.tests_dir),
+        ".gitignore": _GO_GITIGNORE,
+    }
+
+
+_GO_GITIGNORE = """\
+# Binaries / test artifacts
+*.exe
+*.test
+*.out
+# Go workspace
+go.work
+go.work.sum
 """
 
 

--- a/src/orchestrator/sdlc/testenv.py
+++ b/src/orchestrator/sdlc/testenv.py
@@ -262,6 +262,43 @@ class CToolEnvironment:
         return f"c toolchain ({self.build_tool} + system compiler)"
 
 
+class GoToolEnvironment:
+    """Go build toolchain. Dependencies are resolved from ``go.mod`` (not pip), so
+    ``install`` (auto-heal) is a no-op; ``ensure`` runs ``go mod download`` best-effort
+    (a no-op for a stdlib-only greenfield module, and offline-safe). ``python`` is
+    unavailable by design."""
+
+    declared: set[str] = set()
+
+    @property
+    def python(self) -> str:
+        raise RuntimeError("GoToolEnvironment has no Python interpreter")
+
+    async def ensure(self, worktree: Path | str) -> None:
+        exe = shutil.which("go")
+        if exe is None:
+            return None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                exe,
+                "mod",
+                "download",
+                cwd=str(worktree),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            await proc.communicate()
+        except OSError:
+            return None  # best-effort: a build/test run surfaces any real dependency error
+        return None
+
+    async def install(self, packages: list[str]) -> bool:
+        return False  # Go deps are declared in go.mod / fetched by `go get`, not pip
+
+    def describe(self) -> str:
+        return "go toolchain (deps via go mod download)"
+
+
 class SqlToolEnvironment:
     """SQL 'toolchain' for greenfield DDL validation (SQL Track B).
 
@@ -350,6 +387,11 @@ def node_toolchain_available(package_manager: str = "npm") -> bool:
     return shutil.which("node") is not None and shutil.which(package_manager or "npm") is not None
 
 
+def go_toolchain_available() -> bool:
+    """True if the ``go`` toolchain is on PATH (Go codegen prerequisite)."""
+    return shutil.which("go") is not None
+
+
 def make_test_environment(language: str = "python", *, build_tool: str = "") -> TestEnvironment:
     """The test environment for ``language``: Java toolchain, Node toolchain
     (``build_tool`` selects the package manager), or a Python venv
@@ -362,6 +404,8 @@ def make_test_environment(language: str = "python", *, build_tool: str = "") -> 
         return DotnetToolEnvironment()
     if language in ("c", "cpp"):
         return CToolEnvironment(build_tool or "cmake")
+    if language == "go":
+        return GoToolEnvironment()
     if language == "sql":
         return SqlToolEnvironment(build_tool or "postgres")
     if os.getenv("SDLC_TEST_ISOLATION", "venv").lower() == "local":
@@ -375,6 +419,7 @@ def make_test_runner(language: str, env: TestEnvironment) -> TestRunner:
     from orchestrator.sdlc.testrunner import (
         CTestRunner,
         DotnetTestRunner,
+        GoTestRunner,
         MavenTestRunner,
         MesonTestRunner,
         NodeTestRunner,
@@ -390,6 +435,8 @@ def make_test_runner(language: str, env: TestEnvironment) -> TestRunner:
     if language in ("c", "cpp"):
         # The build tool (cmake/meson) is carried on the C/C++ tool environment.
         return MesonTestRunner() if getattr(env, "build_tool", "cmake") == "meson" else CTestRunner()
+    if language == "go":
+        return GoTestRunner()
     if language == "sql":
         dialect = getattr(env, "dialect", "postgres")
         # Default: fast, zero-dependency SQLite. Opt into real Postgres (Docker +
@@ -521,6 +568,7 @@ def _project_dependencies(root: Path) -> list[str]:
 __all__ = [
     "CToolEnvironment",
     "DotnetToolEnvironment",
+    "GoToolEnvironment",
     "JavaToolEnvironment",
     "LocalTestEnvironment",
     "MODULE_TO_PACKAGE",
@@ -532,6 +580,7 @@ __all__ = [
     "cpp_toolchain_available",
     "detect_dotnet_tfm",
     "dotnet_toolchain_available",
+    "go_toolchain_available",
     "java_toolchain_available",
     "meson_toolchain_available",
     "make_test_environment",

--- a/src/orchestrator/sdlc/testrunner.py
+++ b/src/orchestrator/sdlc/testrunner.py
@@ -307,6 +307,69 @@ class MesonTestRunner:
         return TestRunResult(passed=rc == 0, returncode=rc, output=_clip("\n".join(captured)))
 
 
+class GoTestRunner:
+    """Builds and tests the Go module(s) a change actually touched, via ``go build ./...``
+    then ``go test ./... -v`` **run from each changed module's directory**.
+
+    A Go repo is often multi-module (its own ``go.mod`` per subtree); running ``go test
+    ./...`` only from the repo root silently skips code generated into a sub-module — which
+    reports a false green (a passing root module while the changed sub-module never compiled).
+    So this discovers the modules containing the changed ``.go`` files (via ``git status`` +
+    the nearest ``go.mod``) and builds/tests each. The first non-zero step fails the run
+    (``passed`` is rc == 0); its output is what the refine prompt needs. Falls back to the
+    repo root when nothing is detected (fresh greenfield scaffold, or no git)."""
+
+    def __init__(self, go: str = "go", *, timeout: float = 600.0) -> None:
+        self._go = go
+        self._timeout = timeout
+
+    async def run(self, *, path: str) -> TestRunResult:
+        modules = await self._changed_modules(path) or ["."]
+        captured: list[str] = []
+        for mod in modules:
+            cwd = path if mod == "." else str(Path(path) / mod)
+            for argv in ((self._go, "build", "./..."), (self._go, "test", "./...", "-v")):
+                rc, out = await _exec_capture(argv, cwd=cwd, timeout=self._timeout)
+                captured.append(f"# ({mod}) {' '.join(argv)}\n{out}")
+                if rc != 0:
+                    return TestRunResult(passed=False, returncode=rc, output=_clip("\n".join(captured)))
+        return TestRunResult(passed=True, returncode=0, output=_clip("\n".join(captured)))
+
+    async def _changed_modules(self, path: str) -> list[str]:
+        """Repo-relative dirs of the go.mod modules that own the worktree's changed ``.go``
+        files (uncommitted at test time). ``.`` is the root module."""
+        rc, out = await _exec_capture(("git", "status", "--porcelain"), cwd=path, timeout=60.0)
+        if rc != 0:
+            return []
+        root = Path(path)
+        mods: set[str] = set()
+        for line in out.splitlines():
+            name = line[3:].strip() if len(line) > 3 else ""
+            if "->" in name:  # a rename: "old -> new"
+                name = name.split("->", 1)[1].strip()
+            name = name.strip('"')
+            if not name.endswith(".go"):
+                continue
+            mod_dir = _nearest_go_mod(root / name, root)
+            if mod_dir is not None:
+                rel = mod_dir.relative_to(root).as_posix()
+                mods.add("." if rel == "" else rel)
+        return sorted(mods)
+
+
+def _nearest_go_mod(start: Path, root: Path) -> Path | None:
+    """Nearest ancestor of ``start`` (a file) within ``root`` that holds a ``go.mod``."""
+    d = start.parent
+    while True:
+        if (d / "go.mod").is_file():
+            return d
+        if d == root:
+            return None
+        d = d.parent
+        if d != root and root not in d.parents:
+            return None
+
+
 def _clip(output: str) -> str:
     return output[-_MAX_OUTPUT_CHARS:] if len(output) > _MAX_OUTPUT_CHARS else output
 
@@ -449,6 +512,7 @@ class StubTestRunner:
 __all__ = [
     "CTestRunner",
     "DotnetTestRunner",
+    "GoTestRunner",
     "MavenTestRunner",
     "MesonTestRunner",
     "NodeTestRunner",

--- a/tests/pkg/test_default_extractors.py
+++ b/tests/pkg/test_default_extractors.py
@@ -46,6 +46,26 @@ def test_default_includes_cpp_when_available() -> None:
     assert ("cpp" in langs) == have_cpp
 
 
+def test_default_includes_go_when_available() -> None:
+    have_go = importlib.util.find_spec("tree_sitter_go") is not None
+    langs = {e.language for e in default_extractors()}
+    assert ("go" in langs) == have_go
+
+
+def test_repo_extractor_default_handles_go(tmp_path: Path) -> None:
+    pytest.importorskip("tree_sitter_go", reason="install the 'go' extra")
+    pkg = tmp_path / "trace"
+    pkg.mkdir(parents=True)
+    (pkg / "span.go").write_text(
+        "package trace\n\ntype Span struct { name string }\nfunc (s *Span) Name() string { return s.name }\n"
+    )
+    # Default RepoCodeExtractor (no explicit extractors) must now pick up .go.
+    batch = RepoCodeExtractor().extract(tmp_path)
+    types = {n.name for n in batch.nodes if n.kind is NodeKind.TYPE and n.language == "go"}
+    funcs = {n.name for n in batch.nodes if n.kind is NodeKind.FUNCTION and n.language == "go"}
+    assert "Span" in types and "Name" in funcs
+
+
 def test_repo_extractor_default_handles_java(tmp_path: Path) -> None:
     pytest.importorskip("tree_sitter_java", reason="install the 'java' extra")
     src = tmp_path / "src" / "main" / "java" / "com" / "demo"

--- a/tests/pkg/test_go_extractor.py
+++ b/tests/pkg/test_go_extractor.py
@@ -1,0 +1,207 @@
+"""PKG: the Go front-end maps Go source onto the universal facts (phase 4.1).
+
+tree-sitter-go is an optional extra, so these skip cleanly when it's absent. Go's twist:
+the module is the PACKAGE = its directory, so every .go file in a dir merges into one
+Module node (unlike every other front-end, which is one-module-per-file).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestrator.pkg.facts import EdgeKind, Node, NodeKind
+from orchestrator.pkg.go_extractor import GoExtractor
+
+pytest.importorskip("tree_sitter_go", reason="install the 'go' extra")
+
+SPAN = """\
+package trace
+
+import (
+	"context"
+	"fmt"
+	o "go.opentelemetry.io/otel"
+)
+
+type Tracer interface {
+	Start(ctx context.Context, name string) error
+	Close() error
+}
+
+type SpanKind int
+
+type recordingSpan struct {
+	name   string
+	a, b   int
+	Embedded
+}
+
+func New(name string) *recordingSpan {
+	return &recordingSpan{name: name}
+}
+
+func (s *recordingSpan) End() {
+	fmt.Println(s.name)
+}
+
+func (s *recordingSpan) flush() error { return nil }
+"""
+
+
+def _facts(
+    root: Path, rel: str = "trace/span.go", src: str = SPAN
+) -> tuple[dict[str, Node], set[tuple[str, str, EdgeKind]], str]:
+    f = root / rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(src, encoding="utf-8")
+    ex = GoExtractor()
+    module = ex.module_name(f, root)
+    batch = ex.extract(path=f, module=module, rel=rel)
+    by_id = {n.id: n for n in batch.nodes}
+    edges = {(e.src, e.dst, e.kind) for e in batch.edges}
+    return by_id, edges, module
+
+
+def test_module_name_is_the_directory(tmp_path: Path) -> None:
+    _, _, module = _facts(tmp_path)
+    assert module == "trace"  # the package's directory, not the file
+
+
+def test_emits_type_function_field_nodes(tmp_path: Path) -> None:
+    by_id, _, _ = _facts(tmp_path)
+    assert by_id["go:trace"].kind is NodeKind.MODULE
+    assert by_id["go:trace.Tracer"].kind is NodeKind.TYPE  # interface
+    assert by_id["go:trace.recordingSpan"].kind is NodeKind.TYPE  # struct
+    assert by_id["go:trace.SpanKind"].kind is NodeKind.TYPE  # alias
+    assert by_id["go:trace.New"].kind is NodeKind.FUNCTION  # top-level func
+    assert by_id["go:trace.recordingSpan.End"].kind is NodeKind.FUNCTION  # method
+    assert by_id["go:trace.recordingSpan.name"].kind is NodeKind.FIELD
+
+
+def test_multi_name_fields_and_embedded_skipped(tmp_path: Path) -> None:
+    by_id, _, _ = _facts(tmp_path)
+    # `a, b int` → two Field nodes...
+    assert by_id["go:trace.recordingSpan.a"].kind is NodeKind.FIELD
+    assert by_id["go:trace.recordingSpan.b"].kind is NodeKind.FIELD
+    # ...and the anonymous embedded field carries no name → no node in 4.1.
+    assert "go:trace.recordingSpan.Embedded" not in by_id
+
+
+def test_interface_methods_are_functions_under_the_interface(tmp_path: Path) -> None:
+    by_id, edges, _ = _facts(tmp_path)
+    assert by_id["go:trace.Tracer.Start"].kind is NodeKind.FUNCTION
+    assert ("go:trace.Tracer", "go:trace.Tracer.Start", EdgeKind.CONTAINS) in edges
+
+
+def test_method_owned_by_receiver_type(tmp_path: Path) -> None:
+    # `func (s *recordingSpan) End()` → owned by recordingSpan, receiver `*T` stripped to T.
+    _, edges, _ = _facts(tmp_path)
+    assert ("go:trace.recordingSpan", "go:trace.recordingSpan.End", EdgeKind.CONTAINS) in edges
+
+
+def test_imports_and_contains_edges(tmp_path: Path) -> None:
+    _, edges, _ = _facts(tmp_path)
+    assert ("go:trace", "go:context", EdgeKind.IMPORTS) in edges
+    assert ("go:trace", "go:go.opentelemetry.io/otel", EdgeKind.IMPORTS) in edges  # aliased import
+    assert ("go:trace", "go:trace.New", EdgeKind.CONTAINS) in edges
+
+
+def test_calls_resolve_same_file_func_and_receiver_method(tmp_path: Path) -> None:
+    src = (
+        "package svc\n\n"
+        "func helper() int { return 1 }\n\n"
+        "type T struct{}\n"
+        "func (t *T) run() { t.step(); helper() }\n"
+        "func (t *T) step() {}\n"
+    )
+    _, edges, _ = _facts(tmp_path, rel="svc/s.go", src=src)
+    # unqualified same-file func call, and a receiver-method call on the receiver's type.
+    assert ("go:svc.T.run", "go:svc.helper", EdgeKind.CALLS) in edges
+    assert ("go:svc.T.run", "go:svc.T.step", EdgeKind.CALLS) in edges
+
+
+def test_calls_skip_unresolvable_selectors(tmp_path: Path) -> None:
+    # A call on some other object (not the receiver) needs type inference → not emitted.
+    src = "package svc\n\ntype T struct{ dep D }\ntype D struct{}\nfunc (t *T) run() { t.dep.Do() }\n"
+    _, edges, _ = _facts(tmp_path, rel="svc/s.go", src=src)
+    assert not [e for e in edges if e[2] is EdgeKind.CALLS]
+
+
+def test_references_same_package_struct_field(tmp_path: Path) -> None:
+    src = "package m\n\ntype Node struct {\n\tnext *Node\n\tval  int\n\tw    io.Writer\n}\n"
+    _, edges, _ = _facts(tmp_path, rel="m/n.go", src=src)
+    # named same-package field type → REFERENCES; builtin (int) and qualified (io.Writer) skipped.
+    refs = {(e[0], e[1]) for e in edges if e[2] is EdgeKind.REFERENCES}
+    assert refs == {("go:m.Node", "go:m.Node")}
+
+
+def test_implements_by_method_set_across_files(tmp_path: Path) -> None:
+    # The net-new algorithm: a concrete type implements an interface when its method
+    # signatures (name+arity) ⊇ the interface's — even when split across files.
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    pkg = tmp_path / "store"
+    pkg.mkdir()
+    (pkg / "iface.go").write_text(
+        "package store\n\ntype Repo interface {\n\tGet(id int) string\n\tPut(id int, v string)\n}\n"
+    )
+    (pkg / "impl.go").write_text(
+        "package store\n\ntype Cache struct{}\n"
+        'func (c *Cache) Get(id int) string { return "" }\n'
+        "func (c *Cache) Put(id int, v string) {}\n"
+    )
+    batch = RepoCodeExtractor().extract(tmp_path)
+    impls = {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.IMPLEMENTS}
+    assert ("go:store.Cache", "go:store.Repo") in impls
+
+
+def test_implements_precision_arity_guards_false_positive(tmp_path: Path) -> None:
+    # Same method NAMES but a different arity must NOT produce IMPLEMENTS (the guard that
+    # separates a gRPC client's Do(a, b) from a server's Do(a)).
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    pkg = tmp_path / "p"
+    pkg.mkdir()
+    (pkg / "a.go").write_text("package p\n\ntype I interface {\n\tDo(a int, b int)\n}\n")
+    (pkg / "b.go").write_text("package p\n\ntype C struct{}\nfunc (c C) Do(a int) {}\n")
+    batch = RepoCodeExtractor().extract(tmp_path)
+    impls = {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.IMPLEMENTS}
+    assert ("go:p.C", "go:p.I") not in impls
+
+
+def test_package_is_the_directory_files_merge(tmp_path: Path) -> None:
+    # Two files in the same dir share ONE Module node; their decls aggregate under it.
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    pkg = tmp_path / "sdk" / "trace"
+    pkg.mkdir(parents=True)
+    (pkg / "a.go").write_text("package trace\n\ntype A struct { x int }\n")
+    (pkg / "b.go").write_text("package trace\n\ntype B struct { y int }\n")
+    batch = RepoCodeExtractor().extract(tmp_path)
+    modules = [n for n in batch.nodes if n.kind is NodeKind.MODULE and n.id == "go:sdk/trace"]
+    assert len(modules) == 1  # one Module for the package/dir, not one per file
+    by_id = {n.id: n for n in batch.nodes}
+    assert by_id["go:sdk/trace.A"].kind is NodeKind.TYPE
+    assert by_id["go:sdk/trace.B"].kind is NodeKind.TYPE
+    contained = {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.CONTAINS}
+    assert ("go:sdk/trace", "go:sdk/trace.A") in contained
+    assert ("go:sdk/trace", "go:sdk/trace.B") in contained
+
+
+def test_generic_receiver_stripped(tmp_path: Path) -> None:
+    src = "package col\n\ntype Stack[T any] struct { items []T }\n\nfunc (s *Stack[T]) Push(v T) {}\n"
+    by_id, edges, _ = _facts(tmp_path, rel="col/stack.go", src=src)
+    assert by_id["go:col.Stack.Push"].kind is NodeKind.FUNCTION
+    assert ("go:col.Stack", "go:col.Stack.Push", EdgeKind.CONTAINS) in edges
+
+
+def test_repo_extractor_dispatches_go_by_suffix(tmp_path: Path) -> None:
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    (tmp_path / "main.go").write_text("package main\n\nfunc main() {}\n")
+    (tmp_path / "m.py").write_text("def f() -> int:\n    return 1\n")
+    batch = RepoCodeExtractor().extract(tmp_path)
+    langs = {n.language for n in batch.nodes}
+    assert "go" in langs and "python" in langs

--- a/tests/sdlc/test_feature_runner.py
+++ b/tests/sdlc/test_feature_runner.py
@@ -293,6 +293,24 @@ async def test_language_typescript_requires_toolchain(
     assert exc.value.code == 2
 
 
+async def test_language_go_requires_toolchain(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """--language go runs the Go pipeline (root-package scaffold / `go build`+`go test`
+    runner) but preflights the `go` toolchain — fail fast with a clear message when absent."""
+    _install_pipeline(monkeypatch, tmp_path, runner=_PassingRunner)
+    monkeypatch.setattr("orchestrator.sdlc.testenv.go_toolchain_available", lambda: False)
+    with pytest.raises(FeatureRunError, match="Go toolchain") as exc:
+        await run_feature("file://./spec.md", intent_id="intent-a", language="go")
+    assert exc.value.code == 2
+
+
+def test_resolve_language_detects_go(tmp_path: Path) -> None:
+    from orchestrator.sdlc.feature_runner import _resolve_language
+
+    (tmp_path / "go.mod").write_text("module widget\n")
+    (tmp_path / "widget.go").write_text("package widget\n")
+    assert _resolve_language(tmp_path, "auto") == "go"
+
+
 async def test_missing_pytest_fails_fast_with_actionable_message(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/sdlc/test_go_integration.py
+++ b/tests/sdlc/test_go_integration.py
@@ -1,0 +1,62 @@
+"""Go toolchain integration: scaffold → real `go build`/`go test` green/red.
+
+Exercises the real GoTestRunner against a scaffolded Go module. Skips cleanly when
+the `go` toolchain isn't on PATH, so it runs in CI (setup-go) and on a dev box with Go,
+but never blocks the offline suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestrator.sdlc.layout import resolve_layout
+from orchestrator.sdlc.scaffold import scaffold
+from orchestrator.sdlc.testenv import go_toolchain_available
+from orchestrator.sdlc.testrunner import GoTestRunner
+
+pytestmark = pytest.mark.skipif(not go_toolchain_available(), reason="needs the `go` toolchain on PATH")
+
+
+def _scaffold_go(tmp_path: Path) -> None:
+    layout = resolve_layout(tmp_path, mode="new", language="go", package_name="calc")
+    scaffold(tmp_path, layout)  # go.mod (module calc) + calc.go stub at the root
+
+
+async def test_scaffold_alone_is_green(tmp_path: Path) -> None:
+    # A freshly scaffolded module with no tests still builds and `go test` passes.
+    _scaffold_go(tmp_path)
+    result = await GoTestRunner().run(path=str(tmp_path))
+    assert result.passed, result.output
+
+
+async def test_go_build_and_test_pass_for_correct_code(tmp_path: Path) -> None:
+    _scaffold_go(tmp_path)
+    (tmp_path / "add.go").write_text("package calc\n\nfunc Add(a, b int) int { return a + b }\n")
+    (tmp_path / "add_test.go").write_text(
+        'package calc\n\nimport "testing"\n\n'
+        "func TestAdd(t *testing.T) {\n"
+        '\tif Add(2, 3) != 5 {\n\t\tt.Fatalf("want 5, got %d", Add(2, 3))\n\t}\n}\n'
+    )
+    result = await GoTestRunner().run(path=str(tmp_path))
+    assert result.passed, result.output
+
+
+async def test_go_test_fails_for_wrong_code(tmp_path: Path) -> None:
+    _scaffold_go(tmp_path)
+    (tmp_path / "add.go").write_text("package calc\n\nfunc Add(a, b int) int { return a - b }\n")
+    (tmp_path / "add_test.go").write_text(
+        'package calc\n\nimport "testing"\n\n'
+        "func TestAdd(t *testing.T) {\n"
+        '\tif Add(2, 3) != 5 {\n\t\tt.Fatalf("want 5, got %d", Add(2, 3))\n\t}\n}\n'
+    )
+    result = await GoTestRunner().run(path=str(tmp_path))
+    assert not result.passed  # the failing assertion fails `go test`
+
+
+async def test_go_build_fails_for_compile_error(tmp_path: Path) -> None:
+    _scaffold_go(tmp_path)
+    (tmp_path / "bad.go").write_text("package calc\n\nfunc Broken() int { return undefinedSymbol }\n")
+    result = await GoTestRunner().run(path=str(tmp_path))
+    assert not result.passed  # `go build ./...` fails before tests run

--- a/tests/sdlc/test_layout.py
+++ b/tests/sdlc/test_layout.py
@@ -272,6 +272,69 @@ class TestCppLayout:
         assert detect_cpp_layout(tmp_path) == ("engine", "src", "tests")
 
 
+class TestGoLayout:
+    def test_derive_go_module(self) -> None:
+        from orchestrator.sdlc.layout import derive_go_module
+
+        assert derive_go_module("https://x/Example-Service.") == "exampleservice"
+        assert derive_go_module("git@github.com:org/My-Repo.git") == "myrepo"
+        assert derive_go_module("9lives") == "pkg9lives"
+        assert derive_go_module("func") == "funcpkg"  # Go keyword guarded
+        assert derive_go_module("---") == "app"
+
+    def test_new_go_layout_is_root_package(self, tmp_path: Path) -> None:
+        layout = resolve_layout(tmp_path, mode="new", language="go", repo="https://x/widget")
+        assert layout.language == "go" and layout.build_tool == "go" and layout.mode == "new"
+        assert layout.package_name == "widget"
+        # Greenfield Go: a single package at the module root; tests co-located.
+        assert layout.source_dir == "." and layout.tests_dir == "."
+        assert layout.module_rel_path("account") == "./account.go"
+
+    def test_detect_existing_go_module_root(self, tmp_path: Path) -> None:
+        from orchestrator.sdlc.layout import detect_go_layout
+
+        (tmp_path / "go.mod").write_text("module github.com/acme/widget\n\ngo 1.22\n")
+        (tmp_path / "widget.go").write_text("package widget\n")
+        # The dir's EXISTING package clause (not the module path); co-located tests.
+        assert detect_go_layout(tmp_path) == ("widget", ".", ".")
+
+    def test_detect_existing_go_module_subdir(self, tmp_path: Path) -> None:
+        from orchestrator.sdlc.layout import detect_go_layout
+
+        (tmp_path / "go.mod").write_text("module acme\n")
+        pkg = tmp_path / "internal" / "core"
+        pkg.mkdir(parents=True)
+        (pkg / "core.go").write_text("package core\n")
+        # Placement = the lib package; package clause = its own `package core`.
+        assert detect_go_layout(tmp_path) == ("core", "internal/core", "internal/core")
+
+    def test_brownfield_placement_prefers_root_module_lib_over_main_and_demo(self, tmp_path: Path) -> None:
+        # Mirrors the OTel shape that caused 4.4's false green: a root module with a lib
+        # package under tool/, plus a `main` and a nested-module demo. Placement must pick
+        # the root-module lib (tool/util, package util), not demo/ or a main.
+        (tmp_path / "go.mod").write_text("module example.com/app\n\ngo 1.21\n")
+        (tmp_path / "cmd").mkdir()
+        (tmp_path / "cmd" / "main.go").write_text("package main\n\nfunc main() {}\n")
+        (tmp_path / "tool" / "util").mkdir(parents=True)
+        (tmp_path / "tool" / "util" / "util.go").write_text("package util\n")
+        demo = tmp_path / "demo" / "svc"  # a nested module — must be skipped
+        demo.mkdir(parents=True)
+        (demo / "go.mod").write_text("module example.com/app/demo/svc\n")
+        (demo / "svc.go").write_text("package svc\n")
+        from orchestrator.sdlc.layout import detect_go_layout
+
+        detected = detect_go_layout(tmp_path)
+        assert detected is not None
+        pkg, source_dir, _ = detected
+        assert (pkg, source_dir) == ("util", "tool/util")
+
+    def test_auto_existing_go_is_not_scaffolded(self, tmp_path: Path) -> None:
+        (tmp_path / "go.mod").write_text("module acme\n")
+        (tmp_path / "acme.go").write_text("package acme\n")
+        layout = resolve_layout(tmp_path, mode="auto", language="go")
+        assert layout.mode == "existing" and layout.package_name == "acme"
+
+
 def test_new_sql_layout_is_migrations_dir(tmp_path: Path) -> None:
     layout = resolve_layout(tmp_path, mode="new", language="sql", repo="https://x/shop-db")
     assert layout.language == "sql" and layout.mode == "new"

--- a/tests/sdlc/test_scaffold.py
+++ b/tests/sdlc/test_scaffold.py
@@ -229,6 +229,35 @@ def test_scaffold_cpp_is_idempotent(tmp_path: Path) -> None:
     assert scaffold(tmp_path, _CPP_LAYOUT) == []
 
 
+_GO_LAYOUT = TargetLayout(
+    package_name="widget",
+    source_dir=".",
+    tests_dir=".",
+    src_layout=False,
+    mode="new",
+    language="go",
+    build_tool="go",
+)
+
+
+def test_scaffold_go_module(tmp_path: Path) -> None:
+    created = scaffold(tmp_path, _GO_LAYOUT)
+    assert "go.mod" in created and "widget.go" in created
+    gomod = (tmp_path / "go.mod").read_text()
+    assert gomod.startswith("module widget")
+    stub = (tmp_path / "widget.go").read_text()
+    assert stub.rstrip().endswith("package widget")  # package clause = module last element
+    gi = (tmp_path / ".gitignore").read_text()
+    assert "*.test" in gi and "go.work" in gi
+    assert not (tmp_path / "pyproject.toml").exists()
+    assert not (tmp_path / "CMakeLists.txt").exists()
+
+
+def test_scaffold_go_is_idempotent(tmp_path: Path) -> None:
+    scaffold(tmp_path, _GO_LAYOUT)
+    assert scaffold(tmp_path, _GO_LAYOUT) == []
+
+
 def test_scaffold_csharp_honors_target_framework(tmp_path: Path) -> None:
     from dataclasses import replace
 

--- a/tests/sdlc/test_testenv.py
+++ b/tests/sdlc/test_testenv.py
@@ -573,3 +573,103 @@ def test_cpp_toolchain_available(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda name: "/usr/bin/cmake" if name == "cmake" else None,  # no C++ compiler
     )
     assert testenv.cpp_toolchain_available() is False
+
+
+def test_make_test_environment_and_runner_for_go() -> None:
+    from orchestrator.sdlc.testenv import GoToolEnvironment, make_test_environment, make_test_runner
+    from orchestrator.sdlc.testrunner import GoTestRunner
+
+    assert isinstance(make_test_environment("go"), GoToolEnvironment)
+    assert isinstance(make_test_runner("go", GoToolEnvironment()), GoTestRunner)
+
+
+def test_go_env_install_is_noop_and_python_unavailable() -> None:
+    import asyncio
+
+    from orchestrator.sdlc.testenv import GoToolEnvironment
+
+    env = GoToolEnvironment()
+    assert asyncio.run(env.install(["golang.org/x/mod"])) is False  # Go deps via go.mod
+    with pytest.raises(RuntimeError):
+        _ = env.python
+
+
+def test_go_toolchain_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.sdlc import testenv
+
+    monkeypatch.setattr("orchestrator.sdlc.testenv.shutil.which", lambda name: "/usr/bin/go")
+    assert testenv.go_toolchain_available() is True
+    monkeypatch.setattr("orchestrator.sdlc.testenv.shutil.which", lambda _n: None)
+    assert testenv.go_toolchain_available() is False
+
+
+def _mock_go_exec(
+    monkeypatch: pytest.MonkeyPatch,
+    calls: list[tuple[object, ...]],
+    cwds: list[str],
+    *,
+    status: bytes,
+    go_rc: int = 0,
+    go_out: bytes = b"ok",
+) -> None:
+    """Mock create_subprocess_exec: `git status` returns ``status``; each `go` step
+    records (argv, cwd) and returns (go_rc, go_out)."""
+
+    async def fake_exec(*a: object, **k: object) -> _FakeProc:
+        if a and a[0] == "git":
+            return _FakeProc(0, status)
+        calls.append(a)
+        cwds.append(str(k.get("cwd")))
+        return _FakeProc(go_rc, go_out)
+
+    monkeypatch.setattr("orchestrator.sdlc.testrunner.asyncio.create_subprocess_exec", fake_exec)
+
+
+async def test_go_runner_tests_root_when_root_files_change(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from orchestrator.sdlc.testrunner import GoTestRunner
+
+    (tmp_path / "go.mod").write_text("module app\n")
+    (tmp_path / "main.go").write_text("package main\n")
+    calls: list[tuple[object, ...]] = []
+    cwds: list[str] = []
+    _mock_go_exec(monkeypatch, calls, cwds, status=b"?? main.go\n M go.mod\n")
+    result = await GoTestRunner().run(path=str(tmp_path))
+    assert result.passed and result.returncode == 0
+    assert [c[:3] for c in calls] == [("go", "build", "./..."), ("go", "test", "./...")]
+    assert cwds == [str(tmp_path), str(tmp_path)]  # ran in the root module
+
+
+async def test_go_runner_tests_the_changed_submodule(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # The 4.4 fix: code changed inside a sub-module (its own go.mod) must be built/tested
+    # in THAT module — not just the root (which would skip it → a false green).
+    from orchestrator.sdlc.testrunner import GoTestRunner
+
+    (tmp_path / "go.mod").write_text("module app\n")
+    sub = tmp_path / "sub" / "mod"
+    sub.mkdir(parents=True)
+    (sub / "go.mod").write_text("module app/sub/mod\n")
+    (sub / "x.go").write_text("package mod\n")
+    calls: list[tuple[object, ...]] = []
+    cwds: list[str] = []
+    _mock_go_exec(monkeypatch, calls, cwds, status=b" M sub/mod/x.go\n")
+    result = await GoTestRunner().run(path=str(tmp_path))
+    assert result.passed
+    assert cwds == [str(sub), str(sub)]  # built + tested in the sub-module, not the root
+
+
+async def test_go_runner_short_circuits_on_build_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from orchestrator.sdlc.testrunner import GoTestRunner
+
+    (tmp_path / "go.mod").write_text("module app\n")
+    calls: list[tuple[object, ...]] = []
+    cwds: list[str] = []
+    _mock_go_exec(
+        monkeypatch, calls, cwds, status=b"?? bad.go\n", go_rc=2, go_out=b"./bad.go:5:2: undefined: Foo"
+    )
+    result = await GoTestRunner().run(path=str(tmp_path))
+    assert not result.passed and result.returncode == 2
+    assert len(calls) == 1  # a build failure short-circuits before `go test`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,20 @@ def test_sdlc_help_lists_run(runner: CliRunner) -> None:
     assert "run" in result.stdout
 
 
+def test_sdlc_feature_rejects_unknown_language(runner: CliRunner) -> None:
+    # An unsupported --language must error (historically it silently scaffolded Python).
+    result = runner.invoke(app, ["sdlc", "feature", "--source", "jira://X-1", "--language", "rust"])
+    assert result.exit_code == 2
+    assert "not supported" in result.output and "rust" in result.output
+
+
+def test_sdlc_feature_accepts_go_language(runner: CliRunner) -> None:
+    # `go` is a supported language: validation passes it through (the run then fails
+    # later for lack of a configured source/LLM — never the "not supported" error).
+    result = runner.invoke(app, ["sdlc", "feature", "--source", "jira://X-1", "--language", "go"])
+    assert "not supported" not in result.output
+
+
 def test_design_requires_a_title(runner: CliRunner, tmp_path: Path) -> None:
     (tmp_path / "a.py").write_text("def f():\n    return 1\n", encoding="utf-8")
     result = runner.invoke(app, ["design", str(tmp_path)])


### PR DESCRIPTION
Automated sync from the private repo @ 788590c (v3.7.0).

## What's in this release
- chore(release): 3.7.0 — Go, the 8th PKG language
- docs: document Go as a supported language (8th PKG language)
- fix(sdlc): Go brownfield multi-module hardening — close the 4.4 false green (phase 4.5)
- docs(go): 4.4 live-proven — greenfield GREEN (verified), brownfield gap → 4.5
- feat(pkg): Go deeper edges — CALLS, REFERENCES, IMPLEMENTS-by-method-set (Go phase 4.3)
- feat(sdlc): Go codegen + build track — greenfield scaffold, go build/test runner (Go phase 4.2)
- feat(pkg): Go front-end — 8th PKG language, comprehension (Go phase 4.1)
- docs(go): start Go front-end (8th language) — validation target + baseline

Merge to release.