### PR TITLE
Publish v3.8.2 (9866b4e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## 3.8.2 — Doc ingestion reaches HTML and Office
+
+3.8.1 folded Markdown, reST, plain text and PDF into the graph. This release adds the
+remaining **file** formats teams actually keep specs in — **HTML** and **Word/Excel** — so a
+`.docx` architecture doc or an exported HTML spec sitting in your repo becomes `Doc` nodes
+`MENTIONS`-linked to the code it describes, exactly like a README.
+
+Still deterministic, still no LLM, still a no-op on a repo with no docs.
+
+### Added
+
+- **HTML ingestion** (`.html`/`.htm`) — no extra needed. `<h1>`…`<h6>` become section
+  boundaries (so an HTML doc sections exactly like markdown), and inline `<code>` is
+  preserved as a code claim, so the symbols a doc names actually bind. `<script>`/`<style>`
+  bodies are ignored; malformed markup is skipped rather than fatal.
+- **Word & Excel ingestion** behind a new **`[office]`** extra
+  (`pip install 'synaptixs-spine[office]'`). `.docx` maps Word's heading styles to sections
+  and treats monospace runs as code claims — the Word equivalent of backticks — and keeps
+  table text, which is where spec documents put API and field lists. `.xlsx` gives one
+  section per sheet and keeps string cells only (numbers and formula results are data, not
+  prose about code). Encrypted or corrupt documents are skipped.
+- **Markdown front matter** is now read as prose: the *values* of a `---` block (`title:`,
+  `module:`, `tags:`) bind like the text they stand for, while the keys and fences no longer
+  leak into the graph as noise.
+
+### Changed
+
+- Documentation formats are now **registered readers** rather than hard-coded branches, so
+  adding a format touches no existing one. Behaviour for existing formats is unchanged.
+- Standalone `.yaml`/`.yml` files are **deliberately not ingested**. A repo's YAML is
+  overwhelmingly configuration, and treating it as documentation would inflate the doc
+  coverage `state` reports and flood doc-drift with config values that were never prose.
+  YAML's documentary case — front matter — is covered above.
+
 ## 3.8.1 — Doc & PDF ingestion: your docs become code-linked facts
 
 Spine now reads a repository's **documentation** — Markdown, reStructuredText, plain text,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,16 @@ subsystem; that's where the *why* is. `docs/specs/README.md` indexes them.
 
 ## Gotchas that have bitten
 
-- **`md.js` escapes every fence, including ```mermaid** — diagrams in markdown render as
-  raw text in our own web UI (they only look right in GitHub/IDE viewers).
+- **`md.js` renders mermaid, but only a tiny subset** — `mermaidSvg()` (a ~90-line
+  hand-rolled renderer, chosen over a 2.6 MB library because the UI has no build step and
+  must work air-gapped) draws inline SVG for: `flowchart LR|TD|TB|RL`, `subgraph x["Zone"]`
+  /`end`, **quoted** node decls `id["label"]` (`<br/>` for line breaks), and bare-id edges
+  `a --> b` / `a -->|label| b`. Anything else — chained `a --> b --> c`, dotted `-. x .->`,
+  decision `c{...}`, or a node declared inline in an edge line — returns null and the whole
+  block falls back to `<pre>` ("no picture beats a wrong picture"). It renders fine on
+  GitHub either way, so a broken diagram is invisible until you open our own UI. Declare
+  nodes first, then edges, and verify rather than eyeball:
+  `node scripts/check-mermaid.js *.md` (runs the real `md.js`; non-zero on any fallback).
 - **`pkg extract --json` omits edges** — nodes + summary only.
 - **`--language` is not validated in `cli.py`** — an unsupported language silently
   scaffolds a *Python* project (every dispatch chain falls through to the Python branch).

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -184,7 +184,7 @@ At a glance:
 | `localize` | Resolve a stack trace / traceback to the repo symbols it names → the likely fault site + its callers. | no |
 | `regression_gaps` | The production symbols a change (by symbol or trace) reaches that **no test covers** — what could break silently. | no |
 | `root_cause` | A grounded root‑cause report for a bug: fault site, ranked hypotheses + evidence, regression surface, fix approach. Deterministic by default; `use_llm=true` enriches (needs a model). | no |
-| `docs_for` | **Which docs describe the code.** With a `symbol`, the doc pages that mention it; without one, a doc‑coverage summary (% of symbols documented + top drift). Ingests `.md`/`.rst`/`.txt`/**PDF** (`[docs]` extra). | no |
+| `docs_for` | **Which docs describe the code.** With a `symbol`, the doc pages that mention it; without one, a doc‑coverage summary (% of symbols documented + top drift). Ingests `.md`/`.rst`/`.txt`/**HTML**, plus **PDF** (`[docs]`) and **Word/Excel** (`[office]`). | no |
 | [`read_memory_bank`](#read_memory_bank) | Read a repo's committed `episteme/` (code‑true project knowledge). | no |
 | [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
 | [`ingest_preview`](#ingest_preview) | Preview the backlog (derived intents + gaps) for a requirements source — dry‑run. | no |

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -1,0 +1,844 @@
+# Orchestrator (Spine) — CLI Reference
+
+> **Spine** is the product; the command is **`orchestrator`** (package `synaptixs-spine`).
+> Auto-generated from the CLI — run `orchestrator <command> --help` for the live version.
+
+**41 commands** across 7 areas. Every command supports `--help`; repo-analysis commands accept a local path or a git URL.
+
+## Command map
+
+**Getting started & operations** — Set up your environment and run the platform.  
+`init` · `doctor` · `up` · `tui` · `task submit`
+
+**Understand a codebase — the Knowledge Graph** — Extract and read the Product Knowledge Graph (PKG). Deterministic, no LLM. All accept a local path OR a git URL.  
+`understand` · `state` · `profile` · `catalog list` · `catalog plan` · `pkg extract` · `pkg export` · `pkg docs`
+
+**Grounded design, debugging & RCA** — The KG-grounded engineering commands: design a change, research a ticket, and trace/analyze bugs — all anchored to real code.  
+`design` · `investigate` · `localize` · `rca` · `regression` · `audit`
+
+**Requirements intake — source to backlog** — Turn a requirements source (Confluence, Jira, Notion, files, OpenSpec, MCP) into intents/specs and (optionally) tracker issues.  
+`ingest` · `backlog` · `openspec draft`
+
+**The SDLC pipeline — build features** — The autonomous build path: requirements → code → tests → reviewed PR, with human gates.  
+`sdlc feature` · `sdlc run` · `sdlc complete` · `sdlc address-review` · `sdlc remediate`
+
+**MCP — external tools** — Consume onboarded Model Context Protocol servers (governed, audited).  
+`mcp list` · `mcp contracts` · `mcp call` · `mcp ingest-db`
+
+**Registry — templates & contracts** — Manage reusable capability templates and API contracts in the registry service.  
+`template register` · `template list` · `template show` · `template publish` · `template deprecate` · `contract register` · `contract list` · `contract show` · `contract publish` · `contract deprecate`
+
+
+---
+
+## Getting started & operations
+
+Set up your environment and run the platform.
+
+### `orchestrator init`
+
+Scaffold a new project: create a .env from the template, then guide setup.
+
+Creates a commented .env skeleton (from the same env groups `doctor`
+checks), then reports readiness. While required variables are still unset it
+exits non-zero with a call to fill them in and re-run — so `init` is the
+one-command setup loop: run it, fill the blanks, run it again until green.
+
+Safe to re-run: an existing .env is never overwritten (only missing keys are
+appended) unless --force.
+
+```
+orchestrator init [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--path` | Directory to scaffold the .env into. (default: `.`) |
+| `--force` | Overwrite an existing .env with a fresh template. |
+
+### `orchestrator doctor`
+
+Check environment readiness and print a diagnostic report.
+
+Bridges `.env` into the process environment first (same as `ingest` /
+`sdlc`), so the report reflects exactly what the pipeline will see — a
+real exported variable still wins over the file.
+
+```
+orchestrator doctor
+```
+
+### `orchestrator up`
+
+Bring up the whole local stack in one command, then open the inbox.
+
+Starts Docker infra (Postgres + Temporal), applies migrations, and launches
+the web/API server **and** the Temporal worker with sensible defaults — so a
+non-technical user reaches the delegation inbox at `/app` without wiring up
+three terminals. Streams logs until Ctrl-C, then stops the app processes
+(infra containers are left running for fast restarts).
+
+```
+orchestrator up [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--port` | Port for the web UI + API. (default: `8000`) |
+| `--host` | Bind address for the API. (default: `127.0.0.1`) |
+| `--no-docker` | Don't manage Docker; assume Postgres + Temporal are already up. |
+| `--no-worker` | Skip the Temporal worker (browse-only; can't delegate runs). |
+| `--compose-file` | Override the docker compose file to use. |
+
+### `orchestrator tui`
+
+Launch the terminal UI: watch runs, clear gates, and delegate a run.
+
+A keyboard-driven cousin of the web inbox over the same `/v1` API. Needs the
+`tui` extra: `pip install 'synaptixs-spine[tui]'`.
+
+```
+orchestrator tui [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--api-url` | Registry API base URL. (default: `http://localhost:8000`) |
+| `--api-key` | API key for the registry. (default: `dev-key`) |
+
+### `orchestrator task submit`
+
+Submit a task to the orchestrator and print the final state.
+
+```
+orchestrator task submit [OBJECTIVE] [OPTIONS]
+```
+
+**Arguments**
+
+- `OBJECTIVE` — 
+
+| Option | Description |
+|---|---|
+| `--template` | Pin a specific template id; planner chooses otherwise. |
+| `--version` | Pin a specific template version. |
+
+---
+
+## Understand a codebase — the Knowledge Graph
+
+Extract and read the Product Knowledge Graph (PKG). Deterministic, no LLM. All accept a local path OR a git URL.
+
+### `orchestrator understand`
+
+Build a committed `episteme/` — a code-true project knowledge base.
+
+Phase 0: extracts the Product Knowledge Graph + project profile and renders
+architecture / domain-model / tech-context / conventions / glossary as
+markdown in the target repo. Deterministic (no LLM); re-run to refresh.
+`path` may be a local path or a git URL cloned on demand — for a URL the
+clone is transient, so the knowledge base defaults to `./episteme`.
+
+A doc-ingestion post-pass also folds the repo's docs into the graph as `Doc` nodes +
+`MENTIONS` edges: Markdown, reST, plain text and **HTML** need nothing; **PDF** needs the
+`[docs]` extra and **Word/Excel** the `[office]` extra. No-op on a repo with no docs.
+
+```
+orchestrator understand [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to comprehend. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--out` | Knowledge-base dir (default: <repo>/episteme; ./episteme for a URL). |
+| `--refresh` | Re-extract the PKG instead of using the commit cache. |
+| `--dialect` | SQL dialect (postgres\|mysql\|tsql\|oracle\|…); default: auto-detect. |
+
+### `orchestrator state`
+
+Current State — a team-facing snapshot of what a repo is today and how healthy it looks.
+
+Synthesized from the Product Knowledge Graph + project profile (deterministic, no LLM),
+layered on top of `understand`. `--lens developer` gives the technical view;
+`--lens stakeholder` gives plain language. Includes a **Documentation** section — how much
+of the code the ingested docs describe (symbol coverage %) plus top **doc drift**. A report
+is a *view* of the code — re-run to refresh; nothing is written unless `--out` is given.
+
+```
+orchestrator state [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to summarize. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--lens` | Audience: developer \| stakeholder. (default: `developer`) |
+| `--out` | Write the report to this file (default: print to stdout). |
+| `--refresh` | Re-extract the PKG instead of using the commit cache. |
+| `--dialect` | SQL dialect (postgres\|mysql\|tsql\|oracle\|…); default: auto-detect. |
+
+### `orchestrator profile`
+
+Profile a project (languages, framework, DB, tests, task type) — read-only.
+
+`path` is a local path or a git URL (github/bitbucket/gitlab/enterprise),
+cloned on demand.
+
+```
+orchestrator profile [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to profile. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--intent` | Intent title, to classify the task type. |
+| `--json` | Emit the profile as JSON. |
+
+### `orchestrator catalog list`
+
+List the capabilities the orchestrator can assemble (read-only).
+
+```
+orchestrator catalog list [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--json` | Emit the catalog as JSON. |
+
+### `orchestrator catalog plan`
+
+Show the capability plan the orchestrator would assemble for a project.
+
+```
+orchestrator catalog plan [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to plan for. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--intent` | Intent title, to classify the task type. |
+| `--json` | Emit the plan as JSON. |
+
+### `orchestrator pkg extract`
+
+Extract grounded code facts from a repo and print a summary (read-only).
+
+```
+orchestrator pkg extract [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to scan. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--query`, `-q` | Show callers + blast radius of a symbol name. |
+| `--json` | Dump all facts as JSON. |
+| `--dialect` | SQL dialect (postgres\|mysql\|tsql\|oracle\|…); default: auto-detect. |
+
+### `orchestrator pkg export`
+
+Extract facts and export the ontomesh-ready kind-per-table SQLite projection.
+
+```
+orchestrator pkg export [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to scan. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--db` | SQLite file to write. (default: `pkg-facts.db`) |
+
+### `orchestrator pkg docs`
+
+Reconcile the **named** documentation file(s) against the code's fact graph (read-only) and
+print a binding/drift summary — the targeted counterpart to the automatic whole-repo doc
+ingestion that `understand`/`state` perform (which folds *all* docs into the graph as `Doc`
+nodes + `MENTIONS` edges).
+
+```
+orchestrator pkg docs [REPO] [OPTIONS]
+```
+
+**Arguments**
+
+- `REPO` — Repo path or git URL to extract facts from. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--doc`, `-d` | Markdown/text doc(s) to reconcile. (default: `[]`) |
+
+---
+
+## Grounded design, debugging & RCA
+
+The KG-grounded engineering commands: design a change, research a ticket, and trace/analyze bugs — all anchored to real code.
+
+### `orchestrator design`
+
+Grounded feature design: spec × knowledge graph → a design with blast radius.
+
+Produces the M2 design for one feature anchored to the repo's real structure,
+and annotates it with its **blast radius** (which modules it touches, who
+depends on them, the call hotspots) and any **unverified references** (named
+paths absent from the graph). Deterministic by default; `--llm` writes the
+prose. `path` may be a local path or a git URL cloned on demand.
+
+```
+orchestrator design [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to design against. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--title`, `-t` | Feature title (the thing to build). |
+| `--summary`, `-s` | One-line feature summary. |
+| `--criterion`, `-c` | Acceptance criterion (repeatable). |
+| `--spec` | Read the spec from JSON ({title,summary,acceptance_criteria}) or a .md file. |
+| `--out` | Write design.md here (default: print to stdout). |
+| `--llm` | Let an LLM write the design (needs a provider; else heuristic). |
+| `--refresh` | Re-extract the PKG instead of using the commit cache. |
+| `--dialect` | SQL dialect; default: auto-detect. |
+
+### `orchestrator investigate`
+
+Investigation brief: a ticket × the codebase, before you design.
+
+Researches where a ticket lands in the code (knowledge-graph retrieval, with
+`file:line` + caller counts), the relevant committed `episteme/` knowledge,
+and — when a registry DB is configured — prior-run notes. Deterministic, no
+LLM. Pass the ticket via `--source` (e.g. `jira://PROJ-123`) or inline with
+`--title`/`--text`. Feed the result into `orchestrator design`.
+
+```
+orchestrator investigate [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to research against. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--source` | Fetch the ticket from a source, e.g. jira://PROJ-123, confluence://<id>, file://./bug.md. |
+| `--title`, `-t` | Inline ticket title (instead of --source). |
+| `--text` | Inline ticket body (with --title). |
+| `--out` | Write the brief here (default: print to stdout). |
+| `--refresh` | Re-extract the PKG instead of using the commit cache. |
+| `--dialect` | SQL dialect; default: auto-detect. |
+
+### `orchestrator localize`
+
+Fault localization: a stack trace → the repo symbols it names.
+
+Parses a Python traceback / pytest failure, resolves each frame to a
+knowledge-graph symbol (`file:line`), and points at the likely fault site
+plus who calls it. Reads the trace from `--trace <file>`, `--text`, or stdin.
+Deterministic, no LLM — the first step of a root-cause investigation.
+
+```
+orchestrator localize [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to resolve the trace against. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--trace` | File with the stack trace / failing-test output. |
+| `--text` | Inline trace text (instead of --trace). |
+| `--out` | Write the report here (default: print to stdout). |
+| `--refresh` | Re-extract the PKG instead of using the commit cache. |
+| `--dialect` | SQL dialect; default: auto-detect. |
+
+### `orchestrator rca`
+
+Root-cause analysis: a bug → grounded RCA + fix approach (no code changed).
+
+Localizes the bug (a stack trace, a `jira://` Bug, or inline text) against
+the knowledge graph, then reports the fault site, ranked root-cause
+*hypotheses* with evidence (callers, recent churn, the exception), the
+regression surface a fix must cover, and a scoped fix approach. Deterministic
+by default; `--llm` enriches the hypotheses. It stops at the report — a human
+decides whether to build the fix.
+
+```
+orchestrator rca [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to analyze against. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--source` | Fetch the bug from a source, e.g. jira://PROJ-42 (a Bug ticket). |
+| `--trace` | File with a stack trace / failing-test output. |
+| `--text` | Inline bug text / trace (instead of --trace/--source). |
+| `--out` | Write rca.md here (default: print to stdout). |
+| `--llm` | Let an LLM enrich the hypotheses (needs a provider; else deterministic). |
+| `--refresh` | Re-extract the PKG instead of using the commit cache. |
+| `--dialect` | SQL dialect; default: auto-detect. |
+
+### `orchestrator regression`
+
+Regression coverage: what a change should re-test, from the call graph.
+
+For a symbol you're about to change (`--symbol`) or a fault site (`--trace`),
+computes the blast radius and splits it into tests that already exercise it
+and production code in the radius with no covering test — the regression
+gaps. Deterministic, no LLM. Needs a call graph (Python/C/C++/C#/Java/TS).
+
+```
+orchestrator regression [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo path or git URL to analyze. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--symbol`, `-s` | The symbol you're about to change (by name). |
+| `--trace` | A stack trace instead — the fault site becomes the target. |
+| `--out` | Write the plan here (default: print to stdout). |
+| `--refresh` | Re-extract the PKG instead of using the commit cache. |
+| `--dialect` | SQL dialect; default: auto-detect. |
+
+### `orchestrator audit`
+
+Codebase-auditor persona: a read-only agentic audit → findings report.
+
+The auditor navigates the repo via the PKG + file reads (no writes) and
+reports findings anchored to real file:line. Needs an LLM provider (same
+creds the pipeline uses); the model follows `resolve_codegen_model`.
+
+```
+orchestrator audit [PATH] [OPTIONS]
+```
+
+**Arguments**
+
+- `PATH` — Repo or directory to audit. _(default: `.`)_
+
+| Option | Description |
+|---|---|
+| `--focus` | What to look for. (default: `general code quality, correctness risks, and security`) |
+| `--out` | Write the findings report to this file. |
+| `--bundle` | Write the full run bundle (trace + policy blocks) as JSON. |
+
+---
+
+## Requirements intake — source to backlog
+
+Turn a requirements source (Confluence, Jira, Notion, files, OpenSpec, MCP) into intents/specs and (optionally) tracker issues.
+
+### `orchestrator ingest`
+
+Source (Confluence / Notion / local files) → intents → gaps → specs → Jira backlog.
+
+Dry-run by default: fetches the source tree, derives intents, flags
+gaps, drafts specs, and prints the would-be Jira issues without writing
+anything. Pass --create to write to Jira (refused when gaps gate
+approval unless --force).
+
+The lowest-friction source is local files — no SaaS account needed:
+
+    orchestrator ingest --source file://./examples/intake/sample-spec.md
+
+(An LLM key is still required for the intent/spec stages.)
+
+```
+orchestrator ingest [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--source` | Source root, e.g. confluence://<page_id>, jira://<issue-or-project> (read), notion://<page_id>, openspec://<change-id> (spec-driven), or file://./spec.md. |
+| `--create` | Create issues for real (default: dry-run preview). |
+| `--rules` | Path to a gap-rules YAML (defaults to built-ins). |
+| `--force` | Create even when gaps gate the intent-approval bookend. |
+| `--refresh` | Re-extract from the source (default: reuse the cached backlog). |
+
+### `orchestrator backlog`
+
+Render the cached backlog + completion progress as markdown (read-only).
+
+Reads the persisted backlog (from a prior ingest / sdlc feature run) and
+prints a checkbox ledger: [ ] todo, [~] in progress, [x] done. Pass --out to
+write a BACKLOG.md.
+
+```
+orchestrator backlog [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--source` | Source URI whose cached backlog to render, e.g. confluence://<id>. |
+| `--out` | Write the markdown here (default: print to stdout). |
+
+### `orchestrator openspec draft`
+
+Bootstrap OpenSpec change proposals FROM an unstructured source (the write-back).
+
+Runs the LLM intake once (source → intents → specs), then renders each as a
+structured `openspec/changes/<id>/` proposal (proposal.md + specs delta + tasks).
+A human polishes the draft, then implements deterministically:
+
+    orchestrator openspec draft --source confluence://<id> --out ./openspec
+    # …review/edit openspec/changes/<id>/…
+    orchestrator sdlc feature --source openspec://<id> --safe
+
+```
+orchestrator openspec draft [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--source` | Unstructured source to bootstrap FROM, e.g. confluence://<id>. |
+| `--out` | OpenSpec root to write into (changes/<id>/ is created under it). (default: `openspec`) |
+| `--refresh` | Re-extract from the source (default: reuse the cached backlog). |
+| `--overwrite` | Overwrite existing change files (default: never clobber). |
+
+---
+
+## The SDLC pipeline — build features
+
+The autonomous build path: requirements → code → tests → reviewed PR, with human gates.
+
+### `orchestrator sdlc feature`
+
+Linear pipeline for ONE intent, end to end.
+
+source → intent → spec → Jira issue → worktree branch → code generation
+→ test + refine → commit → (push + PR) → Jira update → ready for deployment.
+
+Default --safe makes no external write: it creates a local branch, commits
+the generated + tested code, and prints the diff. Pass --live to create the
+Jira issue, push the branch, open a real PR, and comment the PR link back on
+the issue.
+
+```
+orchestrator sdlc feature [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--source` | Source root, e.g. confluence://<page_id>, jira://<issue-or-project> (read), notion://<page_id>, openspec://<change-id> (spec-driven), or file://./spec.md. |
+| `--intent` | Intent id to implement (default: first derived intent). |
+| `--repo` | Git URL to branch from (default $SDLC_REPO_URL; scratch if unset). |
+| `--model` | Codegen model (default: $SDLC_CODEGEN_MODEL or the adapter default). |
+| `--max-refine` | Max implement→test→refine iterations. (default: `3`) |
+| `--live` | Write for real: create the Jira issue, push the branch + open a PR, comment on Jira. Default --safe stays local (branch + commit + diff, dry-run Jira, no push). |
+| `--layout` | Target structure: auto (scaffold only empty repos), new (always scaffold a src/<pkg>/ skeleton), or existing (follow the repo's layout). (default: `auto`) |
+| `--package-name` | Override the scaffold package name (default: derived from repo). |
+| `--refresh` | Re-extract intents from the source (default: reuse the cached, deterministic backlog). |
+| `--language` | Target language: auto (detect), python, java, typescript, csharp, c, cpp, go, or sql. (default: `auto`) |
+
+### `orchestrator sdlc run`
+
+Start the Block-C SDLC workflow on the sdlc-tasks queue.
+
+Generates a fresh sdlc_id and starts `SDLCWorkflow` with workflow id
+`task-{sdlc_id}` — the id convention the REST `/v1/approvals/*` API
+relies on to route gate decisions back to the workflow. The two human
+gates persist real, decidable ApprovalRequest rows
+(`sdlc-{sdlc_id}-0` for intents, `sdlc-{sdlc_id}-1` for merge).
+
+A worker must be running on the sdlc-tasks queue
+(`python -m orchestrator.sdlc.worker`).
+
+```
+orchestrator sdlc run [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--source` | Source root, e.g. confluence://<page_id>, jira://<issue-or-project> (read), notion://<page_id>, openspec://<change-id> (spec-driven), or file://./spec.md. |
+| `--actor` | Who is launching the run (recorded in audit rows). (default: `cli`) |
+| `--create-jira` | Write Jira issues for real (default: dry-run synthetic keys). |
+| `--wait` | Block until the workflow finishes and print its result (default: return after start). |
+| `--max-features` | Cap features per run (0 = unlimited). |
+| `--max-parallel` | Feature children per batch (1 = sequential). (default: `2`) |
+
+### `orchestrator sdlc complete`
+
+Close the Jira issue for a merged PR (the merge → Done bookend).
+
+The linear `sdlc feature` path stops at an open PR for a human to review
+and merge; this reconciles Jira afterwards. Verifies the PR is merged (via
+`gh`), derives the issue key from the PR's head branch
+(`feat/<sdlc_id>/<KEY>`) unless `--issue` is given, then transitions the
+issue and comments the merge. Needs an authenticated `gh`.
+
+```
+orchestrator sdlc complete [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--pr` | The merged PR URL whose linked issue to close. |
+| `--issue` | Issue key (default: derived from the PR branch feat/<id>/<KEY>). |
+| `--status` | Target Jira status to move the issue to. (default: `Done`) |
+| `--allow-unmerged` | Transition even if the PR is not merged yet. |
+
+### `orchestrator sdlc address-review`
+
+Read a PR's human review comments, revise the change, and push the fix.
+
+Checks out the PR branch into a throwaway clone, feeds the reviewers'
+comments to codegen, re-drives to green (tests + preflight), and pushes a
+follow-up commit to the PR branch. Out-of-band and human-triggered — the
+autonomous run's merge gate stays the bookend. Needs SDLC_CODEGEN=llm and
+an authenticated `gh`.
+
+```
+orchestrator sdlc address-review [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--pr` | The PR URL to address review comments on. |
+| `--repo` | Repo clone URL (defaults to SDLC_REPO_URL). |
+| `--bot-login` | Skip this author's own comments (the agent's account). |
+| `--max-refines` | Refine cycles to reach green. (default: `3`) |
+
+### `orchestrator sdlc remediate`
+
+Spine Seam 3: a drift report → governed remediation runs (one per affected entity).
+
+Plans scoped, guardrailed remediation tasks from the infodrift report (Phase 2) and
+runs each through the codegen pipeline with the task as the spec (intake skipped),
+grounded by ontomesh (Seam 1) when configured. Default --safe is human-gated: it
+leaves a branch + diff to review; --live opens PRs.
+
+```
+orchestrator sdlc remediate [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--report` | Path to an infodrift full_report JSON. |
+| `--mappings` | Path to the confirmed code↔ontology MappingStore JSON. (default: `spine-mappings.json`) |
+| `--repo` | Git URL to branch from (default $SDLC_REPO_URL). |
+| `--min-severity` | Only remediate findings at/above: warning \| critical. (default: `warning`) |
+| `--live` | --safe (default) leaves a reviewable branch+diff per entity (human-gated); --live opens PRs. |
+
+---
+
+## MCP — external tools
+
+Consume onboarded Model Context Protocol servers (governed, audited).
+
+### `orchestrator mcp list`
+
+Discover the allow-listed tools across all configured MCP servers.
+
+```
+orchestrator mcp list [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--config` | Path to an mcpServers JSON file (default: $ORCHESTRATOR_MCP_CONFIG or ./mcp.json). |
+
+### `orchestrator mcp contracts`
+
+Show the ToolContract derived for each onboarded MCP tool (governance view).
+
+```
+orchestrator mcp contracts [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--config` | mcpServers JSON file path. |
+
+### `orchestrator mcp call`
+
+Invoke one onboarded MCP tool (server:tool) with JSON arguments.
+
+```
+orchestrator mcp call [TOOL] [OPTIONS]
+```
+
+**Arguments**
+
+- `TOOL` — Qualified tool name: server:tool.
+
+| Option | Description |
+|---|---|
+| `--args` | JSON object of tool arguments. (default: `{}`) |
+| `--config` | mcpServers JSON file path. |
+
+### `orchestrator mcp ingest-db`
+
+Introspect a DB MCP server's schema into PKG data-layer facts (Entity/Field).
+
+```
+orchestrator mcp ingest-db [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--server` | Name of an onboarded DB MCP server. |
+| `--query-tool` | The server's SQL query tool name. (default: `query`) |
+| `--sql-arg` | The query tool's SQL argument name. (default: `sql`) |
+| `--schema` | DB schema to introspect. (default: `public`) |
+| `--config` | mcpServers JSON file path. |
+
+---
+
+## Registry — templates & contracts
+
+Manage reusable capability templates and API contracts in the registry service.
+
+### `orchestrator template register`
+
+Register a new agent template from a JSON or YAML file.
+
+```
+orchestrator template register [FILE]
+```
+
+**Arguments**
+
+- `FILE` — 
+
+### `orchestrator template list`
+
+List agent templates.
+
+```
+orchestrator template list [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--tag` | Filter by tag. |
+| `--status` | Filter by lifecycle state. |
+
+### `orchestrator template show`
+
+Show the latest published version (or a specific version).
+
+```
+orchestrator template show [ID] [VERSION]
+```
+
+**Arguments**
+
+- `ID` — 
+- `VERSION` — 
+
+### `orchestrator template publish`
+
+Promote a draft to published.
+
+```
+orchestrator template publish [ID] [VERSION]
+```
+
+**Arguments**
+
+- `ID` — 
+- `VERSION` — 
+
+### `orchestrator template deprecate`
+
+Mark a published version as deprecated.
+
+```
+orchestrator template deprecate [ID] [VERSION]
+```
+
+**Arguments**
+
+- `ID` — 
+- `VERSION` — 
+
+### `orchestrator contract register`
+
+Register a new tool contract from a JSON or YAML file.
+
+```
+orchestrator contract register [FILE]
+```
+
+**Arguments**
+
+- `FILE` — 
+
+### `orchestrator contract list`
+
+List tool contracts.
+
+```
+orchestrator contract list [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `--tag` | Filter by tag. |
+| `--status` | Filter by lifecycle state. |
+
+### `orchestrator contract show`
+
+Show the latest published version (or a specific version).
+
+```
+orchestrator contract show [ID] [VERSION]
+```
+
+**Arguments**
+
+- `ID` — 
+- `VERSION` — 
+
+### `orchestrator contract publish`
+
+Promote a draft to published.
+
+```
+orchestrator contract publish [ID] [VERSION]
+```
+
+**Arguments**
+
+- `ID` — 
+- `VERSION` — 
+
+### `orchestrator contract deprecate`
+
+Mark a published version as deprecated.
+
+```
+orchestrator contract deprecate [ID] [VERSION]
+```
+
+**Arguments**
+
+- `ID` — 
+- `VERSION` — 
+
+---

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -169,7 +169,7 @@ At a glance:
 | `localize` | Resolve a stack trace / traceback to the repo symbols it names → the likely fault site + its callers. | no |
 | `regression_gaps` | The production symbols a change (by symbol or trace) reaches that **no test covers** — what could break silently. | no |
 | `root_cause` | A grounded root‑cause report for a bug: fault site, ranked hypotheses + evidence, regression surface, fix approach. Deterministic by default; `use_llm=true` enriches (needs a model). | no |
-| `docs_for` | **Which docs describe the code.** With a `symbol`, the doc pages that mention it; without one, a doc‑coverage summary (% of symbols documented + top drift). Ingests `.md`/`.rst`/`.txt`/**PDF** (`[docs]` extra). | no |
+| `docs_for` | **Which docs describe the code.** With a `symbol`, the doc pages that mention it; without one, a doc‑coverage summary (% of symbols documented + top drift). Ingests `.md`/`.rst`/`.txt`/**HTML**, plus **PDF** (`[docs]`) and **Word/Excel** (`[office]`). | no |
 | [`read_memory_bank`](#read_memory_bank) | Read a repo's committed `episteme/` (code‑true project knowledge). | no |
 | [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
 | [`ingest_preview`](#ingest_preview) | Preview the backlog (derived intents + gaps) for a requirements source — dry‑run. | no |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,7 +39,9 @@ radius) and grounds new code in what already exists. Full guide:
 | C `#include` graph + header/source merge; codegen on **CMake or Meson** | ✅ | `.c`/`.h` per repo; `sdlc feature --language c` |
 | Go — package-per-directory, call graph, **interface satisfaction** (`IMPLEMENTS` by method-set); codegen built + tested with `go build`/`go test`, multi-module aware | ✅ | `pip install 'synaptixs-spine[go]'`; `.go` per repo; `sdlc feature --language go` |
 | Doc ingestion — folds Markdown/reST/text docs into the PKG as `Doc` nodes + `MENTIONS` edges (which docs describe a symbol); section-granular, precision-first, no LLM | ✅ | automatic on `orchestrator understand` / `orchestrator state` |
+| HTML ingestion — `<h1..h6>` become sections, inline `<code>` binds like a backtick | ✅ | automatic (stdlib, no extra) |
 | PDF ingestion — same, for `.pdf` docs (scanned/image-only PDFs skipped, no OCR) | ✅ | `pip install 'synaptixs-spine[docs]'` |
+| Office ingestion — `.docx` (Word heading styles → sections, monospace runs → code claims) and `.xlsx` (sheet → section) | ✅ | `pip install 'synaptixs-spine[office]'` |
 | Doc-grounded codegen — a reused symbol's documenting prose rides into the codegen context | ✅ | automatic in `sdlc feature` grounding when the repo has docs |
 | Committed `episteme/` for humans + any AI tool | ✅ | `orchestrator understand --out episteme` |
 | Current State report — overview, infrastructure/runtime, code structure, **documentation coverage + doc drift**, architecture diagrams (no LLM) | ✅ | `orchestrator state . --lens developer\|stakeholder` |

--- a/KNOWLEDGE_GRAPH.md
+++ b/KNOWLEDGE_GRAPH.md
@@ -42,18 +42,18 @@ language-native parsers, so it's **accurate, not guessed**.
 flowchart TB
     repo["📁 Your repository"]
     subgraph code["Code-native — always on"]
-        pkg["PKG<br/>(code graph)"]
-        mb["episteme/<br/>(committed knowledge)"]
+    pkg["PKG<br/>(code graph)"]
+    mb["episteme/<br/>(committed knowledge)"]
     end
     subgraph dom["Domain — optional"]
-        onto["ontomesh<br/>(business ontology)"]
+    onto["ontomesh<br/>(business ontology)"]
     end
     ground["Grounding"]
     deliver["Governed delivery<br/>(features · fixes · findings)"]
-
-    repo --> pkg --> mb
+    repo --> pkg
+    pkg --> mb
     pkg --> ground
-    onto -. optional .-> ground
+    onto -->|optional| ground
     ground --> deliver
 ```
 
@@ -98,15 +98,26 @@ in-repo (e.g. a third-party class) are marked `external`.
 
 ```mermaid
 flowchart LR
-    M[Module] -->|CONTAINS| T[Type]
-    M -->|IMPORTS| M2[Module]
-    T -->|CONTAINS| F[Function]
-    T -->|IMPLEMENTS| T2[Type]
-    F -->|CALLS| F2[Function]
-    F -->|READS / WRITES| FL[Field]
-    EP[Endpoint] -->|EXPOSES| F
-    EN[Entity] -->|REFERENCES| EN2[Entity]
-    D[Doc] -->|MENTIONS| F
+    M["Module"]
+    M2["Module"]
+    T["Type"]
+    T2["Type"]
+    F["Function"]
+    F2["Function"]
+    FL["Field"]
+    EP["Endpoint"]
+    EN["Entity"]
+    EN2["Entity"]
+    D["Doc"]
+    M -->|CONTAINS| T
+    M -->|IMPORTS| M2
+    T -->|CONTAINS| F
+    T -->|IMPLEMENTS| T2
+    F -->|CALLS| F2
+    F -->|READS / WRITES| FL
+    EP -->|EXPOSES| F
+    EN -->|REFERENCES| EN2
+    D -->|MENTIONS| F
 ```
 
 This is what lets Spine answer questions like *"what calls this function?"*, *"what's the
@@ -119,13 +130,25 @@ walking edges, not by guessing.
 
 ```mermaid
 flowchart LR
-    src["Source files<br/>(.py · .java · .ts/.tsx · .cs · .c/.h · .cpp · .go · .sql)"] --> ext["Language extractor<br/>(tree-sitter / AST / sqlglot)"]
-    ext --> facts["Facts<br/>Nodes + Edges + Provenance"]
-    facts --> cache["Per-commit cache"]
-    facts --> store["Fact store<br/>(queryable)"]
-    store --> mb["episteme/*.md"]
-    store --> grd["Codegen grounding"]
-    store --> db["SQLite projection"]
+    src["Source files<br/>(.py · .java · .ts · .cs<br/>.c/.h · .cpp · .go · .sql)"]
+    docs["Docs<br/>(.md · .rst · .txt · .html<br/>.pdf · .docx · .xlsx)"]
+    ext["Language extractor<br/>(tree-sitter / AST / sqlglot)"]
+    facts["Facts<br/>Nodes + Edges + Provenance"]
+    link["link_docs<br/>(Doc + MENTIONS)"]
+    cache["Per-commit cache"]
+    store["Fact store<br/>(queryable)"]
+    mb["episteme/*.md"]
+    grd["Codegen grounding"]
+    db["SQLite projection"]
+    src --> ext
+    ext --> facts
+    facts --> cache
+    docs --> link
+    facts --> link
+    link --> store
+    store --> mb
+    store --> grd
+    store --> db
 ```
 
 - **Deterministic, no LLM.** Extraction is pure parsing — same code in, same facts out.
@@ -185,7 +208,8 @@ It produces: `architecture.md`, `domain-model.md`, `tech-context.md`, `conventio
 AI tool — reads the same code-true project truth.
 
 A **doc-ingestion post-pass** folds the repo's own documentation (Markdown, reST, plain
-text, and — with the `[docs]` extra — **PDF**) into the same graph: a `Doc` node per doc
+text, **HTML**, and — with extras — **PDF** (`[docs]`) and **Word/Excel** (`[office]`))
+into the same graph: a `Doc` node per doc
 section, `MENTIONS`-linked to each code symbol it names. Nothing to configure; a repo with
 no docs is unaffected. This is what lets `state` report doc coverage and the `docs_for`
 `/spine` tool answer *"which docs describe this symbol?"*.
@@ -304,14 +328,22 @@ For an **existing** repo, the PKG gives Spine an instant, accurate map so new wo
 
 ```mermaid
 flowchart TD
-    A["Existing repo"] --> B["orchestrator understand .<br/>(PKG + episteme/)"]
-    B --> C{What do you want?}
-    C -->|New feature| D["sdlc feature --safe<br/>(grounded in real layout)"]
-    C -->|Bug fix| E["scoped by blast radius<br/>(callers, impacted symbols)"]
-    C -->|Findings| F["profile · audit · reviewer"]
-    D --> G["Reviewed PR"]
+    A["Existing repo"]
+    B["orchestrator understand .<br/>(PKG + episteme/)"]
+    C["What do you want?"]
+    D["sdlc feature --safe<br/>(grounded in real layout)"]
+    E["Scoped by blast radius<br/>(callers, impacted symbols)"]
+    F["profile · audit · reviewer"]
+    G["Reviewed PR"]
+    H["Issues / report"]
+    A --> B
+    B --> C
+    C -->|New feature| D
+    C -->|Bug fix| E
+    C -->|Findings| F
+    D --> G
     E --> G
-    F --> H["Issues / report"]
+    F --> H
 ```
 
 1. **Comprehend** — `orchestrator understand .` builds the graph; `profile`/`audit`
@@ -336,11 +368,17 @@ build**. Knowledge isn't a one-time scan; it compounds.
 
 ```mermaid
 flowchart LR
-    s0["Empty repo<br/>(stub episteme)"] --> s1["Feature 1<br/>scaffolds src/ + tests/"]
-    s1 --> s2["PKG grows<br/>(new nodes + edges)"]
-    s2 --> s3["Feature 2<br/>grounded in Feature 1"]
-    s3 --> s4["PKG grows again…"]
-    s4 --> s5["Mature, self-describing repo"]
+    s0["Empty repo<br/>(stub episteme)"]
+    s1["Feature 1<br/>scaffolds src/ + tests/"]
+    s2["PKG grows<br/>(new nodes + edges)"]
+    s3["Feature 2<br/>grounded in Feature 1"]
+    s4["PKG grows again…"]
+    s5["Mature,<br/>self-describing repo"]
+    s0 --> s1
+    s1 --> s2
+    s2 --> s3
+    s3 --> s4
+    s4 --> s5
 ```
 
 1. The first `understand` writes a **stub** (there's barely any code yet).

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ written to your tracker unless you say so.
 It's built for teams who want agents that are **inspectable, reproducible, and safe
 to run on real code** — not demos.
 
+**How it fits together.** Everything starts from one deterministic graph of your repo —
+built from the code *and* its docs — and every surface is a read of that graph:
+
+```mermaid
+flowchart LR
+    repo["Your repo<br/>(code + docs)"]
+    pkg["Product Knowledge Graph<br/>(deterministic, file:line)"]
+    know["understand / state<br/>(episteme + health)"]
+    ask["What breaks if I<br/>change X? What's<br/>untested?"]
+    build["sdlc feature<br/>(grounded codegen)"]
+    pr["Reviewed PR"]
+    repo --> pkg
+    pkg --> know
+    pkg --> ask
+    pkg --> build
+    build --> pr
+```
+
 ```bash
 pip install synaptixs-spine
 orchestrator init && orchestrator doctor                  # scaffold .env, check readiness
@@ -58,6 +76,7 @@ public issue.
 | **[Using Spine from Claude Code](https://github.com/synaptixs/spine/blob/main/CLAUDE_GUIDE.md)** | Drive Spine from **Claude Code** — install (plugin or MCP server), credentials, the tool reference, and end-to-end greenfield + brownfield walkthroughs. |
 | **[Features & Capabilities](https://github.com/synaptixs/spine/blob/main/FEATURES.md)** | The capability catalog — everything Spine can do today, its status, the command/flag to use it, and a link to each deep dive. |
 | **[Knowledge Graph (PKG)](https://github.com/synaptixs/spine/blob/main/KNOWLEDGE_GRAPH.md)** | How Spine understands your codebase — the code-native graph, its model, the CLI, and how it powers brownfield *and* greenfield work. |
+| **[CLI Reference](https://github.com/synaptixs/spine/blob/main/CLI_REFERENCE.md)** | Every `orchestrator` command across all 7 areas — arguments, options, and defaults. Run `orchestrator <command> --help` for the live version. |
 | **[Operations & Developer Guide](https://github.com/synaptixs/spine/blob/main/OPERATIONS.md)** | How to operate it: deployment modes, the full environment-variable reference, and standing up each advanced capability — including the semantic spine (ontomesh × infodrift). |
 | **[Community brief](https://github.com/synaptixs/spine/blob/main/COMMUNITY.md)** | A one-page overview to share — what it does, lifecycle coverage, how to try it, and the feedback we're looking for. |
 
@@ -165,7 +184,7 @@ queries, stored procedures, and ordered-migration folding, grounded from `.sql` 
 plus *greenfield codegen* (`sdlc feature --language sql`): it generates a migration and
 validates it by applying it to an ephemeral database (in-memory SQLite by default).
 **Documentation** is folded in automatically on `understand`/`state` (Markdown/reST/text
-need nothing; **PDF** needs the `[docs]` extra — `pip install 'synaptixs-spine[docs]'`). Any
+and **HTML** need nothing; **PDF** needs `[docs]`, **Word/Excel** need `[office]`). Any
 LiteLLM-supported provider (Anthropic, OpenAI, Bedrock) or a local Ollama model;
 you can set a different model per stage.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -70,8 +70,9 @@ Optional extras, added when you need them:
   **Meson + Ninja** (matching the target repo's build system); **Go** codegen needs the **`go`
   toolchain** on PATH (`go build`/`go test`). `[sql]` adds `.sql`
   comprehension (schema/queries/procedures + migration folding) — no toolchain needed.
-- `[docs]` — **PDF** doc ingestion (`.md`/`.rst`/`.txt` need no extra). With it, `understand`/`state`
-  fold your PDFs into the graph too; without it, PDFs are simply skipped.
+- `[docs]` — **PDF** doc ingestion; `[office]` — **Word/Excel** (`.docx`/`.xlsx`) ingestion.
+  Markdown, `.rst`, `.txt` and **HTML** need no extra. Without an extra those files are simply
+  skipped, so a base install still ingests everything it can read.
 - `[mcp]` (MCP client), `[otel]` (live tracing)
 
 ### Upgrading
@@ -134,7 +135,8 @@ to refresh (`--refresh` re-extracts instead of using the commit cache). Commit
 `episteme/` so your team — and any AI tool — reads the same project truth.
 
 Your repo's **documentation** is folded in at the same time: Markdown, reST, and plain-text
-docs (and **PDF**, with the `[docs]` extra) become `Doc` nodes linked to the code they
+docs and **HTML** (plus **PDF** with `[docs]`, and **Word/Excel** with `[office]`) become
+`Doc` nodes linked to the code they
 describe. Nothing to turn on — a repo with no docs just skips it. This powers the
 **Documentation** section in `state` (below) and the `docs_for` `/spine` tool.
 
@@ -314,6 +316,28 @@ accumulates its own code-true memory as it grows.
 This is the core loop, with zero infrastructure. It reads one requirement, writes
 code grounded in the target repo's own structure, generates tests, and leaves you
 a **local branch + diff** to inspect. No pushes, no PRs, nothing external.
+
+The full pipeline, and where **you** stay in control — nothing crosses a gate without you:
+
+```mermaid
+flowchart LR
+    src["Requirements source<br/>(Confluence · Jira<br/>OpenSpec · file)"]
+    intent["Intents + specs"]
+    gate1["HUMAN GATE<br/>approve intents"]
+    code["Grounded codegen<br/>+ tests (refine loop)"]
+    review["Review + verify"]
+    gate2["HUMAN GATE<br/>approve merge"]
+    pr["PR opened / merged"]
+    src --> intent
+    intent --> gate1
+    gate1 --> code
+    code --> review
+    review --> gate2
+    gate2 --> pr
+```
+
+> `sdlc feature --safe` (this step) runs the middle of that flow locally and stops at a
+> branch + diff. The two gates are enforced by the autonomous `sdlc run` (Step 7).
 
 ```bash
 orchestrator sdlc feature --source confluence://<page_id> --safe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.8.1"
+version = "3.8.2"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }
@@ -85,11 +85,18 @@ sql-postgres = [
     "testcontainers>=4",
     "psycopg[binary]>=3",
 ]
-# Doc ingestion — PDF support. Markdown/RST/plain-text parse with stdlib; PDF
+# Doc ingestion — PDF support. Markdown/RST/plain-text/HTML parse with stdlib; PDF
 # needs a parser (pypdf, pure-Python), lazy-imported by pkg/doc_source.py so the
 # base install stays stdlib-only: pip install 'synaptixs-spine[docs]'.
 docs = [
     "pypdf>=4",
+]
+# Doc ingestion — Office documents (.docx/.xlsx). Kept out of `[docs]` because that
+# extra's promise is "pure-Python and tiny"; openpyxl is heavier. Same lazy-import
+# contract: pip install 'synaptixs-spine[office]'.
+office = [
+    "python-docx>=1.1",
+    "openpyxl>=3.1",
 ]
 # Onboard external MCP servers (DBs, Atlassian, …) as orchestrator tools. The
 # MCP client lazy-imports this, so the base install stays MCP-free.
@@ -133,6 +140,9 @@ dev = [
     # PDF doc-ingestion parser — pure-Python, so CI exercises the PDF path in
     # doc_source directly rather than skipping it.
     "pypdf>=4",
+    # Office doc-ingestion parsers, so CI exercises the .docx/.xlsx readers too.
+    "python-docx>=1.1",
+    "openpyxl>=3.1",
 ]
 
 [project.scripts]
@@ -257,6 +267,12 @@ ignore_missing_imports = true
 # pkg/doc_source.py; not guaranteed in every env, so don't fail on its absence.
 [[tool.mypy.overrides]]
 module = ["pypdf", "pypdf.*"]
+ignore_missing_imports = true
+
+# `python-docx` (imports as `docx`) and `openpyxl` are the optional `office` extra,
+# lazy-imported by pkg/doc_source.py; not guaranteed in every env.
+[[tool.mypy.overrides]]
+module = ["docx", "docx.*", "openpyxl", "openpyxl.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/scripts/check-mermaid.js
+++ b/scripts/check-mermaid.js
@@ -1,0 +1,55 @@
+// Verify every ```mermaid block in a markdown file actually renders through Spine's OWN
+// renderer (web/static/md.js), instead of silently falling back to a <pre> code block.
+//
+// Why this exists: `md.js` ships a ~90-line hand-rolled `mermaidSvg()` (no build step, must
+// work air-gapped) that supports only a small subset — `flowchart LR|TD|TB|RL`, quoted node
+// declarations `id["label"]`, `subgraph x["Zone"]`/`end`, and bare-id edges `a --> b` /
+// `a -->|label| b`. Anything outside it (chained `a --> b --> c`, dotted `-. x .->`,
+// decision `c{...}`, or a node declared inline in an edge line) makes the whole block fall
+// back to <pre>. GitHub renders those diagrams fine, so a broken one is invisible until you
+// open our own web UI — which is how five diagrams sat broken in KNOWLEDGE_GRAPH.md.
+//
+//     node scripts/check-mermaid.js *.md
+//
+// Exits non-zero if any block falls back, so it can gate a commit or CI step.
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const MD_JS = path.join(__dirname, "..", "src", "orchestrator", "registry", "api", "web", "static", "md.js");
+
+const targets = process.argv.slice(2);
+if (!targets.length) {
+  console.error("usage: node scripts/check-mermaid.js <file.md> [...]");
+  process.exit(2);
+}
+
+const sandbox = { window: {}, console };
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(MD_JS, "utf8"), sandbox);
+const render = sandbox.window.renderMarkdown;
+if (typeof render !== "function") {
+  console.error(`FAIL: ${MD_JS} did not expose window.renderMarkdown`);
+  process.exit(2);
+}
+
+let fail = 0;
+let total = 0;
+for (const target of targets) {
+  const text = fs.readFileSync(target, "utf8");
+  const blocks = [...text.matchAll(/```mermaid\n([\s\S]*?)```/g)].map((m) => m[1]);
+  blocks.forEach((body, i) => {
+    total++;
+    const ok = render("```mermaid\n" + body + "```").includes('<figure class="mermaid"><svg');
+    if (!ok) fail++;
+    const head = (body.split("\n").find((l) => l.trim()) || "").trim().slice(0, 40);
+    console.log(`  ${ok ? "ok      " : "FALLBACK"}  ${target} [block ${i + 1}] ${head}`);
+  });
+}
+
+if (!total) {
+  console.log("no mermaid blocks found");
+  process.exit(0);
+}
+console.log(`\n${total - fail}/${total} render as inline SVG${fail ? ` — ${fail} FELL BACK to <pre>` : ""}`);
+process.exit(fail ? 1 : 0);

--- a/src/orchestrator/knowledge/current_state.py
+++ b/src/orchestrator/knowledge/current_state.py
@@ -614,7 +614,7 @@ def _documentation_section(s: CurrentState) -> list[str]:
         "## Documentation",
         "",
         "_Repo docs folded into the graph (`Doc` nodes + `MENTIONS` edges). Deterministic — "
-        + "a mention counts only when it binds to exactly one symbol._",
+        "a mention counts only when it binds to exactly one symbol._",
         "",
         f"- **{s.docs} doc{'s' if s.docs != 1 else ''}** ingested; they name "
         f"**{s.documented_symbols} of {s.coverable_symbols} symbols** ({pct}% doc coverage).",

--- a/src/orchestrator/pkg/doc_source.py
+++ b/src/orchestrator/pkg/doc_source.py
@@ -1,30 +1,34 @@
 """Read a repo's documentation files into ``DocPage`` rows for the doc-semantic layer.
 
-The counterpart to the language extractors, for prose: walk a repository for
-documentation — text (``.md`` / ``.rst`` / ``.txt`` / ``.markdown``) and **PDF** — and hand
+The counterpart to the language extractors, for prose: walk a repository for documentation —
+markdown, ``.rst``/``.txt``, **HTML**, **PDF**, and **Office** (``.docx``/``.xlsx``) — and hand
 each file to ``pkg.docs`` as a ``DocPage`` (title = repo-relative path, so mentions resolve
 relative to the doc). Deterministic, no LLM, no network.
 
-Text parses with the stdlib. **PDF** needs a parser (``pypdf``, pure-Python) behind the
-optional ``[docs]`` extra, lazy-imported so the base install stays stdlib-only. A PDF with
-no extractable text (a scanned image — no OCR) yields nothing and is skipped; so is any PDF
-when ``pypdf`` isn't installed. Either way ``read_doc_pages`` returns the text docs it could
-read — PDFs are additive, never a hard dependency.
+Formats **register** rather than branch: each is a :class:`DocReader` on the module registry
+(see :func:`register_reader`), so adding one touches no existing reader and no dispatch code.
+A reader returning ``None`` means *skip this file* — too large, unparseable, or an optional
+dependency is missing. Skipping is always non-fatal: an unreadable format is absent from the
+graph, never an error.
+
+Markdown, text, and HTML parse with the stdlib. **PDF** needs ``pypdf`` behind the optional
+``[docs]`` extra; **Office** needs ``python-docx``/``openpyxl`` behind ``[office]``. Both are
+lazy-imported so the base install stays stdlib-only, and an absent extra just means those files
+are skipped — as is a scanned PDF (no extractable text; we don't OCR) or an encrypted document.
 """
 
 from __future__ import annotations
 
 import os
 import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from html.parser import HTMLParser
 from pathlib import Path
 
 from orchestrator.pkg.docs import DocPage
 from orchestrator.pkg.extractor import DEFAULT_IGNORE_DIRS
 
-# Text documentation suffixes (lowercased); PDF is handled separately (needs `[docs]`).
-_TEXT_SUFFIXES = frozenset({".md", ".markdown", ".rst", ".txt"})
-_MARKDOWN_SUFFIXES = frozenset({".md", ".markdown"})
-_PDF_SUFFIX = ".pdf"
 # Skip absurdly large docs (generated dumps, vendored changelogs) — keep the graph legible.
 _MAX_DOC_BYTES = 1_000_000
 # PDFs are binary and legitimately larger; cap bytes and pages so a giant scan can't stall a walk.
@@ -38,10 +42,45 @@ _MAX_SECTIONS = 40
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
 
 
+@dataclass(frozen=True)
+class DocReader:
+    """How one family of file suffixes becomes a doc's text.
+
+    ``read`` returns the doc's text, or ``None`` to **skip** the file — too large, unparseable,
+    or an optional dependency isn't installed. Skipping is always non-fatal: a format we can't
+    read is simply absent from the graph, never an error (the ``pypdf`` precedent).
+
+    ``sections=True`` marks formats whose text carries markdown-style ATX headings, so
+    :func:`split_sections` can split them into section-granular pages. A format that doesn't
+    (plain text, PDF) stays one page per file.
+    """
+
+    name: str
+    suffixes: frozenset[str]
+    read: Callable[[Path], str | None]
+    sections: bool = False
+
+
+_READERS: dict[str, DocReader] = {}
+
+
+def register_reader(reader: DocReader) -> None:
+    """Register ``reader`` for each of its suffixes (last registration wins).
+
+    This is the seam new formats plug into: adding one touches no existing reader and no
+    dispatch branch. Suffixes are matched lowercased.
+    """
+    for suffix in reader.suffixes:
+        _READERS[suffix.lower()] = reader
+
+
 def is_doc_file(path: Path) -> bool:
-    """True for a text-doc or PDF suffix (PDF still needs the ``[docs]`` extra to *read*)."""
-    suffix = path.suffix.lower()
-    return suffix in _TEXT_SUFFIXES or suffix == _PDF_SUFFIX
+    """True when some registered reader claims this suffix.
+
+    A claimed suffix still may not *read* — PDF needs the ``[docs]`` extra — but it is a
+    documentation file as far as the walker is concerned.
+    """
+    return path.suffix.lower() in _READERS
 
 
 def _slug(heading: str) -> str:
@@ -122,18 +161,15 @@ def read_doc_pages(root: Path | str, *, sections: bool = True) -> list[DocPage]:
         dirnames[:] = sorted(d for d in dirnames if d not in DEFAULT_IGNORE_DIRS and not d.startswith("."))
         for name in sorted(filenames):
             path = Path(dirpath) / name
-            suffix = path.suffix.lower()
-            if suffix in _TEXT_SUFFIXES:
-                text = _read_text(path)
-            elif suffix == _PDF_SUFFIX:
-                text = _read_pdf(path)
-            else:
+            reader = _READERS.get(path.suffix.lower())
+            if reader is None:
                 continue
+            text = reader.read(path)
             if text is None:
                 continue
             rel = path.relative_to(root_path).as_posix()
             page = DocPage(title=rel, text=text, base_dir=Path(rel).parent.as_posix(), source_file=rel)
-            if sections and suffix in _MARKDOWN_SUFFIXES:
+            if sections and reader.sections:
                 pages.extend(split_sections(page))
             else:
                 pages.append(page)
@@ -158,4 +194,293 @@ def _read_pdf(path: Path) -> str | None:
     return _read_pdf_text(path)
 
 
-__all__ = ["is_doc_file", "read_doc_pages", "split_sections"]
+# ---- HTML -------------------------------------------------------------------
+
+_HTML_SKIP_TAGS = frozenset({"script", "style", "noscript", "template", "svg"})
+# Tags after which a line break keeps the flattened text readable (and keeps a heading on
+# its own line, which is what makes the markdown-heading trick below work).
+_HTML_BLOCK_TAGS = frozenset(
+    {
+        "p", "div", "section", "article", "header", "footer", "aside", "main", "nav",
+        "ul", "ol", "li", "table", "tr", "td", "th", "br", "hr", "pre", "blockquote",
+        "dl", "dt", "dd", "figcaption",
+    }
+)  # fmt: skip
+_HTML_HEADING_TAG_RE = re.compile(r"h([1-6])")
+# Inline code tags → backticks. `<code>Invoice</code>` is HTML's way of saying `Invoice`, and
+# the binder treats a backticked mention as a high-confidence code claim. Flattening these to
+# bare words would throw away the strongest signal an HTML doc carries.
+_HTML_CODE_TAGS = frozenset({"code", "tt", "kbd", "samp", "var"})
+_CODE_SPAN_RE = re.compile(r"`\s*([^`\n]*?)\s*`")
+
+
+class _HtmlToText(HTMLParser):
+    """Flatten HTML to markdown-ish text, turning ``<h1>``…``<h6>`` into ATX headings.
+
+    Emitting ``#``-style headings is the whole trick: ``split_sections`` then treats an HTML
+    doc exactly like a markdown one, so HTML gets section granularity for free and nothing
+    downstream needs to know HTML exists. Inline ``<code>`` becomes a backtick span for the
+    same reason — it lands in the binder as the high-confidence mention it already was.
+
+    ``<script>``/``<style>`` content is dropped — it's code, not prose, and would otherwise
+    produce a stream of junk mentions.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._out: list[str] = []
+        self._skip = 0
+        self._pre = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in _HTML_SKIP_TAGS:
+            self._skip += 1
+            return
+        if tag == "pre":
+            self._pre += 1
+        if (m := _HTML_HEADING_TAG_RE.fullmatch(tag)) is not None:
+            self._out.append("\n" + "#" * int(m.group(1)) + " ")
+        elif tag in _HTML_CODE_TAGS:
+            # Only *inline* code becomes a backtick span; inside <pre> it's a whole sample, and
+            # wrapping that would produce one enormous backticked "mention" that binds to nothing.
+            if not self._pre:
+                self._out.append(" `")
+        elif tag in _HTML_BLOCK_TAGS:
+            self._out.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in _HTML_SKIP_TAGS:
+            self._skip = max(0, self._skip - 1)
+            return
+        if _HTML_HEADING_TAG_RE.fullmatch(tag) is not None:
+            self._out.append("\n")
+        elif tag in _HTML_CODE_TAGS:
+            if not self._pre:
+                self._out.append("` ")
+        elif tag in _HTML_BLOCK_TAGS:
+            self._out.append("\n")
+        if tag == "pre":
+            self._pre = max(0, self._pre - 1)
+
+    def handle_data(self, data: str) -> None:
+        if self._skip:
+            return
+        text = " ".join(data.split())  # collapse whitespace; block tags supply the newlines
+        if text:
+            self._out.append(text + " ")
+
+    def text(self) -> str:
+        """The flattened text, with code spans tightened and blank-line runs collapsed."""
+        # `handle_data` pads each chunk with a trailing space, so a code span arrives as
+        # "` Invoice `". Tighten it to "`Invoice`" — the binder matches the span's exact
+        # contents, so stray whitespace would stop it resolving. Empty spans are dropped.
+        joined = _CODE_SPAN_RE.sub(lambda m: f"`{m.group(1)}`" if m.group(1) else "", "".join(self._out))
+        out: list[str] = []
+        for raw_line in joined.splitlines():
+            line = re.sub(r"[ \t]{2,}", " ", raw_line).strip()
+            if line or (out and out[-1]):
+                out.append(line)
+        return "\n".join(out).strip()
+
+
+def _read_html(path: Path) -> str | None:
+    raw = _read_text(path)  # reuses the size cap + UTF-8 handling
+    if raw is None:
+        return None
+    parser = _HtmlToText()
+    try:
+        parser.feed(raw)
+        parser.close()
+    except Exception:  # noqa: BLE001 — malformed markup must not fail the walk
+        return None
+    return parser.text() or None
+
+
+# ---- Office (.docx / .xlsx) -------------------------------------------------
+# Both need the `[office]` extra, lazy-imported like `pypdf`: absent → the format is simply
+# skipped. Office files are ZIP containers, so they're binary — `_read_text` never applies.
+
+_MAX_OFFICE_BYTES = 25_000_000
+_MAX_SHEETS = 20
+_MAX_SHEET_ROWS = 500
+_DOCX_HEADING_RE = re.compile(r"heading\s+([1-6])")
+# Fonts Word documents use for inline code. A run in one of these (or in a character style
+# named "…Code…") is the .docx equivalent of a markdown backtick.
+_DOCX_CODE_FONTS = frozenset(
+    {"courier", "courier new", "consolas", "monaco", "menlo", "lucida console", "cascadia mono"}
+)
+
+
+def _docx_heading_level(style_name: str) -> int:
+    """Word's ``Heading 1``…``Heading 6`` → 1–6; ``Title`` → 1; anything else → 0.
+
+    Word's built-in heading styles are the structural equivalent of markdown's ``#`` levels,
+    so mapping them gives ``.docx`` the same section granularity as markdown and HTML.
+    """
+    name = style_name.strip().lower()
+    if name == "title":
+        return 1
+    match = _DOCX_HEADING_RE.fullmatch(name)
+    return int(match.group(1)) if match else 0
+
+
+def _docx_paragraph_text(paragraph: object) -> str:
+    """A paragraph's text, with code-styled runs wrapped in backticks.
+
+    Word marks inline code either with a character style whose name contains "code" or with a
+    monospace font. That is the ``.docx`` equivalent of a markdown backtick or an HTML
+    ``<code>``, and the binder treats a backticked mention as a high-confidence claim — so
+    preserving it is what makes a real Word spec bind instead of reading as plain prose.
+
+    Runs are concatenated *without* inserting separators: Word splits a single word across runs
+    freely (spell-check, formatting), so joining on spaces would fracture identifiers.
+    """
+    parts: list[str] = []
+    for run in getattr(paragraph, "runs", []):
+        text: str = run.text or ""
+        if not text:
+            continue
+        style = (getattr(getattr(run, "style", None), "name", "") or "").lower()
+        font = (getattr(getattr(run, "font", None), "name", "") or "").lower()
+        stripped = text.strip()
+        if stripped and ("code" in style or font in _DOCX_CODE_FONTS):
+            # replace() keeps the run's own leading/trailing spacing intact.
+            parts.append(text.replace(stripped, f"`{stripped}`", 1))
+        else:
+            parts.append(text)
+    raw = "".join(parts) if parts else str(getattr(paragraph, "text", ""))
+    return " ".join(raw.split())
+
+
+def _read_docx(path: Path) -> str | None:
+    """A ``.docx``'s text, with Word heading styles emitted as ATX headings."""
+    try:
+        import docx
+    except ImportError:
+        return None
+    try:
+        if path.stat().st_size > _MAX_OFFICE_BYTES:
+            return None
+        document = docx.Document(str(path))
+        parts: list[str] = []
+        for paragraph in document.paragraphs:
+            text = _docx_paragraph_text(paragraph)
+            if not text:
+                continue
+            level = _docx_heading_level(getattr(paragraph.style, "name", "") or "")
+            parts.append(f"{'#' * level} {text}" if level else text)
+        # Tables carry real content in spec documents (API tables, field lists), so keep the
+        # cell text as prose rows rather than dropping it.
+        for table in document.tables:
+            for row in table.rows:
+                cells = [" ".join(cell.text.split()) for cell in row.cells]
+                line = " · ".join(c for c in cells if c)
+                if line:
+                    parts.append(line)
+    except Exception:  # noqa: BLE001 — encrypted/corrupt docx raises assorted errors
+        return None
+    return "\n\n".join(parts) or None
+
+
+def _read_xlsx(path: Path) -> str | None:
+    """A workbook's text: one ATX section per sheet, string cells joined as prose.
+
+    Only *string* cells are kept — numbers, dates and formula results are data, not prose
+    about code, and would add noise without ever binding. Bounded by sheet and row caps.
+    """
+    try:
+        import openpyxl
+    except ImportError:
+        return None
+    book = None
+    try:
+        if path.stat().st_size > _MAX_OFFICE_BYTES:
+            return None
+        book = openpyxl.load_workbook(str(path), read_only=True, data_only=True)
+        parts: list[str] = []
+        for name in book.sheetnames[:_MAX_SHEETS]:
+            rows: list[str] = []
+            for row in book[name].iter_rows(max_row=_MAX_SHEET_ROWS, values_only=True):
+                cells = [" ".join(v.split()) for v in row if isinstance(v, str) and v.strip()]
+                if cells:
+                    rows.append(" · ".join(cells))
+            if rows:
+                parts.append(f"# {name}\n" + "\n".join(rows))
+    except Exception:  # noqa: BLE001 — encrypted/corrupt workbooks raise assorted errors
+        return None
+    finally:
+        if book is not None:
+            book.close()
+    return "\n\n".join(parts) or None
+
+
+# ---- markdown front matter --------------------------------------------------
+
+_FRONT_MATTER_RE = re.compile(r"\A---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|\Z)", re.DOTALL)
+
+
+def _front_matter_prose(block: str) -> str:
+    """The *values* of a YAML front-matter block, one per line.
+
+    Keys are dropped deliberately: ``module: billing.invoice`` is a claim about
+    ``billing.invoice``, not about the word "module". Keeping keys would feed the binder a
+    stream of config-shaped identifiers and inflate drift with things no one wrote as prose.
+    Deliberately line-based, not a YAML parse — this needs no dependency, and front matter that
+    isn't valid YAML (templated, hand-edited) still yields its values instead of nothing.
+    """
+    out: list[str] = []
+    for line in block.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- "):
+            value = stripped[2:]
+        elif ":" in stripped:
+            value = stripped.split(":", 1)[1]
+        else:
+            value = stripped
+        value = value.strip().strip("'\"")
+        if value:
+            out.append(value)
+    return "\n".join(out)
+
+
+def _read_markdown(path: Path) -> str | None:
+    """Markdown text, with any YAML front matter reduced to its values.
+
+    Front matter is document *metadata* (``title:``, ``module:``, ``tags:``). Left raw, the
+    ``---`` fences and bare ``key:`` names leak into mention extraction as noise; reduced to
+    values, a ``module: billing.invoice`` front-matter line binds like the prose it stands for.
+    """
+    raw = _read_text(path)
+    if raw is None:
+        return None
+    match = _FRONT_MATTER_RE.match(raw)
+    if match is None:
+        return raw
+    prose = _front_matter_prose(match.group(1))
+    body = raw[match.end() :]
+    return f"{prose}\n\n{body}" if prose else body
+
+
+# ---- built-in readers -------------------------------------------------------
+# Registered here rather than branched in `read_doc_pages`, so a new format is one
+# `register_reader` call and touches nothing that already works.
+
+register_reader(DocReader("markdown", frozenset({".md", ".markdown"}), _read_markdown, sections=True))
+register_reader(DocReader("text", frozenset({".rst", ".txt"}), _read_text))
+register_reader(DocReader("html", frozenset({".html", ".htm"}), _read_html, sections=True))
+register_reader(DocReader("pdf", frozenset({".pdf"}), _read_pdf))
+register_reader(DocReader("docx", frozenset({".docx"}), _read_docx, sections=True))
+register_reader(DocReader("xlsx", frozenset({".xlsx"}), _read_xlsx, sections=True))
+
+# NOT registered: standalone `.yaml`/`.yml`. A repo's YAML is overwhelmingly *configuration*
+# (CI workflows, compose files, manifests), not documentation, and ingesting it would corrupt
+# the two doc surfaces we just built: `state`'s doc-coverage would climb because a CI file
+# happens to name a module, and `doc_drift` would flag every identifier-shaped config value as
+# a stale documentation claim. YAML's genuinely documentary case — front matter on a markdown
+# doc — is handled by `_read_markdown` above. A repo that wants config ingested can
+# `register_reader` a YAML reader itself.
+
+
+__all__ = ["DocReader", "is_doc_file", "read_doc_pages", "register_reader", "split_sections"]

--- a/tests/pkg/test_doc_source.py
+++ b/tests/pkg/test_doc_source.py
@@ -1,0 +1,231 @@
+"""The doc-reader seam: formats register, they don't branch.
+
+`test_doc_link.py` covers what ingestion *produces* (Doc nodes, MENTIONS, drift). This file
+covers the reader layer itself — the registry, and each format's text extraction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from orchestrator.pkg.doc_source import (
+    _READERS,
+    DocReader,
+    _docx_heading_level,
+    is_doc_file,
+    read_doc_pages,
+    register_reader,
+)
+
+
+@pytest.fixture
+def restore_readers() -> Iterator[None]:
+    """Snapshot/restore the global registry so a test registration can't leak."""
+    saved = dict(_READERS)
+    yield
+    _READERS.clear()
+    _READERS.update(saved)
+
+
+# ---- the seam ---------------------------------------------------------------
+
+
+def test_builtin_readers_are_registered() -> None:
+    for suffix in (".md", ".markdown", ".rst", ".txt", ".html", ".htm", ".pdf", ".docx", ".xlsx"):
+        assert suffix in _READERS, suffix
+    # Formats that carry headings are section-split; flat ones are not.
+    assert _READERS[".html"].sections is True
+    assert _READERS[".md"].sections is True
+    assert _READERS[".docx"].sections is True
+    assert _READERS[".rst"].sections is False
+    assert _READERS[".pdf"].sections is False
+    assert _READERS[".rst"].sections is False
+    assert _READERS[".pdf"].sections is False
+
+
+def test_register_reader_adds_a_format_without_touching_dispatch(
+    tmp_path: Path, restore_readers: None
+) -> None:
+    register_reader(DocReader("shouty", frozenset({".loud"}), lambda p: p.read_text().upper()))
+    (tmp_path / "note.loud").write_text("calls `validate`\n", encoding="utf-8")
+
+    assert is_doc_file(Path("x.loud"))
+    pages = {p.title: p.text for p in read_doc_pages(tmp_path)}
+    assert pages["note.loud"].strip() == "CALLS `VALIDATE`"
+
+
+def test_reader_returning_none_skips_the_file(tmp_path: Path, restore_readers: None) -> None:
+    register_reader(DocReader("never", frozenset({".nope"}), lambda _p: None))
+    (tmp_path / "a.nope").write_text("ignored\n", encoding="utf-8")
+    (tmp_path / "b.md").write_text("kept\n", encoding="utf-8")
+    # A reader that declines is non-fatal — the walk continues (the pypdf precedent).
+    assert {p.title for p in read_doc_pages(tmp_path)} == {"b.md"}
+
+
+def test_unregistered_suffix_is_ignored(tmp_path: Path) -> None:
+    (tmp_path / "app.py").write_text("x = 1\n", encoding="utf-8")
+    assert read_doc_pages(tmp_path) == []
+    assert not is_doc_file(Path("app.py"))
+
+
+# ---- HTML (G2 phase 1) ------------------------------------------------------
+
+_HTML_DOC = """<html><head>
+<style>.a{color:red}</style>
+<script>var apply_discount = 1;</script>
+</head><body>
+<h1>Overview</h1>
+<p>Nothing to see.</p>
+<h2>Billing</h2>
+<p>The <code>Invoice</code> type totals lines; see <code>calc_tax</code>.</p>
+<pre><code>Invoice().total()</code></pre>
+</body></html>
+"""
+
+
+def test_html_headings_become_sections(tmp_path: Path) -> None:
+    (tmp_path / "guide.html").write_text(_HTML_DOC, encoding="utf-8")
+    pages = {p.title: p for p in read_doc_pages(tmp_path)}
+    # <h1>/<h2> map to ATX headings, so split_sections treats HTML exactly like markdown.
+    assert set(pages) == {"guide.html#overview", "guide.html#billing"}
+    assert pages["guide.html#billing"].source_file == "guide.html"
+
+
+def test_html_inline_code_becomes_backticks(tmp_path: Path) -> None:
+    (tmp_path / "guide.html").write_text(_HTML_DOC, encoding="utf-8")
+    billing = next(p for p in read_doc_pages(tmp_path) if p.title.endswith("#billing"))
+    # <code>X</code> is HTML's backtick — preserved so the binder sees a high-confidence claim.
+    assert "`Invoice`" in billing.text
+    assert "`calc_tax`" in billing.text
+
+
+def test_html_drops_script_and_style(tmp_path: Path) -> None:
+    (tmp_path / "guide.html").write_text(_HTML_DOC, encoding="utf-8")
+    text = " ".join(p.text for p in read_doc_pages(tmp_path))
+    assert "apply_discount" not in text  # <script> body is code, not prose
+    assert "color:red" not in text
+
+
+def test_html_pre_block_is_not_backticked(tmp_path: Path) -> None:
+    (tmp_path / "guide.html").write_text(_HTML_DOC, encoding="utf-8")
+    text = " ".join(p.text for p in read_doc_pages(tmp_path))
+    # The sample survives as plain text, but isn't wrapped into one giant backtick span.
+    assert "Invoice().total()" in text
+    assert "`Invoice().total()`" not in text
+
+
+def test_html_without_headings_stays_whole(tmp_path: Path) -> None:
+    (tmp_path / "flat.html").write_text("<p>just <code>prose</code> here</p>", encoding="utf-8")
+    assert [p.title for p in read_doc_pages(tmp_path)] == ["flat.html"]
+
+
+def test_malformed_html_is_skipped_not_fatal(tmp_path: Path) -> None:
+    (tmp_path / "bad.html").write_text("<<<>>> \x00 not really markup", encoding="utf-8")
+    (tmp_path / "ok.md").write_text("fine\n", encoding="utf-8")
+    assert "ok.md" in {p.title for p in read_doc_pages(tmp_path)}
+
+
+# ---- markdown front matter (G2 phase 1) -------------------------------------
+
+
+def test_front_matter_keeps_values_drops_keys(tmp_path: Path) -> None:
+    (tmp_path / "spec.md").write_text(
+        "---\ntitle: Billing spec\nmodule: 'billing.tax.calc_tax'\ntags:\n  - finance\n---\n\nbody prose\n",
+        encoding="utf-8",
+    )
+    text = read_doc_pages(tmp_path)[0].text
+    assert "billing.tax.calc_tax" in text  # the value is a real code claim
+    assert "finance" in text and "Billing spec" in text
+    assert "module:" not in text and "---" not in text  # keys and fences are noise
+    assert "body prose" in text
+
+
+def test_markdown_without_front_matter_is_untouched(tmp_path: Path) -> None:
+    (tmp_path / "plain.md").write_text("# Title\n\nsome `calc_tax` prose\n", encoding="utf-8")
+    assert read_doc_pages(tmp_path, sections=False)[0].text == "# Title\n\nsome `calc_tax` prose\n"
+
+
+def test_standalone_yaml_is_not_ingested(tmp_path: Path) -> None:
+    """Config is not documentation — see the note by the reader registrations.
+
+    Ingesting CI/compose/manifest YAML would inflate `state`'s doc-coverage and flood
+    doc_drift with identifier-shaped config values."""
+    (tmp_path / "docker-compose.yml").write_text("services:\n  api:\n    image: app\n", encoding="utf-8")
+    (tmp_path / "ci.yaml").write_text("jobs:\n  test:\n    run: orchestrator.cli\n", encoding="utf-8")
+    assert read_doc_pages(tmp_path) == []
+
+
+# ---- Office (G2 phase 2) ----------------------------------------------------
+
+
+def _docx(path: Path) -> None:
+    """A realistic Word spec: heading styles, a monospace code run, and a table."""
+    docx = pytest.importorskip("docx")  # the [office] extra
+    doc = docx.Document()
+    doc.add_heading("Billing Architecture", level=1)
+    doc.add_paragraph("Overview prose.")
+    doc.add_heading("Tax", level=2)
+    para = doc.add_paragraph("Applied by ")
+    run = para.add_run("calc_tax")
+    run.font.name = "Consolas"  # Word's inline code
+    para.add_run(" before totalling.")
+    table = doc.add_table(rows=1, cols=2)
+    table.rows[0].cells[0].text = "Symbol"
+    table.rows[0].cells[1].text = "apply_discount"
+    doc.save(str(path))
+
+
+def test_docx_heading_styles_become_sections(tmp_path: Path) -> None:
+    _docx(tmp_path / "spec.docx")
+    titles = {p.title for p in read_doc_pages(tmp_path)}
+    # Word "Heading 1"/"Heading 2" map to ATX levels, so .docx sections like markdown does.
+    assert titles == {"spec.docx#billing-architecture", "spec.docx#tax"}
+
+
+def test_docx_monospace_run_becomes_backticks(tmp_path: Path) -> None:
+    _docx(tmp_path / "spec.docx")
+    tax = next(p for p in read_doc_pages(tmp_path) if p.title.endswith("#tax"))
+    # A Consolas run is Word's inline code — preserved as a high-confidence claim.
+    assert "`calc_tax`" in tax.text
+    # Runs concatenate without inserted separators, so identifiers aren't fractured.
+    assert "cal c_tax" not in tax.text
+
+
+def test_docx_table_text_is_kept(tmp_path: Path) -> None:
+    _docx(tmp_path / "spec.docx")
+    text = " ".join(p.text for p in read_doc_pages(tmp_path))
+    assert "apply_discount" in text  # spec tables carry real content
+
+
+def test_docx_heading_level_mapping() -> None:
+    assert _docx_heading_level("Heading 1") == 1
+    assert _docx_heading_level("heading 6") == 6
+    assert _docx_heading_level("Title") == 1
+    assert _docx_heading_level("Normal") == 0
+    assert _docx_heading_level("Heading 9") == 0  # outside ATX range
+
+
+def test_xlsx_sheet_becomes_a_section_with_string_cells(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")  # the [office] extra
+    book = openpyxl.Workbook()
+    sheet = book.active
+    sheet.title = "API Surface"
+    sheet.append(["Endpoint", "Handler"])
+    sheet.append(["/invoices", "calc_tax"])
+    sheet.append([1, 2.5])  # numeric row: data, not prose
+    book.save(str(tmp_path / "matrix.xlsx"))
+
+    pages = {p.title: p.text for p in read_doc_pages(tmp_path)}
+    assert "matrix.xlsx#api-surface" in pages
+    assert "calc_tax" in pages["matrix.xlsx#api-surface"]
+    assert "2.5" not in pages["matrix.xlsx#api-surface"]
+
+
+def test_corrupt_office_file_is_skipped_not_fatal(tmp_path: Path) -> None:
+    (tmp_path / "broken.docx").write_bytes(b"not a zip at all")
+    (tmp_path / "broken.xlsx").write_bytes(b"also not a zip")
+    (tmp_path / "ok.md").write_text("fine\n", encoding="utf-8")
+    assert {p.title for p in read_doc_pages(tmp_path)} == {"ok.md"}


### PR DESCRIPTION
Automated sync from the private repo @ 9866b4e (v3.8.2).

## What's in this release
- chore(release): 3.8.2 — HTML + Office doc ingestion
- feat(pkg): ingest Word + Excel documents (G2 phase 2)
- feat(pkg): ingest HTML docs + markdown front matter (G2 phase 1)
- refactor(pkg): extract a doc-reader registry from doc_source (G2 Wave 0.1)
- docs: make every mermaid diagram render in Spine's own UI, add two more
- docs: track CLI_REFERENCE.md into the repo

Merge to release.