### PR TITLE
chore(codeql): stop two quality queries from blocking merges

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,40 @@
+name: "Spine CodeQL config"
+
+# Keeps the full security-and-quality suite and drops only the quality queries that
+# misread idiomatic typed Python. Every security query stays enabled.
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  # `py/ineffectual-statement` — "Statement has no effect".
+  #
+  # Fires on `...` as the body of a Protocol method stub, which is the idiomatic form
+  # (PEP 544):
+  #
+  #     class AsrBackend(Protocol):
+  #         def version(self) -> str: ...
+  #
+  # There are ~48 of these across 24 files in src/ — the codebase leans on Protocols
+  # for every injectable seam. The query has no way to tell a stub body from dead code,
+  # so it produced 51 open alerts, none of them real.
+  #
+  # This mattered beyond noise: the "Protect main" ruleset sets
+  # required_review_thread_resolution, and CodeQL posts each alert as a *review thread*
+  # on the PR. So every PR that added a Protocol method blocked its own merge on
+  # unresolvable threads, while GitHub reported it as "waiting for review" — which sent
+  # people hunting for missing approvals instead. Hit on PR #66.
+  - exclude:
+      id: py/ineffectual-statement
+
+  # `py/unused-global-variable` — same false-positive class, 27 open alerts.
+  #
+  # A module-level constant whose only consumer is a *function-local* `from … import`
+  # doesn't count as used by this query. Worse than noise here too: GitHub Autofix acted
+  # on it and renamed `SUPPORTED_LANGUAGES` to `_unused_supported_languages`, breaking
+  # the import and failing mypy on the release PR for v3.7.0.
+  #
+  # Prefer the in-module fix where it's natural (reference the constant from a function
+  # in its own module, as `unsupported_language_error()` does) — but the query is not a
+  # reliable signal, so it should not gate a merge.
+  - exclude:
+      id: py/unused-global-variable

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,10 @@ jobs:
         uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           language: ${{ matrix.language }}
-          queries: security-and-quality
+          # Query selection lives in the config file, not here — it also carries the
+          # query-filters that drop two quality queries which can't read typed-Python
+          # idiom. Setting `queries:` here as well would ADD to the config, not replace it.
+          config-file: .github/codeql/codeql-config.yml
 
       - name: Analyze
         uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3


### PR DESCRIPTION
Two CodeQL *quality* queries can't read idiomatic typed Python, and between them account for **78 of the repo's open alerts** — none of them real:

| Rule | Open alerts | Fires on |
|---|---|---|
| `py/ineffectual-statement` | 51 | `...` as a `Protocol` method-stub body (PEP 544) — ~48 across 24 files |
| `py/unused-global-variable` | 27 | a module-level constant whose only consumer is a function-local `from … import` |

**Why this was worse than noise.** CodeQL posts each alert as a review *thread*, and the `Protect main` ruleset sets `required_review_thread_resolution`. So any PR adding a `Protocol` method blocked its own merge on threads that can never be legitimately resolved — while GitHub reported the cause as *"waiting for review"*. On #66 that misdirection drew **ten approvals** chasing a blocker that was actually three unresolved CodeQL threads.

The same class of finding previously drove an Autofix that renamed `SUPPORTED_LANGUAGES` → `_unused_supported_variable` and broke the v3.7.0 release PR.

## Change

Query selection moves out of the workflow's inline `queries:` input and into `.github/codeql/codeql-config.yml`, which keeps the **full `security-and-quality` suite** and excludes only those two ids. Every security query stays enabled.

One gotcha recorded in the config: the inline `queries:` input **adds to** a `config-file` rather than replacing it, so it had to be removed rather than left alongside.

## Verified

Both YAML files parse; the init step resolves to `config-file` only. `understand --check` unaffected (`.yml` isn't an ingested doc suffix).