### PR TITLE
fix(sdlc): refuse generated code that shadows a first-party module

### DIFF
--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -1453,6 +1453,17 @@ def apply_files(
                 f"refusing to create {rel!r}: it would shadow the Python "
                 f"standard-library module {target.stem!r}"
             )
+        # First-party shadow guard: the same failure one layer in. A model that wants
+        # `orchestrator.cli.regression` will happily create `orchestrator/cli/__init__.py`
+        # beside the existing `cli.py` — which does not extend the CLI, it hides it, and
+        # every command in the product stops resolving. Observed on a real run.
+        shadowed = _shadows_first_party(root, target)
+        if not target.exists() and shadowed is not None:
+            raise CodegenError(
+                f"refusing to create {rel!r}: it would shadow the existing module "
+                f"{shadowed.relative_to(root.resolve()).as_posix()!r}. Edit that module "
+                "instead of creating a package beside it."
+            )
         # Brownfield create-only guard (deterministic, not prompt-hope):
         # when grounded, the worktree is a real repo — a model "fix" that
         # rewrites a pre-existing module it didn't create this session
@@ -1585,6 +1596,36 @@ def _shadows_stdlib(root: Path, target: Path) -> bool:
     if target.suffix != ".py" or target.parent != root.resolve():
         return False
     return target.stem in sys.stdlib_module_names
+
+
+def _shadows_first_party(root: Path, target: Path) -> Path | None:
+    """The existing module ``target`` would hide, or ``None``.
+
+    Two shapes, both of which make an import resolve to the new thing and silently orphan
+    the old one:
+
+    * ``pkg/name/__init__.py`` created while ``pkg/name.py`` exists — the package wins;
+    * ``pkg/name.py`` created while ``pkg/name/__init__.py`` exists — ambiguous at best.
+
+    The stdlib guard next door catches the same mistake against Python's own modules. This
+    is the first-party half, and it is the more dangerous one: shadowing `statistics` breaks
+    a library nobody in the repo wrote, while shadowing `cli.py` breaks the product.
+    """
+    if target.suffix != ".py":
+        return None
+    # Both sides resolved before comparing: on macOS a temp root is /var/... while its
+    # resolution is /private/var/..., and an unresolved sibling then looks like it lives
+    # outside the worktree. `_safe_target` has already proven containment anyway.
+    resolved_root = root.resolve()
+    candidate = (
+        target.parent.with_suffix(".py")
+        if target.name == "__init__.py"
+        else target.with_suffix("") / "__init__.py"
+    )
+    candidate = candidate.resolve()
+    if not candidate.is_file() or not candidate.is_relative_to(resolved_root):
+        return None
+    return candidate
 
 
 def _safe_target(root: Path, rel: str) -> Path:

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -821,6 +821,40 @@ async def test_new_root_module_shadowing_stdlib_is_rejected(tmp_path: Path) -> N
         await adapter.implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
 
 
+async def test_a_package_shadowing_an_existing_module_is_rejected(tmp_path: Path) -> None:
+    """The real case, reproduced: a run wanted `orchestrator.cli.regression`, so it created
+    `orchestrator/cli/__init__.py` beside the existing `cli.py`. That does not extend the
+    CLI — it hides it, and every command in the product stops resolving.
+
+    The stdlib guard next door never fired, because `cli` is ours.
+    """
+    (tmp_path / "orchestrator").mkdir()
+    (tmp_path / "orchestrator" / "cli.py").write_text("app = 1\n", encoding="utf-8")
+    llm = _ScriptedLLM([_files_response({"orchestrator/cli/__init__.py": "app = 2\n"})])
+
+    with pytest.raises(CodegenError, match="shadow the existing module 'orchestrator/cli.py'"):
+        await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
+
+
+async def test_a_module_shadowing_an_existing_package_is_rejected(tmp_path: Path) -> None:
+    """The mirror image, equally ambiguous: `pkg.py` beside `pkg/__init__.py`."""
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    llm = _ScriptedLLM([_files_response({"pkg.py": "X = 1\n"})])
+
+    with pytest.raises(CodegenError, match="shadow the existing module"):
+        await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
+
+
+async def test_a_new_package_beside_nothing_is_fine(tmp_path: Path) -> None:
+    """The guard must not block ordinary new packages, which is most of greenfield work."""
+    llm = _ScriptedLLM([_files_response({"newpkg/__init__.py": "X = 1\n"})])
+
+    change = await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
+
+    assert change.files == [str(tmp_path / "newpkg" / "__init__.py")]
+
+
 async def test_stdlib_name_inside_a_package_is_fine(tmp_path: Path) -> None:
     llm = _ScriptedLLM([_files_response({"mypkg/types.py": "X = 1\n"})])
     adapter = LLMCodegenAdapter(llm)


### PR DESCRIPTION
Closes **[SSPN-30](https://fibonacci-solutions.atlassian.net/browse/SSPN-30)**. Small, and the one open finding that can break the *product* rather than the agent.

## What happened

A real run wanting `orchestrator.cli.regression` created **`orchestrator/cli/__init__.py` beside the existing `cli.py`**:

```
[refine] ['__init__.py', 'regression.py'] - Create src/orchestrator/cli/__init__.py to make cli
  a package, and place regression.py inside it so the import path resolves correctly.
[refine] ['__init__.py'] - Add app() entry-point to orchestrator.cli.__init__ so test_cli.py
  and test_launch.py can import it
```

That doesn't extend the CLI — it **hides** it. Every command in the product stops resolving, and the refine loop then spent its next iteration patching the file that had just broken everything.

A stdlib shadow guard has existed since run #15 created a root `statistics.py`. It never fired here, because `cli` is ours. This is the first-party half — **and the more dangerous one**: shadowing `statistics` breaks a library nobody in this repo wrote; shadowing `cli.py` breaks the product.

## The change

Both shapes are refused, since both make an import resolve to the new thing and silently orphan the old one:

| Created | While this exists |
|---|---|
| `pkg/name/__init__.py` | `pkg/name.py` |
| `pkg/name.py` | `pkg/name/__init__.py` |

The error names the module being shadowed and says to edit it instead — rather than failing with an import error at test time and letting a model theorise about the cause.

Ordinary new packages are untouched. That's most of greenfield work, and a guard that blocked it would be worse than the bug.

## A bug in the fix, caught by exercising it

The first version silently never fired: on macOS a worktree under `/var` resolves to `/private/var`, so an unresolved sibling looked like it lived outside the worktree and the containment check rejected it. Both sides are resolved before comparing now. It surfaced only because I ran the predicate directly instead of trusting it — worth noting, since a guard that never fires looks exactly like a guard that works.

## How it was tested

```
pytest              2246 passed, 30 skipped   (2243 before — 3 new)
mypy src tests      no issues in 590 source files
ruff check . / ruff format --check .
```

Tests reproduce the real `cli.py` case exactly, the mirror image, and assert a plain new package still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)