### PR TITLE
fix(sdlc): carry the agreed design into every codegen prompt

### DIFF
--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -74,6 +74,9 @@ class RunContext:
     worktree: str = ""
     pr_url: str | None = None
     spec: dict[str, Any] | None = None
+    # The design, rendered — handed to codegen so the implement stage acts on what the
+    # design stage decided rather than re-deriving its own view of the ticket.
+    plan: str = ""
     stages: list[StageResult] = field(default_factory=list)
 
     @property
@@ -232,8 +235,12 @@ async def _stage_design(
     # this stage runnable with no provider configured. Wiring the model in is phase 2 work,
     # not skeleton work.
     design = await produce_design(spec, overview=overview, store=store, llm=None)
-    path = ctx.write_artifact("design.md", render_design_md(spec, design))
+    rendered = render_design_md(spec, design)
+    path = ctx.write_artifact("design.md", rendered)
     touched = len(design.get("files_to_touch") or [])
+    # Carried into the implement stage. Writing an artifact nobody reads is the difference
+    # between chaining commands and connecting them.
+    ctx.plan = rendered
     ctx.record("design", "ok", f"{touched} file(s) proposed", path)
     emit(f"[design] {touched} file(s) proposed · {path}")
 
@@ -260,6 +267,7 @@ async def _stage_implement(
             max_refine=max_refine,
             live=ctx.live,
             issue=issue,
+            design=ctx.plan,
             base_branch=base_branch,
             language=language,
             spec=ctx.spec,

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -668,6 +668,9 @@ class LLMCodegenAdapter:
         model: str = _DEFAULT_CODEGEN_MODEL,
         grounder: CodegenGrounder | None = None,
         grounder_factory: Callable[[Path], CodegenGrounder] | None = None,
+        # The approach an earlier stage already decided. Empty by default, so a standalone
+        # `sdlc feature` builds exactly the prompt it builds today.
+        design: str = "",
         layout: TargetLayout | None = None,
         agentic: bool = False,
         skills: list[str] | None = None,
@@ -706,6 +709,7 @@ class LLMCodegenAdapter:
         # factory builds one per worktree root, for the worker's fan-out where
         # one shared adapter serves many target clones.
         self._grounder = grounder
+        self._design = design.strip()
         self._grounder_factory = grounder_factory
         self._grounders: dict[Path, CodegenGrounder | None] = {}
         # The target layout pins where generated files go (package + dirs). When
@@ -919,6 +923,27 @@ class LLMCodegenAdapter:
     def _refine_system(self) -> str:
         return _REFINE_SYSTEMS.get(self._language(), _REFINE_SYSTEM)
 
+    def _design_block(self) -> str:
+        """The design an earlier stage produced, or ''.
+
+        Research and design are worthless to a model that never sees them: before this, the
+        pipeline investigated a ticket, designed a change, and then generated code as if
+        neither had happened. It is stated as a decision already taken, and as *guidance
+        rather than gospel* — the design was written before the code was read, so a model
+        with the file in front of it may know better, and should say so rather than
+        silently follow a plan that does not fit.
+        """
+        if not self._design:
+            return ""
+        return (
+            "PLAN ALREADY AGREED FOR THIS TICKET (from the design stage — research and a "
+            "grounded design were done before you were called; this is what they concluded):\n"
+            f"{self._design}\n\n"
+            "Follow it where it fits. It was written from the graph, not from reading every "
+            "file, so if the code contradicts it, do what the code requires and say so in "
+            "your summary — do not follow a plan you can see is wrong.\n\n"
+        )
+
     def _grounding(self, spec: dict[str, Any], root: Path) -> str:
         """The PKG context block (with trailing separator), or ''."""
         grounder = self._resolve_grounder(root)
@@ -970,7 +995,7 @@ class LLMCodegenAdapter:
     ) -> CodeChange:
         root = Path(path)
         task = (
-            f"{self._layout_block()}{self._grounding(spec, root)}Issue: {issue_key}\n\n"
+            f"{self._layout_block()}{self._grounding(spec, root)}{self._design_block()}Issue: {issue_key}\n\n"
             f"SPEC:\n{_spec_text(spec)}"
             f"{_named_existing_files(spec, root)}{self._convention_block(root)}"
         )
@@ -1094,7 +1119,7 @@ class LLMCodegenAdapter:
 
         root = Path(path)
         task = (
-            f"{self._layout_block()}{self._grounding(spec, root)}Issue: {issue_key}\n\n"
+            f"{self._layout_block()}{self._grounding(spec, root)}{self._design_block()}Issue: {issue_key}\n\n"
             f"SPEC:\n{_spec_text(spec)}"
             f"{_named_existing_files(spec, root)}{self._convention_block(root)}"
         )
@@ -1204,7 +1229,7 @@ class LLMCodegenAdapter:
         root = Path(path)
         return await self._generate(
             self._condition_system(self._tests_system(), self._skills, phase="author_tests"),
-            f"{self._layout_block()}{self._grounding(spec, root)}Issue: {issue_key}\n\n"
+            f"{self._layout_block()}{self._grounding(spec, root)}{self._design_block()}Issue: {issue_key}\n\n"
             f"SPEC:\n{_spec_text(spec)}\n\n"
             f"CURRENT SOURCE FILES:\n{self._session_files(root, include_tests=False)}"
             f"{self._convention_block(root)}",
@@ -1215,7 +1240,7 @@ class LLMCodegenAdapter:
         root = Path(path)
         return await self._generate(
             self._condition_system(self._refine_system(), self._skills, phase="refine"),
-            f"{self._layout_block()}{self._grounding(spec, root)}Issue: {issue_key}\n\n"
+            f"{self._layout_block()}{self._grounding(spec, root)}{self._design_block()}Issue: {issue_key}\n\n"
             f"SPEC:\n{_spec_text(spec)}\n\n"
             "IMPORTANT: Fix the IMPLEMENTATION files only. Do NOT modify test files to "
             "make them match a broken implementation — fix the source code so the tests "

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -176,6 +176,7 @@ async def run_feature(
     max_refine: int = 3,
     live: bool = False,
     issue: str | None = None,
+    design: str = "",
     base_branch: str | None = None,
     layout_mode: str = "auto",
     package_name: str | None = None,
@@ -192,6 +193,10 @@ async def run_feature(
     ``issue`` adopts an issue that already exists instead of creating one, so
     a run can be pointed at the ticket the work is actually for. Without it the
     issue is created as before.
+
+    ``design`` is what an earlier stage already produced (`sdlc autorun`), carried
+    into every codegen prompt. Empty by default: a standalone run builds exactly the
+    prompt it builds today.
     """
     emit: Callable[[str], None] = log or (lambda _m: None)
     adopt_key = _validated_issue_key(issue)
@@ -450,7 +455,15 @@ async def run_feature(
     emit(f"[persona] software_engineer · skills: {', '.join(capability_plan.skills) or '(none selected)'}")
 
     codegen_model = resolve_codegen_model(model)
-    codegen_kwargs: dict[str, Any] = {"grounder": grounder, "layout": layout, "persona": SOFTWARE_ENGINEER}
+    codegen_kwargs: dict[str, Any] = {
+        "grounder": grounder,
+        "layout": layout,
+        "persona": SOFTWARE_ENGINEER,
+        # Research and design are worthless to a model that never sees them.
+        "design": design,
+    }
+    if design:
+        emit(f"[design] carrying {len(design)} chars of agreed design into codegen")
     if codegen_model:
         codegen_kwargs["model"] = codegen_model
     codegen = LLMCodegenAdapter(llm, **codegen_kwargs)

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -119,6 +119,21 @@ def test_one_spec_is_resolved_once_and_injected_downstream(
     assert seen["feature_kwargs"]["spec"] == ctx.spec
 
 
+def test_the_design_is_handed_to_the_implement_stage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Chaining commands is not connecting them: before this the design was written to disk
+    and codegen never saw it, so the agent researched, designed, then implemented as if
+    neither had happened."""
+    seen = _install(monkeypatch)
+
+    ctx = _run(tmp_path)
+
+    assert ctx.plan.startswith("# Design")
+    assert seen["feature_kwargs"]["design"] == ctx.plan
+    # ...and it is the same text the artifact holds, so what a human reads is what the model got.
+    design_artifact = next(s.artifact for s in ctx.stages if s.name == "design")
+    assert Path(design_artifact).read_text(encoding="utf-8") == ctx.plan
+
+
 def test_artifacts_are_written_outside_the_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """``understand`` ingests markdown from disk regardless of git, so a brief written into
     the working tree would become a Doc node and change the graph the next stage reads."""

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -954,3 +954,62 @@ async def test_convention_block_injected_into_prompts(tmp_path: Path) -> None:
     prompt = llm.calls[0][-1].content
     assert "REPO CONVENTIONS" in prompt
     assert "from __future__ import annotations" in prompt
+
+
+# ---- the design reaches the prompt (SSPN-28) --------------------------------
+
+
+async def test_the_agreed_design_reaches_the_codegen_prompt(tmp_path: Path) -> None:
+    """Research and design are worthless to a model that never sees them.
+
+    Before this, `sdlc autorun` investigated a ticket, designed a change, wrote the design to
+    disk, and then generated code as if neither had happened. The assertion is on the *prompt*
+    rather than on the artifact, because writing a file nobody reads is exactly the bug.
+    """
+    llm = _ScriptedLLM([_files_response({"src/x.py": "x = 1\n"})])
+    adapter = LLMCodegenAdapter(llm, design="## Approach\nEdit cli.py, not a new package.")
+
+    await adapter.implement(
+        spec={"title": "t", "summary": "s", "acceptance_criteria": ["a"]},
+        path=str(tmp_path),
+        issue_key="ENG-1",
+    )
+
+    prompt = "\n".join(m.content for m in llm.calls[0])
+    assert "PLAN ALREADY AGREED" in prompt
+    assert "Edit cli.py, not a new package." in prompt
+    # Guidance, not gospel: the design was written before the code was read.
+    assert "do not follow a plan you can see is wrong" in prompt
+
+
+async def test_the_prompt_is_unchanged_without_a_design(tmp_path: Path) -> None:
+    """`sdlc feature` standalone must build exactly the prompt it builds today."""
+    with_design = _ScriptedLLM([_files_response({"src/x.py": "x = 1\n"})])
+    without = _ScriptedLLM([_files_response({"src/x.py": "x = 1\n"})])
+    spec = {"title": "t", "summary": "s", "acceptance_criteria": ["a"]}
+
+    # Separate worktrees: codegen observes repo conventions from the directory it is given,
+    # so a file written by the first run would change the second run's prompt for reasons
+    # that have nothing to do with the design.
+    (a := tmp_path / "a").mkdir()
+    (b := tmp_path / "b").mkdir()
+    await LLMCodegenAdapter(with_design, design="   ").implement(spec=spec, path=str(a), issue_key="ENG-1")
+    await LLMCodegenAdapter(without).implement(spec=spec, path=str(b), issue_key="ENG-1")
+
+    assert [m.content for m in with_design.calls[0]] == [m.content for m in without.calls[0]]
+    assert "PLAN ALREADY AGREED" not in "\n".join(m.content for m in without.calls[0])
+
+
+async def test_the_design_also_reaches_the_refine_prompt(tmp_path: Path) -> None:
+    """A refine that has forgotten the plan re-solves the ticket its own way."""
+    llm = _ScriptedLLM([_files_response({"src/x.py": "x = 2\n"})])
+    adapter = LLMCodegenAdapter(llm, design="## Approach\nEdit cli.py, not a new package.")
+
+    await adapter.refine(
+        spec={"title": "t", "summary": "s", "acceptance_criteria": ["a"]},
+        path=str(tmp_path),
+        issue_key="ENG-1",
+        failures="E   assert 1 == 2",
+    )
+
+    assert "Edit cli.py, not a new package." in "\n".join(m.content for m in llm.calls[0])


### PR DESCRIPTION
Closes **[SSPN-28](https://fibonacci-solutions.atlassian.net/browse/SSPN-28)**.

Stacked on [#100](https://github.com/synaptixs/spine/pull/100) (the skeleton) — merge that first.

## What & why

The skeleton ran investigate → design → implement in order, and **the implement stage never saw what design produced**. `run_feature` builds its own grounding; the design artifact was written to the run directory and ignored. The agent researched a ticket, designed a change, then generated code as if neither had happened.

Chaining commands is not connecting them. This is the connection.

## The change

| File | Change |
|---|---|
| `src/orchestrator/sdlc/codegen.py` | `LLMCodegenAdapter(design=…)` → a plan block in all four prompts |
| `src/orchestrator/sdlc/feature_runner.py` | `run_feature(design=…)` passes it through |
| `src/orchestrator/sdlc/autorun.py` | The design stage hands its rendered output to implement |
| `tests/sdlc/test_codegen.py`, `tests/sdlc/test_autorun.py` | 4 new tests |

**All four prompts**, not just `implement`: a refine that has forgotten the plan re-solves the ticket its own way, which is how a three-iteration loop ends up somewhere the design never proposed.

**Guidance, not gospel.** The design is written from the graph, before any file is read. A model with the code in front of it may know better, and is told to say so rather than silently follow a plan it can see is wrong:

> *"Follow it where it fits… if the code contradicts it, do what the code requires and say so in your summary — do not follow a plan you can see is wrong."*

**Additive.** `design` defaults to empty and a test asserts the no-design prompt is **byte-identical** to today's. Standalone `sdlc feature` is unchanged.

## Verified on a real run, not just in tests

```
[design]   5 file(s) proposed · .../design.md
[grounding] target-KG context: 6992 chars
[design]   carrying 4470 chars of agreed design into codegen
```

**Being straight about what this does not fix yet:** the design being carried is still the deterministic fallback, whose file list is unrelated to the ticket ([SSPN-29](https://fibonacci-solutions.atlassian.net/browse/SSPN-29)). Output quality will not visibly improve until that lands. The pipe is connected; the water is not yet clean.

## Naming note

Called `design` rather than `plan` at the runner seam because `run_feature` already has a `plan` — the `BacklogPlan` from intake. Shadowing it produced seven type errors that were, in fairness, the compiler making the same point.

## How it was tested

```
pytest              2196 passed, 30 skipped   (2192 before — 4 new)
mypy src tests      no issues in 584 source files
ruff check . / ruff format --check .
```

The tests assert on the **prompt**, not the artifact — writing a file nobody reads is precisely the bug being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)