### PR TITLE
fix(sdlc): propose files the ticket lands in, not the graph's biggest modules

### DIFF
--- a/src/orchestrator/sdlc/design.py
+++ b/src/orchestrator/sdlc/design.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import re
 from typing import TYPE_CHECKING, Any
 
 from orchestrator.runtime import ArtifactStore
@@ -65,22 +66,94 @@ def _structure_lines(overview: dict[str, Any] | None) -> list[str]:
     return lines
 
 
-def _fallback_design(spec: dict[str, Any], overview: dict[str, Any] | None) -> dict[str, Any]:
-    mods = [str(m["module"]) for m in (overview or {}).get("modules", [])[:5]]
+def _landing_files(spec: dict[str, Any], store: FactStore | None) -> list[str]:
+    """Where this *ticket* lands, from the same reading `investigate` does.
+
+    The previous heuristic listed the overview's biggest modules, which is a fact about the
+    repo rather than about the ticket: a request to add a CLI flag came back as "touch
+    registry/db/models.py, sdlc/testenv.py, sdlc/codegen.py". Plausible-looking and wrong is
+    the worst thing a design can be, and once the design is carried into codegen it is an
+    instruction to edit the wrong files.
+
+    Reusing the investigation keeps the two stages agreeing with each other instead of
+    contradicting each other — they now answer "where does this land" the same way, because
+    it is the same code answering.
+    """
+    if store is None:
+        return []
+    from orchestrator.sdlc.investigate import build_investigation
+
+    investigation = build_investigation(
+        str(spec.get("title", "")), str(spec.get("summary", "")), store=store, max_symbols=8
+    )
+    files: list[str] = []
+    for landing in investigation.landing:
+        path = landing.where.split(":", 1)[0]
+        if path and path not in files:
+            files.append(path)
+    return files[:5]
+
+
+def _overview_files(spec: dict[str, Any], overview: dict[str, Any] | None) -> list[str]:
+    """Ticket words matched against module and symbol names, for callers with no graph.
+
+    The SDLC activity path carries a persisted overview, not a ``FactStore``. Matching the
+    ticket's own words against what the overview names is weaker than the graph reading, but
+    it is still *about the ticket* — where ranking modules by size was only ever about the
+    repo. A module nothing in the ticket mentions is not proposed at all.
+    """
+    modules = (overview or {}).get("modules") or []
+    if not modules:
+        return []
+    text = " ".join(
+        [str(spec.get("title", "")), str(spec.get("summary", ""))]
+        + [str(a) for a in (spec.get("acceptance_criteria") or [])]
+    ).lower()
+    tokens = {t for t in re.split(r"[^a-z0-9]+", text) if len(t) > 3}
+    if not tokens:
+        return []
+
+    symbols_by_module: dict[str, list[str]] = {}
+    for sym in (overview or {}).get("top_symbols") or []:
+        symbols_by_module.setdefault(str(sym.get("module", "")), []).append(str(sym.get("name", "")).lower())
+
+    scored: list[tuple[int, str]] = []
+    for module in modules:
+        name = str(module.get("module", ""))
+        haystack = {*re.split(r"[^a-z0-9]+", name.lower()), *symbols_by_module.get(name, [])}
+        hits = len(tokens & haystack)
+        if hits:
+            scored.append((hits, name))
+    scored.sort(key=lambda pair: (-pair[0], pair[1]))
+    return [name for _, name in scored[:5]]
+
+
+def _fallback_design(
+    spec: dict[str, Any], overview: dict[str, Any] | None, store: FactStore | None = None
+) -> dict[str, Any]:
+    # The graph reading first; the overview's names second; nothing at all rather than a guess.
+    files = _landing_files(spec, store) or _overview_files(spec, overview)
     ac = [str(a) for a in (spec.get("acceptance_criteria") or [])]
+    # Say which it is. A consumer — a human reading design.md, or the codegen prompt now
+    # carrying it — has to be able to tell a grounded reading from a shrug.
+    risks = ["Heuristic design (no LLM) — confirm the affected files before building."]
+    if not files:
+        risks = [
+            "Heuristic design (no LLM) and nothing in the graph matched this ticket's words, "
+            "so no files are proposed. Locate the change before building rather than trusting "
+            "this list."
+        ]
     return {
         "approach": (
             f"Implement '{spec.get('title', 'the feature')}' following the repo's existing "
             "structure and conventions."
         ),
-        "files_to_touch": mods,
+        "files_to_touch": files,
         "interfaces": [],
         "data_changes": [],
-        "risks": (
-            ["Heuristic design (no LLM) — confirm the affected modules before building."] if mods else []
-        ),
+        "risks": risks,
         "test_strategy": "Add tests covering each acceptance criterion: " + "; ".join(ac[:6]),
-        "grounded": bool(overview),
+        "grounded": bool(files),
         "llm": False,
     }
 
