### PR TITLE
feat(sdlc): judge the ticket before building it (validity gate)

### DIFF
--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -36,7 +36,7 @@ from typing import Any, Literal
 StageStatus = Literal["ok", "skipped", "failed"]
 
 # The order is the contract: research before design, design before code, code before review.
-STAGES: tuple[str, ...] = ("intake", "investigate", "design", "implement", "review")
+STAGES: tuple[str, ...] = ("intake", "investigate", "validity", "design", "implement", "review")
 
 
 class AutorunError(RuntimeError):
@@ -78,6 +78,10 @@ class RunContext:
     # The design, rendered — handed to codegen so the implement stage acts on what the
     # design stage decided rather than re-deriving its own view of the ticket.
     plan: str = ""
+    # Where the investigation says this ticket lands. Shared with the validity gate so the
+    # two cannot disagree about what the ticket is even about.
+    landing: list[str] = field(default_factory=list)
+    verdict: str = ""
     stages: list[StageResult] = field(default_factory=list)
     # Durable state. Written after every stage, so a crash leaves a findable run rather than
     # a mystery worktree and a ticket stuck In Progress.
@@ -139,6 +143,7 @@ async def autorun(
     max_refine: int = 3,
     base_branch: str | None = None,
     language: str = "auto",
+    issue_type: str = "",
     artifacts_dir: Path | None = None,
     resume: str | None = None,
     max_cost_usd: float | None = None,
@@ -216,6 +221,7 @@ async def autorun(
     await _stage_intake(ctx, intent_id=intent_id, emit=emit)
     store, overview = _load_graph(ctx, emit=emit)
     _stage_investigate(ctx, store=store, emit=emit)
+    _stage_validity(ctx, store=store, issue_type=issue_type, emit=emit)
     await _stage_design(ctx, store=store, overview=overview, emit=emit)
     await _stage_implement(
         ctx,
@@ -303,9 +309,49 @@ def _stage_investigate(ctx: RunContext, *, store: Any, emit: Callable[[str], Non
         root=ctx.root,
     )
     path = ctx.write_artifact("investigation.md", render_investigation_md(investigation))
+    ctx.landing = []
+    for land in getattr(investigation, "landing", []) or []:
+        where = str(getattr(land, "where", "")).split(":", 1)[0]
+        if where and where not in ctx.landing:
+            ctx.landing.append(where)
     landed = len(getattr(investigation, "landing", []) or [])
     ctx.record_stage("investigate", "ok", f"{landed} symbol(s) this ticket lands on", path)
     emit(f"[investigate] {landed} symbol(s) · {path}")
+
+
+def _stage_validity(ctx: RunContext, *, store: Any, issue_type: str, emit: Callable[[str], None]) -> None:
+    """Is this ticket worth building, and is what it says about the code true?
+
+    The only stage that can stop a run before any code is written, and the reason the agent
+    is trustworthy at all: a ticket claiming eleven entities where the source has seven
+    would otherwise be built to a false premise, pass its own tests, and be wrong.
+    """
+    from orchestrator.sdlc.validity import Verdict, assess
+
+    assessment = assess(
+        ctx.spec or {},
+        store=store,
+        landing=ctx.landing,
+        issue_type=issue_type or str((ctx.spec or {}).get("issue_type", "")),
+        issue_key=ctx.issue_key,
+        prior_runs=ctx.store.all() if ctx.store is not None else [],
+    )
+    ctx.verdict = assessment.verdict.value
+    path = ctx.write_artifact("validity.md", assessment.render())
+
+    if assessment.verdict is Verdict.PROCEED:
+        ctx.record_stage("validity", "ok", "PROCEED — nothing contradicts the code", path)
+        emit("[validity] PROCEED")
+        return
+
+    detail = "; ".join(f.detail for f in assessment.findings) or assessment.verdict.value
+    ctx.record_stage("validity", "failed", f"{assessment.verdict.value}: {detail}", path)
+    # Parked, not failed: a refused ticket is a decision waiting for a human, and the run
+    # keeps its evidence so the human is not asked to take the agent's word for it.
+    ctx.checkpoint(status="parked", verdict=ctx.verdict, parked_reason=detail)
+    emit(f"[validity] {assessment.verdict.value} — {detail}")
+    emit(f"[validity] evidence in {path}")
+    raise AutorunError(f"{assessment.verdict.value}: {detail} — run parked, nothing was built.", code=5)
 
 
 async def _stage_design(

--- a/src/orchestrator/sdlc/validity.py
+++ b/src/orchestrator/sdlc/validity.py
@@ -1,0 +1,255 @@
+"""Is this ticket worth building — and is what it says about the code even true?
+
+The one piece of judgment in the run agent. Everything else composes tools that already
+exist; this decides whether to use them at all.
+
+**Why it exists.** Two tickets in one cycle would have wasted a full run each:
+
+* SSPN-3's acceptance criterion said *"11 ``Entity`` nodes on this repo"*. The source has 7.
+  An agent that treats criteria as ground truth either loops forever trying to reach 11 or
+  declares success at 7 and calls the criterion met.
+* SSPN-18 was a design defect described in prose, with no traceback. The RCA path localizes
+  from stack frames, so it resolved to nothing and reported *"the fault may be in a
+  dependency"* — pointing away from a bug squarely inside this repo.
+
+So the gate returns **one of a fixed set of verdicts with evidence**, never prose, and
+refusing a ticket is a first-class outcome rather than an error path.
+
+**Deterministic, no LLM.** Every check here reads the graph and compares it to what the
+ticket claims. A model asked "is this ticket sound?" produces a confident opinion; the graph
+produces a count. Where a check cannot be made from facts it is not made at all — the gate
+under-claims rather than guessing, because a gate that cries wolf gets switched off.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from orchestrator.pkg import FactStore
+from orchestrator.pkg.facts import NodeKind
+
+
+class Verdict(str, Enum):
+    """The gate's answer. ``PROCEED`` is the only one that continues a run."""
+
+    PROCEED = "PROCEED"
+    CRITERIA_WRONG = "CRITERIA_WRONG"  # a criterion contradicts the source
+    UNLOCALIZED = "UNLOCALIZED"  # a Bug that resolves to no symbol
+    ALREADY_DONE = "ALREADY_DONE"  # the graph says it exists
+    DUPLICATE = "DUPLICATE"  # another run already covered it
+    TOO_BIG = "TOO_BIG"  # split it before building it
+
+
+# Countable things a ticket can assert about a repo, and the node kind that answers it.
+# Only kinds the graph can count exactly: a claim about "functions" is rarely meant literally,
+# where "3 endpoints" or "11 entities" is a checkable statement of fact.
+_COUNTABLE: dict[str, NodeKind] = {
+    "entity": NodeKind.ENTITY,
+    "entities": NodeKind.ENTITY,
+    "table": NodeKind.ENTITY,
+    "tables": NodeKind.ENTITY,
+    "endpoint": NodeKind.ENDPOINT,
+    "endpoints": NodeKind.ENDPOINT,
+    "route": NodeKind.ENDPOINT,
+    "routes": NodeKind.ENDPOINT,
+    "module": NodeKind.MODULE,
+    "modules": NodeKind.MODULE,
+}
+
+# "11 Entity nodes", "7 tables", "≥ 70 route handlers". The noun may be wrapped in backticks
+# and followed by a qualifier ("nodes", "handlers"), which is why the kind word is matched
+# rather than the whole phrase.
+_CLAIM = re.compile(
+    r"(?P<count>\d+)\s+`?(?P<kind>[A-Za-z]+)`?\s*(?:nodes?|handlers?|declarations?)?\b",
+    re.IGNORECASE,
+)
+
+# Phrases that make a count a claim about *this repo as it is*, rather than a target to reach.
+# "add 3 endpoints" is work; "3 endpoints on this repo" is an assertion that can be false.
+_ASSERTS_CURRENT = re.compile(
+    r"\b(on|in)\s+(this|the)\s+(repo|repository|codebase|project)\b|\bcurrently\b|\bthere are\b",
+    re.IGNORECASE,
+)
+
+DEFAULT_MAX_CRITERIA = 12
+DEFAULT_MAX_FILES = 15
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One thing the gate noticed, with the evidence that makes it checkable."""
+
+    check: str
+    detail: str
+    evidence: str = ""
+
+
+@dataclass
+class Assessment:
+    verdict: Verdict = Verdict.PROCEED
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def proceed(self) -> bool:
+        return self.verdict is Verdict.PROCEED
+
+    def render(self) -> str:
+        lines = [f"**Verdict:** {self.verdict.value}", ""]
+        if not self.findings:
+            lines.append("Nothing in this ticket contradicts the code.")
+            return "\n".join(lines)
+        for finding in self.findings:
+            lines.append(f"- **{finding.check}** — {finding.detail}")
+            if finding.evidence:
+                lines.append(f"    - {finding.evidence}")
+        return "\n".join(lines)
+
+
+def _criteria_text(spec: dict[str, Any]) -> list[str]:
+    return [str(a) for a in (spec.get("acceptance_criteria") or [])]
+
+
+def _count_of(store: FactStore, kind: NodeKind) -> int:
+    """Grounded nodes only: an external placeholder is a table someone else owns, not one
+    this repo has."""
+    return len([n for n in store.nodes if n.kind is kind and not n.external])
+
+
+def _check_countable_claims(spec: dict[str, Any], store: FactStore) -> list[Finding]:
+    """A criterion that states a number the graph can check, and gets it wrong.
+
+    This is the SSPN-3 case exactly: *"11 Entity nodes on this repo"* against a source with
+    seven ``__tablename__`` declarations. The number is not a target to reach — the phrasing
+    asserts a present fact — so building to it is building to a false premise.
+    """
+    findings: list[Finding] = []
+    for criterion in _criteria_text(spec):
+        if not _ASSERTS_CURRENT.search(criterion):
+            continue
+        for match in _CLAIM.finditer(criterion):
+            kind = _COUNTABLE.get(match.group("kind").lower())
+            if kind is None:
+                continue
+            claimed = int(match.group("count"))
+            actual = _count_of(store, kind)
+            # A "≥ N" style criterion is satisfied by more, so only a strict mismatch counts.
+            at_least = bool(re.search(r"(≥|>=|at least|or more)\s*$", criterion[: match.start()].strip()))
+            if (at_least and actual >= claimed) or (not at_least and actual == claimed):
+                continue
+            findings.append(
+                Finding(
+                    check="countable-claim",
+                    detail=(
+                        f"the ticket says {claimed} {match.group('kind')} "
+                        f"{'or more ' if at_least else ''}exist here; the graph holds {actual}"
+                    ),
+                    evidence=criterion.strip(),
+                )
+            )
+    return findings
+
+
+def _check_localization(spec: dict[str, Any], landing: list[str], issue_type: str) -> list[Finding]:
+    """A Bug describes something that already exists. If nothing in the graph matches it, the
+    run has nowhere to start, and guessing a fault site is the failure RCA exists to avoid."""
+    if issue_type.strip().lower() not in {"bug", "defect"}:
+        return []
+    if landing:
+        return []
+    return [
+        Finding(
+            check="localization",
+            detail="nothing in the graph matches this bug's words, so there is no fault site to work from",
+            evidence="add a traceback, a failing test, or the symbol involved",
+        )
+    ]
+
+
+def _check_size(spec: dict[str, Any], files: list[str], max_criteria: int, max_files: int) -> list[Finding]:
+    findings: list[Finding] = []
+    criteria = _criteria_text(spec)
+    if len(criteria) > max_criteria:
+        findings.append(
+            Finding(
+                check="size",
+                detail=f"{len(criteria)} acceptance criteria — more than one change's worth",
+                evidence=f"cap is {max_criteria}; split the ticket before building it",
+            )
+        )
+    if len(files) > max_files:
+        findings.append(
+            Finding(
+                check="size",
+                detail=f"the change lands in {len(files)} modules",
+                evidence=f"cap is {max_files}",
+            )
+        )
+    return findings
+
+
+def _check_prior_runs(issue_key: str, runs: list[Any]) -> list[Finding]:
+    """Another run already carried this ticket to a PR. Doing it twice produces two branches
+    and two PRs for one piece of work — the duplicate problem, one level up."""
+    for record in runs:
+        if record.issue_key and record.issue_key == issue_key and record.status == "done":
+            return [
+                Finding(
+                    check="prior-run",
+                    detail=f"run {record.run_id} already completed this ticket",
+                    evidence=f"PR {record.pr_url}" if record.pr_url else "no PR recorded",
+                )
+            ]
+    return []
+
+
+def assess(
+    spec: dict[str, Any],
+    *,
+    store: FactStore,
+    landing: list[str] | None = None,
+    issue_type: str = "",
+    issue_key: str = "",
+    prior_runs: list[Any] | None = None,
+    max_criteria: int = DEFAULT_MAX_CRITERIA,
+    max_files: int = DEFAULT_MAX_FILES,
+) -> Assessment:
+    """Judge one ticket against the code. Deterministic; the graph answers, not a model.
+
+    ``landing`` is where the investigation says this ticket lands — passed in rather than
+    recomputed so the gate and the brief cannot disagree.
+    """
+    landing = landing or []
+    findings: list[Finding] = []
+
+    duplicate = _check_prior_runs(issue_key, prior_runs or [])
+    if duplicate:
+        return Assessment(verdict=Verdict.DUPLICATE, findings=duplicate)
+
+    wrong = _check_countable_claims(spec, store)
+    if wrong:
+        # Ordered first because it is the one failure that makes every later stage pointless:
+        # code built to a false premise passes its own tests and is still wrong.
+        return Assessment(verdict=Verdict.CRITERIA_WRONG, findings=wrong)
+
+    unlocalized = _check_localization(spec, landing, issue_type)
+    if unlocalized:
+        return Assessment(verdict=Verdict.UNLOCALIZED, findings=unlocalized)
+
+    oversized = _check_size(spec, landing, max_criteria, max_files)
+    if oversized:
+        return Assessment(verdict=Verdict.TOO_BIG, findings=oversized)
+
+    return Assessment(verdict=Verdict.PROCEED, findings=findings)
+
+
+__all__ = [
+    "DEFAULT_MAX_CRITERIA",
+    "DEFAULT_MAX_FILES",
+    "Assessment",
+    "Finding",
+    "Verdict",
+    "assess",
+]

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -103,7 +103,8 @@ def test_stages_run_in_order_and_record_themselves(monkeypatch: pytest.MonkeyPat
     ctx = _run(tmp_path)
 
     assert [s.name for s in ctx.stages] == list(STAGES)
-    assert [s.status for s in ctx.stages] == ["ok", "ok", "ok", "ok", "skipped"]
+    assert [s.status for s in ctx.stages] == ["ok", "ok", "ok", "ok", "ok", "skipped"]
+    assert ctx.verdict == "PROCEED"
     assert ctx.passed
 
 
@@ -143,7 +144,7 @@ def test_artifacts_are_written_outside_the_repo(monkeypatch: pytest.MonkeyPatch,
     ctx = _run(tmp_path)
 
     written = [Path(s.artifact) for s in ctx.stages if s.artifact]
-    assert {p.name for p in written} == {"investigation.md", "design.md"}
+    assert {p.name for p in written} == {"investigation.md", "validity.md", "design.md"}
     repo = tmp_path / "repo"
     for path in written:
         assert path.is_file()

--- a/tests/sdlc/test_validity.py
+++ b/tests/sdlc/test_validity.py
@@ -1,0 +1,178 @@
+"""The validity gate, judged against tickets whose right answer is already known.
+
+The corpus is this project's own board. SSPN-3 shipped with an acceptance criterion claiming
+eleven entities where the source has seven; SSPN-18 was a design defect written in prose with
+no traceback. Both cost a human to notice. These tests assert the gate notices instead.
+
+The bar is deliberately asymmetric: a false *refusal* wastes a human's attention and teaches
+people to switch the gate off, so every check here must be answerable from the graph. Where
+it cannot be, the gate says PROCEED and lets the run continue.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from orchestrator.pkg import FactStore
+from orchestrator.pkg.facts import FactBatch, Node, NodeKind, Provenance
+from orchestrator.sdlc.validity import Verdict, assess
+
+
+def _graph(*, entities: int = 0, endpoints: int = 0, modules: int = 1) -> FactStore:
+    batch = FactBatch()
+    for i in range(modules):
+        batch.add_node(Node(f"py:m{i}", NodeKind.MODULE, f"m{i}", "python", Provenance(f"m{i}.py", 1)))
+    for i in range(entities):
+        batch.add_node(
+            Node(f"py:entity:t{i}", NodeKind.ENTITY, f"t{i}", "python", Provenance("models.py", i + 1))
+        )
+    for i in range(endpoints):
+        batch.add_node(
+            Node(
+                f"py:endpoint:GET /r{i}",
+                NodeKind.ENDPOINT,
+                f"GET /r{i}",
+                "python",
+                Provenance("api.py", i + 1),
+            )
+        )
+    return FactStore(batch)
+
+
+def _spec(*criteria: str, **extra: Any) -> dict[str, Any]:
+    return {"title": "t", "summary": "s", "acceptance_criteria": list(criteria), **extra}
+
+
+# ---- the corpus ------------------------------------------------------------
+
+
+def test_the_sspn3_criterion_is_refused() -> None:
+    """Verbatim from the ticket that shipped with it. The source had seven."""
+    assessment = assess(
+        _spec("11 `Entity` nodes on this repo, one per `__tablename__`."),
+        store=_graph(entities=7),
+    )
+
+    assert assessment.verdict is Verdict.CRITERIA_WRONG
+    assert "11" in assessment.render() and "7" in assessment.render()
+    # The evidence is the criterion itself, so a human is not asked to take our word for it.
+    assert "one per `__tablename__`" in assessment.findings[0].evidence
+
+
+def test_the_corrected_criterion_proceeds() -> None:
+    assessment = assess(
+        _spec("7 `Entity` nodes on this repo, one per `__tablename__`."), store=_graph(entities=7)
+    )
+    assert assessment.verdict is Verdict.PROCEED
+
+
+def test_a_met_at_least_target_proceeds() -> None:
+    """SSPN-2's shape: "≥ 70 of 77" is satisfied by more, and refusing it would be the false
+    refusal that gets a gate switched off."""
+    assessment = assess(
+        _spec("On this repo, at least 70 route handlers carry an inbound EXPOSES edge."),
+        store=_graph(endpoints=77),
+    )
+    assert assessment.verdict is Verdict.PROCEED
+
+
+def test_an_unmet_at_least_target_is_refused() -> None:
+    assessment = assess(
+        _spec("On this repo, at least 70 endpoints carry an inbound EXPOSES edge."),
+        store=_graph(endpoints=12),
+    )
+    assert assessment.verdict is Verdict.CRITERIA_WRONG
+    assert "or more" in assessment.findings[0].detail
+
+
+def test_a_number_that_is_a_target_not_a_claim_proceeds() -> None:
+    """ "Add 3 endpoints" is work to do. Only a claim *about the repo as it is* can be false."""
+    assessment = assess(_spec("Add 3 endpoints for the export flow."), store=_graph(endpoints=0))
+    assert assessment.verdict is Verdict.PROCEED
+
+
+def test_a_bug_that_lands_nowhere_is_refused() -> None:
+    """SSPN-18's shape: a design defect in prose, with nothing for the run to work from."""
+    assessment = assess(_spec("the cache serves a stale graph"), store=_graph(), issue_type="Bug")
+
+    assert assessment.verdict is Verdict.UNLOCALIZED
+    assert "traceback" in assessment.findings[0].evidence
+
+
+def test_a_bug_that_lands_somewhere_proceeds() -> None:
+    assessment = assess(
+        _spec("the cache serves a stale graph"),
+        store=_graph(),
+        issue_type="Bug",
+        landing=["src/orchestrator/pkg/persistence.py"],
+    )
+    assert assessment.verdict is Verdict.PROCEED
+
+
+def test_a_story_that_lands_nowhere_still_proceeds() -> None:
+    """A feature can legitimately be about code that does not exist yet — that is the whole
+    point of a feature. Only a Bug must resolve to something."""
+    assessment = assess(_spec("add a brand new subsystem"), store=_graph(), issue_type="Story")
+    assert assessment.verdict is Verdict.PROCEED
+
+
+# ---- size and duplication --------------------------------------------------
+
+
+def test_a_ticket_with_too_many_criteria_is_refused() -> None:
+    assessment = assess(_spec(*[f"criterion {i}" for i in range(15)]), store=_graph())
+
+    assert assessment.verdict is Verdict.TOO_BIG
+    assert "15 acceptance criteria" in assessment.findings[0].detail
+
+
+def test_a_ticket_landing_in_too_many_modules_is_refused() -> None:
+    assessment = assess(_spec("do the thing"), store=_graph(), landing=[f"src/m{i}.py" for i in range(20)])
+    assert assessment.verdict is Verdict.TOO_BIG
+
+
+def test_a_ticket_a_previous_run_completed_is_a_duplicate() -> None:
+    """Two runs on one ticket produce two branches and two PRs for one piece of work."""
+
+    class _Record:
+        run_id = "earlier"
+        issue_key = "SSPN-9"
+        status = "done"
+        pr_url = "https://github.com/x/y/pull/1"
+
+    assessment = assess(_spec("do the thing"), store=_graph(), issue_key="SSPN-9", prior_runs=[_Record()])
+
+    assert assessment.verdict is Verdict.DUPLICATE
+    assert "pull/1" in assessment.findings[0].evidence
+
+
+def test_a_failed_previous_run_does_not_block_a_retry() -> None:
+    class _Record:
+        run_id = "earlier"
+        issue_key = "SSPN-9"
+        status = "failed"
+        pr_url = ""
+
+    assessment = assess(_spec("do the thing"), store=_graph(), issue_key="SSPN-9", prior_runs=[_Record()])
+    assert assessment.verdict is Verdict.PROCEED
+
+
+# ---- the gate does not cry wolf --------------------------------------------
+
+
+def test_prose_with_numbers_in_it_is_not_a_claim() -> None:
+    """Version numbers, HTTP codes and counts of things the graph does not model must not
+    trip the gate: a check that fires on ordinary English is a check people disable."""
+    store = _graph(entities=7, endpoints=3)
+    for criterion in (
+        "An unknown --format value exits 2 with a message naming the valid values.",
+        "Bump the cache format version to 4.",
+        "The endpoint returns 404 when the run is missing.",
+        "Add 2 fixtures covering the empty case.",
+    ):
+        assert assess(_spec(criterion), store=store).verdict is Verdict.PROCEED, criterion
+
+
+def test_an_empty_ticket_proceeds() -> None:
+    """Nothing to contradict. Emptiness is intake's problem, not the gate's."""
+    assert assess({}, store=_graph()).verdict is Verdict.PROCEED


### PR DESCRIPTION
Closes **[SSPN-23](https://fibonacci-solutions.atlassian.net/browse/SSPN-23)** — phase 4, and the one piece of real judgment in the programme.

## Why

Two tickets in one cycle would have wasted a full run each:

- **SSPN-3** claimed *"11 `Entity` nodes on this repo"*. The source has **7**. An agent treating criteria as ground truth either loops forever trying to reach 11, or declares success at 7 and calls the criterion met.
- **SSPN-18** was a design defect in prose with no traceback, so RCA resolved it to nothing and reported *"the fault may be in a dependency"* — pointing away from a bug squarely inside this repo.

## What

`assess()` returns **one of six verdicts with evidence**, never prose. `PROCEED` is the only one that continues a run; the rest park it with the evidence attached, **before any code exists**.

| Verdict | Fires when |
|---|---|
| `CRITERIA_WRONG` | A criterion states a count the graph contradicts |
| `UNLOCALIZED` | A **Bug** that matches nothing in the graph |
| `TOO_BIG` | Too many criteria, or lands in too many modules |
| `DUPLICATE` | A previous run already completed this ticket |
| `ALREADY_DONE` | Reserved — see below |
| `PROCEED` | Nothing contradicts the code |

Deterministic and no-LLM. A model asked *"is this ticket sound?"* produces a confident opinion; the graph produces a count.

## The design is shaped by not crying wolf

A false refusal wastes a human's attention and teaches people to switch the gate off, so it under-claims by construction:

- A number is checked only when the phrasing asserts a **present fact** — *"add 3 endpoints"* is work to do, not a claim that can be false.
- *"at least 70"* is satisfied by 77; only a strict shortfall is refused.
- A **Story** that lands nowhere still proceeds — a feature is allowed to be about code that doesn't exist yet. Only a Bug must resolve to something.
- Version numbers, HTTP codes and ordinary English with digits in it have their own test asserting they pass.

The gate reuses the **investigation's landing** rather than recomputing it, so the brief and the gate cannot disagree about what the ticket is even about.

## Verified on the real corpus

Pointed at SSPN-3's original ticket, the agent refuses it end to end:

```
[validity] CRITERIA_WRONG — the ticket says 11 Entity exist here; the graph holds 7
[validity] evidence in .../validity.md
CRITERIA_WRONG: ... — run parked, nothing was built.
```

14 corpus tests, including SSPN-3 verbatim, its corrected form, SSPN-2's "≥70" shape (met and unmet), and SSPN-18's unlocalizable prose.

## Deliberately not in this PR

- **`ALREADY_DONE`** is declared but never returned: I could not find a check for it answerable from the graph without guessing, and a verdict that fires on a hunch is worse than one that never fires. It stays in the enum because the shape is right; the check needs evidence I don't have yet.
- **Posting the verdict to the ticket** is a live write and belongs with the approval/notify work in [SSPN-25](https://fibonacci-solutions.atlassian.net/browse/SSPN-25). Today the evidence is written to the run directory and the run parks.
- **SSPN-31's invented `generated_at` criterion** — catching "this criterion violates a documented invariant" needs semantic reading, not counting. Recorded on that ticket, not smuggled in here.

## How it was tested

```
pytest              2230 passed, 30 skipped   (2216 before — 14 new)
mypy src tests      no issues in 588 source files
ruff check . / ruff format --check .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)