### PR TITLE
Publish v3.8.0 (9384ec2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "spine",
       "source": "./plugins/spine",
-      "description": "An AI-native SDLC engineer you delegate tickets to: build a repo's Product Knowledge Graph, ground new code in what already exists, generate + test it, and — on confirm — open a PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, and C++, exposed as MCP tools.",
+      "description": "Understand any codebase, then ship changes to it. Read-only comprehension tools hand you engineering decisions (what breaks if you change X, what's untested, where a ticket/bug lands) from a deterministic Product Knowledge Graph; then delegate a ticket and, on confirm, get a reviewed, tested PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, C++, and Go, exposed as MCP tools + an understand-codebase skill.",
       "version": "2.5.0",
       "category": "Engineering",
       "keywords": ["sdlc", "codegen", "mcp", "knowledge-graph", "greenfield", "brownfield", "pkg"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## 3.8.0 — The `/spine` comprehension skill
+
+Spine's read-only comprehension is now a **drop-in skill** any assistant can call — Codex
+(plugin) and Claude Code (an `understand-codebase` Agent Skill) — so you can ask about a
+codebase in plain language and get engineering *decisions*, not just a map: what a change
+breaks, what's untested, and where a ticket or bug lands, each grounded to `file:line`.
+
+### Added
+
+- **Comprehension MCP tools** on the Spine plugin server, all read-only, deterministic
+  (no LLM), and needing no credentials: `map_repo` (structure, call-hotspots, coverage
+  gaps, recommendations), `blast_radius` ("what breaks if I change X" — callers +
+  cross-layer reach), `explain_symbol`, `investigate` (where a ticket lands), `localize`
+  (stack trace → fault site), and `regression_gaps` (blast-radius symbols with no covering
+  test). Each returns structured fields **plus** a `markdown` rendering. They join
+  `read_memory_bank` (a repo's committed `episteme/`).
+- **`root_cause`** — a grounded root-cause report (fault site, ranked hypotheses with
+  evidence, regression surface, fix approach). Deterministic by default; `use_llm=true`
+  opts into LLM-enriched hypotheses.
+- **`understand-codebase` Agent Skill** bundled with the Claude Code plugin — tells Claude
+  which tool to reach for, so you just ask in plain language.
+- **git-URL support** across the comprehension tools — point them at a local path *or* a
+  git URL (shallow-cloned behind the same host allow-list as the CLI). Serve them to a
+  remote host over HTTP with `orchestrator-mcp --http`.
+
 ## 3.7.0 — Go: the 8th PKG language
 
 Go is now a first-class language across the whole stack — comprehension, the call and

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -176,11 +176,48 @@ At a glance:
 | Tool | What it does | Writes? |
 |---|---|---|
 | [`doctor`](#doctor) | Environment readiness (LLM, source, tracker, GitHub). | no |
-| [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
+| **Understand a codebase — the comprehension tools** | | |
+| `map_repo` | A skim‑first map of a repo: languages, components, **call‑hotspots**, **test‑coverage gaps**, prioritized **recommendations**. Structured + markdown. | no |
+| `blast_radius` | **"What breaks if I change X"** — a symbol's direct callers plus the cross‑layer set a change ripples into, each with `file:line`. | no |
+| `explain_symbol` | What a symbol is and how it connects — kind, location, who calls it, what it calls, what it contains. | no |
+| `investigate` | Where a ticket lands in the code: the real symbols to start from (`file:line` + caller counts) + owning areas. | no |
+| `localize` | Resolve a stack trace / traceback to the repo symbols it names → the likely fault site + its callers. | no |
+| `regression_gaps` | The production symbols a change (by symbol or trace) reaches that **no test covers** — what could break silently. | no |
+| `root_cause` | A grounded root‑cause report for a bug: fault site, ranked hypotheses + evidence, regression surface, fix approach. Deterministic by default; `use_llm=true` enriches (needs a model). | no |
 | [`read_memory_bank`](#read_memory_bank) | Read a repo's committed `episteme/` (code‑true project knowledge). | no |
+| [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
 | [`ingest_preview`](#ingest_preview) | Preview the backlog (derived intents + gaps) for a requirements source — dry‑run. | no |
-| [`sdlc_feature`](#sdlc_feature) | **The main one.** One intent end‑to‑end: spec → grounded codegen → tests → branch → *(optionally)* PR. | gated |
+| [`sdlc_feature`](#sdlc_feature) | **Ship it.** One intent end‑to‑end: spec → grounded codegen → tests → branch → *(optionally)* PR. | gated |
 | [`sdlc_start_run` + gate tools](#the-autonomous-run-sdlc_start_run--friends) | Drive the long, autonomous, gated run as a job (needs the Mode‑B backend). | gated |
+
+> **The comprehension tools are read‑only, need no credentials, and are deterministic** (only
+> `root_cause`'s opt‑in `use_llm` uses a model). They ship with an **`understand-codebase` skill**
+> that tells Claude *when* to reach for each — so you can just ask in plain language and Claude picks
+> the tool. Try: *"Map this repo and tell me what's untested,"* or *"What breaks if I change
+> `create_app`?"* `repo_path` is a **local path or a git URL** (shallow‑cloned behind the CLI's host
+> allow‑list); each returns structured fields **plus** a `markdown` rendering, bounded (top‑N +
+> `file:line`). To serve them to a **remote** host over HTTP, run the streamable‑HTTP server
+> (`orchestrator-mcp --http`, bearer/OAuth auth from env) — it registers the same tools.
+
+### Using the `understand-codebase` skill
+
+Spine's Claude Code plugin bundles an **Agent Skill** called `understand-codebase`. A skill is a
+short instruction sheet Claude reads automatically — it tells Claude *which comprehension tool to
+reach for* on which kind of question, so **you don't have to name tools**: just ask in plain
+language and Claude picks `map_repo` / `blast_radius` / `localize` / … for you.
+
+- **Install:** nothing extra — it ships **with the plugin** (§3a). Once `spine` is installed and
+  enabled, the skill and its MCP tools are both available. (Confirm with `/plugin list`; the skill
+  activates on its own when your question matches.)
+- **Use it:** ask naturally about a repository. For example —
+  - *"Map this repo and tell me what's untested."* → `map_repo`
+  - *"What breaks if I change `create_app`?"* → `blast_radius`
+  - *"Here's a traceback — where's the bug?"* (paste it) → `localize` → `regression_gaps`
+  - *"Where would a rate-limiting feature land in this codebase?"* → `investigate`
+- **Scope:** the skill only *reads* — understanding, not editing. To actually change code, use the
+  gated [`sdlc_feature`](#sdlc_feature) (which requires an explicit `confirm` for any external write).
+- **In Codex:** there's no separate skill file — Codex calls the same MCP tools directly (the tool
+  descriptions carry the same guidance). See [CODEX_GUIDE §6](CODEX_GUIDE.md#6-the-tools-spine-exposes).
 
 Each tool below shows the **Claude prompt** (what you type), the **tool call** it maps to
 (the literal arguments — handy if you call it programmatically or want to be precise), and

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -161,11 +161,29 @@ At a glance:
 | Tool | What it does | Writes? |
 |---|---|---|
 | [`doctor`](#doctor) | Environment readiness (LLM, source, tracker, GitHub). | no |
-| [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
+| **Understand a codebase — the comprehension tools** | | |
+| `map_repo` | A skim‑first map of a repo: languages, components, **call‑hotspots**, **test‑coverage gaps**, prioritized **recommendations**. Structured + markdown. | no |
+| `blast_radius` | **"What breaks if I change X"** — a symbol's direct callers plus the cross‑layer set a change ripples into, each with `file:line`. | no |
+| `explain_symbol` | What a symbol is and how it connects — kind, location, who calls it, what it calls, what it contains. | no |
+| `investigate` | Where a ticket lands in the code: the real symbols to start from (`file:line` + caller counts) + owning areas. | no |
+| `localize` | Resolve a stack trace / traceback to the repo symbols it names → the likely fault site + its callers. | no |
+| `regression_gaps` | The production symbols a change (by symbol or trace) reaches that **no test covers** — what could break silently. | no |
+| `root_cause` | A grounded root‑cause report for a bug: fault site, ranked hypotheses + evidence, regression surface, fix approach. Deterministic by default; `use_llm=true` enriches (needs a model). | no |
 | [`read_memory_bank`](#read_memory_bank) | Read a repo's committed `episteme/` (code‑true project knowledge). | no |
+| [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
 | [`ingest_preview`](#ingest_preview) | Preview the backlog (derived intents + gaps) for a requirements source — dry‑run. | no |
-| [`sdlc_feature`](#sdlc_feature) | **The main one.** One intent end‑to‑end: spec → grounded codegen → tests → branch → *(optionally)* PR. | gated |
+| [`sdlc_feature`](#sdlc_feature) | **Ship it.** One intent end‑to‑end: spec → grounded codegen → tests → branch → *(optionally)* PR. | gated |
 | [`sdlc_start_run` + gate tools](#the-autonomous-run-sdlc_start_run--friends) | Drive the long, autonomous, gated run as a job (needs the Mode‑B backend). | gated |
+
+> **The comprehension tools are read‑only, need no credentials, and are deterministic** (only
+> `root_cause`'s opt‑in `use_llm` uses a model) — the differentiator: they don't just map the code,
+> they hand Codex **engineering decisions** (what breaks, what's untested, where a change lands).
+> `repo_path` is a **local path or a git URL** (shallow‑cloned behind the same host allow‑list as the
+> CLI); each returns structured fields **plus** a `markdown` rendering, bounded (top‑N with
+> `file:line`). Example — *"Use spine's `blast_radius` on `repo_path=.` for `symbol=create_app` and
+> tell me what a change would touch."* To serve these to a **remote** Codex/host over HTTP, run the
+> streamable‑HTTP server (`orchestrator-mcp --http`, bearer/OAuth auth from env — see §3b); it
+> registers the exact same tools.
 
 Each tool below shows the **Codex prompt** (what you type), the **tool call** it maps to
 (the literal arguments — handy if you call it programmatically or want to be precise), and

--- a/codex-marketplace/plugins/spine/.codex-plugin/plugin.json
+++ b/codex-marketplace/plugins/spine/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spine",
   "version": "2.5.0",
-  "description": "Spine — delegate a ticket, get a reviewed PR. Builds a Product Knowledge Graph of your repo, grounds new code in what already exists, generates + tests it, and (on confirm) opens a PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, and C++.",
+  "description": "Spine — understand any codebase, then ship changes to it. Read-only comprehension tools hand you engineering decisions (what breaks if you change X, what's untested, where a ticket lands) from a deterministic Product Knowledge Graph; then delegate a ticket and (on confirm) get a reviewed, tested PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, C++, and Go.",
   "author": {
     "name": "Synaptixs",
     "url": "https://github.com/synaptixs/spine"
@@ -22,7 +22,7 @@
   "interface": {
     "displayName": "Spine",
     "shortDescription": "Delegate a ticket; get a reviewed PR",
-    "longDescription": "Spine is an AI-native SDLC engineer you delegate tickets to. It builds a Product Knowledge Graph of your repository, grounds new code in what already exists, generates and tests it, and — when you confirm — opens a pull request. Works for greenfield and brownfield repos across Python, Java, TypeScript, C#, C, and C++. Safe by default: a local branch + diff with no external writes; live writes (a real Jira issue + PR) are gated behind an explicit confirm.",
+    "longDescription": "Spine understands a codebase as engineering decisions, then engineers within it. Its read-only comprehension tools — map_repo, blast_radius, explain_symbol, investigate, localize, regression_gaps — answer 'what breaks if I change X', 'what's untested', and 'where does this ticket land' from a deterministic Product Knowledge Graph (no LLM, no credentials, every fact file:line-grounded). Then delegate a ticket: Spine grounds new code in what already exists, generates and tests it, and — when you confirm — opens a pull request. Works for greenfield and brownfield repos across Python, Java, TypeScript, C#, C, C++, and Go. Safe by default: a local branch + diff with no external writes; live writes (a real Jira issue + PR) are gated behind an explicit confirm.",
     "developerName": "Synaptixs",
     "category": "Engineering",
     "capabilities": [

--- a/plugins/spine/.claude-plugin/plugin.json
+++ b/plugins/spine/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "spine",
   "displayName": "Spine",
   "version": "2.5.0",
-  "description": "Delegate a ticket, get a reviewed PR. Spine builds a Product Knowledge Graph of your repo, grounds new code in what already exists, generates + tests it, and — when you confirm — opens a pull request. Greenfield + brownfield across Python, Java, TypeScript, C#, C, and C++. Safe by default: a local branch + diff with no external writes; live writes (a real Jira issue + PR) are gated behind an explicit confirm.",
+  "description": "Understand any codebase, then ship changes to it. Read-only comprehension tools (map_repo, blast_radius, explain_symbol, investigate, localize, regression_gaps) hand you engineering decisions — what breaks if you change X, what's untested, where a ticket or bug lands — from a deterministic Product Knowledge Graph (no LLM, no credentials, every fact file:line-grounded). Then delegate a ticket and, on confirm, get a reviewed, tested PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, C++, and Go. Safe by default: local branch + diff, no external writes; live writes are gated behind an explicit confirm.",
   "author": {
     "name": "Synaptixs",
     "url": "https://github.com/synaptixs/spine"

--- a/plugins/spine/skills/understand-codebase/SKILL.md
+++ b/plugins/spine/skills/understand-codebase/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: understand-codebase
+description: >-
+  Understand an unfamiliar codebase or plan a change safely, using Spine's deterministic
+  knowledge-graph MCP tools. Reach for this before answering structural questions about a
+  repo you don't know, before editing code, or when debugging — it hands you engineering
+  decisions (what a change breaks, what's untested, where a ticket or bug lands), each
+  grounded to file:line. Triggers: "how does this repo work", "what breaks if I change X",
+  "where do I fix this / where does this land", "what's untested here", "explain this symbol",
+  "map this codebase". Tools: map_repo, blast_radius, explain_symbol, investigate, localize,
+  regression_gaps (all read-only, no credentials, from the Spine plugin).
+---
+
+# Understand a codebase with Spine
+
+Spine reads a repository's **Product Knowledge Graph** — a deterministic, no-LLM index of its
+modules, types, functions, call sites, and blast radius, with every fact grounded to `file:line`.
+These MCP tools turn that graph into *decisions*, not just lookups: what a change breaks, what's
+untested, where work lands. They're **read-only, need no credentials**, and take a local
+`repo_path` (default: the current repository).
+
+Use them before grepping or guessing about an unfamiliar repo — they're faster and more accurate,
+and they cite their sources.
+
+## Which tool for which question
+
+| You want to… | Call |
+|---|---|
+| get oriented in a repo you don't know | **`map_repo`** — languages, components, call-hotspots, test-coverage gaps, prioritized recommendations |
+| know what changing a symbol will affect | **`blast_radius(symbol=…)`** — direct callers + the cross-layer set a change ripples into, each `file:line` |
+| understand one symbol | **`explain_symbol(symbol=…)`** — kind, location, who calls it, what it calls, what it contains |
+| find where a feature/ticket lands | **`investigate(title=…, problem=…)`** — the real symbols to start from |
+| pin a bug from a stack trace | **`localize(trace=…)`** — resolve each frame to the repo symbol; the likely fault site |
+| see what a change could break silently | **`regression_gaps(symbol=… or trace=…)`** — blast-radius symbols with **no covering test** |
+| root-cause a bug (hypotheses + fix approach) | **`root_cause(bug=…)`** — fault site, ranked hypotheses with evidence, regression surface, fix approach; deterministic (add `use_llm=true` for richer hypotheses) |
+
+Read a repo's committed knowledge base with **`read_memory_bank`** when one exists (built by
+`orchestrator understand`).
+
+`repo_path` defaults to the current repository, and also accepts a **git URL** (e.g.
+`https://github.com/org/repo`) — Spine shallow-clones it, extracts, and cleans up.
+
+## How to work
+
+1. **Orient first.** For an unfamiliar repo, call `map_repo` before answering structural questions
+   or planning a change — one call beats many greps.
+2. **Check the blast radius before editing.** `blast_radius(symbol=…)` shows who depends on what
+   you're about to touch; `regression_gaps` shows what has no test, so you know what could break
+   silently.
+3. **For a bug, go trace → fault → coverage.** `localize(trace=…)` finds the fault site; then
+   `regression_gaps(trace=…)` shows the coverage around it.
+4. **Cite `file:line`.** Every tool returns provenance and a `markdown` field you can show the user
+   directly — ground your answer in it rather than paraphrasing.
+
+## Good to know
+
+- **Deterministic:** same commit in → same answer out (a commit-keyed cache makes re-runs cheap).
+- **Structured + readable:** each tool returns typed fields (symbols, counts, `file:line`, gaps)
+  **and** a `markdown` rendering.
+- **Understanding vs. changing:** these tools only *read*. To actually change the code — spec →
+  grounded codegen → tests → branch/PR — use Spine's gated `sdlc_feature`, which requires an
+  explicit `confirm` for any external write. Keep the two separate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.7.0"
+version = "3.8.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -5,15 +5,22 @@ here the orchestrator is the server, so Claude Code / Codex / Claude Desktop can
 call its capabilities as tools. The MCP server is a thin façade — each tool runs
 the real engine (intake, PKG grounding, readiness).
 
-Slice 1 exposes read/safe tools only (no external writes): ``doctor``,
-``ingest_preview`` (dry-run), ``pkg_grounding``. The heavy gated ``sdlc`` run is
-a later, job-style addition. Tool *implementations* are module-level functions
-(unit-testable without the ``mcp`` extra); ``build_server`` lazy-imports
+Two tiers of tools. **Read-only comprehension** (no writes) — ``doctor``, ``pkg_grounding``,
+``read_memory_bank``, ``ingest_preview`` (dry-run), and the graph-query set ``map_repo`` /
+``blast_radius`` / ``explain_symbol`` / ``investigate`` / ``localize`` / ``regression_gaps`` /
+``root_cause`` — hands an assistant Spine's *engineering decisions* (what breaks, what's
+untested, where a change lands) with ``file:line`` provenance. All deterministic + no
+credentials, except ``root_cause``'s opt-in ``use_llm`` enrichment. The graph-query tools take
+a local path **or a git URL** (shallow-cloned behind the CLI's SSRF/host-allow-list guard). The
+heavy **gated ``sdlc``** run (real writes → PR) is the second tier. Tool *implementations* are
+module-level functions (unit-testable without the ``mcp`` extra); ``build_server`` lazy-imports
 ``FastMCP`` and registers them.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from typing import Any
 
 
@@ -135,6 +142,292 @@ def read_memory_bank(repo_path: str, section: str | None = None) -> dict[str, An
     return _read(repo_path, section)
 
 
+# --- comprehension / graph-query tools --------------------------------------------------
+# Thin façades over the same engine the `state` / `investigate` / `localize` / `regression`
+# / `pkg` / `rca` CLI commands use. Each returns structured fields an assistant reasons over,
+# plus a ``markdown`` rendering. ``repo_path`` is a local path OR a git URL (shallow-cloned
+# behind the same SSRF/host-allow-list guard as the CLI). Read-only + deterministic + no
+# credentials — except ``root_cause``'s opt-in ``use_llm`` enrichment.
+
+
+@contextmanager
+def _open_repo(repo_path: str) -> Iterator[Any]:
+    """Yield a local repo ``Path`` for a local path OR a git URL (shallow-cloned + cleaned up),
+    resolved through the same guard as the CLI's ``_repo_arg``."""
+    from orchestrator.registry.api.config import Settings
+    from orchestrator.registry.api.workspace import materialize_repo_source, resolve_repo_source
+
+    source = resolve_repo_source(repo_path, Settings(repo_allow_any_local=True))
+    with materialize_repo_source(source, log=lambda _m: None) as path:
+        yield path
+
+
+@contextmanager
+def _repo_store(repo_path: str) -> Iterator[tuple[Any, Any]]:
+    """Yield ``(FactStore, repo Path)`` for a local path or git URL."""
+    from orchestrator.pkg import FactStore, load_or_extract
+
+    with _open_repo(repo_path) as repo:
+        yield FactStore(load_or_extract(repo)), repo
+
+
+def _in_repo(repo_path: str, fn: Callable[[Any], dict[str, Any]]) -> dict[str, Any]:
+    """Run ``fn(repo)`` inside a resolved repo; a bad path / URL returns ``{"error": …}``."""
+    from orchestrator.registry.api.workspace import RepoPathError, RepoSourceError
+
+    try:
+        with _open_repo(repo_path) as repo:
+            return fn(repo)
+    except (RepoSourceError, RepoPathError) as exc:
+        return {"error": str(exc)}
+
+
+def _in_repo_store(repo_path: str, fn: Callable[[Any, Any], dict[str, Any]]) -> dict[str, Any]:
+    """Run ``fn(store, repo)`` inside a resolved repo; a bad path / URL returns ``{"error": …}``."""
+    from orchestrator.registry.api.workspace import RepoPathError, RepoSourceError
+
+    try:
+        with _repo_store(repo_path) as (store, repo):
+            return fn(store, repo)
+    except (RepoSourceError, RepoPathError) as exc:
+        return {"error": str(exc)}
+
+
+def map_repo(repo_path: str, lens: str = "developer") -> dict[str, Any]:
+    """A skim-first map of a repo: languages, components, **call-hotspots**, **test-coverage
+    gaps**, and prioritized **recommendations**. Deterministic (no LLM). ``lens`` is
+    ``developer`` (technical) or ``stakeholder`` (plain language). ``repo_path`` is a local path
+    or a git URL."""
+    if lens not in ("developer", "stakeholder"):
+        return {"error": "lens must be 'developer' or 'stakeholder'"}
+
+    def run(repo: Any) -> dict[str, Any]:
+        from orchestrator.knowledge.current_state import load_current_state, render_current_state
+
+        state, _batch = load_current_state(repo)
+        return {
+            "languages": state.languages,
+            "counts": state.counts,
+            "areas": state.areas,
+            "files": state.modules,
+            "has_call_graph": state.has_calls,
+            "call_hotspots": [{"function": n, "call_sites": c} for n, c in state.call_hotspots],
+            "coverage": {
+                "tested_areas": state.tested_areas,
+                "total_areas": state.areas,
+                "largest_untested": [{"area": a, "types": c} for a, c in state.untested_top],
+            },
+            "recommendations": [{"priority": p, "action": t} for p, t in state.recommendations],
+            "markdown": render_current_state(state, lens=lens),
+        }
+
+    return _in_repo(repo_path, run)
+
+
+def blast_radius(repo_path: str, symbol: str) -> dict[str, Any]:
+    """ "What breaks if I change X" — a symbol's direct callers plus the cross-layer set a
+    change ripples into (CALLS + IMPORTS + REFERENCES), each with ``file:line``. Deterministic."""
+
+    def run(store: Any, _repo: Any) -> dict[str, Any]:
+        matches = store.find(symbol)
+        if not matches:
+            return {"symbol": symbol, "found": False, "matches": []}
+        out: list[dict[str, Any]] = []
+        for node in matches[:5]:
+            callers = store.callers_of(node.id)
+            touched = store.touches(node.id)
+            out.append(
+                {
+                    "id": node.id,
+                    "kind": node.kind.value,
+                    "where": str(node.provenance) if node.provenance else None,
+                    "caller_count": len(callers),
+                    "callers": [{"id": cs.caller.id, "at": cs.at} for cs in callers[:25]],
+                    "touch_count": len(touched),
+                    "touches": [
+                        {"id": t.id, "where": str(t.provenance) if t.provenance else None}
+                        for t in touched[:25]
+                    ],
+                }
+            )
+        return {"symbol": symbol, "found": True, "matches": out, "markdown": _blast_markdown(out)}
+
+    return _in_repo_store(repo_path, run)
+
+
+def explain_symbol(repo_path: str, symbol: str) -> dict[str, Any]:
+    """What a symbol is and how it connects: kind, location, who calls it, what it calls, and
+    what it contains. Deterministic (no LLM)."""
+
+    def run(store: Any, _repo: Any) -> dict[str, Any]:
+        matches = store.find(symbol)
+        if not matches:
+            return {"symbol": symbol, "found": False, "matches": []}
+        out = [
+            {
+                "id": node.id,
+                "kind": node.kind.value,
+                "name": node.name,
+                "language": node.language,
+                "where": str(node.provenance) if node.provenance else None,
+                "called_by": [cs.caller.id for cs in store.callers_of(node.id)[:15]],
+                "calls": [n.id for n in store.callees_of(node.id)[:15]],
+                "contains": [n.id for n in store.children_of(node.id)[:25]],
+            }
+            for node in matches[:5]
+        ]
+        return {"symbol": symbol, "found": True, "matches": out}
+
+    return _in_repo_store(repo_path, run)
+
+
+def investigate(repo_path: str, title: str, problem: str = "") -> dict[str, Any]:
+    """Where a ticket lands in the code: the real symbols to start from (``file:line`` + caller
+    counts), the owning areas, and any committed ``episteme/`` knowledge. Deterministic (no LLM)."""
+    if not title and not problem:
+        return {"error": "provide a ticket title (and optionally a problem description)"}
+
+    def run(store: Any, repo: Any) -> dict[str, Any]:
+        from orchestrator.sdlc.investigate import build_investigation, render_investigation_md
+
+        inv = build_investigation(title, problem, store=store, root=repo)
+        return {
+            "title": inv.title,
+            "landing": [
+                {"name": h.name, "kind": h.kind, "where": h.where, "callers": h.callers, "module": h.module}
+                for h in inv.landing
+            ],
+            "areas": inv.areas,
+            "has_knowledge": bool(inv.knowledge),
+            "markdown": render_investigation_md(inv),
+        }
+
+    return _in_repo_store(repo_path, run)
+
+
+def localize(repo_path: str, trace: str) -> dict[str, Any]:
+    """Resolve a stack trace / traceback to the repo symbols it names, pointing at the likely
+    fault site and its callers. Deterministic (no LLM)."""
+    if not trace.strip():
+        return {"error": "provide a stack trace / traceback text"}
+
+    def run(store: Any, _repo: Any) -> dict[str, Any]:
+        from orchestrator.sdlc.localize import localize_trace, render_localization_md
+
+        loc = localize_trace(trace, store=store)
+        return {
+            "exception": loc.exception,
+            "grounded": loc.grounded,
+            "fault": (
+                {"func": loc.fault.func, "where": loc.fault.where, "id": loc.fault.node_id}
+                if loc.fault
+                else None
+            ),
+            "frames": [
+                {
+                    "func": f.func,
+                    "trace_at": f"{f.file}:{f.line}",
+                    "resolved": f.resolved,
+                    "id": f.node_id,
+                    "where": f.where,
+                }
+                for f in loc.frames
+            ],
+            "callers": loc.callers,
+            "markdown": render_localization_md(loc),
+        }
+
+    return _in_repo_store(repo_path, run)
+
+
+def regression_gaps(repo_path: str, symbol: str = "", trace: str = "") -> dict[str, Any]:
+    """Blast-radius test-coverage gaps for a change: the production symbols a change to
+    ``symbol`` (or the fault site in ``trace``) reaches that **no test covers**. Deterministic."""
+    if not symbol and not trace.strip():
+        return {"error": "provide a symbol name or a stack trace"}
+
+    def run(store: Any, _repo: Any) -> dict[str, Any]:
+        from orchestrator.sdlc.coverage import (
+            build_regression_plan,
+            render_regression_plan_md,
+            resolve_target,
+        )
+
+        if trace.strip():
+            from orchestrator.sdlc.localize import localize_trace
+
+            loc = localize_trace(trace, store=store)
+            target_id = loc.fault.node_id if (loc.fault and loc.fault.node_id) else None
+        else:
+            target_id = resolve_target(store, symbol)
+        if not target_id:
+            return {"target": symbol or "(trace)", "found": False}
+        plan = build_regression_plan(store, target_id)
+        return {
+            "target": plan.target,
+            "found": True,
+            "target_covered": plan.target_covered,
+            "call_graph_available": plan.call_graph_available,
+            "impacted_count": len(plan.impacted),
+            "uncovered": [{"name": i.name, "where": i.where} for i in plan.impacted if not i.covered],
+            "covering_tests": plan.covering_tests,
+            "truncated": plan.truncated,
+            "markdown": render_regression_plan_md(plan),
+        }
+
+    return _in_repo_store(repo_path, run)
+
+
+async def root_cause(repo_path: str, bug: str, use_llm: bool = False) -> dict[str, Any]:
+    """A grounded root-cause report for a bug (a stack trace, an error message, or a
+    description): the fault site, ranked root-cause **hypotheses** with evidence, the regression
+    surface a fix must cover, and a scoped fix approach. **Deterministic by default** (no LLM,
+    no credentials); ``use_llm=true`` opts into LLM-enriched hypotheses (needs a model). Stops
+    at analysis — it never changes code."""
+    if not bug.strip():
+        return {"error": "provide the bug: a stack trace, an error message, or a description"}
+    from orchestrator.registry.api.workspace import RepoPathError, RepoSourceError
+    from orchestrator.sdlc.rca import build_rca, render_rca_md
+
+    client: Any = None
+    if use_llm:
+        from orchestrator.core.env import load_local_env
+        from orchestrator.core.llm import LiteLLMClient
+        from orchestrator.sdlc.codegen import resolve_codegen_model
+
+        load_local_env()
+        if not resolve_codegen_model():
+            return {
+                "error": "use_llm=true needs a model — set ORCHESTRATOR_INTAKE_MODEL (or SDLC_CODEGEN_MODEL)."
+            }
+        client = LiteLLMClient()
+
+    try:
+        with _repo_store(repo_path) as (store, repo):
+            report = await build_rca(bug, store=store, root=repo, llm=client)
+    except (RepoSourceError, RepoPathError) as exc:
+        return {"error": str(exc)}
+    return {
+        "fault_site": report.fault_site,
+        "used_llm": bool(client),
+        "hypotheses": [{"claim": h.claim, "evidence": list(h.evidence)} for h in report.hypotheses],
+        "regression_surface": report.regression_surface,
+        "fix_approach": report.fix_approach,
+        "markdown": render_rca_md(report),
+    }
+
+
+def _blast_markdown(matches: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    for m in matches:
+        lines.append(f"### `{m['id']}` — {m['kind']}" + (f" @ {m['where']}" if m["where"] else ""))
+        lines.append(
+            f"- **Called by ({m['caller_count']}):** " + ", ".join(c["id"] for c in m["callers"][:10])
+        )
+        lines.append(f"- **Touches ({m['touch_count']}):** " + ", ".join(t["id"] for t in m["touches"][:10]))
+    return "\n".join(lines)
+
+
 # ---- job-style autonomous run (the full gated SDLC workflow) ----------------
 #
 # Unlike ``sdlc_feature`` (one intent, runs to completion in a single call), the
@@ -206,6 +499,15 @@ _TOOLS = (
     ingest_preview,
     pkg_grounding,
     read_memory_bank,
+    # comprehension / graph-query (read-only; deterministic, except root_cause's opt-in LLM)
+    map_repo,
+    blast_radius,
+    explain_symbol,
+    investigate,
+    localize,
+    regression_gaps,
+    root_cause,
+    # gated codegen / run control
     sdlc_feature,
     sdlc_start_run,
     sdlc_run_status,
@@ -280,12 +582,19 @@ def build_http_server(
 
 
 __all__ = [
+    "blast_radius",
     "build_http_server",
     "build_server",
     "doctor",
+    "explain_symbol",
     "ingest_preview",
+    "investigate",
+    "localize",
+    "map_repo",
     "pkg_grounding",
     "read_memory_bank",
+    "regression_gaps",
+    "root_cause",
     "sdlc_decide_gate",
     "sdlc_feature",
     "sdlc_run_result",

--- a/tests/plugin/test_manifests.py
+++ b/tests/plugin/test_manifests.py
@@ -1,0 +1,49 @@
+"""The plugin manifests + the understand-codebase Agent Skill stay valid and in sync."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SKILL = _ROOT / "plugins" / "spine" / "skills" / "understand-codebase" / "SKILL.md"
+_MANIFESTS = [
+    _ROOT / "plugins" / "spine" / ".claude-plugin" / "plugin.json",
+    _ROOT / ".claude-plugin" / "marketplace.json",
+    _ROOT / "codex-marketplace" / "plugins" / "spine" / ".codex-plugin" / "plugin.json",
+]
+# The comprehension tools the plugin's pitch should surface.
+_COMP_TOOLS = ("map_repo", "blast_radius", "explain_symbol", "investigate", "localize", "regression_gaps")
+
+
+def test_understand_codebase_skill_has_frontmatter() -> None:
+    assert _SKILL.is_file(), f"missing skill file: {_SKILL}"
+    text = _SKILL.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), "SKILL.md must open with YAML frontmatter"
+    _, fm, _body = text.split("---\n", 2)
+    assert "name: understand-codebase" in fm
+    assert "description:" in fm
+    # The description is the trigger — it must name the tools so the skill activates on the
+    # right questions.
+    assert "blast_radius" in fm and "map_repo" in fm
+
+
+def test_skill_body_documents_each_tool() -> None:
+    body = _SKILL.read_text(encoding="utf-8").split("---\n", 2)[2]
+    for tool in _COMP_TOOLS:
+        assert tool in body, f"{tool} not mentioned in the skill body"
+
+
+@pytest.mark.parametrize("manifest", _MANIFESTS, ids=lambda p: p.parent.name)
+def test_manifest_is_valid_json(manifest: Path) -> None:
+    assert manifest.is_file(), f"missing manifest: {manifest}"
+    json.loads(manifest.read_text(encoding="utf-8"))  # raises on invalid JSON
+
+
+def test_plugin_pitch_leads_with_comprehension_and_go() -> None:
+    for manifest in _MANIFESTS:
+        blob = manifest.read_text(encoding="utf-8")
+        assert "comprehension" in blob, f"{manifest} pitch should surface the comprehension tools"
+        assert "Go" in blob, f"{manifest} language list should include Go"

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -10,9 +10,16 @@ from typing import Any
 import pytest
 
 from orchestrator.plugin.server import (
+    blast_radius,
     doctor,
+    explain_symbol,
     ingest_preview,
+    investigate,
+    localize,
+    map_repo,
     pkg_grounding,
+    regression_gaps,
+    root_cause,
     sdlc_decide_gate,
     sdlc_feature,
     sdlc_run_result,
@@ -50,6 +57,145 @@ def test_pkg_grounding_empty_for_unrelated_repo(tmp_path: Path) -> None:
     (tmp_path / "unrelated.py").write_text("class WebhookRouter:\n    pass\n", encoding="utf-8")
     out = pkg_grounding(str(tmp_path), "persist the token ledger to disk")
     assert out["chars"] == 0 and out["context"] == ""
+
+
+# ---- comprehension / graph-query tools (read-only, no `mcp` extra needed) ---------
+
+_APP = "def validate(x):\n    if not x:\n        raise ValueError('empty')\n    return True\n"
+_WEB = "import app\n\n\ndef handler(x):\n    return app.validate(x)\n"
+_TEST = "import app\n\n\ndef test_validate():\n    assert app.validate(1)\n"
+
+
+def _comprehension_repo(tmp_path: Path) -> str:
+    (tmp_path / "app.py").write_text(_APP, encoding="utf-8")
+    (tmp_path / "web.py").write_text(_WEB, encoding="utf-8")
+    (tmp_path / "test_app.py").write_text(_TEST, encoding="utf-8")
+    return str(tmp_path)
+
+
+def test_map_repo_structured_and_markdown(tmp_path: Path) -> None:
+    out = map_repo(_comprehension_repo(tmp_path))
+    assert "python" in out["languages"]
+    assert {"languages", "call_hotspots", "coverage", "recommendations", "markdown"} <= set(out)
+    assert out["files"] >= 3 and "total_areas" in out["coverage"]
+    assert out["markdown"].startswith("# Current State")
+
+
+def test_map_repo_rejects_unknown_lens(tmp_path: Path) -> None:
+    assert "error" in map_repo(_comprehension_repo(tmp_path), lens="martian")
+
+
+def test_blast_radius_reports_callers_and_touches(tmp_path: Path) -> None:
+    out = blast_radius(_comprehension_repo(tmp_path), "validate")
+    assert out["found"]
+    m = out["matches"][0]
+    # `handler` calls `validate`, so it's a caller and in the blast radius.
+    assert m["caller_count"] >= 1
+    assert any("handler" in c["id"] for c in m["callers"])
+    assert "markdown" in out
+
+
+def test_blast_radius_not_found(tmp_path: Path) -> None:
+    out = blast_radius(_comprehension_repo(tmp_path), "does_not_exist")
+    assert out["found"] is False and out["matches"] == []
+
+
+def test_explain_symbol_lists_callers(tmp_path: Path) -> None:
+    out = explain_symbol(_comprehension_repo(tmp_path), "validate")
+    assert out["found"]
+    assert any("handler" in c for c in out["matches"][0]["called_by"])
+
+
+def test_investigate_lands_on_real_symbols(tmp_path: Path) -> None:
+    out = investigate(_comprehension_repo(tmp_path), "validate rejects empty input")
+    names = {h["name"] for h in out["landing"]}
+    assert "validate" in names
+    assert out["markdown"].startswith("# Investigation")
+
+
+def test_investigate_requires_a_ticket(tmp_path: Path) -> None:
+    assert "error" in investigate(_comprehension_repo(tmp_path), "", "")
+
+
+def test_localize_resolves_the_fault_frame(tmp_path: Path) -> None:
+    repo = _comprehension_repo(tmp_path)
+    trace = (
+        "Traceback (most recent call last):\n"
+        f'  File "{Path(repo) / "app.py"}", line 3, in validate\n'
+        "    raise ValueError('empty')\n"
+        "ValueError: empty\n"
+    )
+    out = localize(repo, trace)
+    assert out["grounded"] and out["fault"] is not None
+    assert out["fault"]["func"] == "validate"
+    assert "ValueError" in out["exception"]
+
+
+def test_localize_requires_a_trace(tmp_path: Path) -> None:
+    assert "error" in localize(_comprehension_repo(tmp_path), "   ")
+
+
+def test_regression_gaps_flags_untested_caller(tmp_path: Path) -> None:
+    # A test exercises `validate`, but `handler` (in its blast radius) has no covering test.
+    out = regression_gaps(_comprehension_repo(tmp_path), symbol="validate")
+    assert out["found"]
+    assert any(u["name"] == "handler" for u in out["uncovered"])
+
+
+def test_regression_gaps_needs_symbol_or_trace(tmp_path: Path) -> None:
+    assert "error" in regression_gaps(_comprehension_repo(tmp_path))
+
+
+async def test_root_cause_deterministic_by_default(tmp_path: Path) -> None:
+    repo = _comprehension_repo(tmp_path)
+    trace = (
+        "Traceback (most recent call last):\n"
+        f'  File "{Path(repo) / "app.py"}", line 3, in validate\n'
+        "    raise ValueError('empty')\n"
+        "ValueError: empty\n"
+    )
+    out = await root_cause(repo, trace)  # use_llm defaults to False — no key needed
+    assert out["used_llm"] is False
+    assert "validate" in out["fault_site"]
+    assert out["hypotheses"] and "markdown" in out
+
+
+async def test_root_cause_requires_a_bug(tmp_path: Path) -> None:
+    assert "error" in await root_cause(_comprehension_repo(tmp_path), "   ")
+
+
+async def test_root_cause_llm_without_model_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # use_llm=true without a configured model must fail fast with a clear message (no crash).
+    monkeypatch.setattr("orchestrator.sdlc.codegen.resolve_codegen_model", lambda *a, **k: None)
+    out = await root_cause(_comprehension_repo(tmp_path), "boom", use_llm=True)
+    assert "error" in out and "model" in out["error"]
+
+
+def test_bad_repo_path_returns_error_not_exception(tmp_path: Path) -> None:
+    missing = str(tmp_path / "nope")
+    assert "error" in map_repo(missing)
+    assert "error" in blast_radius(missing, "x")
+
+
+def test_disallowed_git_url_is_rejected() -> None:
+    # A URL on a non-allowlisted host is refused by the same SSRF guard as the CLI (no clone).
+    out = map_repo("https://evil.example.com/x/y.git")
+    assert "error" in out
+
+
+def test_comprehension_tools_are_registered() -> None:
+    from orchestrator.plugin.server import _TOOLS
+
+    names = {fn.__name__ for fn in _TOOLS}
+    assert {
+        "map_repo",
+        "blast_radius",
+        "explain_symbol",
+        "investigate",
+        "localize",
+        "regression_gaps",
+        "root_cause",
+    } <= names
 
 
 async def test_ingest_preview_summarizes_a_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Automated sync from the private repo @ 9384ec2 (v3.8.0).

## What's in this release
- chore(release): 3.8.0 — the /spine comprehension skill
- docs: refresh Graphify comparison (Go + /spine skill) + how to use the skill
- feat(plugin): root_cause tool + git-URL support — /spine comprehension, Phase 3
- feat(plugin): understand-codebase Agent Skill — /spine comprehension, Phase 2 (Claude)
- feat(plugin): comprehension MCP tools — the /spine skill, Phase 1 (Codex first)
- docs(skill): spec for /spine — the drop-in comprehension skill (MCP tools + Agent Skill)

Merge to release.