### PR TITLE
chore(release): 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## 3.10.0 — Diagrams and recordings become facts
+
+A codebase's knowledge was never only in its code and its prose. Architecture diagrams,
+screenshots of a dashboard, a recorded design review where the one person who remembers why
+explains it — Spine could read none of it. Media ingestion closes that: images go through
+OCR, audio and video through speech-to-text, and both land as reviewable artifacts under
+`.spine-media/`.
+
+The split is deliberate. `media extract` is the only thing that runs a model; the
+deterministic graph build *reads* the committed artifacts and never produces them. So
+`understand` and `state` stay no-LLM and reproducible — same commit in, same graph out —
+while the slow, non-deterministic part is an explicit, reviewable step you run and commit.
+An artifact you can read and diff is also an artifact you can correct when OCR mangles a
+label.
+
+Transcription is the first path in Spine that can leave your machine, so it carries a
+structural consent gate rather than a warning in the docs. A backend advertises whether it
+is off-machine; a remote one refuses to run without per-run `--allow-remote`. The default
+backend is local, the default consent is absent, and the API key is read from the
+environment rather than a flag that would land in shell history.
+
+### Added
+
+- `orchestrator media extract` — OCR for images (the `[media]` extra: pytesseract,
+  Pillow) and speech-to-text for audio and video (the `[asr]` extra: Whisper, kept
+  separate because it pulls a full ML stack including torch). Output goes to
+  `.spine-media/` as reviewable, committable artifacts keyed by content hash;
+  re-extraction is skipped when an artifact is already current unless `--force`.
+- A consent gate on off-machine transcription. `--asr local` (the default) and image OCR
+  run entirely on this machine; `--asr api` uploads audio and refuses to run without
+  `--allow-remote`. Oversized files are skipped rather than truncated silently.
+- `docs/specs/` and `docs/evals/` are tracked in the repo again — the design records that
+  say *why* a subsystem is shaped the way it is. This also removes a class of CI failure:
+  doc ingestion reads markdown from disk whether or not git tracks it, so docs that existed
+  locally but not in the repo made a contributor's `episteme/` describe pages CI could not
+  see, and `understand --check` failed on a diff nobody could reproduce.
+
+### Changed
+
+- CodeQL query selection moved into `.github/codeql/codeql-config.yml`. The full
+  `security-and-quality` suite still runs; two quality queries that misread idiomatic typed
+  Python are excluded — `py/ineffectual-statement` fired on `...` as a `Protocol` method-stub
+  body (PEP 544), and `py/unused-global-variable` on constants consumed only through a
+  function-local import. Between them they accounted for 78 open alerts, none real, and
+  because CodeQL posts alerts as review *threads* they blocked merges on a branch ruleset
+  that requires thread resolution.
+
 ## 3.9.3 — Endpoints that are actually endpoints
 
 A REST client is not a REST server, but the Java front-end couldn't tell them apart. It

--- a/episteme/README.md
+++ b/episteme/README.md
@@ -4,7 +4,7 @@
 Code-true knowledge base for **synaptixs-spine** (brownfield), built by `orchestrator understand` from the Product Knowledge Graph + project profile.
 
 <!-- spine-stamp -->
-Generated from commit `dc5d95dfbfc2377d2f83bac9bf775e72400a8a97` **plus uncommitted changes** by **Spine 3.9.3**.
+Generated from commit `1c0389de6cf83c33ad63908a81ffcf102777ab54` **plus uncommitted changes** by **Spine 3.10.0**.
 Verify it still matches the code with `orchestrator understand --check`.
 <!-- /spine-stamp -->
 

--- a/episteme/architecture.md
+++ b/episteme/architecture.md
@@ -146,10 +146,11 @@ _The repo's own prose folded into the graph (`Doc` nodes + `MENTIONS` edges). A 
 
 **919 docs** ingested, naming **463 of 6432 symbols** (7% doc coverage).
 
-**580 potential drift** — the docs name code the graph doesn't have (renamed or removed symbols, or prose the binder can't resolve).
+**581 potential drift** — the docs name code the graph doesn't have (renamed or removed symbols, or prose the binder can't resolve).
 
 | The docs claim… | …in |
 |---|---|
+| `Protocol` | CHANGELOG.md |
 | `javax.ws.rs` | CHANGELOG.md |
 | `jakarta.ws.rs` | CHANGELOG.md |
 | `click.core` | CHANGELOG.md |
