### PR TITLE
docs(mcp): cover Docker, multiple servers, and the traps that cost a session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ build/
 
 # Disk-backed artifact store written by `orchestrator up` (fs mode)
 .orchestrator-artifacts/
+
+# MCP client config — machine-specific paths, and the file people paste tokens into.
+# The tracked `.mcp.json` is the OTHER direction (how Claude Code launches Spine).
+mcp.json

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -691,31 +691,97 @@ Claude or Codex.
 ```bash
 pip install 'synaptixs-spine[mcp]'        # or from source: uv sync --extra mcp
 ```
-Supply an `mcpServers` JSON file via `--config`, `$ORCHESTRATOR_MCP_CONFIG`, or
-`./mcp.json`. Transport is inferred (`command` → stdio, `url` → HTTP). Example
-`mcp.json` for Atlassian:
+> **Install the extra first, or the failure is silent.** Without it, `mcp list` prints an
+> empty tool list rather than an error — a missing dependency currently looks identical to an
+> unreachable server. If you see zero tools, check this before debugging the server.
+
+**Two files, one character apart, opposite directions.** `mcp.json` (no leading dot) is what
+*Spine reads* to find servers it may call. A tracked `.mcp.json` is the reverse — how Claude
+Code launches Spine *as* a server. Editing the wrong one is the most common setup mistake.
+
+Supply the `mcpServers` JSON via `--config`, `$ORCHESTRATOR_MCP_CONFIG`, or `./mcp.json`.
+Transport is inferred (`command` → stdio, `url` → HTTP).
+
+**9.1a — Atlassian via Docker (recommended: no tokens in the config file).**
+`mcp.json` is *not* gitignored by default and is exactly the file people paste tokens into.
+Pass credentials with `--env-file` instead, so the config carries nothing secret and stays
+safe to commit or share:
 ```json
 {
   "mcpServers": {
-    "confluence": {
-      "command": "uvx",
-      "args": ["mcp-atlassian"],
-      "env": {
-        "CONFLUENCE_URL": "https://your-org.atlassian.net/wiki",
-        "CONFLUENCE_USERNAME": "you@org.com",
-        "CONFLUENCE_API_TOKEN": "<token>",
-        "JIRA_URL": "https://your-org.atlassian.net",
-        "JIRA_USERNAME": "you@org.com",
-        "JIRA_API_TOKEN": "<token>"
-      },
-      "allow": ["confluence_get_page", "confluence_get_page_children", "jira_get_issue", "jira_search"]
+    "atlassian": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "--env-file", "/abs/path/to/.env",
+               "ghcr.io/sooperset/mcp-atlassian:latest"],
+      "allow": ["jira_get_issue", "jira_search",
+                "confluence_get_page", "confluence_get_page_children"]
     }
   }
 }
 ```
+`mcp-atlassian` expects **different variable names** than Spine's own `CONFLUENCE_*`/`JIRA_*`.
+The token names already match; add four aliases to your `.env` (same values you already have):
+```
+JIRA_URL=https://your-org.atlassian.net            # Spine calls this JIRA_BASE_URL
+JIRA_USERNAME=you@org.com                          # Spine calls this JIRA_EMAIL
+CONFLUENCE_URL=https://your-org.atlassian.net/wiki # note the /wiki suffix
+CONFLUENCE_USERNAME=you@org.com
+```
+Use an **absolute** path for `--env-file`: the server is launched as a subprocess whose working
+directory you do not control. And note Docker's `--env-file` does **not** strip inline comments —
+`FOO=bar  # note` yields the value `bar  # note`. Keep comments on their own lines.
+
+**9.1b — Atlassian via `uvx`** (no Docker; installs into your environment):
+```json
+{
+  "mcpServers": {
+    "atlassian": {
+      "command": "uvx",
+      "args": ["mcp-atlassian"],
+      "env": { "JIRA_URL": "https://your-org.atlassian.net", "JIRA_USERNAME": "you@org.com" },
+      "allow": ["jira_get_issue", "jira_search", "confluence_get_page"]
+    }
+  }
+}
+```
+The inline `env` block is convenient but puts values **in the file** — fine for non-secrets,
+wrong for tokens. Prefer `--env-file` (9.1a) whenever credentials are involved.
+
+**9.1c — Several servers at once.** `mcpServers` is a map; add as many as you need. Each is
+launched independently, and **one unreachable server does not blank the others** — the rest
+still list their tools:
+```json
+{
+  "mcpServers": {
+    "atlassian": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "--env-file", "/abs/path/to/.env",
+               "ghcr.io/sooperset/mcp-atlassian:latest"],
+      "allow": ["jira_get_issue", "jira_search", "confluence_get_page"]
+    },
+    "postgres": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "DATABASE_URI",
+               "mcp/postgres:latest"],
+      "allow": ["query", "list_schemas"]
+    },
+    "internal": {
+      "url": "https://mcp.your-org.internal/sse",
+      "headers": { "Authorization": "Bearer ${INTERNAL_MCP_TOKEN}" },
+      "write_enabled": false
+    }
+  }
+}
+```
+Tool names are namespaced `server:tool`, so two servers may expose the same tool name without
+colliding. Point the Atlassian presets at a specific server with `MCP_JIRA_SERVER` /
+`MCP_CONFLUENCE_SERVER` when you run more than one that could serve them.
+
 - **`allow`** is an allow-list — only those tools are callable (omit = all, with a warning).
 - **Writes are off by default**: mutating tools are refused unless you set
   `write_enabled: true` on that server.
