### PR TITLE
feat(sdlc): drive one ticket through the happy path (walking skeleton)

### DIFF
--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -654,6 +654,72 @@ async def _run_address_review(*, pr: str, repo: str | None, bot_login: str | Non
     _print(result.__dict__)
 
 
+@sdlc_app.command("autorun")
+def sdlc_autorun(
+    source: Annotated[
+        str,
+        typer.Option("--source", help="Source root, e.g. jira://<issue-key>, confluence://<page_id>."),
+    ],
+    issue: Annotated[
+        str | None,
+        typer.Option("--issue", help="Adopt an existing tracker issue instead of creating one."),
+    ] = None,
+    intent: Annotated[
+        str | None, typer.Option("--intent", help="Intent id to implement (default: the first).")
+    ] = None,
+    repo: Annotated[
+        str | None, typer.Option("--repo", help="Git URL to branch from (default $SDLC_REPO_URL).")
+    ] = None,
+    path: Annotated[str, typer.Option("--path", help="Repo to reason about (the graph).")] = ".",
+    live: Annotated[
+        bool,
+        typer.Option("--live/--safe", help="Write for real. Default --safe makes no external write."),
+    ] = False,
+    max_refine: Annotated[int, typer.Option("--max-refine", help="Max test→refine loops.")] = 3,
+    base: Annotated[str | None, typer.Option("--base", help="PR target branch.")] = None,
+    language: Annotated[str, typer.Option("--language", help="Target language (auto detects).")] = "auto",
+    out: Annotated[
+        Path | None,
+        typer.Option("--out", help="Where run artifacts go (default: a run dir under the temp dir)."),
+    ] = None,
+) -> None:
+    """Drive ONE ticket through the whole happy path: research → design → code → tests → PR.
+
+    The stages are the commands you already have — `investigate`, `design`, `sdlc feature` —
+    called in order with the same spec, and each result recorded. Default --safe makes no
+    external write anywhere in the chain.
+
+    It does not yet judge whether the ticket is worth doing, enforce a budget, survive a
+    crash, or loop on review findings. Each stage says plainly when it skipped and why; see
+    docs/specs/autonomous-run-agent.md for what lands when.
+    """
+    import asyncio
+
+    from orchestrator.sdlc.autorun import AutorunError, autorun, render_summary
+
+    async def _go() -> None:
+        try:
+            ctx = await autorun(
+                source,
+                issue=issue,
+                intent_id=intent,
+                repo=repo,
+                root=path,
+                live=live,
+                max_refine=max_refine,
+                base_branch=base,
+                language=language,
+                artifacts_dir=out,
+                log=typer.echo,
+            )
+        except AutorunError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=exc.code) from exc
+        typer.echo("\n" + render_summary(ctx))
+
+    asyncio.run(_go())
+
+
 @sdlc_app.command("feature")
 def sdlc_feature(
     source: Annotated[

--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -1,0 +1,324 @@
+"""One ticket, driven through the stages Spine already has — the walking skeleton.
+
+Every stage of this loop exists as a command: `investigate`, `design`, `sdlc feature`,
+`codereview`. Nothing called them in order or carried state between them, so a human was the
+connective tissue. This is the connective tissue, and nothing more: the happy path, in order,
+with each stage's result recorded.
+
+**What this deliberately does NOT do yet** (see `docs/specs/autonomous-run-agent.md`): it does
+not judge whether the ticket is worth doing (phase 4), does not enforce budgets or survive a
+crash (phase 3), and does not loop on review findings (phase 5). Those are the parts that make
+autonomy safe, and each is its own story. A skeleton that pretended to have them would be
+worse than one that says plainly where it stops — every stage records `skipped` with a reason
+rather than quietly doing nothing.
+
+**Additive by construction.** Every stage is a call into an existing entry point, unchanged: a
+human can still run any of them by hand and get exactly what they get today. This module owns
+sequencing and state, never behaviour.
+
+**Artifacts go outside the repo.** The brief and design are markdown, and `understand` ingests
+markdown from disk whether or not git tracks it — so writing them into the working tree would
+turn a run's own notes into `Doc` nodes and change the graph the next stage reads. They land
+under a run directory in the system temp dir unless ``SPINE_RUN_ARTIFACTS`` says otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+StageStatus = Literal["ok", "skipped", "failed"]
+
+# The order is the contract: research before design, design before code, code before review.
+STAGES: tuple[str, ...] = ("intake", "investigate", "design", "implement", "review")
+
+
+class AutorunError(RuntimeError):
+    """The run cannot continue. ``code`` mirrors the CLI exit code."""
+
+    def __init__(self, message: str, *, code: int = 1) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class StageResult:
+    """What one stage did — including, explicitly, when it did nothing."""
+
+    name: str
+    status: StageStatus
+    detail: str
+    artifact: str = ""
+
+
+@dataclass
+class RunContext:
+    """State carried between stages. The thing a supervisor will later persist.
+
+    Phase 3 gives this a home in the registry DB, an idempotency key and a budget. For now it
+    lives for the length of one process, which is exactly the limitation the next story fixes.
+    """
+
+    run_id: str
+    source: str
+    live: bool
+    root: Path
+    artifacts_dir: Path
+    issue_key: str = ""
+    branch: str = ""
+    worktree: str = ""
+    pr_url: str | None = None
+    spec: dict[str, Any] | None = None
+    stages: list[StageResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(stage.status != "failed" for stage in self.stages)
+
+    def record(self, name: str, status: StageStatus, detail: str, artifact: str = "") -> StageResult:
+        result = StageResult(name=name, status=status, detail=detail, artifact=artifact)
+        self.stages.append(result)
+        return result
+
+    def write_artifact(self, name: str, body: str) -> str:
+        self.artifacts_dir.mkdir(parents=True, exist_ok=True)
+        path = self.artifacts_dir / name
+        path.write_text(body, encoding="utf-8")
+        return str(path)
+
+
+def default_artifacts_dir(run_id: str) -> Path:
+    """Where a run's markdown goes — outside the repo, on purpose.
+
+    ``understand`` reads markdown from disk regardless of git, so a brief written into the
+    working tree becomes a ``Doc`` node and changes the graph the next stage reads.
+    """
+    base = os.getenv("SPINE_RUN_ARTIFACTS") or str(Path(tempfile.gettempdir()) / "spine-runs")
+    return Path(base) / run_id
+
+
+async def autorun(
+    source: str,
+    *,
+    issue: str | None = None,
+    intent_id: str | None = None,
+    repo: str | None = None,
+    root: Path | str = ".",
+    live: bool = False,
+    max_refine: int = 3,
+    base_branch: str | None = None,
+    language: str = "auto",
+    artifacts_dir: Path | None = None,
+    log: Callable[[str], None] | None = None,
+) -> RunContext:
+    """Drive one ticket through the happy path. Safe mode by default.
+
+    ``--safe`` makes no external write anywhere in the chain, exactly as `sdlc feature --safe`
+    does today: the brief and design are written to the run directory, the code is committed
+    locally, and no tracker or forge is touched.
+    """
+    emit: Callable[[str], None] = log or (lambda _m: None)
+    run_id = uuid.uuid4().hex[:16]
+    ctx = RunContext(
+        run_id=run_id,
+        source=source,
+        live=live,
+        root=Path(root),
+        artifacts_dir=artifacts_dir or default_artifacts_dir(run_id),
+    )
+    emit(f"[autorun] run {run_id} · source {source} · {'live' if live else 'safe'}")
+
+    await _stage_intake(ctx, intent_id=intent_id, emit=emit)
+    store, overview = _load_graph(ctx, emit=emit)
+    _stage_investigate(ctx, store=store, emit=emit)
+    await _stage_design(ctx, store=store, overview=overview, emit=emit)
+    await _stage_implement(
+        ctx,
+        issue=issue,
+        intent_id=intent_id,
+        repo=repo,
+        max_refine=max_refine,
+        base_branch=base_branch,
+        language=language,
+        emit=emit,
+    )
+    _stage_review(ctx, emit=emit)
+
+    emit(f"[autorun] artifacts in {ctx.artifacts_dir}")
+    return ctx
+
+
+# ---- stages ----------------------------------------------------------------
+
+
+async def _stage_intake(ctx: RunContext, *, intent_id: str | None, emit: Callable[[str], None]) -> None:
+    """Resolve the source to one spec, once, and hand it to every later stage.
+
+    ``run_feature`` can do its own intake, but then the brief and design would be written for
+    a spec the implementation stage might re-derive differently. Resolving here and injecting
+    it keeps all four stages talking about the same thing.
+    """
+    from orchestrator.core.env import load_local_env
+    from orchestrator.intake.cache import analyze_cached
+    from orchestrator.intake.factory import IntakeNotConfiguredError, build_service_for
+    from orchestrator.intake.service import parse_source_uri
+
+    load_local_env()
+    parse_source_uri(ctx.source)
+    try:
+        service = build_service_for(ctx.source, dry_run=True)
+    except IntakeNotConfiguredError as exc:
+        ctx.record("intake", "failed", str(exc))
+        raise AutorunError(str(exc), code=2) from exc
+
+    plan = await analyze_cached(service, ctx.source, refresh=False, log=emit)
+    if not plan.specs:
+        ctx.record("intake", "failed", "no specs derived from the source")
+        raise AutorunError("No specs derived from the source — nothing to implement.", code=3)
+
+    chosen = next((s for s in plan.specs if s.intent_id == intent_id), None) if intent_id else plan.specs[0]
+    if chosen is None:
+        ids = ", ".join(s.intent_id for s in plan.specs)
+        ctx.record("intake", "failed", f"intent {intent_id!r} not found")
+        raise AutorunError(f"Intent {intent_id!r} not found. Available: {ids}", code=3)
+
+    ctx.spec = chosen.model_dump()
+    ctx.record("intake", "ok", f"spec: {ctx.spec.get('title', '')}")
+    emit(f"[intake] {ctx.spec.get('title', '')} (intent {ctx.spec.get('intent_id', '')})")
+
+
+def _load_graph(ctx: RunContext, *, emit: Callable[[str], None]) -> tuple[Any, dict[str, Any]]:
+    """One extraction, shared by investigate and design.
+
+    Both stages want the same graph of the same commit; extracting twice would be slower and,
+    on a tree that changed underneath, inconsistent.
+    """
+    from orchestrator.pkg import FactStore, load_or_extract
+    from orchestrator.pkg.overview import build_overview
+
+    batch = load_or_extract(ctx.root)
+    emit(f"[graph] {len(batch.nodes)} nodes, {len(batch.edges)} edges")
+    return FactStore(batch), build_overview(batch)
+
+
+def _stage_investigate(ctx: RunContext, *, store: Any, emit: Callable[[str], None]) -> None:
+    from orchestrator.sdlc.investigate import build_investigation, render_investigation_md
+
+    spec = ctx.spec or {}
+    investigation = build_investigation(
+        str(spec.get("title", "")),
+        str(spec.get("summary", "")),
+        store=store,
+        root=ctx.root,
+    )
+    path = ctx.write_artifact("investigation.md", render_investigation_md(investigation))
+    landed = len(getattr(investigation, "landing", []) or [])
+    ctx.record("investigate", "ok", f"{landed} symbol(s) this ticket lands on", path)
+    emit(f"[investigate] {landed} symbol(s) · {path}")
+
+
+async def _stage_design(
+    ctx: RunContext, *, store: Any, overview: dict[str, Any], emit: Callable[[str], None]
+) -> None:
+    from orchestrator.sdlc.design import produce_design, render_design_md
+
+    spec = ctx.spec or {}
+    # No LLM here yet: the deterministic design is the honest skeleton default, and it keeps
+    # this stage runnable with no provider configured. Wiring the model in is phase 2 work,
+    # not skeleton work.
+    design = await produce_design(spec, overview=overview, store=store, llm=None)
+    path = ctx.write_artifact("design.md", render_design_md(spec, design))
+    touched = len(design.get("files_to_touch") or [])
+    ctx.record("design", "ok", f"{touched} file(s) proposed", path)
+    emit(f"[design] {touched} file(s) proposed · {path}")
+
+
+async def _stage_implement(
+    ctx: RunContext,
+    *,
+    issue: str | None,
+    intent_id: str | None,
+    repo: str | None,
+    max_refine: int,
+    base_branch: str | None,
+    language: str,
+    emit: Callable[[str], None],
+) -> None:
+    """Codegen, tests and (live) the PR — `sdlc feature`, unchanged, with our spec injected."""
+    from orchestrator.sdlc.feature_runner import FeatureRunError, run_feature
+
+    try:
+        result = await run_feature(
+            ctx.source,
+            intent_id=intent_id,
+            repo=repo,
+            max_refine=max_refine,
+            live=ctx.live,
+            issue=issue,
+            base_branch=base_branch,
+            language=language,
+            spec=ctx.spec,
+            log=emit,
+        )
+    except FeatureRunError as exc:
+        ctx.record("implement", "failed", str(exc))
+        raise AutorunError(str(exc), code=exc.code) from exc
+
+    ctx.issue_key = result.issue_key
+    ctx.branch = result.branch
+    ctx.worktree = result.worktree
+    ctx.pr_url = result.pr_url
+    ctx.record(
+        "implement",
+        "ok",
+        f"{len(result.files)} file(s) changed on {result.branch} after {result.iterations} test run(s)",
+    )
+
+
+def _stage_review(ctx: RunContext, *, emit: Callable[[str], None]) -> None:
+    """Grounded review of the change.
+
+    Skipped in safe mode with a reason rather than silently: the reviewer reads a *pull
+    request*, and safe mode opens none. Closing the review→fix→re-test loop is its own story;
+    this stage exists so the skeleton's shape is honest about where that loop will attach.
+    """
+    if not ctx.pr_url:
+        ctx.record("review", "skipped", "no PR to review (safe mode opens none)")
+        emit("[review] skipped — safe mode opens no PR")
+        return
+    ctx.record("review", "skipped", f"review of {ctx.pr_url} not wired yet (SSPN-24)")
+    emit(f"[review] skipped — {ctx.pr_url} awaits the review loop (SSPN-24)")
+
+
+def render_summary(ctx: RunContext) -> str:
+    """One table: what ran, what it did, where the artifact is."""
+    lines = [
+        f"run {ctx.run_id} · {'live' if ctx.live else 'safe'} · {ctx.source}",
+        "",
+        "| Stage | Status | Detail |",
+        "|---|---|---|",
+    ]
+    for stage in ctx.stages:
+        lines.append(f"| {stage.name} | {stage.status} | {stage.detail} |")
+    if ctx.issue_key:
+        lines += ["", f"issue: {ctx.issue_key}"]
+    if ctx.pr_url:
+        lines.append(f"PR: {ctx.pr_url}")
+    lines.append(f"artifacts: {ctx.artifacts_dir}")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "STAGES",
+    "AutorunError",
+    "RunContext",
+    "StageResult",
+    "autorun",
+    "default_artifacts_dir",
+    "render_summary",
+]

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -1,0 +1,216 @@
+"""The walking skeleton: stages in order, state carried, and honest about where it stops.
+
+These tests stub the stages' *entry points*, not their internals — the skeleton's job is
+sequencing and state, and that is what should break a test when it regresses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from orchestrator.sdlc.autorun import (
+    STAGES,
+    AutorunError,
+    RunContext,
+    autorun,
+    default_artifacts_dir,
+    render_summary,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_intake_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The intake plan is cached by source uri, and every test here uses the same uri —
+    without this, the second test reads the first one's specs."""
+    monkeypatch.setenv("ORCHESTRATOR_INTAKE_CACHE_DIR", str(tmp_path / "intake-cache"))
+    monkeypatch.setenv("SDLC_TEST_ISOLATION", "local")
+
+
+class _Spec:
+    def __init__(self, intent_id: str = "intent-a") -> None:
+        self.intent_id = intent_id
+
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "title": "Add CSV export",
+            "intent_id": self.intent_id,
+            "summary": "Users need their data out",
+            "acceptance_criteria": ["exports a csv"],
+        }
+
+
+class _Plan:
+    def __init__(self, specs: list[_Spec]) -> None:
+        self.specs = specs
+        self.documents: list[Any] = []
+        self.intents: list[Any] = []
+        self.gaps: list[Any] = []
+        self.blocked = False
+        self.truncated = False
+
+
+class _Service:
+    def __init__(self, specs: list[_Spec]) -> None:
+        self._specs = specs
+
+    async def analyze(self, root_id: str) -> _Plan:
+        return _Plan(self._specs)
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    specs: list[_Spec] | None = None,
+    feature: Any = None,
+    calls: list[str] | None = None,
+) -> dict[str, Any]:
+    """Stub every stage boundary; record what the implement stage was handed."""
+    seen: dict[str, Any] = {}
+    monkeypatch.setattr("orchestrator.core.env.load_local_env", lambda *a, **k: 0)
+    monkeypatch.setattr(
+        "orchestrator.intake.factory.build_service_for",
+        lambda *a, **k: _Service(specs if specs is not None else [_Spec()]),
+    )
+
+    async def _feature(source: str, **kwargs: Any) -> Any:
+        seen["feature_kwargs"] = kwargs
+        if calls is not None:
+            calls.append("implement")
+        if feature is not None:
+            raise feature
+        return SimpleNamespace(
+            passed=True,
+            issue_key="SSPN-42",
+            branch="feat/abc/SSPN-42",
+            worktree="/tmp/ws",
+            files=["src/x.py"],
+            iterations=1,
+            pr_url=None,
+        )
+
+    monkeypatch.setattr("orchestrator.sdlc.feature_runner.run_feature", _feature)
+    return seen
+
+
+def test_stages_run_in_order_and_record_themselves(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install(monkeypatch)
+
+    ctx = _run(tmp_path)
+
+    assert [s.name for s in ctx.stages] == list(STAGES)
+    assert [s.status for s in ctx.stages] == ["ok", "ok", "ok", "ok", "skipped"]
+    assert ctx.passed
+
+
+def test_one_spec_is_resolved_once_and_injected_downstream(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Intake happens here, not again inside the feature runner — otherwise the brief and
+    design describe a spec the implementation might re-derive differently."""
+    seen = _install(monkeypatch)
+
+    ctx = _run(tmp_path)
+
+    assert ctx.spec is not None and ctx.spec["title"] == "Add CSV export"
+    assert seen["feature_kwargs"]["spec"] == ctx.spec
+
+
+def test_artifacts_are_written_outside_the_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``understand`` ingests markdown from disk regardless of git, so a brief written into
+    the working tree would become a Doc node and change the graph the next stage reads."""
+    _install(monkeypatch)
+
+    ctx = _run(tmp_path)
+
+    written = [Path(s.artifact) for s in ctx.stages if s.artifact]
+    assert {p.name for p in written} == {"investigation.md", "design.md"}
+    repo = tmp_path / "repo"
+    for path in written:
+        assert path.is_file()
+        assert repo not in path.parents  # never inside the repo under analysis
+
+
+def test_the_default_artifact_dir_is_not_the_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SPINE_RUN_ARTIFACTS", raising=False)
+    assert Path.cwd() not in default_artifacts_dir("abc123").parents
+
+
+def test_safe_mode_opens_no_pr_and_says_why(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The skeleton must be honest about where it stops rather than quietly doing nothing."""
+    seen = _install(monkeypatch)
+
+    ctx = _run(tmp_path)
+
+    assert seen["feature_kwargs"]["live"] is False
+    review = next(s for s in ctx.stages if s.name == "review")
+    assert review.status == "skipped"
+    assert "safe mode" in review.detail
+    assert ctx.pr_url is None
+
+
+def test_a_failing_stage_stops_the_chain(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """No stage runs on the back of a failed one, and the failure is recorded before raising."""
+    from orchestrator.sdlc.feature_runner import FeatureRunError
+
+    calls: list[str] = []
+    _install(monkeypatch, feature=FeatureRunError("VERDICT: FAILED", code=1), calls=calls)
+
+    with pytest.raises(AutorunError, match="VERDICT: FAILED") as exc:
+        _run(tmp_path)
+
+    assert exc.value.code == 1
+    assert calls == ["implement"]
+
+
+def test_no_specs_fails_before_any_graph_work(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install(monkeypatch, specs=[])
+
+    with pytest.raises(AutorunError, match="No specs") as exc:
+        _run(tmp_path)
+
+    assert exc.value.code == 3
+
+
+def test_an_unknown_intent_names_what_is_available(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install(monkeypatch, specs=[_Spec("intent-a"), _Spec("intent-b")])
+
+    with pytest.raises(AutorunError, match="intent-a, intent-b") as exc:
+        _run(tmp_path, intent_id="nope")
+
+    assert exc.value.code == 3
+
+
+def test_the_summary_reports_every_stage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install(monkeypatch)
+
+    summary = render_summary(_run(tmp_path))
+
+    for stage in STAGES:
+        assert f"| {stage} |" in summary
+    assert "SSPN-42" in summary
+
+
+# ---- helper ----------------------------------------------------------------
+
+
+def _run(tmp_path: Path, *, intent_id: str | None = None, live: bool = False) -> RunContext:
+    """Run the skeleton against a tiny real repo, so the graph stages do real work."""
+    import asyncio
+
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    (repo / "mod.py").write_text("def export_csv(rows):\n    return rows\n", encoding="utf-8")
+
+    return asyncio.run(
+        autorun(
+            "file://./spec.md",
+            intent_id=intent_id,
+            root=repo,
+            live=live,
+            artifacts_dir=tmp_path / "artifacts",
+        )
+    )


### PR DESCRIPTION
Closes **[SSPN-21](https://fibonacci-solutions.atlassian.net/browse/SSPN-21)** — phase 2 of the agent programme.

## What

`orchestrator sdlc autorun --source jira://KEY [--safe|--live]` chains the stages that already exist: **intake → investigate → design → implement → review**. Each result is recorded; safe mode makes no external write anywhere in the chain.

**Additive by construction.** Every stage is a call into an existing entry point, unchanged. A human can still run any of them by hand and get exactly what they get today. This module owns sequencing and state, never behaviour.

Three decisions worth reviewing:

- **Intake runs once, here**, and the spec is injected into `run_feature` (which supports `spec=`). Otherwise the brief and design describe a spec the implementation might re-derive differently.
- **The graph is extracted once** and shared by investigate and design, which would otherwise disagree if the tree moved between them.
- **Artifacts land outside the repo** (temp dir, or `SPINE_RUN_ARTIFACTS`). `understand` ingests markdown from disk whether or not git tracks it, so writing a brief into the working tree would turn a run's own notes into `Doc` nodes and change the graph the next stage reads.

## What it deliberately does not do

No validity gate (SSPN-23), no budgets or crash recovery (SSPN-22), no review loop (SSPN-24). Every stage records `skipped` **with a reason** rather than quietly doing nothing.

## What the first real run found — the point of a skeleton

Run against a real ticket (`--format json` for `orchestrator regression`), safe mode. The chain executed; `implement` ended in a clean `VERDICT: FAILED`. Four findings, none fixed here:

**1. The design stage's output is not consumed by the implement stage.** `run_feature` does its own grounding and never sees the design artifact. The stages are sequential but not *connected* — arguably the single most important thing the skeleton was built to expose.

**2. The no-LLM design is not usable as guidance.** Its "files to touch" for a CLI flag were `registry/db/models.py`, `sdlc/testenv.py`, `sdlc/codegen.py`. It's a fallback meant to be replaced by an LLM design; the skeleton wires `llm=None` deliberately, so this is a gap in what the skeleton can honestly claim, not a regression.

**3. Codegen proposed creating `src/orchestrator/cli/__init__.py`** — which would shadow the existing single-module `cli.py` and break every command. A stdlib shadow guard already exists (see CLAUDE.md); there is none for first-party modules.

**4. Intake invented acceptance criteria**, including a `"generated_at"` ISO-8601 timestamp in the output. That would violate the determinism invariant if built. This is precisely the case the validity gate exists to catch.

## How it was tested

```
pytest              2192 passed, 30 skipped   (2183 before — 9 new)
mypy src tests      no issues in 584 source files
ruff check . / ruff format --check .
```

The tests stub stage *boundaries*, not internals: order, spec injection, artifact location, safe-mode silence, and that a failing stage stops the chain with nothing running after it.

Carries no `episteme/` changes — the new post-merge workflow owns that.

## Checklist
- [x] Quality gate green locally
- [x] Tests added — 9
- [x] No secrets committed
- [x] Docs updated if behavior changed — the spec already describes this phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)