@@ -157,8 +158,7 @@ _The repo's own prose folded into the graph (`Doc` nodes + `MENTIONS` edges). A 
 | `go.mod` | CHANGELOG.md |
 | `current_state` | CHANGELOG.md |
 | `click._winconsole` | CHANGELOG.md |
-| `click.exceptions` | CHANGELOG.md |
-| … | _+572 more_ |
+| … | _+573 more_ |
 
 ## Possibly unused
 _**108 of 947 internal symbols** have no caller, subclass or doc reference in the graph. **Candidates, not verdicts**: calls through an attribute chain are skipped rather than guessed at, and dynamic dispatch, registries and reflection are invisible. Public symbols are excluded — having no in-repo caller is what being an API looks like._

--- a/episteme/tech-context.md
+++ b/episteme/tech-context.md
@@ -9,7 +9,7 @@
 | Migrations | yes |
 | Test runner | pytest |
 | Task type (default) | feature |
-| Version | `3.9.3` |
+| Version | `3.10.0` |
 | Requires Python | `>=3.12` |
 
 ## Infrastructure & runtime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.9.3"
+version = "3.10.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -667,7 +667,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.15' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -698,43 +698,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -2149,7 +2149,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2188,7 +2188,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2200,7 +2200,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2230,9 +2230,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2244,7 +2244,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3688,7 +3688,7 @@ wheels = [
 
 [[package]]
 name = "synaptixs-spine"
-version = "3.8.2"
+version = "3.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -3759,6 +3759,10 @@ java = [
 mcp = [
     { name = "mcp" },
 ]
+media = [
+    { name = "pillow" },
+    { name = "pytesseract" },
+]
 office = [
     { name = "openpyxl" },
     { name = "python-docx" },
@@ -3803,6 +3807,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.50" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
+    { name = "openai-whisper", marker = "extra == 'asr'", specifier = ">=20231117" },
     { name = "openpyxl", marker = "extra == 'dev'", specifier = ">=3.1" },
     { name = "openpyxl", marker = "extra == 'office'", specifier = ">=3.1" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27" },
@@ -3853,7 +3858,7 @@ requires-dist = [
     { name = "types-pyyaml", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
-provides-extras = ["security", "java", "typescript", "csharp", "c", "cpp", "go", "sql", "sql-postgres", "docs", "office", "mcp", "sdlc", "tui", "otel", "dev"]
+provides-extras = ["security", "java", "typescript", "csharp", "c", "cpp", "go", "sql", "sql-postgres", "docs", "office", "mcp", "media", "asr", "sdlc", "tui", "otel", "dev"]
 
 [[package]]
 name = "temporalio"


### PR DESCRIPTION
Version bump + changelog for **3.10.0**, ahead of the `develop → main` release PR.

**Minor, not patch.** Media ingestion adds a new command surface (`orchestrator media extract`) and two optional-dependency extras. A patch version would tell anyone reading it that this is a safe no-new-surface upgrade, and installing `[asr]` pulls a full ML stack including torch.

## What 3.10.0 contains

- **G3 media ingestion** — OCR for images, speech-to-text for audio/video, into reviewable `.spine-media/` artifacts. `media extract` is the only thing that runs a model; the deterministic graph build reads the artifacts and never produces them, so `understand`/`state` stay no-LLM and reproducible.
- **Design records back in the repo** (`docs/specs/`, `docs/evals/`) — also removes a class of CI failure, since doc ingestion reads markdown from disk whether or not git tracks it.
- **CodeQL config** — excludes two quality queries that misread typed-Python idiom and were blocking merges through the thread-resolution rule.

## Consent gate — reviewed

Transcription is the first path in Spine that can leave the machine, so it was worth checking before publishing an immutable artifact. The gate is the first statement in `extract_media`, before any file read or network call; `--asr` defaults to `local`, `--allow-remote` defaults to false, and the API key comes from the environment rather than a flag that lands in shell history. Covered by tests for refuse-without-consent, run-with-consent, and local-needs-no-gate.

One follow-up, not a blocker: `build_media_artifact` is exported and calls the backend without the gate. No live bypass — its only caller in `src/` is the gated `extract_media` — but the module docstring's *"no way to send audio off-machine by accident"* is stronger than the code guarantees for a library consumer importing the builder directly. Either gate it too, or narrow the claim to the CLI path.

## Verified

`mypy src tests` clean (560 files) · `ruff format --check .` clean (582 files) · `understand --check` current (9635 nodes) · **1965 tests pass**, 29 skipped (optional extras absent locally).

`uv.lock`: the project's own pin had drifted to 3.8.2, now 3.10.0. Same package set, no dependency version changed; remaining churn is CUDA platform markers.