@@ -177,9 +250,11 @@ async def produce_design(
     """
     ctx = {"overview": overview, "memory_bank": memory_bank or {}}
     try:
-        design = await _llm_design(spec, ctx, llm) if llm is not None else _fallback_design(spec, overview)
+        design = (
+            await _llm_design(spec, ctx, llm) if llm is not None else _fallback_design(spec, overview, store)
+        )
     except Exception:  # noqa: BLE001 — LLM/parse failure → deterministic design, never blocks
-        design = _fallback_design(spec, overview)
+        design = _fallback_design(spec, overview, store)
     if store is not None:
         with contextlib.suppress(Exception):  # impact is an annotation; never fail the design
             from orchestrator.sdlc.impact import blast_radius, to_dict

--- a/tests/sdlc/test_design.py
+++ b/tests/sdlc/test_design.py
@@ -48,8 +48,11 @@ async def test_heuristic_design_grounded_in_graph_and_persisted() -> None:
     assert out["issue_key"] == "SDLC-1" and out["llm"] is False
     d = out["design"]
     assert d["grounded"] is True
-    # files-to-touch come from the real modules in the graph overview
-    assert "report.py" in d["files_to_touch"] and "web.py" in d["files_to_touch"]
+    # Files-to-touch are matched to the *ticket*, not ranked by module size: the spec says
+    # "Export a report as CSV", so report.py is proposed and web.py — which the ticket never
+    # mentions — is not. Ranking by size is what produced designs naming the graph's biggest
+    # modules for a change that lived somewhere else entirely.
+    assert d["files_to_touch"] == ["report.py"]
     assert "Downloads a .csv" in d["test_strategy"]
     # persisted under the per-feature namespace
     assert out["artifacts"]["design.md"] == "run/R/feature/SDLC-1/design.md"
@@ -202,3 +205,82 @@ def test_render_design_md_sections() -> None:
         _SPEC, {"approach": "A", "files_to_touch": ["x.py"], "test_strategy": "T", "llm": True}
     )
     assert "## Approach" in md and "## Files to touch" in md and "x.py" in md and "## Test strategy" in md
+
+
+# --------------------------------------------------------------------------- #
+# Heuristic files-to-touch (SSPN-29)
+# --------------------------------------------------------------------------- #
+
+
+def _graph_with(*modules: str) -> Any:
+    """A store whose graph holds one function per named module."""
+    from orchestrator.pkg import FactStore
+    from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+
+    batch = FactBatch()
+    for module in modules:
+        mid = f"py:{module.removesuffix('.py').replace('/', '.')}"
+        batch.add_node(Node(mid, NodeKind.MODULE, module, "python", Provenance(module, 1)))
+        fname = module.removesuffix(".py").split("/")[-1]
+        fid = f"{mid}.{fname}_handler"
+        batch.add_node(Node(fid, NodeKind.FUNCTION, f"{fname}_handler", "python", Provenance(module, 5)))
+        batch.add_edge(Edge(mid, fid, EdgeKind.CONTAINS))
+    return FactStore(batch)
+
+
+async def test_heuristic_files_come_from_where_the_ticket_lands() -> None:
+    """The bug this closes: the design listed the graph's biggest modules regardless of the
+    ticket, so a request to add a CLI flag came back as "touch registry/db/models.py".
+
+    Once the design is carried into codegen, a wrong file list stops being cosmetic and
+    becomes an instruction to edit the wrong files.
+    """
+    from orchestrator.sdlc.design import produce_design
+
+    store = _graph_with("src/exporter.py", "src/unrelated.py")
+    design = await produce_design(
+        {"title": "Fix the exporter", "summary": "exporter drops the header", "acceptance_criteria": []},
+        overview=None,
+        store=store,
+        llm=None,
+    )
+
+    assert design["files_to_touch"] == ["src/exporter.py"]
+    assert design["grounded"] is True
+
+
+async def test_a_design_that_cannot_tell_says_so_and_proposes_nothing() -> None:
+    """Naming none is a usable answer; naming the wrong five is not."""
+    from orchestrator.sdlc.design import produce_design
+
+    design = await produce_design(
+        {"title": "Something unrelated to any code here", "summary": "", "acceptance_criteria": []},
+        overview=None,
+        store=_graph_with("src/exporter.py"),
+        llm=None,
+    )
+
+    assert design["files_to_touch"] == []
+    assert design["grounded"] is False
+    assert any("no files are proposed" in risk for risk in design["risks"])
+
+
+async def test_the_design_agrees_with_the_investigation() -> None:
+    """Two stages answering "where does this land" differently is worse than either being
+    wrong alone — a reader cannot tell which to believe. They now share the same code."""
+    from orchestrator.sdlc.design import produce_design
+    from orchestrator.sdlc.investigate import build_investigation
+
+    store = _graph_with("src/exporter.py", "src/other.py")
+    spec: dict[str, Any] = {
+        "title": "Fix the exporter",
+        "summary": "exporter drops the header",
+        "acceptance_criteria": [],
+    }
+
+    design = await produce_design(spec, overview=None, store=store, llm=None)
+    investigation = build_investigation(str(spec["title"]), str(spec["summary"]), store=store)
+
+    landed = [land.where.split(":", 1)[0] for land in investigation.landing]
+    assert design["files_to_touch"]
+    assert all(f in landed for f in design["files_to_touch"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,10 +69,15 @@ def test_design_requires_a_title(runner: CliRunner, tmp_path: Path) -> None:
 
 def test_design_emits_grounded_blast_radius(runner: CliRunner, tmp_path: Path) -> None:
     """`design` grounds the spec in the repo's real modules and annotates the
-    blast radius from the knowledge graph (heuristic path — no LLM)."""
-    (tmp_path / "report.py").write_text("def render(rows):\n    return rows\n", encoding="utf-8")
+    blast radius from the knowledge graph (heuristic path — no LLM).
+
+    The fixture names something the ticket is actually about. It used to define `render` and
+    still expect a design for "Add CSV export" to propose `report.py` — which only worked
+    because the heuristic ranked modules by size rather than by relevance to the ticket.
+    """
+    (tmp_path / "report.py").write_text("def export_csv(rows):\n    return rows\n", encoding="utf-8")
     (tmp_path / "web.py").write_text(
-        "import report\n\ndef handler(rows):\n    return report.render(rows)\n", encoding="utf-8"
+        "import report\n\ndef handler(rows):\n    return report.export_csv(rows)\n", encoding="utf-8"
     )
     result = runner.invoke(app, ["design", str(tmp_path), "--title", "Add CSV export"])
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
Closes **[SSPN-29](https://fibonacci-solutions.atlassian.net/browse/SSPN-29)**.

Stacked on [#100](https://github.com/synaptixs/spine/pull/100)/[#101](https://github.com/synaptixs/spine/pull/101); merge those first.

## What & why

The heuristic design listed the **top five modules of the graph overview** as "files to touch" — a fact about the repo, not about the ticket. A request to add a `--format json` flag to one CLI command came back as:

```
src/orchestrator/registry/db/models.py
tests/sdlc/test_testenv.py
src/orchestrator/sdlc/codegen.py
src/orchestrator/knowledge/renderers.py
src/orchestrator/sdlc/testenv.py
```

Plausible-looking and wrong is the worst thing a design can be — and it stopped being cosmetic the moment [#101](https://github.com/synaptixs/spine/pull/101) started carrying the design into the codegen prompt. A wrong file list is an instruction to edit the wrong files.

## The change

Files now come from **where the ticket lands**, read the same way `investigate` reads it — `GroundedRetriever.relevant_symbols` resolved to owning modules. Literally the same code, so the two stages can no longer contradict each other about where a change belongs; a reader who sees them disagree cannot tell which to believe.

| Caller | Reading |
|---|---|
| Has a `FactStore` (CLI, autorun) | The graph: where the ticket's words land |
| Overview only (SDLC activity path) | The ticket's words matched against module and symbol names |
| Nothing matches | **No files**, and a risk line saying so |

Naming none is a usable answer; naming the wrong five is not.

## Measured on the ticket that exposed it

`src/orchestrator/cli.py` is now the **first** file proposed — the actual home of `orchestrator regression`, absent from the old list entirely.

## Two existing tests asserted the old behaviour

Updated rather than worked around, and both are stronger for it:

- `test_design_emits_grounded_blast_radius` defined `render` and expected a design for *"Add CSV export"* to name `report.py` — which only passed because size ranking got there by accident. Its fixture now defines `export_csv`, so the grounding is real.
- The unit expectation tightens from `report.py` **and** `web.py` to `report.py` alone: the ticket says *"Export a report as CSV"* and never mentions web.

## How it was tested

```
pytest              2216 passed, 30 skipped   (2213 before — 3 new)
mypy src tests      no issues in 586 source files
ruff check . / ruff format --check .
```

New tests: files come from where the ticket lands; a design that cannot tell proposes nothing and says so; and the design agrees with the investigation on the same spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)