### PR TITLE
feat(java): extract JAX-RS endpoints

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -35,7 +35,7 @@ radius) and grounds new code in what already exists. Full guide:
 | Multi-language comprehension + codegen — Python, Java, TypeScript, C#, C, C++, Go | ✅ | automatic per repo |
 | SQL data-layer comprehension — schema, queries, stored procedures, migration folding | ✅ | `pip install 'synaptixs-spine[sql]'`; `.sql` per repo |
 | SQL greenfield codegen — generate a migration, validate on an ephemeral DB | ✅ | `sdlc feature --language sql` (in-memory SQLite; `SDLC_SQL_ENGINE=postgres` for real Postgres) |
-| Framework-aware edges — ASP.NET Core endpoints, EF Core entities (C#) | ✅ | emitted into the PKG on `pkg extract` / `understand` |
+| Framework-aware edges — JAX-RS endpoints (Java); ASP.NET Core endpoints and EF Core entities (C#) | ✅ | emitted into the PKG on `pkg extract` / `understand` |
 | C `#include` graph + header/source merge; codegen on **CMake or Meson** | ✅ | `.c`/`.h` per repo; `sdlc feature --language c` |
 | Go — package-per-directory, call graph, **interface satisfaction** (`IMPLEMENTS` by method-set); codegen built + tested with `go build`/`go test`, multi-module aware | ✅ | `pip install 'synaptixs-spine[go]'`; `.go` per repo; `sdlc feature --language go` |
 | Doc ingestion — folds Markdown/reST/text docs into the PKG as `Doc` nodes + `MENTIONS` edges (which docs describe a symbol); section-granular, precision-first, no LLM | ✅ | automatic on `orchestrator understand` / `orchestrator state` |

--- a/KNOWLEDGE_GRAPH.md
+++ b/KNOWLEDGE_GRAPH.md
@@ -156,12 +156,16 @@ flowchart LR
   | Language | Status | Enable with |
   |---|---|---|
   | Python | ✅ built-in | (default) |
-  | Java | ✅ | `pip install 'synaptixs-spine[java]'` |
+  | Java | ✅ + JAX-RS endpoints | `pip install 'synaptixs-spine[java]'` |
   | TypeScript / TSX | ✅ | `pip install 'synaptixs-spine[typescript]'` |
   | C# | ✅ + framework edges | `pip install 'synaptixs-spine[csharp]'` |
   | C | ✅ + `#include` graph | `pip install 'synaptixs-spine[c]'` |
   | C++ | ✅ classes/namespaces/inheritance | `pip install 'synaptixs-spine[cpp]'` |
   | Go | ✅ + interface satisfaction (`IMPLEMENTS`) | `pip install 'synaptixs-spine[go]'` |
+
+  Java lifts JAX-RS / Jakarta REST resource methods into `Endpoint` nodes with
+  `EXPOSES` edges to their handlers. Both `javax.ws.rs` and `jakarta.ws.rs`
+  annotations are recognized.
 
   C# additionally lifts **framework edges** into the graph: ASP.NET Core controllers
   and Minimal-API routes become `Endpoint` nodes with `EXPOSES` edges to their

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ writes) so you can inspect everything first.
 Graph** of your repo — modules, types, functions, call sites, blast radius — and
 grounds new code in what already exists, so output reads like your team wrote it.
 Works across **Python, Java, TypeScript, C#, C, C++, and Go**, plus **SQL** data-layer
-comprehension (schema, queries, stored procedures, migration folding). It even reads your
+comprehension (schema, queries, stored procedures, migration folding). Java JAX-RS and
+Jakarta REST resources are captured as grounded API endpoints. It even reads your
 **documentation** — Markdown, reST, plain text, and **PDF** — folding it into the graph as
 `Doc` nodes linked to the code they describe, so you can ask *which docs cover this symbol*,
 *how documented the code is*, and *where the docs have drifted from the code*. `orchestrator
@@ -183,7 +184,8 @@ see the [Setup guide](https://github.com/synaptixs/spine/blob/main/SETUP.md).
 
 **Which languages and models?**
 Code generation and comprehension cover **Python, Java, TypeScript, C#, C, C++, and Go**
-(C# also extracts ASP.NET Core endpoints and EF Core entities; C builds the
+(Java also extracts JAX-RS / Jakarta REST endpoints; C# extracts ASP.NET Core endpoints
+and EF Core entities; C builds the
 `#include` graph and merges header declarations with their source definitions; C++ is
 a superset of the C front-end that adds classes, namespaces, inheritance, member
 functions, and templates, and shares C's CMake/Meson + `ctest` codegen; **Go** models a

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -257,8 +257,10 @@ is: `orchestrator understand .` → commit `episteme/`, then re-run whenever the
 > generates a DDL migration for the intent, and validates it by **applying it to an ephemeral
 > database** (in-memory SQLite by default — zero toolchain; set `SDLC_SQL_ENGINE=postgres`
 > with the `[sql-postgres]` extra + Docker for real-Postgres fidelity). A failed apply is the
-> refine signal, exactly like a failing test. For **C#**, the graph additionally captures
-> ASP.NET Core endpoints (`EXPOSES`) and EF Core entities (`REFERENCES`); codegen scaffolds a
+> refine signal, exactly like a failing test. For **Java**, JAX-RS / Jakarta REST resource
+> methods become endpoints with `EXPOSES` edges to their handlers. For **C#**, the graph
+> additionally captures ASP.NET Core endpoints (`EXPOSES`) and EF Core entities
+> (`REFERENCES`); codegen scaffolds a
 > solution + xUnit project and runs `dotnet test` (needs the **.NET SDK**). For **C**,
 > it builds the `#include` graph and merges header declarations with their source
 > definitions; codegen scaffolds a **CMake** project (greenfield) or works in a brownfield

--- a/src/orchestrator/pkg/java_extractor.py
+++ b/src/orchestrator/pkg/java_extractor.py
@@ -10,12 +10,14 @@ base install stays stdlib-only and importing this module never fails.
 Emits the high-confidence declaration subset, precision-first like the Python
 front-end: ``Module`` (the package), ``Type`` (class/interface/enum/record),
 ``Function`` (method/constructor), ``Field`` nodes; ``IMPORTS``, ``CONTAINS``,
-and ``IMPLEMENTS`` (extends + implements) edges. ``CALLS`` is emitted only where
-the callee resolves precisely (a second pass over method bodies): unqualified /
-``this.`` calls to a sibling method, and ``Type.method()`` calls whose ``Type``
-resolves via imports or the same package. Instance calls on a typed variable
-(``obj.method()``) are skipped — they'd need type inference, and a guessed edge
-poisons grounding. Overloads collapse onto one id (no arity in ids).
+and ``IMPLEMENTS`` (extends + implements) edges; JAX-RS / Jakarta REST
+annotations become ``Endpoint`` nodes with ``EXPOSES`` edges to their handler
+methods. ``CALLS`` is emitted only where the callee resolves precisely (a
+second pass over method bodies): unqualified / ``this.`` calls to a sibling
+method, and ``Type.method()`` calls whose ``Type`` resolves via imports or the
+same package. Instance calls on a typed variable (``obj.method()``) are skipped
+— they'd need type inference, and a guessed edge poisons grounding. Overloads
+collapse onto one id (no arity in ids).
 """
 
 from __future__ import annotations
@@ -34,6 +36,15 @@ _PACKAGE_RE = re.compile(r"^\s*package\s+([\w.]+)\s*;", re.M)
 _TYPE_DECLS = frozenset(
     {"class_declaration", "interface_declaration", "enum_declaration", "record_declaration"}
 )
+_HTTP_VERB_ANNOTATIONS = {
+    "GET": "GET",
+    "POST": "POST",
+    "PUT": "PUT",
+    "DELETE": "DELETE",
+    "PATCH": "PATCH",
+    "HEAD": "HEAD",
+    "OPTIONS": "OPTIONS",
+}
 
 
 class JavaExtractor:
@@ -118,6 +129,7 @@ class JavaExtractor:
         body = node.child_by_field_name("body")
         if body is None:
             return
+        class_path = _path_annotation(node, source)
         methods = type_methods.setdefault(type_id, set())
         for member in body.named_children:
             mline = member.start_point[0] + 1
@@ -128,6 +140,8 @@ class JavaExtractor:
                     batch.add_node(Node(fid, NodeKind.FUNCTION, mname, "java", Provenance(rel, mline)))
                     batch.add_edge(Edge(type_id, fid, EdgeKind.CONTAINS, Provenance(rel, mline)))
                     methods.add(mname)
+                    if member.type == "method_declaration":
+                        _jax_rs_endpoints(member, fid, class_path, source, rel, batch)
                     mbody = member.child_by_field_name("body")
                     if mbody is not None:
                         funcs.append((fid, type_id, mbody))
@@ -202,6 +216,128 @@ class JavaExtractor:
         if package:  # same-package sibling type
             return f"java:{package}.{name}"
         return None
+
+
+def _jax_rs_endpoints(
+    method: TSNode,
+    method_id: str,
+    class_path: str | None,
+    source: bytes,
+    rel: str,
+    batch: FactBatch,
+) -> None:
+    """Emit JAX-RS/Jakarta REST endpoints for a verb-annotated handler.
+
+    Annotation names are matched by their final segment, so both ``@GET`` and
+    ``@jakarta.ws.rs.GET`` work. A ``@Path`` without an HTTP verb is a sub-resource
+    locator and is deliberately skipped. ``@Produces``/``@Consumes`` are not
+    captured, and cross-file ``@ApplicationPath`` resolution is out of scope.
+    """
+    annotations = _annotations(method, source)
+    verbs = list(
+        dict.fromkeys(
+            _HTTP_VERB_ANNOTATIONS[name] for name, _ in annotations if name in _HTTP_VERB_ANNOTATIONS
+        )
+    )
+    if not verbs:
+        return
+    method_path = next(
+        (_annotation_string_arg(annotation, source) for name, annotation in annotations if name == "Path"),
+        "",
+    )
+    if class_path is None or method_path is None:
+        return  # a non-literal @Path cannot be grounded precisely
+    full_path = _join_path(class_path, method_path)
+    line = method.start_point[0] + 1
+    provenance = Provenance(rel, line)
+    for verb in verbs:
+        endpoint_id = f"java:endpoint:{verb} {full_path}"
+        batch.add_node(
+            Node(
+                endpoint_id,
+                NodeKind.ENDPOINT,
+                f"{verb} {full_path}",
+                "java",
+                provenance,
+            )
+        )
+        batch.add_edge(Edge(endpoint_id, method_id, EdgeKind.EXPOSES, provenance))
+
+
+def _path_annotation(node: TSNode, source: bytes) -> str | None:
+    """Return ``@Path`` text, empty when absent, or ``None`` when non-literal."""
+    return next(
+        (
+            _annotation_string_arg(annotation, source)
+            for name, annotation in _annotations(node, source)
+            if name == "Path"
+        ),
+        "",
+    )
+
+
+def _annotations(node: TSNode, source: bytes) -> list[tuple[str, TSNode]]:
+    """Return declaration annotations as ``(last dotted name segment, node)``."""
+    modifiers = next((child for child in node.named_children if child.type == "modifiers"), None)
+    if modifiers is None:
+        return []
+    annotations: list[tuple[str, TSNode]] = []
+    for child in modifiers.named_children:
+        if child.type not in ("annotation", "marker_annotation"):
+            continue
+        name = _field_text(child, "name", source).rsplit(".", 1)[-1]
+        if name:
+            annotations.append((name, child))
+    return annotations
+
+
+def _annotation_string_arg(annotation: TSNode, source: bytes) -> str | None:
+    """Return a direct string or ``value = "..."`` argument, else ``None``."""
+    arguments = annotation.child_by_field_name("arguments")
+    if arguments is None:
+        return None
+    for child in arguments.named_children:
+        candidate = child.child_by_field_name("value") if child.type == "element_value_pair" else child
+        if candidate is not None and candidate.type == "string_literal":
+            return _string_literal(candidate, source)
+    return None
+
+
+def _string_literal(node: TSNode, source: bytes) -> str | None:
+    """Decode Java string escapes useful in URI paths while preserving templates."""
+    value = _text(node, source)
+    if len(value) < 2 or not value.startswith('"') or not value.endswith('"'):
+        return None
+    inner = value[1:-1]
+    escapes = {
+        "b": "\b",
+        "t": "\t",
+        "n": "\n",
+        "f": "\f",
+        "r": "\r",
+        '"': '"',
+        "'": "'",
+        "\\": "\\",
+    }
+
+    def replace_escape(match: re.Match[str]) -> str:
+        unicode_digits = match.group(1)
+        if unicode_digits is not None:
+            return chr(int(unicode_digits, 16))
+        escaped = match.group(2)
+        return escapes.get(escaped or "", match.group(0))
+
+    return re.sub(
+        r"\\(?:u([0-9a-fA-F]{4})|([btnfr\"'\\]))",
+        replace_escape,
+        inner,
+    )
+
+
+def _join_path(prefix: str, suffix: str) -> str:
+    """Join class and method JAX-RS paths into one normalized absolute path."""
+    parts = [part.strip("/") for part in (prefix, suffix) if part and part.strip("/")]
+    return "/" + "/".join(parts) if parts else "/"
 
 
 def _supertypes(node: TSNode, source: bytes) -> list[str]:

--- a/tests/pkg/test_java_extractor.py
+++ b/tests/pkg/test_java_extractor.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from orchestrator.pkg.facts import EdgeKind, FactBatch, NodeKind
+from orchestrator.pkg.facts import EdgeKind, FactBatch, NodeKind, Provenance
 from orchestrator.pkg.java_extractor import JavaExtractor
 
 pytest.importorskip("tree_sitter_java", reason="install the 'java' extra")
@@ -128,3 +128,118 @@ def test_emits_calls_for_sibling_and_static(tmp_path: Path) -> None:
     assert ("java:com.ex.Foo.a", "java:com.other.Helper.help") in calls
     # obj.ignored() (instance call on a variable) is skipped — no type inference
     assert not any(dst.endswith(".ignored") for _, dst in calls)
+
+
+JAX_RS_RESOURCE = """\
+package com.example.orders;
+
+@Path("/orders")
+public class OrderResource {
+    @GET
+    @Path("/{id}")
+    public Order getOrder() { return find(); }
+
+    @POST
+    public Order create() { return save(); }
+
+    @jakarta.ws.rs.PUT
+    @jakarta.ws.rs.Path(value = "/{id}")
+    public Order replace() { return save(); }
+
+    @DELETE
+    @Path("/{id}")
+    public void delete() {}
+
+    @PATCH
+    @Path("/{id}")
+    public Order patch() { return save(); }
+
+    @HEAD
+    public void head() {}
+
+    @OPTIONS
+    public void options() {}
+
+    @Path("/children")
+    public ChildResource children() { return childResource; }
+
+    private Order find() { return null; }
+    private Order save() { return null; }
+}
+"""
+
+
+def test_jax_rs_endpoints_expose_grounded_handlers(tmp_path: Path) -> None:
+    batch, _ = _facts(tmp_path, JAX_RS_RESOURCE, "OrderResource.java")
+    by_id = {node.id: node for node in batch.nodes}
+    exposes = {(edge.src, edge.dst): edge for edge in batch.edges if edge.kind is EdgeKind.EXPOSES}
+    base = "java:com.example.orders.OrderResource"
+    expected = {
+        "java:endpoint:GET /orders/{id}": (f"{base}.getOrder", 5),
+        "java:endpoint:POST /orders": (f"{base}.create", 9),
+        "java:endpoint:PUT /orders/{id}": (f"{base}.replace", 12),
+        "java:endpoint:DELETE /orders/{id}": (f"{base}.delete", 16),
+        "java:endpoint:PATCH /orders/{id}": (f"{base}.patch", 20),
+        "java:endpoint:HEAD /orders": (f"{base}.head", 24),
+        "java:endpoint:OPTIONS /orders": (f"{base}.options", 27),
+    }
+
+    for endpoint_id, (handler_id, line) in expected.items():
+        endpoint = by_id[endpoint_id]
+        handler = by_id[handler_id]
+        edge = exposes[(endpoint_id, handler_id)]
+        assert endpoint.kind is NodeKind.ENDPOINT
+        assert endpoint.name == endpoint_id.removeprefix("java:endpoint:")
+        assert endpoint.provenance == handler.provenance == edge.provenance
+        assert endpoint.provenance == Provenance("src/OrderResource.java", line)
+        assert handler.kind is NodeKind.FUNCTION
+        assert handler.grounded
+
+    # A @Path-only method is a sub-resource locator, not an HTTP endpoint.
+    assert not [
+        node for node in batch.nodes if node.kind is NodeKind.ENDPOINT and node.name.endswith("/children")
+    ]
+
+
+ASYMMETRIC_JAX_RS_PATHS = """\
+package com.example.health;
+
+@javax.ws.rs.Path("/health")
+class HealthResource {
+    @javax.ws.rs.GET
+    String status() { return "ok"; }
+}
+
+class MetricsResource {
+    @GET
+    @Path("/metrics")
+    String metrics() { return "ok"; }
+}
+
+@Path(ROOT_PATH)
+class DynamicResource {
+    @GET
+    String unresolved() { return "unknown"; }
+}
+"""
+
+
+def test_jax_rs_supports_asymmetric_and_qualified_annotations(tmp_path: Path) -> None:
+    batch, _ = _facts(tmp_path, ASYMMETRIC_JAX_RS_PATHS, "Resources.java")
+    exposes = {(edge.src, edge.dst) for edge in batch.edges if edge.kind is EdgeKind.EXPOSES}
+    assert (
+        "java:endpoint:GET /health",
+        "java:com.example.health.HealthResource.status",
+    ) in exposes
+    assert (
+        "java:endpoint:GET /metrics",
+        "java:com.example.health.MetricsResource.metrics",
+    ) in exposes
+    assert not any(dst.endswith(".unresolved") for _, dst in exposes)
+
+
+def test_jax_rs_extraction_is_deterministic(tmp_path: Path) -> None:
+    first, _ = _facts(tmp_path, JAX_RS_RESOURCE, "OrderResource.java")
+    second, _ = _facts(tmp_path, JAX_RS_RESOURCE, "OrderResource.java")
+    assert first.nodes == second.nodes
+    assert first.edges == second.edges


### PR DESCRIPTION
## What & why

Implements [Discussion #54](https://github.com/synaptixs/spine/discussions/54) by adding grounded JAX-RS / Jakarta REST endpoint extraction to the Java frontend.

- Recognizes GET, POST, PUT, DELETE, PATCH, HEAD, and OPTIONS annotations by their final name segment, covering both `javax.ws.rs` and `jakarta.ws.rs` forms.
- Combines class-level and method-level `@Path` values while preserving path templates such as `{id}`.
- Emits deterministic `Endpoint` nodes and `EXPOSES` edges to real handler methods with handler provenance.
- Skips sub-resource locators and non-literal paths when they cannot be grounded precisely.
- Documents the new Java framework-aware graph behavior.

## How it was tested

- `.venv/bin/ruff check .` — passed
- `.venv/bin/ruff format --check .` — passed (563 files)
- `.venv/bin/mypy src tests` — passed (541 source files)
- `.venv/bin/pytest -q tests/pkg/test_java_extractor.py` — 11 passed
- Full pytest run — 1813 passed, 22 skipped, 51 deselected; initially failing Temporal and Maven integration groups passed on isolated reruns (29 and 2 tests respectively). One TypeScript integration remains environment-blocked because npm cannot reach either the configured corporate registry or the public registry.

## Checklist

- [x] Quality gate green locally (`mypy src tests`, `ruff format --check .`)
- [x] Tests added/updated where it matters
- [x] No secrets committed
- [x] Docs updated if behavior changed