+- **Servers run on your machine.** A stdio server's `command` is executed locally; Docker at
+  least confines it. Review what you onboard.
 
 **9.2 — Inspect + call:**
 ```bash

--- a/episteme/README.md
+++ b/episteme/README.md
@@ -4,7 +4,7 @@
 Code-true knowledge base for **synaptixs-spine** (brownfield), built by `orchestrator understand` from the Product Knowledge Graph + project profile.
 
 <!-- spine-stamp -->
-Generated from commit `a2d47c25767c631fd7bed5992c3ce12281ce0e2e` **plus uncommitted changes** by **Spine 3.11.1**.
+Generated from commit `d568adef212fcae120990b6a4da7c36373ca3414` **plus uncommitted changes** by **Spine 3.11.1**.
 Verify it still matches the code with `orchestrator understand --check`.
 <!-- /spine-stamp -->
 

--- a/episteme/architecture.md
+++ b/episteme/architecture.md
@@ -152,7 +152,7 @@ _The repo's own prose folded into the graph (`Doc` nodes + `MENTIONS` edges). A 
 
 **923 docs** ingested, naming **470 of 6515 symbols** (7% doc coverage).
 
-**584 potential drift** — the docs name code the graph doesn't have (renamed or removed symbols, or prose the binder can't resolve).
+**585 potential drift** — the docs name code the graph doesn't have (renamed or removed symbols, or prose the binder can't resolve).
 
 | The docs claim… | …in |
 |---|---|
@@ -164,7 +164,7 @@ _The repo's own prose folded into the graph (`Doc` nodes + `MENTIONS` edges). A 
 | `go.mod` | CHANGELOG.md |
 | `current_state` | CHANGELOG.md |
 | `click._winconsole` | CHANGELOG.md |
-| … | _+576 more_ |
+| … | _+577 more_ |
 
 ## Possibly unused
 _**111 of 956 internal symbols** have no caller, subclass or doc reference in the graph. **Candidates, not verdicts**: calls through an attribute chain are skipped rather than guessed at, and dynamic dispatch, registries and reflection are invisible. Public symbols are excluded — having no in-repo caller is what being an API looks like._


### PR DESCRIPTION
Setting up the Atlassian MCP server end to end turned up four things the guide did not say — **three of which sent me debugging the wrong layer.**

## The install failure is silent

Without the `mcp` extra, `mcp list` prints an **empty tool list rather than an error**. `MCPRegistry.list_tools` catches every exception into `mcp.list_failed` — correct for *"a down server must not blank the rest"*, wrong for a missing dependency, which is permanent and actionable. I found it only by calling the registry directly.

Now documented as the first thing to check when you see zero tools. (A follow-up worth doing: distinguish config errors from outages in that handler.)

## `mcp.json` vs `.mcp.json`

One character apart, opposite directions. Spine reads **`mcp.json`** to find servers it may call; the tracked **`.mcp.json`** tells Claude Code how to launch Spine *as* a server. Editing the wrong one gives you *"no servers configured"* next to a file that plainly configures a server.

## The old example leaked tokens by design

It put raw API tokens **inline in `mcp.json`** — a file that was **not gitignored**, in a public repo. Replaced with a Docker recipe passing credentials via `--env-file`, so the config carries nothing secret and stays safe to commit. `mcp.json` is now gitignored too; the inline `env` block stays documented for non-secrets.

## Also recorded

- `mcp-atlassian` expects **different variable names** than Spine (`JIRA_URL` vs `JIRA_BASE_URL`, `JIRA_USERNAME` vs `JIRA_EMAIL`) though the token names match — four aliases bridge it.
- `--env-file` must be an **absolute path**: the server runs as a subprocess whose working directory you do not control.
- Docker's `--env-file` does **not** strip inline comments — `FOO=bar # note` yields a value containing the comment.
- Servers execute locally; Docker at least confines them.

## New: 9.1c — several servers at once

Tool names are namespaced `server:tool` so two servers cannot collide, and one unreachable server does not blank the others. Example covers stdio-via-Docker, and HTTP.

## Verified

All three JSON examples parse. Handshake proven live against `ghcr.io/sooperset/mcp-atlassian`: four tools discovered, all `read_only`.