### PR TITLE
feat(sdlc): close the review loop — find, fix, prove, and know when to stop

### DIFF
--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -82,6 +82,10 @@ class RunContext:
     # two cannot disagree about what the ticket is even about.
     landing: list[str] = field(default_factory=list)
     verdict: str = ""
+    # Set by the implement stage: the same adapter and runner that built the change also fix
+    # what review finds, so the fixer knows the repo's conventions and the layout it chose.
+    fixer: Any = None
+    tests: Any = None
     stages: list[StageResult] = field(default_factory=list)
     # Durable state. Written after every stage, so a crash leaves a findable run rather than
     # a mystery worktree and a ticket stuck In Progress.
@@ -141,6 +145,7 @@ async def autorun(
     root: Path | str = ".",
     live: bool = False,
     max_refine: int = 3,
+    review_rounds: int = 2,
     base_branch: str | None = None,
     language: str = "auto",
     issue_type: str = "",
@@ -234,7 +239,7 @@ async def autorun(
         budget=budget,
         emit=emit,
     )
-    _stage_review(ctx, emit=emit)
+    await _stage_review(ctx, fixer=ctx.fixer, tests=ctx.tests, max_rounds=review_rounds, emit=emit)
 
     ctx.checkpoint(phase="done", status="done", spent_usd=_spent(budget, run_id))
     emit(f"[autorun] artifacts in {ctx.artifacts_dir}")
@@ -427,6 +432,7 @@ async def _stage_implement(
     ctx.branch = result.branch
     ctx.worktree = result.worktree
     ctx.pr_url = result.pr_url
+    ctx.fixer, ctx.tests = result.codegen, result.tests
     ctx.record_stage(
         "implement",
         "ok",
@@ -434,19 +440,37 @@ async def _stage_implement(
     )
 
 
-def _stage_review(ctx: RunContext, *, emit: Callable[[str], None]) -> None:
-    """Grounded review of the change.
+async def _stage_review(
+    ctx: RunContext, *, fixer: Any, tests: Any, max_rounds: int, emit: Callable[[str], None]
+) -> None:
+    """Review the change and fix what it finds, before anyone is asked to look at it.
 
-    Skipped in safe mode with a reason rather than silently: the reviewer reads a *pull
-    request*, and safe mode opens none. Closing the review→fix→re-test loop is its own story;
-    this stage exists so the skeleton's shape is honest about where that loop will attach.
+    Runs on the worktree diff rather than a pull request: a loop that waited for a PR could
+    never fix anything *before* opening one, which is the entire point.
     """
-    if not ctx.pr_url:
-        ctx.record_stage("review", "skipped", "no PR to review (safe mode opens none)")
-        emit("[review] skipped — safe mode opens no PR")
+    from orchestrator.sdlc.reviewloop import review_and_fix
+
+    if not ctx.worktree:
+        ctx.record_stage("review", "skipped", "no worktree to review")
+        emit("[review] skipped — nothing was built")
         return
-    ctx.record_stage("review", "skipped", f"review of {ctx.pr_url} not wired yet (SSPN-24)")
-    emit(f"[review] skipped — {ctx.pr_url} awaits the review loop (SSPN-24)")
+
+    outcome = await review_and_fix(
+        path=ctx.worktree,
+        spec=ctx.spec or {},
+        issue_key=ctx.issue_key,
+        fixer=fixer,
+        tests=tests,
+        max_rounds=max_rounds,
+    )
+    path = ctx.write_artifact("review.md", outcome.render())
+    detail = f"{outcome.stopped}"
+    if outcome.remaining:
+        detail += f" · {len(outcome.remaining)} unresolved"
+    if outcome.deferred:
+        detail += f" · {len(outcome.deferred)} for a human"
+    ctx.record_stage("review", "ok" if outcome.clean else "failed", detail, path)
+    emit(f"[review] {detail}")
 
 
 def render_summary(ctx: RunContext) -> str:

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -75,6 +75,11 @@ class FeatureRunResult:
     live: bool
     files: list[str] = field(default_factory=list)
     pr_url: str | None = None
+    # The adapter and runner that built this change, so a later stage can fix what review
+    # finds *with the same tools* — same layout, same conventions, same test environment.
+    # Rebuilding them elsewhere would review one change and fix a differently-configured one.
+    codegen: Any = None
+    tests: Any = None
 
 
 async def _local_commit(path: Path, message: str) -> None:
@@ -574,6 +579,8 @@ async def run_feature(
         live=live,
         files=files,
         pr_url=pr_url,
+        codegen=codegen,
+        tests=runner,
     )
 
 

--- a/src/orchestrator/sdlc/reviewloop.py
+++ b/src/orchestrator/sdlc/reviewloop.py
@@ -1,0 +1,265 @@
+"""Review the change, fix what it found, prove the fix — bounded, and honest about stopping.
+
+The pipeline could already review a pull request and revise one on demand. What it could not
+do is *close the loop*: nothing took a review's findings, fixed them, re-ran the tests, and
+reviewed again. A human sat in that gap.
+
+Three rules shape this, and they are the difference between a loop and a spin:
+
+**Bounded.** Rounds are capped. A model that cannot fix something in two attempts is not
+going to fix it in five; it is going to rewrite more each time, which is how a small
+correction becomes an unreviewable diff.
+
+**A round that changes nothing ends it.** Identical to the refine loop's rule, for the same
+reason: if the fixer edited no file, the next review sees the same code and returns the same
+findings. Spending a second call to watch that happen is waste, and spending three is a bug.
+
+**A fix that breaks the tests is not a fix.** If the suite was green and a review fix turns it
+red, the loop stops and says so rather than continuing to "improve" a broken change. The
+regression is the finding at that point.
+
+Some findings are not the fixer's to act on — a design objection, a "this whole approach is
+wrong". Those are returned as *deferred* with their evidence, for a human or a ticket, rather
+than fed to a model that will dutifully paper over them.
+
+Reviewing works on the **worktree diff**, not a GitHub pull request: the loop has to run
+before a PR exists, which is the whole point of fixing things first.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from orchestrator.codereview.github_client import ChangedFile, PRDiff
+from orchestrator.codereview.verifiers import Finding, Severity, run_verifiers
+
+# Two rounds. The first fixes what review found; the second proves the fix and catches what
+# the fix broke. A third has, in practice, meant the model is rewriting rather than repairing.
+DEFAULT_MAX_ROUNDS = 2
+
+# Severities worth interrupting a run for. A nit is real feedback and belongs on the PR for a
+# human to weigh — it is not worth an LLM call and a re-test cycle.
+_ACTIONABLE = (Severity.BLOCKER, Severity.WARNING)
+
+
+class Reviewer(Protocol):
+    """The LLM half of a review. Optional: verifiers alone still find real defects."""
+
+    async def review(self, diff: PRDiff) -> tuple[str, list[Finding]]: ...
+
+
+class Fixer(Protocol):
+    """Whatever can edit the worktree — in practice the codegen adapter's ``refine``."""
+
+    async def refine(self, *, spec: dict[str, Any], path: str, issue_key: str, failures: str) -> Any: ...
+
+
+class Tests(Protocol):
+    async def run(self, *, path: str) -> Any: ...
+
+
+@dataclass(frozen=True)
+class Round:
+    """What one pass of review-and-fix did."""
+
+    number: int
+    findings: int
+    fixed_files: tuple[str, ...] = ()
+    tests_passed: bool | None = None
+    note: str = ""
+
+
+@dataclass
+class LoopResult:
+    """Where the loop stopped, and why — never just 'done'."""
+
+    rounds: list[Round] = field(default_factory=list)
+    remaining: list[Finding] = field(default_factory=list)
+    deferred: list[Finding] = field(default_factory=list)
+    stopped: str = ""
+    clean: bool = False
+
+    def render(self) -> str:
+        lines = [f"**Review loop:** {self.stopped}", ""]
+        for r in self.rounds:
+            detail = f"{r.findings} finding(s)"
+            if r.fixed_files:
+                detail += f" · edited {', '.join(r.fixed_files)}"
+            if r.tests_passed is not None:
+                detail += f" · tests {'passed' if r.tests_passed else 'FAILED'}"
+            if r.note:
+                detail += f" · {r.note}"
+            lines.append(f"- round {r.number}: {detail}")
+        if self.remaining:
+            lines += ["", "**Unresolved:**"]
+            lines += [f"- {f.severity.value} {f.path}:{f.line} — {f.message}" for f in self.remaining]
+        if self.deferred:
+            lines += ["", "**Not the fixer's to decide** (for a human or a ticket):"]
+            lines += [f"- {f.severity.value} {f.path}:{f.line} — {f.message}" for f in self.deferred]
+        return "\n".join(lines)
+
+
+async def worktree_diff(path: Path | str, *, base: str = "HEAD~1") -> PRDiff:
+    """The change under review, read from git rather than from a forge.
+
+    ``pr_number=0`` marks it as a local diff: the reviewer only reads files and patches, and
+    a loop that waited for a pull request could never fix anything *before* opening one.
+    """
+    files: list[ChangedFile] = []
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "diff",
+            "--unified=3",
+            base,
+            cwd=str(path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except OSError:
+        # The worktree is gone, or was never a directory. Nothing to review is a fact, not a
+        # crash — a reaped or relocated worktree must not take the run down with it.
+        return PRDiff(repo="", pr_number=0, head_sha="", files=())
+    out, _ = await proc.communicate()
+    if proc.returncode != 0:
+        return PRDiff(repo="", pr_number=0, head_sha="", files=())
+
+    current: str | None = None
+    buffer: list[str] = []
+    for line in out.decode("utf-8", "replace").splitlines():
+        if line.startswith("diff --git "):
+            if current:
+                files.append(_changed_file(current, buffer))
+            current = line.split(" b/", 1)[-1]
+            buffer = []
+        elif current:
+            buffer.append(line)
+    if current:
+        files.append(_changed_file(current, buffer))
+    return PRDiff(repo="", pr_number=0, head_sha="", files=tuple(files))
+
+
+def _changed_file(filename: str, lines: list[str]) -> ChangedFile:
+    patch = "\n".join(lines)
+    return ChangedFile(
+        filename=filename,
+        status="modified",
+        additions=sum(1 for line in lines if line.startswith("+") and not line.startswith("+++")),
+        deletions=sum(1 for line in lines if line.startswith("-") and not line.startswith("---")),
+        patch=patch,
+    )
+
+
+def _is_deferred(finding: Finding) -> bool:
+    """Findings a fixer should not be handed.
+
+    A design objection ("this belongs in another module", "the approach is wrong") is not
+    something to patch — asking a model to satisfy it produces a change that answers the
+    words rather than the concern. It goes to a human with its evidence intact.
+    """
+    text = f"{finding.rule} {finding.message}".lower()
+    return any(
+        marker in text
+        for marker in ("design", "architecture", "approach", "belongs in", "out of scope", "rethink")
+    )
+
+
+async def review_and_fix(
+    *,
+    path: Path | str,
+    spec: dict[str, Any],
+    issue_key: str,
+    fixer: Fixer | None = None,
+    tests: Tests | None = None,
+    reviewer: Reviewer | None = None,
+    base: str = "HEAD~1",
+    max_rounds: int = DEFAULT_MAX_ROUNDS,
+) -> LoopResult:
+    """Review the worktree, fix what is actionable, re-test, and review again — bounded."""
+    result = LoopResult()
+
+    for number in range(1, max_rounds + 1):
+        diff = await worktree_diff(path, base=base)
+        if not diff.files:
+            result.stopped = "nothing to review — the worktree has no diff"
+            result.clean = True
+            return result
+
+        findings = list(run_verifiers(diff))
+        if reviewer is not None:
+            _, llm_findings = await reviewer.review(diff)
+            findings.extend(llm_findings)
+
+        deferred = [f for f in findings if _is_deferred(f)]
+        actionable = [f for f in findings if f.severity in _ACTIONABLE and f not in deferred]
+        result.deferred = deferred
+
+        if not actionable:
+            result.rounds.append(Round(number=number, findings=len(findings), note="nothing to fix"))
+            result.remaining = [f for f in findings if f not in deferred]
+            result.stopped = "review clean" if not findings else "only advisory findings remain"
+            result.clean = True
+            return result
+
+        if fixer is None:
+            result.rounds.append(Round(number=number, findings=len(findings), note="no fixer"))
+            result.remaining = actionable
+            result.stopped = "findings reported — no fixer wired"
+            return result
+
+        change = await fixer.refine(
+            spec=spec, path=str(path), issue_key=issue_key, failures=_render_findings(actionable)
+        )
+        edited = tuple(getattr(change, "files", ()) or ())
+        if not edited:
+            # Identical to the refine loop's rule: nothing changed, so the next review sees
+            # the same code and says the same thing.
+            result.rounds.append(Round(number=number, findings=len(findings), note="fix changed nothing"))
+            result.remaining = actionable
+            result.stopped = "the fixer edited nothing — not fixable by editing code"
+            return result
+
+        passed: bool | None = None
+        if tests is not None:
+            outcome = await tests.run(path=str(path))
+            passed = bool(getattr(outcome, "passed", False))
+            if not passed:
+                result.rounds.append(
+                    Round(number=number, findings=len(findings), fixed_files=edited, tests_passed=False)
+                )
+                result.remaining = actionable
+                result.stopped = "a review fix broke the tests — stopping rather than building on it"
+                return result
+
+        result.rounds.append(
+            Round(number=number, findings=len(findings), fixed_files=edited, tests_passed=passed)
+        )
+
+    # Out of rounds with work still outstanding. Say so: silence here reads as success.
+    diff = await worktree_diff(path, base=base)
+    findings = list(run_verifiers(diff))
+    result.remaining = [f for f in findings if f.severity in _ACTIONABLE]
+    result.stopped = f"review budget spent after {max_rounds} round(s)"
+    result.clean = not result.remaining
+    return result
+
+
+def _render_findings(findings: list[Finding]) -> str:
+    """Findings as the fixer's input. Typed data rendered at the boundary, not prose passed
+    around — the loop needs to count and compare them, a model needs to read them."""
+    lines = ["The reviewer found these issues in the change. Fix them:"]
+    for f in findings:
+        lines.append(f"- [{f.severity.value}] {f.path}:{f.line} ({f.rule}) — {f.message}")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "DEFAULT_MAX_ROUNDS",
+    "LoopResult",
+    "Round",
+    "review_and_fix",
+    "worktree_diff",
+]

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -64,6 +64,7 @@ class _Service:
 
 def _install(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
     *,
     specs: list[_Spec] | None = None,
     feature: Any = None,
@@ -77,7 +78,7 @@ def _install(
         lambda *a, **k: _Service(specs if specs is not None else [_Spec()]),
     )
 
-    async def _feature(source: str, **kwargs: Any) -> Any:
+    async def _feature(source: str, **kwargs: Any) -> Any:  # noqa: ARG001
         seen["feature_kwargs"] = kwargs
         if calls is not None:
             calls.append("implement")
@@ -87,10 +88,14 @@ def _install(
             passed=True,
             issue_key="SSPN-42",
             branch="feat/abc/SSPN-42",
-            worktree="/tmp/ws",
+            worktree=str(tmp_path / "repo"),
             files=["src/x.py"],
             iterations=1,
             pr_url=None,
+            # The implement stage hands its adapter and runner on, so review fixes the change
+            # with the same tools that built it. None here: these tests stub the loop out.
+            codegen=None,
+            tests=None,
         )
 
     monkeypatch.setattr("orchestrator.sdlc.feature_runner.run_feature", _feature)
@@ -98,12 +103,14 @@ def _install(
 
 
 def test_stages_run_in_order_and_record_themselves(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    _install(monkeypatch)
+    _install(monkeypatch, tmp_path)
 
     ctx = _run(tmp_path)
 
     assert [s.name for s in ctx.stages] == list(STAGES)
-    assert [s.status for s in ctx.stages] == ["ok", "ok", "ok", "ok", "ok", "skipped"]
+    # Review runs for real now: the stub worktree is not a git repo, so there is no diff to
+    # review and the loop says so rather than pretending it reviewed something.
+    assert [s.status for s in ctx.stages] == ["ok"] * 6
     assert ctx.verdict == "PROCEED"
     assert ctx.passed
 
@@ -113,7 +120,7 @@ def test_one_spec_is_resolved_once_and_injected_downstream(
 ) -> None:
     """Intake happens here, not again inside the feature runner — otherwise the brief and
     design describe a spec the implementation might re-derive differently."""
-    seen = _install(monkeypatch)
+    seen = _install(monkeypatch, tmp_path)
 
     ctx = _run(tmp_path)
 
@@ -125,7 +132,7 @@ def test_the_design_is_handed_to_the_implement_stage(monkeypatch: pytest.MonkeyP
     """Chaining commands is not connecting them: before this the design was written to disk
     and codegen never saw it, so the agent researched, designed, then implemented as if
     neither had happened."""
-    seen = _install(monkeypatch)
+    seen = _install(monkeypatch, tmp_path)
 
     ctx = _run(tmp_path)
 
@@ -139,12 +146,17 @@ def test_the_design_is_handed_to_the_implement_stage(monkeypatch: pytest.MonkeyP
 def test_artifacts_are_written_outside_the_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """``understand`` ingests markdown from disk regardless of git, so a brief written into
     the working tree would become a Doc node and change the graph the next stage reads."""
-    _install(monkeypatch)
+    _install(monkeypatch, tmp_path)
 
     ctx = _run(tmp_path)
 
     written = [Path(s.artifact) for s in ctx.stages if s.artifact]
-    assert {p.name for p in written} == {"investigation.md", "validity.md", "design.md"}
+    assert {p.name for p in written} == {
+        "investigation.md",
+        "validity.md",
+        "design.md",
+        "review.md",
+    }
     repo = tmp_path / "repo"
     for path in written:
         assert path.is_file()
@@ -158,14 +170,15 @@ def test_the_default_artifact_dir_is_not_the_repo(monkeypatch: pytest.MonkeyPatc
 
 def test_safe_mode_opens_no_pr_and_says_why(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The skeleton must be honest about where it stops rather than quietly doing nothing."""
-    seen = _install(monkeypatch)
+    seen = _install(monkeypatch, tmp_path)
 
     ctx = _run(tmp_path)
 
     assert seen["feature_kwargs"]["live"] is False
+    # Review still runs in safe mode — it reads the worktree, not a pull request, which is
+    # the point: findings get fixed *before* anyone is asked to look at the change.
     review = next(s for s in ctx.stages if s.name == "review")
-    assert review.status == "skipped"
-    assert "safe mode" in review.detail
+    assert review.status == "ok"
     assert ctx.pr_url is None
 
 
@@ -174,7 +187,7 @@ def test_a_failing_stage_stops_the_chain(monkeypatch: pytest.MonkeyPatch, tmp_pa
     from orchestrator.sdlc.feature_runner import FeatureRunError
 
     calls: list[str] = []
-    _install(monkeypatch, feature=FeatureRunError("VERDICT: FAILED", code=1), calls=calls)
+    _install(monkeypatch, tmp_path, feature=FeatureRunError("VERDICT: FAILED", code=1), calls=calls)
 
     with pytest.raises(AutorunError, match="VERDICT: FAILED") as exc:
         _run(tmp_path)
@@ -184,7 +197,7 @@ def test_a_failing_stage_stops_the_chain(monkeypatch: pytest.MonkeyPatch, tmp_pa
 
 
 def test_no_specs_fails_before_any_graph_work(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    _install(monkeypatch, specs=[])
+    _install(monkeypatch, tmp_path, specs=[])
 
     with pytest.raises(AutorunError, match="No specs") as exc:
         _run(tmp_path)
@@ -193,7 +206,7 @@ def test_no_specs_fails_before_any_graph_work(monkeypatch: pytest.MonkeyPatch, t
 
 
 def test_an_unknown_intent_names_what_is_available(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    _install(monkeypatch, specs=[_Spec("intent-a"), _Spec("intent-b")])
+    _install(monkeypatch, tmp_path, specs=[_Spec("intent-a"), _Spec("intent-b")])
 
     with pytest.raises(AutorunError, match="intent-a, intent-b") as exc:
         _run(tmp_path, intent_id="nope")
@@ -202,7 +215,7 @@ def test_an_unknown_intent_names_what_is_available(monkeypatch: pytest.MonkeyPat
 
 
 def test_the_summary_reports_every_stage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    _install(monkeypatch)
+    _install(monkeypatch, tmp_path)
 
     summary = render_summary(_run(tmp_path))
 
@@ -216,7 +229,7 @@ def test_the_summary_reports_every_stage(monkeypatch: pytest.MonkeyPatch, tmp_pa
 
 def test_a_run_records_itself_as_it_goes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A kill at any point must leave a findable run, not a mystery worktree."""
-    _install(monkeypatch)
+    _install(monkeypatch, tmp_path)
     store = RunStore(root=tmp_path / "state")
 
     ctx = _run(tmp_path, store=store)
@@ -225,7 +238,8 @@ def test_a_run_records_itself_as_it_goes(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert saved is not None
     assert saved.status == "done" and saved.phase == "done"
     assert saved.issue_key == "SSPN-42"
-    assert saved.branch == "feat/abc/SSPN-42" and saved.worktree == "/tmp/ws"
+    assert saved.branch == "feat/abc/SSPN-42"
+    assert saved.worktree == str(tmp_path / "repo")
 
 
 def test_resume_adopts_the_issue_the_previous_attempt_created(
@@ -233,7 +247,7 @@ def test_resume_adopts_the_issue_the_previous_attempt_created(
 ) -> None:
     """The half that must never happen twice. A crashed run that already created a ticket is
     exactly how a duplicate got minted before `--issue` adoption existed."""
-    seen = _install(monkeypatch)
+    seen = _install(monkeypatch, tmp_path)
     store = RunStore(root=tmp_path / "state")
     store.save(RunRecord(run_id="prev", source="file://./spec.md", issue_key="SSPN-77", status="running"))
 
@@ -246,7 +260,7 @@ def test_resume_adopts_the_issue_the_previous_attempt_created(
 def test_resuming_a_run_that_does_not_exist_is_refused(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    _install(monkeypatch)
+    _install(monkeypatch, tmp_path)
 
     with pytest.raises(AutorunError, match="no run 'nope'") as exc:
         _run(tmp_path, store=RunStore(root=tmp_path / "state"), resume="nope")
@@ -258,7 +272,7 @@ def test_a_second_run_cannot_take_a_held_ticket(monkeypatch: pytest.MonkeyPatch,
     """Two live runs on one ticket race for the same branch and the same issue."""
     import os
 
-    _install(monkeypatch)
+    _install(monkeypatch, tmp_path)
     store = RunStore(root=tmp_path / "state")
     store.save(RunRecord(run_id="held", source="s", issue_key="SSPN-5", status="running", pid=os.getpid()))
 
@@ -271,7 +285,7 @@ def test_a_second_run_cannot_take_a_held_ticket(monkeypatch: pytest.MonkeyPatch,
 
 def test_an_abandoned_run_does_not_block_the_ticket(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A dead process must not hold a ticket hostage."""
-    _install(monkeypatch)
+    _install(monkeypatch, tmp_path)
     store = RunStore(root=tmp_path / "state")
     store.save(RunRecord(run_id="dead", source="s", issue_key="SSPN-5", status="running", pid=999_999))
 
@@ -285,7 +299,7 @@ def test_budget_exhaustion_parks_the_run(monkeypatch: pytest.MonkeyPatch, tmp_pa
     because the wallet ran dry is worse than stopping."""
     from orchestrator.core.llm import BudgetExceededError
 
-    _install(monkeypatch, feature=BudgetExceededError("run cap $1.00 exhausted"))
+    _install(monkeypatch, tmp_path, feature=BudgetExceededError("run cap $1.00 exhausted"))
     store = RunStore(root=tmp_path / "state")
 
     with pytest.raises(AutorunError, match="budget exhausted") as exc:
@@ -300,7 +314,7 @@ def test_budget_exhaustion_parks_the_run(monkeypatch: pytest.MonkeyPatch, tmp_pa
 def test_a_failed_run_is_recorded_as_failed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     from orchestrator.sdlc.feature_runner import FeatureRunError
 
-    _install(monkeypatch, feature=FeatureRunError("VERDICT: FAILED", code=1))
+    _install(monkeypatch, tmp_path, feature=FeatureRunError("VERDICT: FAILED", code=1))
     store = RunStore(root=tmp_path / "state")
 
     with pytest.raises(AutorunError):

--- a/tests/sdlc/test_reviewloop.py
+++ b/tests/sdlc/test_reviewloop.py
@@ -1,0 +1,252 @@
+"""Review → fix → re-test → re-review, and the four ways it is allowed to stop.
+
+The loop's value is not that it fixes things — a model will always produce *an* edit. It is
+that it knows when to stop: out of rounds, nothing changed, the fix broke the tests, or the
+finding was never the fixer's to act on. Each of those is asserted here, because a loop that
+cannot stop is worse than no loop at all.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from orchestrator.codereview.github_client import ChangedFile, PRDiff
+from orchestrator.codereview.verifiers import Finding, Severity
+from orchestrator.sdlc.reviewloop import review_and_fix, worktree_diff
+
+
+def _repo(tmp_path: Path, *, second_commit: str = "x = 2\n") -> Path:
+    """A git repo with two commits, so ``git diff HEAD~1`` has something to say."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def run(*args: str) -> None:
+        subprocess.run(args, cwd=repo, capture_output=True, check=True)
+
+    run("git", "init", "-q")
+    run("git", "config", "user.email", "t@t")
+    run("git", "config", "user.name", "t")
+    (repo / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    run("git", "add", "-A")
+    run("git", "commit", "-qm", "base")
+    (repo / "mod.py").write_text(second_commit, encoding="utf-8")
+    run("git", "add", "-A")
+    run("git", "commit", "-qm", "change")
+    return repo
+
+
+def _finding(message: str = "hardcoded secret", severity: Severity = Severity.BLOCKER) -> Finding:
+    return Finding(verifier_id="test", rule="R1", severity=severity, path="mod.py", line=1, message=message)
+
+
+class _Reviewer:
+    """Returns queued finding-sets, one per round."""
+
+    def __init__(self, rounds: list[list[Finding]]) -> None:
+        self._rounds = list(rounds)
+        self.calls = 0
+
+    async def review(self, diff: PRDiff) -> tuple[str, list[Finding]]:
+        self.calls += 1
+        return ("summary", self._rounds.pop(0) if self._rounds else [])
+
+
+class _Fixer:
+    def __init__(self, edits: list[list[str]]) -> None:
+        self._edits = list(edits)
+        self.prompts: list[str] = []
+
+    async def refine(self, *, spec: dict[str, Any], path: str, issue_key: str, failures: str) -> Any:
+        self.prompts.append(failures)
+        return SimpleNamespace(files=self._edits.pop(0) if self._edits else [], summary="fixed")
+
+
+class _Tests:
+    def __init__(self, results: list[bool]) -> None:
+        self._results = list(results)
+
+    async def run(self, *, path: str) -> Any:
+        return SimpleNamespace(passed=self._results.pop(0) if self._results else True, output="")
+
+
+# ---- the happy case: found, fixed, proven ----------------------------------
+
+
+async def test_a_finding_is_fixed_and_the_fix_is_proven(tmp_path: Path) -> None:
+    """The acceptance criterion: a defect is found, fixed, re-tested and re-reviewed with no
+    human in the loop."""
+    repo = _repo(tmp_path)
+    reviewer = _Reviewer([[_finding()], []])  # round 1 finds it, round 2 is clean
+    fixer = _Fixer([["mod.py"]])
+    tests = _Tests([True])
+
+    result = await review_and_fix(
+        path=repo, spec={}, issue_key="X-1", fixer=fixer, tests=tests, reviewer=reviewer
+    )
+
+    assert result.clean
+    assert len(result.rounds) == 2
+    assert result.rounds[0].fixed_files == ("mod.py",)
+    assert result.rounds[0].tests_passed is True
+    assert result.stopped == "review clean"
+    # The fixer was handed the finding as data it can act on, not as prose.
+    assert "mod.py:1" in fixer.prompts[0] and "blocker" in fixer.prompts[0]
+
+
+async def test_a_clean_review_does_not_call_the_fixer(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    fixer = _Fixer([])
+
+    result = await review_and_fix(path=repo, spec={}, issue_key="X-1", fixer=fixer, reviewer=_Reviewer([[]]))
+
+    assert result.clean and fixer.prompts == []
+
+
+# ---- the four ways it stops ------------------------------------------------
+
+
+async def test_a_fix_that_changes_nothing_ends_the_loop(tmp_path: Path) -> None:
+    """The refine loop's rule: no edit means the next review sees the same code."""
+    repo = _repo(tmp_path)
+    reviewer = _Reviewer([[_finding()], [_finding()]])
+    fixer = _Fixer([[]])  # edits nothing
+
+    result = await review_and_fix(
+        path=repo, spec={}, issue_key="X-1", fixer=fixer, reviewer=reviewer, max_rounds=3
+    )
+
+    assert not result.clean
+    assert "edited nothing" in result.stopped
+    assert len(result.rounds) == 1  # did not spend a second round watching the same finding
+    assert reviewer.calls == 1
+
+
+async def test_a_fix_that_breaks_the_tests_stops_the_loop(tmp_path: Path) -> None:
+    """A green suite turned red by a review fix is a regression, not progress."""
+    repo = _repo(tmp_path)
+    result = await review_and_fix(
+        path=repo,
+        spec={},
+        issue_key="X-1",
+        fixer=_Fixer([["mod.py"]]),
+        tests=_Tests([False]),
+        reviewer=_Reviewer([[_finding()], []]),
+        max_rounds=3,
+    )
+
+    assert not result.clean
+    assert "broke the tests" in result.stopped
+    assert result.rounds[-1].tests_passed is False
+
+
+async def test_the_loop_is_bounded(tmp_path: Path) -> None:
+    """A model that cannot fix something in two attempts rewrites more each time."""
+    repo = _repo(tmp_path)
+    reviewer = _Reviewer([[_finding()], [_finding()], [_finding()]])
+
+    result = await review_and_fix(
+        path=repo,
+        spec={},
+        issue_key="X-1",
+        fixer=_Fixer([["mod.py"], ["mod.py"], ["mod.py"]]),
+        tests=_Tests([True, True, True]),
+        reviewer=reviewer,
+        max_rounds=2,
+    )
+
+    assert len(result.rounds) == 2
+    assert "budget spent after 2 round" in result.stopped
+    assert reviewer.calls == 2
+
+
+async def test_a_design_objection_is_deferred_not_patched(tmp_path: Path) -> None:
+    """Asking a model to satisfy "the approach is wrong" produces a change that answers the
+    words rather than the concern. It goes to a human with its evidence."""
+    repo = _repo(tmp_path)
+    objection = _finding("this belongs in another module — the design is wrong")
+    fixer = _Fixer([])
+
+    result = await review_and_fix(
+        path=repo, spec={}, issue_key="X-1", fixer=fixer, reviewer=_Reviewer([[objection]])
+    )
+
+    assert fixer.prompts == []  # never handed to the fixer
+    assert [f.message for f in result.deferred] == [objection.message]
+    assert "for a human or a ticket" in result.render()
+
+
+# ---- inputs and edges ------------------------------------------------------
+
+
+async def test_advisory_findings_do_not_trigger_a_fix_cycle(tmp_path: Path) -> None:
+    """A nit is real feedback for a human, not worth an LLM call and a re-test."""
+    repo = _repo(tmp_path)
+    fixer = _Fixer([])
+
+    result = await review_and_fix(
+        path=repo,
+        spec={},
+        issue_key="X-1",
+        fixer=fixer,
+        reviewer=_Reviewer([[_finding("prefer f-strings", Severity.NIT)]]),
+    )
+
+    assert fixer.prompts == []
+    assert result.clean and "advisory" in result.stopped
+
+
+async def test_the_diff_is_read_from_the_worktree(tmp_path: Path) -> None:
+    """No pull request exists yet — that is the point of fixing things first."""
+    diff = await worktree_diff(_repo(tmp_path))
+
+    assert [f.filename for f in diff.files] == ["mod.py"]
+    assert diff.pr_number == 0
+    assert "x = 2" in diff.diff_text
+
+
+async def test_a_missing_worktree_is_not_a_crash(tmp_path: Path) -> None:
+    """A reaped or relocated worktree must not take the run down with it."""
+    diff = await worktree_diff(tmp_path / "gone")
+    assert diff.files == ()
+
+    result = await review_and_fix(path=tmp_path / "gone", spec={}, issue_key="X-1")
+    assert result.clean and "no diff" in result.stopped
+
+
+async def test_findings_are_reported_when_no_fixer_is_wired(tmp_path: Path) -> None:
+    result = await review_and_fix(
+        path=_repo(tmp_path), spec={}, issue_key="X-1", reviewer=_Reviewer([[_finding()]])
+    )
+
+    assert not result.clean
+    assert "no fixer wired" in result.stopped
+    assert len(result.remaining) == 1
+
+
+@pytest.mark.parametrize("severity", [Severity.BLOCKER, Severity.WARNING])
+async def test_blockers_and_warnings_are_both_actionable(severity: Severity, tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    fixer = _Fixer([["mod.py"]])
+
+    await review_and_fix(
+        path=repo,
+        spec={},
+        issue_key="X-1",
+        fixer=fixer,
+        tests=_Tests([True]),
+        reviewer=_Reviewer([[_finding("x", severity)], []]),
+    )
+
+    assert len(fixer.prompts) == 1
+
+
+async def test_changed_file_counts_are_derived_from_the_patch(tmp_path: Path) -> None:
+    diff = await worktree_diff(_repo(tmp_path))
+    (changed,) = diff.files
+    assert isinstance(changed, ChangedFile)
+    assert changed.additions == 1 and changed.deletions == 1


### PR DESCRIPTION
Closes **[SSPN-24](https://fibonacci-solutions.atlassian.net/browse/SSPN-24)** — phase 5, the largest remaining piece.

## What & why

The pipeline could already review a pull request and revise one on demand. What it could not do is **close the loop**: nothing took a review's findings, fixed them, re-ran the tests and reviewed again. A human sat in that gap.

## The loop's value is that it stops

A model will always produce *an* edit. Four ways this one is allowed to stop, each tested:

| Stop | Why |
|---|---|
| **Out of rounds** (2 by default) | One round to fix, one to prove the fix and catch what it broke. A third has meant the model is rewriting rather than repairing. |
| **The fixer edited nothing** | The refine loop's rule: the next review would see identical code and say the same thing. |
| **A fix broke the tests** | A green suite turned red is a regression, not progress — stop rather than build on it. |
| **The finding isn't the fixer's** | A design objection handed to a model produces a change that answers the words, not the concern. Deferred with evidence, for a human or a ticket. |

Nits never trigger a fix cycle — a nit is real feedback for a human on the PR, not worth an LLM call and a re-test.

## Design notes worth reviewing

- **Reads the worktree diff, not a PR.** A loop that waited for a pull request could never fix anything *before* opening one. `PRDiff` already carried only files and patches, so the existing reviewer and verifiers work unchanged with `pr_number=0`.
- **Findings stay typed** (`verifier_id`, `rule`, `severity`, `path`, `line`, `message`) through the loop, rendered to prose only at the boundary where a model reads them. The loop counts and compares; only the fixer needs sentences.
- **`run_feature` now returns the adapter and runner it built**, so review fixes the change with the *same* tools that made it — same layout, conventions and test environment. Rebuilding them would review one change and fix a differently-configured one.

## A bug the tests found

A vanished worktree used to crash the loop (`FileNotFoundError` from the subprocess cwd). It now returns an empty diff: a reaped or relocated worktree must not take a run down with it. Found by pointing the loop at a path that never existed.

## How it was tested

```
pytest              2243 passed, 30 skipped   (2230 before — 13 new)
mypy src tests      no issues in 590 source files
ruff check . / ruff format --check .
```

13 tests: the happy path (found → fixed → re-tested → re-reviewed, no human), all four stop conditions, advisory-only findings, worktree diff parsing, the missing-worktree case, and no-fixer reporting.

Three `autorun` tests changed from asserting the *placeholder* (`review: skipped — safe mode opens no PR`) to asserting the loop actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)