### PR TITLE
feat(sdlc): give a run durable state, a spend cap, and a way back

### DIFF
--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -22,6 +22,7 @@ import json
 import os
 import sys
 from collections.abc import Iterator
+from dataclasses import asdict
 from datetime import UTC
 from pathlib import Path
 from typing import Annotated, Any
@@ -654,6 +655,45 @@ async def _run_address_review(*, pr: str, repo: str | None, bot_login: str | Non
     _print(result.__dict__)
 
 
+@sdlc_app.command("runs")
+def sdlc_runs(
+    action: Annotated[
+        str, typer.Argument(help="list | show <run-id> | reap — inspect autorun's durable state.")
+    ] = "list",
+    run_id: Annotated[str | None, typer.Argument(help="Run id, for show.")] = None,
+) -> None:
+    """Inspect what `sdlc autorun` has running, parked or abandoned.
+
+    `reap` reports what a dead run left behind — worktree, branch, issue — and changes
+    nothing: a worktree may hold the only copy of someone's work, and a ticket's status is
+    an outward-facing write. Cleaning up stays a human's call.
+    """
+    import json as _json
+
+    from orchestrator.sdlc.runstate import RunStore, render_reap, render_runs
+
+    store = RunStore()
+    if action == "list":
+        typer.echo(render_runs(store.all()))
+        return
+    if action == "reap":
+        stale = store.stale()
+        typer.echo(render_reap(stale))
+        raise typer.Exit(code=1 if stale else 0)
+    if action == "show":
+        if not run_id:
+            typer.echo("show needs a run id", err=True)
+            raise typer.Exit(code=2)
+        record = store.load(run_id)
+        if record is None:
+            typer.echo(f"no run {run_id!r}", err=True)
+            raise typer.Exit(code=2)
+        typer.echo(_json.dumps(asdict(record), indent=2, sort_keys=True))
+        return
+    typer.echo(f"Unknown action {action!r}. Use list, show or reap.", err=True)
+    raise typer.Exit(code=2)
+
+
 @sdlc_app.command("autorun")
 def sdlc_autorun(
     source: Annotated[
@@ -681,6 +721,14 @@ def sdlc_autorun(
     out: Annotated[
         Path | None,
         typer.Option("--out", help="Where run artifacts go (default: a run dir under the temp dir)."),
+    ] = None,
+    resume: Annotated[
+        str | None,
+        typer.Option("--resume", help="Continue a run by id — adopts the issue it already created."),
+    ] = None,
+    max_cost: Annotated[
+        float | None,
+        typer.Option("--max-cost", help="Cap LLM spend (USD) for this run; exhausting it parks it."),
     ] = None,
 ) -> None:
     """Drive ONE ticket through the whole happy path: research → design → code → tests → PR.
@@ -710,6 +758,8 @@ def sdlc_autorun(
                 base_branch=base,
                 language=language,
                 artifacts_dir=out,
+                resume=resume,
+                max_cost_usd=max_cost,
                 log=typer.echo,
             )
         except AutorunError as exc:

--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -78,15 +79,37 @@ class RunContext:
     # design stage decided rather than re-deriving its own view of the ticket.
     plan: str = ""
     stages: list[StageResult] = field(default_factory=list)
+    # Durable state. Written after every stage, so a crash leaves a findable run rather than
+    # a mystery worktree and a ticket stuck In Progress.
+    record: Any = None
+    store: Any = None
 
     @property
     def passed(self) -> bool:
         return all(stage.status != "failed" for stage in self.stages)
 
-    def record(self, name: str, status: StageStatus, detail: str, artifact: str = "") -> StageResult:
+    def record_stage(self, name: str, status: StageStatus, detail: str, artifact: str = "") -> StageResult:
         result = StageResult(name=name, status=status, detail=detail, artifact=artifact)
         self.stages.append(result)
+        self.checkpoint(phase=name, status="failed" if status == "failed" else None)
         return result
+
+    def checkpoint(self, *, phase: str | None = None, status: str | None = None, **fields: Any) -> None:
+        """Persist what we know. Cheap, and the only thing standing between a kill -9 and an
+        orphaned worktree nobody can attribute."""
+        if self.record is None or self.store is None:
+            return
+        if phase is not None:
+            self.record.phase = phase
+        if status is not None:
+            self.record.status = status
+        self.record.issue_key = self.issue_key or self.record.issue_key
+        self.record.branch = self.branch or self.record.branch
+        self.record.worktree = self.worktree or self.record.worktree
+        self.record.pr_url = self.pr_url or self.record.pr_url
+        for key, value in fields.items():
+            setattr(self.record, key, value)
+        self.store.save(self.record)
 
     def write_artifact(self, name: str, body: str) -> str:
         self.artifacts_dir.mkdir(parents=True, exist_ok=True)
@@ -117,6 +140,9 @@ async def autorun(
     base_branch: str | None = None,
     language: str = "auto",
     artifacts_dir: Path | None = None,
+    resume: str | None = None,
+    max_cost_usd: float | None = None,
+    store: Any = None,
     log: Callable[[str], None] | None = None,
 ) -> RunContext:
     """Drive one ticket through the happy path. Safe mode by default.
@@ -124,9 +150,31 @@ async def autorun(
     ``--safe`` makes no external write anywhere in the chain, exactly as `sdlc feature --safe`
     does today: the brief and design are written to the run directory, the code is committed
     locally, and no tracker or forge is touched.
+
+    ``resume`` continues a run that already exists: it keeps the run id, and adopts the
+    tracker issue that run already created rather than creating a second one. ``max_cost_usd``
+    caps LLM spend for the run; exhausting it parks the run instead of shipping half a change.
     """
+    from orchestrator.core.llm import RunBudget
+    from orchestrator.sdlc.runstate import RunRecord, RunStore
+
     emit: Callable[[str], None] = log or (lambda _m: None)
-    run_id = uuid.uuid4().hex[:16]
+    store = store or RunStore()
+
+    record = store.load(resume) if resume else None
+    if resume and record is None:
+        raise AutorunError(f"no run {resume!r} to resume", code=2)
+    if record is not None:
+        emit(f"[autorun] resuming {record.run_id} · phase {record.phase or 'start'}")
+        if record.issue_key:
+            # The half that must not happen twice. A crashed run that had already created a
+            # ticket is why `--issue` adoption exists at all.
+            issue = issue or record.issue_key
+            emit(f"[autorun] adopting {record.issue_key} from the previous attempt")
+        record.status = "running"
+        record.pid = os.getpid()
+    run_id = record.run_id if record else uuid.uuid4().hex[:16]
+
     ctx = RunContext(
         run_id=run_id,
         source=source,
@@ -134,7 +182,36 @@ async def autorun(
         root=Path(root),
         artifacts_dir=artifacts_dir or default_artifacts_dir(run_id),
     )
+    if record is None:
+        record = RunRecord(
+            run_id=run_id,
+            source=source,
+            live=live,
+            started_at=time.time(),
+            pid=os.getpid(),
+            artifacts_dir=str(ctx.artifacts_dir),
+        )
+    # One run owns one ticket. A second run against a ticket someone else is driving would
+    # race it for the same branch and the same issue — the duplicate-ticket failure again,
+    # this time with two live processes.
+    if issue:
+        held = store.active_for_issue(issue)
+        if held is not None and held.run_id != run_id:
+            raise AutorunError(
+                f"{issue} is already held by run {held.run_id} ({held.status}). "
+                f"Resume it with --resume {held.run_id}, or reap it if its process is gone.",
+                code=2,
+            )
+        record.issue_key = issue
+
+    ctx.record, ctx.store = record, store
+    ctx.issue_key = record.issue_key
+    ctx.checkpoint(phase="start", status="running")
+
+    budget = RunBudget(max_cost_usd=max_cost_usd) if max_cost_usd else None
     emit(f"[autorun] run {run_id} · source {source} · {'live' if live else 'safe'}")
+    if budget is not None:
+        emit(f"[budget] cap ${max_cost_usd:.2f} for this run")
 
     await _stage_intake(ctx, intent_id=intent_id, emit=emit)
     store, overview = _load_graph(ctx, emit=emit)
@@ -148,12 +225,18 @@ async def autorun(
         max_refine=max_refine,
         base_branch=base_branch,
         language=language,
+        budget=budget,
         emit=emit,
     )
     _stage_review(ctx, emit=emit)
 
+    ctx.checkpoint(phase="done", status="done", spent_usd=_spent(budget, run_id))
     emit(f"[autorun] artifacts in {ctx.artifacts_dir}")
     return ctx
+
+
+def _spent(budget: Any, run_id: str) -> float:
+    return float(budget.spent(run_id)) if budget is not None else 0.0
 
 
 # ---- stages ----------------------------------------------------------------
@@ -176,22 +259,22 @@ async def _stage_intake(ctx: RunContext, *, intent_id: str | None, emit: Callabl
     try:
         service = build_service_for(ctx.source, dry_run=True)
     except IntakeNotConfiguredError as exc:
-        ctx.record("intake", "failed", str(exc))
+        ctx.record_stage("intake", "failed", str(exc))
         raise AutorunError(str(exc), code=2) from exc
 
     plan = await analyze_cached(service, ctx.source, refresh=False, log=emit)
     if not plan.specs:
-        ctx.record("intake", "failed", "no specs derived from the source")
+        ctx.record_stage("intake", "failed", "no specs derived from the source")
         raise AutorunError("No specs derived from the source — nothing to implement.", code=3)
 
     chosen = next((s for s in plan.specs if s.intent_id == intent_id), None) if intent_id else plan.specs[0]
     if chosen is None:
         ids = ", ".join(s.intent_id for s in plan.specs)
-        ctx.record("intake", "failed", f"intent {intent_id!r} not found")
+        ctx.record_stage("intake", "failed", f"intent {intent_id!r} not found")
         raise AutorunError(f"Intent {intent_id!r} not found. Available: {ids}", code=3)
 
     ctx.spec = chosen.model_dump()
-    ctx.record("intake", "ok", f"spec: {ctx.spec.get('title', '')}")
+    ctx.record_stage("intake", "ok", f"spec: {ctx.spec.get('title', '')}")
     emit(f"[intake] {ctx.spec.get('title', '')} (intent {ctx.spec.get('intent_id', '')})")
 
 
@@ -221,7 +304,7 @@ def _stage_investigate(ctx: RunContext, *, store: Any, emit: Callable[[str], Non
     )
     path = ctx.write_artifact("investigation.md", render_investigation_md(investigation))
     landed = len(getattr(investigation, "landing", []) or [])
-    ctx.record("investigate", "ok", f"{landed} symbol(s) this ticket lands on", path)
+    ctx.record_stage("investigate", "ok", f"{landed} symbol(s) this ticket lands on", path)
     emit(f"[investigate] {landed} symbol(s) · {path}")
 
 
@@ -241,7 +324,7 @@ async def _stage_design(
     # Carried into the implement stage. Writing an artifact nobody reads is the difference
     # between chaining commands and connecting them.
     ctx.plan = rendered
-    ctx.record("design", "ok", f"{touched} file(s) proposed", path)
+    ctx.record_stage("design", "ok", f"{touched} file(s) proposed", path)
     emit(f"[design] {touched} file(s) proposed · {path}")
 
 
@@ -254,34 +337,51 @@ async def _stage_implement(
     max_refine: int,
     base_branch: str | None,
     language: str,
+    budget: Any,
     emit: Callable[[str], None],
 ) -> None:
     """Codegen, tests and (live) the PR — `sdlc feature`, unchanged, with our spec injected."""
+    import contextlib
+
+    from orchestrator.core.llm import BudgetExceededError
     from orchestrator.sdlc.feature_runner import FeatureRunError, run_feature
 
+    # Attribute spend to this run. Without it every charge lands on the shared "unscoped"
+    # bucket, the cap is enforced against the wrong total, and the run record reports $0.00
+    # for a run that spent real money.
+    scope = budget.activate(ctx.run_id) if budget is not None else contextlib.nullcontext()
     try:
-        result = await run_feature(
-            ctx.source,
-            intent_id=intent_id,
-            repo=repo,
-            max_refine=max_refine,
-            live=ctx.live,
-            issue=issue,
-            design=ctx.plan,
-            base_branch=base_branch,
-            language=language,
-            spec=ctx.spec,
-            log=emit,
-        )
+        with scope:
+            result = await run_feature(
+                ctx.source,
+                intent_id=intent_id,
+                repo=repo,
+                max_refine=max_refine,
+                live=ctx.live,
+                issue=issue,
+                design=ctx.plan,
+                base_branch=base_branch,
+                language=language,
+                spec=ctx.spec,
+                budget=budget,
+                log=emit,
+            )
+    except BudgetExceededError as exc:
+        # Out of money mid-change. Park it: the work so far is on a branch and a human can
+        # decide whether to raise the cap or drop it. Shipping half a change would be worse.
+        ctx.record_stage("implement", "failed", f"budget exhausted: {exc}")
+        ctx.checkpoint(status="parked", parked_reason=str(exc), spent_usd=_spent(budget, ctx.run_id))
+        raise AutorunError(f"budget exhausted — run parked: {exc}", code=4) from exc
     except FeatureRunError as exc:
-        ctx.record("implement", "failed", str(exc))
+        ctx.record_stage("implement", "failed", str(exc))
+        ctx.checkpoint(status="failed")
         raise AutorunError(str(exc), code=exc.code) from exc
 
     ctx.issue_key = result.issue_key
     ctx.branch = result.branch
     ctx.worktree = result.worktree
     ctx.pr_url = result.pr_url
-    ctx.record(
+    ctx.record_stage(
         "implement",
         "ok",
         f"{len(result.files)} file(s) changed on {result.branch} after {result.iterations} test run(s)",
@@ -296,10 +396,10 @@ def _stage_review(ctx: RunContext, *, emit: Callable[[str], None]) -> None:
     this stage exists so the skeleton's shape is honest about where that loop will attach.
     """
     if not ctx.pr_url:
-        ctx.record("review", "skipped", "no PR to review (safe mode opens none)")
+        ctx.record_stage("review", "skipped", "no PR to review (safe mode opens none)")
         emit("[review] skipped — safe mode opens no PR")
         return
-    ctx.record("review", "skipped", f"review of {ctx.pr_url} not wired yet (SSPN-24)")
+    ctx.record_stage("review", "skipped", f"review of {ctx.pr_url} not wired yet (SSPN-24)")
     emit(f"[review] skipped — {ctx.pr_url} awaits the review loop (SSPN-24)")
 
 

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -177,6 +177,7 @@ async def run_feature(
     live: bool = False,
     issue: str | None = None,
     design: str = "",
+    budget: Any = None,
     base_branch: str | None = None,
     layout_mode: str = "auto",
     package_name: str | None = None,
@@ -235,7 +236,15 @@ async def run_feature(
     # Wrap in RecordingLLMClient — the OTel chokepoint (emits an llm.complete span
     # per call) + per-stage token ledger. Drop-in (implements LLMClient), so the
     # linear CLI path is now traced like the worker path.
-    llm = RecordingLLMClient(LiteLLMClient())
+    # A supervisor may hand us a spend cap. Wrapping *under* the recorder keeps the ledger
+    # and the OTel spans intact — the budget refuses the call, the recorder still sees every
+    # call that happened. Without a budget this is exactly the client it always was.
+    inner: Any = LiteLLMClient()
+    if budget is not None:
+        from orchestrator.core.llm import BudgetedLLMClient
+
+        inner = BudgetedLLMClient(inner, budget)
+    llm = RecordingLLMClient(inner)
 
     # 1. Obtain the spec. Normally: source → intents → specs (intake, cached +
     #    temperature-0 so a pinned --intent stays addressable). When a spec is

--- a/src/orchestrator/sdlc/runstate.py
+++ b/src/orchestrator/sdlc/runstate.py
@@ -1,0 +1,201 @@
+"""What a run knows about itself, on disk — so a crash is recoverable, not fatal.
+
+The walking skeleton held its state in a local variable for the length of one process. Kill
+it and you lose which ticket it owned, which worktree it built, and whether it had already
+created a tracker issue — the last of which is how a crashed run once minted a duplicate
+ticket that had to be deleted by hand.
+
+A run record fixes three things at once:
+
+* **Resume, not restart.** A retry picks up the same run, adopts the issue it already
+  created, and does not do the outward-facing half twice.
+* **One run owns one ticket.** Starting a second run against a ticket that already has a live
+  one is refused, rather than racing it.
+* **Reap.** A run whose process is gone is *findable* — with its worktree, branch and issue —
+  instead of being a mystery worktree and a ticket stuck In Progress.
+
+**Deliberately file-backed, not a database table.** The linear path runs with zero infra;
+requiring Postgres to run one ticket would make the supervisor less useful than the thing it
+supervises. The registry DB is the right home once a run spans processes (Mode B), and the
+record shape here is what that table will hold. Writes are atomic (temp file + replace) so a
+kill mid-write leaves the previous record readable rather than a truncated one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+RunStatus = Literal["running", "parked", "done", "failed", "abandoned"]
+
+# How long a record may go without a heartbeat before the reaper calls it abandoned. A stage
+# can legitimately take minutes (codegen, a test suite), so this is generous: the cost of
+# declaring a live run dead is worse than noticing a dead one late.
+STALE_AFTER_SECONDS = 3600.0
+
+
+@dataclass
+class RunRecord:
+    """One run's durable state. Everything a resume or a reaper needs, and nothing else."""
+
+    run_id: str
+    source: str
+    status: RunStatus = "running"
+    phase: str = ""
+    issue_key: str = ""
+    branch: str = ""
+    worktree: str = ""
+    pr_url: str = ""
+    verdict: str = ""
+    parked_reason: str = ""
+    spent_usd: float = 0.0
+    started_at: float = 0.0
+    heartbeat_at: float = 0.0
+    pid: int = 0
+    live: bool = False
+    artifacts_dir: str = ""
+
+    @property
+    def is_live_process(self) -> bool:
+        """Whether the owning process still exists.
+
+        A pid alone is not proof — pids are reused — so the heartbeat is what decides, and
+        the pid check only rules out the obvious case of a process that is plainly gone.
+        """
+        if self.status != "running":
+            return False
+        if time.time() - self.heartbeat_at > STALE_AFTER_SECONDS:
+            return False
+        if not self.pid:
+            return True
+        try:
+            os.kill(self.pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:  # someone else's process, so it does exist
+            return True
+        return True
+
+
+@dataclass
+class RunStore:
+    """Records on disk, one JSON file per run."""
+
+    root: Path = field(default_factory=lambda: default_state_dir())
+
+    def path_for(self, run_id: str) -> Path:
+        return self.root / f"{run_id}.json"
+
+    def save(self, record: RunRecord) -> None:
+        """Atomic write: a kill mid-save leaves the previous record, never a half-written one."""
+        self.root.mkdir(parents=True, exist_ok=True)
+        record.heartbeat_at = time.time()
+        payload = json.dumps(asdict(record), indent=2, sort_keys=True)
+        fd, tmp = tempfile.mkstemp(dir=str(self.root), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+            os.replace(tmp, self.path_for(record.run_id))
+        except BaseException:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+
+    def load(self, run_id: str) -> RunRecord | None:
+        path = self.path_for(run_id)
+        if not path.is_file():
+            return None
+        try:
+            raw: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None  # unreadable record: treat as absent rather than crash a resume
+        known = {f for f in RunRecord.__dataclass_fields__}
+        return RunRecord(**{k: v for k, v in raw.items() if k in known})
+
+    def all(self) -> list[RunRecord]:
+        if not self.root.is_dir():
+            return []
+        records = [self.load(p.stem) for p in sorted(self.root.glob("*.json"))]
+        return [r for r in records if r is not None]
+
+    def active_for_issue(self, issue_key: str) -> RunRecord | None:
+        """A run still holding this ticket, if any — the one-run-per-ticket guard."""
+        if not issue_key:
+            return None
+        for record in self.all():
+            if record.issue_key != issue_key or record.status not in ("running", "parked"):
+                continue
+            # Parked means waiting for a human, not finished — it still owns the ticket.
+            if record.status == "parked" or record.is_live_process:
+                return record
+        return None
+
+    def stale(self) -> list[RunRecord]:
+        """Records claiming to be running whose process is gone — the reaper's input."""
+        return [r for r in self.all() if r.status == "running" and not r.is_live_process]
+
+
+def default_state_dir() -> Path:
+    """Outside the repo, like run artifacts: state is not source, and markdown in the tree
+    becomes ``Doc`` nodes."""
+    base = os.getenv("SPINE_RUN_STATE") or str(Path(tempfile.gettempdir()) / "spine-runs")
+    return Path(base) / "_state"
+
+
+def render_runs(records: list[RunRecord]) -> str:
+    """One table: which runs exist, what they hold, and whether anyone is still driving."""
+    if not records:
+        return "No runs recorded."
+    lines = ["| Run | Status | Phase | Issue | Spent | Alive |", "|---|---|---|---|---|---|"]
+    for r in sorted(records, key=lambda r: r.started_at, reverse=True):
+        alive = "yes" if r.is_live_process else "no"
+        lines.append(
+            f"| {r.run_id} | {r.status} | {r.phase or '—'} | {r.issue_key or '—'} "
+            f"| ${r.spent_usd:.2f} | {alive} |"
+        )
+    return "\n".join(lines)
+
+
+def render_reap(records: list[RunRecord]) -> str:
+    """What a dead run left behind. Reported, never cleaned up silently — a worktree may hold
+    the only copy of work someone wants, and a ticket's status is an outward-facing write."""
+    if not records:
+        return "Nothing to reap — no run is claiming to be alive without a process."
+    lines = [f"{len(records)} abandoned run(s):", ""]
+    for r in records:
+        lines.append(f"- **{r.run_id}** · last seen {_ago(r.heartbeat_at)} · phase {r.phase or '—'}")
+        if r.issue_key:
+            lines.append(f"    - issue `{r.issue_key}` may be left In Progress")
+        if r.worktree:
+            lines.append(f"    - worktree `{r.worktree}`")
+        if r.branch:
+            lines.append(f"    - branch `{r.branch}`")
+        if r.pr_url:
+            lines.append(f"    - PR {r.pr_url}")
+    return "\n".join(lines)
+
+
+def _ago(when: float) -> str:
+    if not when:
+        return "never"
+    seconds = max(0, int(time.time() - when))
+    if seconds < 60:
+        return f"{seconds}s ago"
+    if seconds < 3600:
+        return f"{seconds // 60}m ago"
+    return f"{seconds // 3600}h ago"
+
+
+__all__ = [
+    "STALE_AFTER_SECONDS",
+    "RunRecord",
+    "RunStatus",
+    "RunStore",
+    "default_state_dir",
+    "render_reap",
+    "render_runs",
+]

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -20,6 +20,7 @@ from orchestrator.sdlc.autorun import (
     default_artifacts_dir,
     render_summary,
 )
+from orchestrator.sdlc.runstate import RunRecord, RunStore
 
 
 @pytest.fixture(autouse=True)
@@ -209,10 +210,117 @@ def test_the_summary_reports_every_stage(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert "SSPN-42" in summary
 
 
+# ---- supervisor: state, resume, one-run-per-ticket, budget (SSPN-22) --------
+
+
+def test_a_run_records_itself_as_it_goes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A kill at any point must leave a findable run, not a mystery worktree."""
+    _install(monkeypatch)
+    store = RunStore(root=tmp_path / "state")
+
+    ctx = _run(tmp_path, store=store)
+
+    saved = store.load(ctx.run_id)
+    assert saved is not None
+    assert saved.status == "done" and saved.phase == "done"
+    assert saved.issue_key == "SSPN-42"
+    assert saved.branch == "feat/abc/SSPN-42" and saved.worktree == "/tmp/ws"
+
+
+def test_resume_adopts_the_issue_the_previous_attempt_created(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The half that must never happen twice. A crashed run that already created a ticket is
+    exactly how a duplicate got minted before `--issue` adoption existed."""
+    seen = _install(monkeypatch)
+    store = RunStore(root=tmp_path / "state")
+    store.save(RunRecord(run_id="prev", source="file://./spec.md", issue_key="SSPN-77", status="running"))
+
+    ctx = _run(tmp_path, store=store, resume="prev")
+
+    assert ctx.run_id == "prev"
+    assert seen["feature_kwargs"]["issue"] == "SSPN-77"
+
+
+def test_resuming_a_run_that_does_not_exist_is_refused(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install(monkeypatch)
+
+    with pytest.raises(AutorunError, match="no run 'nope'") as exc:
+        _run(tmp_path, store=RunStore(root=tmp_path / "state"), resume="nope")
+
+    assert exc.value.code == 2
+
+
+def test_a_second_run_cannot_take_a_held_ticket(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Two live runs on one ticket race for the same branch and the same issue."""
+    import os
+
+    _install(monkeypatch)
+    store = RunStore(root=tmp_path / "state")
+    store.save(RunRecord(run_id="held", source="s", issue_key="SSPN-5", status="running", pid=os.getpid()))
+
+    with pytest.raises(AutorunError, match="already held by run held") as exc:
+        _run(tmp_path, store=store, issue="SSPN-5")
+
+    assert exc.value.code == 2
+    assert "--resume held" in str(exc.value)  # says how to continue it
+
+
+def test_an_abandoned_run_does_not_block_the_ticket(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A dead process must not hold a ticket hostage."""
+    _install(monkeypatch)
+    store = RunStore(root=tmp_path / "state")
+    store.save(RunRecord(run_id="dead", source="s", issue_key="SSPN-5", status="running", pid=999_999))
+
+    ctx = _run(tmp_path, store=store, issue="SSPN-5")
+
+    assert ctx.passed
+
+
+def test_budget_exhaustion_parks_the_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Out of money mid-change: park it with the work on a branch. Shipping half a change
+    because the wallet ran dry is worse than stopping."""
+    from orchestrator.core.llm import BudgetExceededError
+
+    _install(monkeypatch, feature=BudgetExceededError("run cap $1.00 exhausted"))
+    store = RunStore(root=tmp_path / "state")
+
+    with pytest.raises(AutorunError, match="budget exhausted") as exc:
+        _run(tmp_path, store=store, max_cost_usd=1.0)
+
+    assert exc.value.code == 4
+    parked = [r for r in store.all() if r.status == "parked"]
+    assert len(parked) == 1
+    assert "exhausted" in parked[0].parked_reason
+
+
+def test_a_failed_run_is_recorded_as_failed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from orchestrator.sdlc.feature_runner import FeatureRunError
+
+    _install(monkeypatch, feature=FeatureRunError("VERDICT: FAILED", code=1))
+    store = RunStore(root=tmp_path / "state")
+
+    with pytest.raises(AutorunError):
+        _run(tmp_path, store=store)
+
+    assert [r.status for r in store.all()] == ["failed"]
+
+
 # ---- helper ----------------------------------------------------------------
 
 
-def _run(tmp_path: Path, *, intent_id: str | None = None, live: bool = False) -> RunContext:
+def _run(
+    tmp_path: Path,
+    *,
+    intent_id: str | None = None,
+    live: bool = False,
+    store: Any = None,
+    resume: str | None = None,
+    issue: str | None = None,
+    max_cost_usd: float | None = None,
+) -> RunContext:
     """Run the skeleton against a tiny real repo, so the graph stages do real work."""
     import asyncio
 
@@ -227,5 +335,9 @@ def _run(tmp_path: Path, *, intent_id: str | None = None, live: bool = False) ->
             root=repo,
             live=live,
             artifacts_dir=tmp_path / "artifacts",
+            store=store or RunStore(root=tmp_path / "state"),
+            resume=resume,
+            issue=issue,
+            max_cost_usd=max_cost_usd,
         )
     )

--- a/tests/sdlc/test_runstate.py
+++ b/tests/sdlc/test_runstate.py
@@ -1,0 +1,145 @@
+"""Durable run state: resume instead of restart, one run per ticket, and find the dead ones.
+
+The failures these guard against all happened for real. A crashed run minted a duplicate
+ticket because nothing recorded that it had already created one; a killed run left a worktree
+and a ticket stuck In Progress with nothing tying them together.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from orchestrator.sdlc.runstate import (
+    STALE_AFTER_SECONDS,
+    RunRecord,
+    RunStore,
+    default_state_dir,
+    render_reap,
+    render_runs,
+)
+
+
+def _store(tmp_path: Path) -> RunStore:
+    return RunStore(root=tmp_path / "state")
+
+
+def test_a_record_round_trips(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.save(RunRecord(run_id="abc", source="jira://X-1", issue_key="X-1", started_at=time.time()))
+
+    loaded = store.load("abc")
+
+    assert loaded is not None
+    assert (loaded.run_id, loaded.source, loaded.issue_key) == ("abc", "jira://X-1", "X-1")
+    assert loaded.heartbeat_at > 0  # stamped on save, so staleness is measurable
+
+
+def test_an_unknown_or_unreadable_record_reads_as_absent(tmp_path: Path) -> None:
+    """A resume must fail with 'no such run', not with a JSON error from a half-written file."""
+    store = _store(tmp_path)
+    store.root.mkdir(parents=True)
+    (store.root / "broken.json").write_text("{ not json", encoding="utf-8")
+
+    assert store.load("missing") is None
+    assert store.load("broken") is None
+
+
+def test_a_write_is_atomic(tmp_path: Path) -> None:
+    """A kill mid-save must leave the previous record readable, never a truncated one."""
+    store = _store(tmp_path)
+    record = RunRecord(run_id="abc", source="s", phase="design")
+    store.save(record)
+    record.phase = "implement"
+    store.save(record)
+
+    assert store.load("abc") is not None
+    assert store.load("abc").phase == "implement"  # type: ignore[union-attr]
+    assert not list(store.root.glob("*.tmp"))  # no debris left behind
+
+
+def test_a_ticket_is_held_by_at_most_one_live_run(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.save(RunRecord(run_id="live", source="s", issue_key="X-1", status="running", pid=os.getpid()))
+
+    held = store.active_for_issue("X-1")
+
+    assert held is not None and held.run_id == "live"
+    assert store.active_for_issue("X-2") is None
+
+
+def test_a_finished_run_does_not_hold_its_ticket(tmp_path: Path) -> None:
+    """Otherwise a ticket could never be worked twice — a fix and its follow-up would collide."""
+    store = _store(tmp_path)
+    store.save(RunRecord(run_id="old", source="s", issue_key="X-1", status="done"))
+
+    assert store.active_for_issue("X-1") is None
+
+
+def test_a_parked_run_keeps_holding_its_ticket(tmp_path: Path) -> None:
+    """Parked means waiting for a human, not finished — starting a second run would race it."""
+    store = _store(tmp_path)
+    store.save(RunRecord(run_id="p", source="s", issue_key="X-1", status="parked", pid=999999))
+
+    held = store.active_for_issue("X-1")
+
+    assert held is not None and held.run_id == "p"
+
+
+def test_a_run_whose_process_is_gone_is_reapable(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.save(
+        RunRecord(
+            run_id="dead",
+            source="s",
+            issue_key="X-9",
+            status="running",
+            worktree="/tmp/ws",
+            branch="feat/x",
+            pid=999_999,  # not a live pid
+        )
+    )
+
+    stale = store.stale()
+
+    assert [r.run_id for r in stale] == ["dead"]
+    report = render_reap(stale)
+    assert "X-9" in report and "/tmp/ws" in report and "feat/x" in report
+
+
+def test_a_silent_run_goes_stale_even_if_the_pid_is_reused(tmp_path: Path) -> None:
+    """A pid is not proof — pids get reused — so the heartbeat is what decides."""
+    store = _store(tmp_path)
+    record = RunRecord(run_id="quiet", source="s", status="running", pid=os.getpid())
+    store.save(record)
+    record.heartbeat_at = time.time() - (STALE_AFTER_SECONDS + 1)
+    store.save(record)
+    # save() re-stamps the heartbeat, so write the aged record directly.
+    path = store.path_for("quiet")
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            f'"heartbeat_at": {store.load("quiet").heartbeat_at}',  # type: ignore[union-attr]
+            f'"heartbeat_at": {time.time() - STALE_AFTER_SECONDS - 1}',
+        ),
+        encoding="utf-8",
+    )
+
+    assert [r.run_id for r in store.stale()] == ["quiet"]
+
+
+def test_the_state_dir_is_outside_the_repo(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("SPINE_RUN_STATE", raising=False)
+    assert Path.cwd() not in default_state_dir().parents
+
+
+def test_the_listing_says_who_is_still_driving(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.save(RunRecord(run_id="a", source="s", status="running", pid=os.getpid(), issue_key="X-1"))
+    store.save(RunRecord(run_id="b", source="s", status="parked", issue_key="X-2", spent_usd=1.5))
+
+    table = render_runs(store.all())
+
+    assert "X-1" in table and "X-2" in table
+    assert "$1.50" in table
+    assert render_runs([]) == "No runs recorded."


### PR DESCRIPTION
Closes **[SSPN-22](https://fibonacci-solutions.atlassian.net/browse/SSPN-22)** — phase 3.

Stacked on [#100](https://github.com/synaptixs/spine/pull/100) and [#101](https://github.com/synaptixs/spine/pull/101); merge those first.

## What & why

The skeleton kept its state in a local variable for the length of one process. Kill it and you lost which ticket it owned, which worktree it built, and whether it had **already created a tracker issue** — the last of which is exactly how a crashed run once minted a duplicate that had to be deleted by hand.

`RunRecord` is written after every stage, atomically (temp file + replace), so a kill mid-write leaves the previous record readable rather than a truncated one.

| Capability | How |
|---|---|
| **Resume, not restart** | `--resume <id>` keeps the run id and **adopts the issue the previous attempt created**, so the outward-facing half never happens twice |
| **One run owns one ticket** | A second run against a held ticket is refused, and told how to continue the first |
| **Reap** | `sdlc runs reap` finds runs claiming to be alive whose process is gone, and reports the worktree, branch and issue each left behind |
| **Bounded spend** | `--max-cost` reuses the existing `RunBudget` / `BudgetedLLMClient` that the Temporal worker already uses — the linear path simply never had them wired |

New surface: `sdlc runs list|show|reap`, and `sdlc autorun --resume --max-cost`.

## Decisions worth reviewing

- **Reap reports, never cleans up.** A worktree may hold the only copy of someone's work, and a ticket's status is an outward-facing write. Cleanup stays a human's call.
- **Liveness is heartbeat-first.** Pids get reused, so the pid check only rules out the plainly-dead case.
- **Parked keeps holding its ticket** — parked means waiting for a human, not finished. A `done` run releases it, or a fix and its follow-up could never both be worked.
- **File-backed, not a DB table.** The linear path runs with zero infra; requiring Postgres to run one ticket would make the supervisor less useful than the thing it supervises. The record shape is what the Mode-B table will hold.

## A bug the live run caught

The first live run reported `spent $0.07 of $0.01 cap` for run **`'unscoped'`**, and the record showed `$0.00`. The budget was never *activated* for the run, so every charge landed on the shared bucket and the cap was enforced against the wrong total. Fixed, and re-verified:

```
budget exhausted — run parked: LLM budget exhausted for run 'ef920ca58c8e4500': spent $0.05 of $0.01 cap

| Run              | Status | Phase     | Issue | Spent | Alive |
| ef920ca58c8e4500 | parked | implement | —     | $0.05 | no    |
```

## Deferred, deliberately

Parking against an `ApprovalRequest` with a timeout is [SSPN-25](https://fibonacci-solutions.atlassian.net/browse/SSPN-25); a run parks and is findable today, but nobody is notified. Reverting a ticket's status on reap needs the same approval path. Neither is smuggled in here.

## How it was tested

```
pytest              2213 passed, 30 skipped   (2196 before — 17 new)
mypy src tests      no issues in 586 source files
ruff check . / ruff format --check .
```

17 tests: round-trip, unreadable-record tolerance, atomic write, the ticket guard (held / finished / parked / abandoned), resume adoption, budget parking, and failure recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)