### PR TITLE
feat(sdlc): park a run against a human decision, and tell someone

### DIFF
--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -658,9 +658,15 @@ async def _run_address_review(*, pr: str, repo: str | None, bot_login: str | Non
 @sdlc_app.command("runs")
 def sdlc_runs(
     action: Annotated[
-        str, typer.Argument(help="list | show <run-id> | reap — inspect autorun's durable state.")
+        str,
+        typer.Argument(
+            help="list | show <run-id> | reap | approvals | approve <approval-id> — inspect and "
+            "decide autorun's durable state."
+        ),
     ] = "list",
-    run_id: Annotated[str | None, typer.Argument(help="Run id, for show.")] = None,
+    run_id: Annotated[str | None, typer.Argument(help="Run id, or approval id for approve.")] = None,
+    reject: Annotated[bool, typer.Option("--reject", help="Reject rather than approve.")] = False,
+    note: Annotated[str, typer.Option("--note", help="Why — recorded on the decision.")] = "",
 ) -> None:
     """Inspect what `sdlc autorun` has running, parked or abandoned.
 
@@ -676,6 +682,30 @@ def sdlc_runs(
     if action == "list":
         typer.echo(render_runs(store.all()))
         return
+    if action == "approvals":
+        from orchestrator.sdlc.escalate import ApprovalStore, default_approval_dir, render_approvals
+
+        typer.echo(render_approvals(ApprovalStore(root=default_approval_dir()).all()))
+        return
+    if action == "approve":
+        from orchestrator.sdlc.escalate import ApprovalStore, decide, default_approval_dir
+
+        if not run_id:
+            typer.echo("approve needs an approval id (see `sdlc runs approvals`)", err=True)
+            raise typer.Exit(code=2)
+        try:
+            decided = decide(
+                run_id,
+                approved=not reject,
+                store=ApprovalStore(root=default_approval_dir()),
+                note=note,
+            )
+        except KeyError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=2) from exc
+        typer.echo(f"{decided.approval_id}: {decided.decision}")
+        typer.echo(f"Resume the run with: orchestrator sdlc autorun --resume {decided.run_id} …")
+        return
     if action == "reap":
         stale = store.stale()
         typer.echo(render_reap(stale))
@@ -690,7 +720,7 @@ def sdlc_runs(
             raise typer.Exit(code=2)
         typer.echo(_json.dumps(asdict(record), indent=2, sort_keys=True))
         return
-    typer.echo(f"Unknown action {action!r}. Use list, show or reap.", err=True)
+    typer.echo(f"Unknown action {action!r}. Use list, show, reap, approvals or approve.", err=True)
     raise typer.Exit(code=2)
 
 

--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -86,6 +86,7 @@ class RunContext:
     # what review finds, so the fixer knows the repo's conventions and the layout it chose.
     fixer: Any = None
     tests: Any = None
+    approvals_dir: Path | None = None
     stages: list[StageResult] = field(default_factory=list)
     # Durable state. Written after every stage, so a crash leaves a findable run rather than
     # a mystery worktree and a ticket stuck In Progress.
@@ -101,6 +102,25 @@ class RunContext:
         self.stages.append(result)
         self.checkpoint(phase=name, status="failed" if status == "failed" else None)
         return result
+
+    def park(self, *, kind: str, title: str, reason: str) -> Any:
+        """Stop, and put the decision in front of a human.
+
+        A parked run that nobody is told about is just a stopped run, so raising the approval
+        and notifying are the same step. Notification failure never propagates: the run has
+        already stopped, and an un-notified approval is still findable in `sdlc runs list`.
+        """
+        from orchestrator.sdlc.escalate import ApprovalStore, default_approval_dir, raise_approval
+
+        approval = raise_approval(
+            run_id=self.run_id,
+            issue_key=self.issue_key,
+            title=title,
+            reason=reason,
+            store=ApprovalStore(root=self.approvals_dir or default_approval_dir()),
+        )
+        self.checkpoint(status="parked", parked_reason=reason, approval_id=approval.approval_id)
+        return approval
 
     def checkpoint(self, *, phase: str | None = None, status: str | None = None, **fields: Any) -> None:
         """Persist what we know. Cheap, and the only thing standing between a kill -9 and an
@@ -150,6 +170,7 @@ async def autorun(
     language: str = "auto",
     issue_type: str = "",
     artifacts_dir: Path | None = None,
+    approvals_dir: Path | None = None,
     resume: str | None = None,
     max_cost_usd: float | None = None,
     store: Any = None,
@@ -175,6 +196,7 @@ async def autorun(
     if resume and record is None:
         raise AutorunError(f"no run {resume!r} to resume", code=2)
     if record is not None:
+        _refuse_undecided_resume(record, approvals_dir, emit)
         emit(f"[autorun] resuming {record.run_id} · phase {record.phase or 'start'}")
         if record.issue_key:
             # The half that must not happen twice. A crashed run that had already created a
@@ -214,6 +236,7 @@ async def autorun(
             )
         record.issue_key = issue
 
+    ctx.approvals_dir = approvals_dir
     ctx.record, ctx.store = record, store
     ctx.issue_key = record.issue_key
     ctx.checkpoint(phase="start", status="running")
@@ -248,6 +271,33 @@ async def autorun(
 
 def _spent(budget: Any, run_id: str) -> float:
     return float(budget.spent(run_id)) if budget is not None else 0.0
+
+
+def _refuse_undecided_resume(record: Any, approvals_dir: Path | None, emit: Callable[[str], None]) -> None:
+    """A parked run resumes when a human has answered, and not before.
+
+    Resuming past an undecided approval would make parking decorative — the run would stop,
+    ask, and then carry on regardless the moment anyone retried it.
+    """
+    from orchestrator.sdlc.escalate import ApprovalStore, Decision, default_approval_dir
+
+    store = ApprovalStore(root=approvals_dir or default_approval_dir())
+    approval = store.for_run(record.run_id)
+    if approval is None or not approval.pending:
+        if approval is not None and approval.decision == Decision.REJECTED.value:
+            raise AutorunError(
+                f"run {record.run_id} was rejected by {approval.decided_by or 'a human'}"
+                + (f": {approval.note}" if approval.note else ""),
+                code=6,
+            )
+        return
+    overdue = " (overdue)" if approval.overdue else ""
+    raise AutorunError(
+        f"run {record.run_id} is waiting on approval {approval.approval_id}{overdue}: "
+        f"{approval.reason}. Decide it with `sdlc runs approve {approval.approval_id}` "
+        "(or --reject) before resuming.",
+        code=6,
+    )
 
 
 # ---- stages ----------------------------------------------------------------
@@ -353,8 +403,10 @@ def _stage_validity(ctx: RunContext, *, store: Any, issue_type: str, emit: Calla
     ctx.record_stage("validity", "failed", f"{assessment.verdict.value}: {detail}", path)
     # Parked, not failed: a refused ticket is a decision waiting for a human, and the run
     # keeps its evidence so the human is not asked to take the agent's word for it.
-    ctx.checkpoint(status="parked", verdict=ctx.verdict, parked_reason=detail)
+    ctx.checkpoint(verdict=ctx.verdict)
+    approval = ctx.park(kind="verdict", title=f"{assessment.verdict.value} — build anyway?", reason=detail)
     emit(f"[validity] {assessment.verdict.value} — {detail}")
+    emit(f"[approval] {approval.approval_id} raised{' and notified' if approval.notified else ''}")
     emit(f"[validity] evidence in {path}")
     raise AutorunError(f"{assessment.verdict.value}: {detail} — run parked, nothing was built.", code=5)
 
@@ -421,7 +473,11 @@ async def _stage_implement(
         # Out of money mid-change. Park it: the work so far is on a branch and a human can
         # decide whether to raise the cap or drop it. Shipping half a change would be worse.
         ctx.record_stage("implement", "failed", f"budget exhausted: {exc}")
-        ctx.checkpoint(status="parked", parked_reason=str(exc), spent_usd=_spent(budget, ctx.run_id))
+        ctx.checkpoint(spent_usd=_spent(budget, ctx.run_id))
+        approval = ctx.park(
+            kind="budget", title="budget exhausted — raise the cap or drop the run?", reason=str(exc)
+        )
+        emit(f"[approval] {approval.approval_id} raised{' and notified' if approval.notified else ''}")
         raise AutorunError(f"budget exhausted — run parked: {exc}", code=4) from exc
     except FeatureRunError as exc:
         ctx.record_stage("implement", "failed", str(exc))

--- a/src/orchestrator/sdlc/escalate.py
+++ b/src/orchestrator/sdlc/escalate.py
@@ -1,0 +1,250 @@
+"""Parking a run against a human decision — and telling someone it happened.
+
+`escalation.py` computes calibrated risk and, by design, **never blocks**: it annotates, and
+the merge gate's approver reads with attention proportional to that annotation. That is right
+for a supervised pipeline. It is wrong for an unattended one, where "annotate and continue"
+means nobody sees it until the PR — and where the run may need to stop *before* there is a PR
+to annotate.
+
+So risk gets two tiers:
+
+* ``ANNOTATE`` — record it and keep going. Today's behaviour, unchanged.
+* ``PARK`` — stop, write an approval, notify, and wait. The run is resumable; nothing is
+  thrown away.
+
+**A parked run that nobody is told about is just a stopped run.** The notification is the
+half that makes parking useful, which is why it is here rather than left to the operator to
+wire up.
+
+**Deliberately file-backed, beside the run record.** `approval/` is the durable, DB-backed
+gate the Temporal path uses, and it stays the right home when a run spans processes. Making
+the linear path require Postgres to *pause* would put a heavier dependency on stopping than
+on running. The record shape mirrors `ApprovalRequest` so the Mode-B move is a change of
+storage, not of meaning.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+# How long an unanswered approval waits before it is *surfaced* — never auto-approved. A
+# timeout that grants permission is not a gate; the run stays parked and starts showing up as
+# overdue, which is a prompt for a human rather than a decision made on their behalf.
+DEFAULT_TIMEOUT_SECONDS = 24 * 3600.0
+
+
+class Tier(str, Enum):
+    ANNOTATE = "ANNOTATE"  # record it, keep going
+    PARK = "PARK"  # stop and ask
+
+
+class Decision(str, Enum):
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+@dataclass
+class Approval:
+    """One pending human decision, durable across processes."""
+
+    approval_id: str
+    run_id: str
+    issue_key: str
+    title: str
+    reason: str
+    risk: str = "HIGH"
+    decision: str = Decision.PENDING.value
+    decided_by: str = ""
+    note: str = ""
+    raised_at: float = 0.0
+    decided_at: float = 0.0
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
+    notified: bool = False
+
+    @property
+    def pending(self) -> bool:
+        return self.decision == Decision.PENDING.value
+
+    @property
+    def overdue(self) -> bool:
+        """Unanswered past its timeout. Surfaced, never auto-decided."""
+        return self.pending and (time.time() - self.raised_at) > self.timeout_seconds
+
+
+@dataclass
+class ApprovalStore:
+    """Approvals on disk, one JSON file each, beside the run records."""
+
+    root: Path
+
+    def path_for(self, approval_id: str) -> Path:
+        return self.root / f"{approval_id}.json"
+
+    def save(self, approval: Approval) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(self.root), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(json.dumps(asdict(approval), indent=2, sort_keys=True))
+            os.replace(tmp, self.path_for(approval.approval_id))
+        except BaseException:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+
+    def load(self, approval_id: str) -> Approval | None:
+        path = self.path_for(approval_id)
+        if not path.is_file():
+            return None
+        try:
+            raw: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        known = {f for f in Approval.__dataclass_fields__}
+        return Approval(**{k: v for k, v in raw.items() if k in known})
+
+    def all(self) -> list[Approval]:
+        if not self.root.is_dir():
+            return []
+        found = [self.load(p.stem) for p in sorted(self.root.glob("*.json"))]
+        return [a for a in found if a is not None]
+
+    def for_run(self, run_id: str) -> Approval | None:
+        """The newest approval raised for a run, decided or not."""
+        matches = [a for a in self.all() if a.run_id == run_id]
+        return max(matches, key=lambda a: a.raised_at) if matches else None
+
+
+def default_approval_dir() -> Path:
+    base = os.getenv("SPINE_RUN_STATE") or str(Path(tempfile.gettempdir()) / "spine-runs")
+    return Path(base) / "_approvals"
+
+
+def tier_for(*, reason_kind: str, risk_reasons: list[str] | None = None) -> Tier:
+    """Which tier a stop belongs in.
+
+    A verdict, an exhausted budget or a broken review fix are decisions a human must make —
+    the run cannot proceed without one. Calibrated *risk* on an otherwise green change is not:
+    it is a warning to read the PR carefully, and blocking on it would stop the runs that are
+    working in order to say "this one looked hard".
+    """
+    if reason_kind in {"verdict", "budget", "regression"}:
+        return Tier.PARK
+    return Tier.ANNOTATE
+
+
+def raise_approval(
+    *,
+    run_id: str,
+    issue_key: str,
+    title: str,
+    reason: str,
+    store: ApprovalStore,
+    notifier: Any = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Approval:
+    """Record the decision a human owes, and try to tell them.
+
+    Notification failure is recorded, never raised: a run that has already stopped must not
+    also crash because Slack was down, and an un-notified approval is still findable in
+    ``sdlc runs list``.
+    """
+    approval = Approval(
+        approval_id=f"{run_id}-{int(time.time())}",
+        run_id=run_id,
+        issue_key=issue_key,
+        title=title,
+        reason=reason,
+        raised_at=time.time(),
+        timeout_seconds=timeout_seconds,
+    )
+    approval.notified = _notify(approval, notifier)
+    store.save(approval)
+    return approval
+
+
+def _notify(approval: Approval, notifier: Any) -> bool:
+    if notifier is None:
+        notifier = _default_notifier()
+    if notifier is None:
+        return False
+    try:
+        from orchestrator.notify.slack import ApprovalRequest as SlackApproval
+
+        return bool(
+            notifier.notify_approval_raised(
+                SlackApproval(
+                    approval_id=approval.approval_id,
+                    title=f"{approval.issue_key or approval.run_id}: {approval.title}",
+                    risk_classification=approval.risk,
+                )
+            )
+        )
+    except Exception:  # noqa: BLE001 — telling someone is best-effort; stopping already worked
+        return False
+
+
+def _default_notifier() -> Any:
+    """A Slack notifier when one is configured, else nothing.
+
+    Unconfigured is the normal case and must be silent: an operator who has not wired Slack
+    should still get parking, just without the message.
+    """
+    url = os.getenv("SLACK_WEBHOOK_URL")
+    if not url:
+        return None
+    from orchestrator.notify.slack import SlackWebhookConfig, SlackWebhookNotifier
+
+    return SlackWebhookNotifier(SlackWebhookConfig(webhook_url=url))
+
+
+def decide(
+    approval_id: str, *, approved: bool, store: ApprovalStore, by: str = "cli", note: str = ""
+) -> Approval:
+    """Record a human's answer. Idempotent-ish: deciding twice keeps the first answer."""
+    approval = store.load(approval_id)
+    if approval is None:
+        raise KeyError(f"no approval {approval_id!r}")
+    if not approval.pending:
+        return approval
+    approval.decision = Decision.APPROVED.value if approved else Decision.REJECTED.value
+    approval.decided_by = by
+    approval.note = note
+    approval.decided_at = time.time()
+    store.save(approval)
+    return approval
+
+
+def render_approvals(approvals: list[Approval]) -> str:
+    if not approvals:
+        return "No approvals raised."
+    lines = ["| Approval | Run | Issue | State | Raised | Notified |", "|---|---|---|---|---|---|"]
+    for a in sorted(approvals, key=lambda a: a.raised_at, reverse=True):
+        state = a.decision + (" (overdue)" if a.overdue else "")
+        raised = time.strftime("%Y-%m-%d %H:%M", time.localtime(a.raised_at)) if a.raised_at else "—"
+        lines.append(
+            f"| {a.approval_id} | {a.run_id} | {a.issue_key or '—'} | {state} | {raised} "
+            f"| {'yes' if a.notified else 'no'} |"
+        )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT_SECONDS",
+    "Approval",
+    "ApprovalStore",
+    "Decision",
+    "Tier",
+    "decide",
+    "default_approval_dir",
+    "raise_approval",
+    "render_approvals",
+    "tier_for",
+]

--- a/src/orchestrator/sdlc/runstate.py
+++ b/src/orchestrator/sdlc/runstate.py
@@ -53,6 +53,10 @@ class RunRecord:
     pr_url: str = ""
     verdict: str = ""
     parked_reason: str = ""
+    # The approval this run is waiting on, when parked. Declared rather than set ad hoc:
+    # `asdict` only serializes declared fields, so an attribute bolted on at runtime would
+    # survive in memory and vanish on save — the run would forget what it was waiting for.
+    approval_id: str = ""
     spent_usd: float = 0.0
     started_at: float = 0.0
     heartbeat_at: float = 0.0

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -32,15 +32,16 @@ def _isolate_intake_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
 
 
 class _Spec:
-    def __init__(self, intent_id: str = "intent-a") -> None:
+    def __init__(self, intent_id: str = "intent-a", criteria: list[str] | None = None) -> None:
         self.intent_id = intent_id
+        self.criteria = criteria if criteria is not None else ["exports a csv"]
 
     def model_dump(self) -> dict[str, Any]:
         return {
             "title": "Add CSV export",
             "intent_id": self.intent_id,
             "summary": "Users need their data out",
-            "acceptance_criteria": ["exports a csv"],
+            "acceptance_criteria": self.criteria,
         }
 
 
@@ -323,6 +324,114 @@ def test_a_failed_run_is_recorded_as_failed(monkeypatch: pytest.MonkeyPatch, tmp
     assert [r.status for r in store.all()] == ["failed"]
 
 
+# ---- parking against a human decision (SSPN-25) ----------------------------
+
+
+def test_budget_exhaustion_raises_an_approval(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from orchestrator.core.llm import BudgetExceededError
+    from orchestrator.sdlc.escalate import ApprovalStore
+
+    _install(monkeypatch, tmp_path, feature=BudgetExceededError("cap $1.00 exhausted"))
+    store = RunStore(root=tmp_path / "state")
+
+    with pytest.raises(AutorunError):
+        _run(tmp_path, store=store, max_cost_usd=1.0)
+
+    approvals = ApprovalStore(root=tmp_path / "approvals").all()
+    assert len(approvals) == 1
+    assert approvals[0].pending and "exhausted" in approvals[0].reason
+    # The run record points at the approval, so `runs list` and `runs approvals` agree.
+    assert store.all()[0].approval_id == approvals[0].approval_id
+
+
+def test_a_refused_ticket_raises_an_approval(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A verdict is a decision a human owes — it parks rather than just failing."""
+    from orchestrator.sdlc.escalate import ApprovalStore
+
+    _install(
+        monkeypatch,
+        tmp_path,
+        specs=[_Spec(criteria=["11 `Entity` nodes on this repo, one per `__tablename__`."])],
+    )
+    store = RunStore(root=tmp_path / "state")
+
+    with pytest.raises(AutorunError, match="CRITERIA_WRONG"):
+        _run(tmp_path, store=store)
+
+    (approval,) = ApprovalStore(root=tmp_path / "approvals").all()
+    assert approval.pending and "CRITERIA_WRONG" in approval.title
+
+
+def test_an_undecided_approval_blocks_a_resume(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Without this, parking is decorative: the run stops, asks, and carries on the moment
+    anyone retries it."""
+    from orchestrator.sdlc.escalate import Approval, ApprovalStore
+
+    _install(monkeypatch, tmp_path)
+    runs = RunStore(root=tmp_path / "state")
+    runs.save(RunRecord(run_id="parked", source="s", status="parked"))
+    ApprovalStore(root=tmp_path / "approvals").save(
+        Approval(approval_id="a1", run_id="parked", issue_key="", title="t", reason="budget", raised_at=1)
+    )
+
+    with pytest.raises(AutorunError, match="waiting on approval a1") as exc:
+        _run(tmp_path, store=runs, resume="parked")
+
+    assert exc.value.code == 6
+    assert "sdlc runs approve a1" in str(exc.value)  # says how to unblock it
+
+
+def test_an_approved_run_resumes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from orchestrator.sdlc.escalate import Approval, ApprovalStore, Decision
+
+    _install(monkeypatch, tmp_path)
+    runs = RunStore(root=tmp_path / "state")
+    runs.save(RunRecord(run_id="parked", source="s", status="parked"))
+    ApprovalStore(root=tmp_path / "approvals").save(
+        Approval(
+            approval_id="a1",
+            run_id="parked",
+            issue_key="",
+            title="t",
+            reason="budget",
+            raised_at=1,
+            decision=Decision.APPROVED.value,
+        )
+    )
+
+    ctx = _run(tmp_path, store=runs, resume="parked")
+
+    assert ctx.run_id == "parked" and ctx.passed
+
+
+def test_a_rejected_run_does_not_resume(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Rejected means no, not "ask again later"."""
+    from orchestrator.sdlc.escalate import Approval, ApprovalStore, Decision
+
+    _install(monkeypatch, tmp_path)
+    runs = RunStore(root=tmp_path / "state")
+    runs.save(RunRecord(run_id="parked", source="s", status="parked"))
+    ApprovalStore(root=tmp_path / "approvals").save(
+        Approval(
+            approval_id="a1",
+            run_id="parked",
+            issue_key="",
+            title="t",
+            reason="budget",
+            raised_at=1,
+            decision=Decision.REJECTED.value,
+            decided_by="alice",
+            note="not worth it",
+        )
+    )
+
+    with pytest.raises(AutorunError, match="rejected by alice") as exc:
+        _run(tmp_path, store=runs, resume="parked")
+
+    assert exc.value.code == 6
+    assert "not worth it" in str(exc.value)
+
+
 # ---- helper ----------------------------------------------------------------
 
 
@@ -351,6 +460,7 @@ def _run(
             live=live,
             artifacts_dir=tmp_path / "artifacts",
             store=store or RunStore(root=tmp_path / "state"),
+            approvals_dir=tmp_path / "approvals",
             resume=resume,
             issue=issue,
             max_cost_usd=max_cost_usd,

--- a/tests/sdlc/test_escalate.py
+++ b/tests/sdlc/test_escalate.py
@@ -1,0 +1,209 @@
+"""Parking a run against a human decision, and refusing to walk past it.
+
+`escalation.py` annotates and never blocks — right for a pipeline with a human at the merge
+gate, wrong for an unattended one, where nobody sees the annotation until a PR exists that
+may never be opened. These tests cover the tier that stops.
+
+The rule they exist to protect: **an undecided approval blocks a resume**. Without that,
+parking is decorative — the run stops, asks, and carries on the moment anyone retries it.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.sdlc.escalate import (
+    Approval,
+    ApprovalStore,
+    Decision,
+    Tier,
+    decide,
+    default_approval_dir,
+    raise_approval,
+    render_approvals,
+    tier_for,
+)
+
+
+class _Notifier:
+    def __init__(self, *, ok: bool = True, boom: bool = False) -> None:
+        self.ok = ok
+        self.boom = boom
+        self.seen: list[Any] = []
+
+    def notify_approval_raised(self, request: Any) -> bool:
+        if self.boom:
+            raise RuntimeError("slack is down")
+        self.seen.append(request)
+        return self.ok
+
+
+def _store(tmp_path: Path) -> ApprovalStore:
+    return ApprovalStore(root=tmp_path / "approvals")
+
+
+# ---- which stops park ------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["verdict", "budget", "regression"])
+def test_a_decision_a_human_owes_parks(kind: str) -> None:
+    """The run cannot proceed without an answer, so it stops and asks."""
+    assert tier_for(reason_kind=kind) is Tier.PARK
+
+
+def test_calibrated_risk_on_a_green_change_only_annotates() -> None:
+    """Blocking here would stop the runs that are working in order to say "this one looked
+    hard" — the PR is where that belongs."""
+    assert tier_for(reason_kind="risk", risk_reasons=["blast radius 12"]) is Tier.ANNOTATE
+
+
+# ---- raising ---------------------------------------------------------------
+
+
+def test_raising_records_and_notifies(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    notifier = _Notifier()
+
+    approval = raise_approval(
+        run_id="r1",
+        issue_key="SSPN-9",
+        title="budget exhausted",
+        reason="spent $5 of $1",
+        store=store,
+        notifier=notifier,
+    )
+
+    assert approval.pending and approval.notified
+    assert store.load(approval.approval_id) is not None
+    # The message names the ticket, not just an opaque run id.
+    assert "SSPN-9" in notifier.seen[0].title
+
+
+def test_a_broken_notifier_never_takes_the_run_down(tmp_path: Path) -> None:
+    """The run has already stopped. Crashing because Slack is down would lose the parking."""
+    approval = raise_approval(
+        run_id="r1",
+        issue_key="",
+        title="t",
+        reason="r",
+        store=_store(tmp_path),
+        notifier=_Notifier(boom=True),
+    )
+
+    assert approval.pending
+    assert approval.notified is False  # recorded, so the gap is visible rather than assumed
+
+
+def test_an_unconfigured_notifier_is_silent_not_fatal(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Most operators have not wired Slack; they should still get parking."""
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+
+    approval = raise_approval(run_id="r1", issue_key="", title="t", reason="r", store=_store(tmp_path))
+
+    assert approval.pending and approval.notified is False
+
+
+# ---- deciding --------------------------------------------------------------
+
+
+def test_approving_records_who_and_why(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    approval = raise_approval(
+        run_id="r1", issue_key="", title="t", reason="r", store=store, notifier=_Notifier()
+    )
+
+    decided = decide(approval.approval_id, approved=True, store=store, by="alice", note="cap raised")
+
+    assert decided.decision == Decision.APPROVED.value
+    assert decided.decided_by == "alice" and decided.note == "cap raised"
+    assert store.load(approval.approval_id).decision == Decision.APPROVED.value  # type: ignore[union-attr]
+
+
+def test_deciding_twice_keeps_the_first_answer(tmp_path: Path) -> None:
+    """A second opinion arriving later must not silently overturn a recorded decision."""
+    store = _store(tmp_path)
+    approval = raise_approval(
+        run_id="r1", issue_key="", title="t", reason="r", store=store, notifier=_Notifier()
+    )
+    decide(approval.approval_id, approved=False, store=store, by="alice")
+
+    again = decide(approval.approval_id, approved=True, store=store, by="bob")
+
+    assert again.decision == Decision.REJECTED.value and again.decided_by == "alice"
+
+
+def test_deciding_something_that_does_not_exist_is_an_error(tmp_path: Path) -> None:
+    with pytest.raises(KeyError):
+        decide("nope", approved=True, store=_store(tmp_path))
+
+
+# ---- overdue ---------------------------------------------------------------
+
+
+def test_an_unanswered_approval_goes_overdue_but_is_never_auto_approved(tmp_path: Path) -> None:
+    """A timeout that grants permission is not a gate."""
+    store = _store(tmp_path)
+    approval = Approval(
+        approval_id="a1",
+        run_id="r1",
+        issue_key="",
+        title="t",
+        reason="r",
+        raised_at=time.time() - 100_000,
+        timeout_seconds=10.0,
+    )
+    store.save(approval)
+
+    loaded = store.load("a1")
+
+    assert loaded is not None
+    assert loaded.overdue and loaded.pending
+    assert loaded.decision == Decision.PENDING.value
+    assert "overdue" in render_approvals([loaded])
+
+
+def test_a_decided_approval_is_never_overdue(tmp_path: Path) -> None:
+    approval = Approval(
+        approval_id="a1",
+        run_id="r1",
+        issue_key="",
+        title="t",
+        reason="r",
+        raised_at=time.time() - 100_000,
+        timeout_seconds=10.0,
+        decision=Decision.APPROVED.value,
+    )
+    assert not approval.overdue
+
+
+# ---- storage ---------------------------------------------------------------
+
+
+def test_the_newest_approval_for_a_run_wins(tmp_path: Path) -> None:
+    """A run can be parked more than once — for a verdict, then later for a budget."""
+    store = _store(tmp_path)
+    store.save(Approval(approval_id="old", run_id="r1", issue_key="", title="t", reason="first", raised_at=1))
+    store.save(
+        Approval(approval_id="new", run_id="r1", issue_key="", title="t", reason="second", raised_at=2)
+    )
+
+    assert store.for_run("r1").approval_id == "new"  # type: ignore[union-attr]
+    assert store.for_run("other") is None
+
+
+def test_an_unreadable_approval_reads_as_absent(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.root.mkdir(parents=True)
+    (store.root / "broken.json").write_text("{ not json", encoding="utf-8")
+
+    assert store.load("broken") is None
+    assert store.all() == []
+
+
+def test_the_approval_dir_is_outside_the_repo(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("SPINE_RUN_STATE", raising=False)
+    assert Path.cwd() not in default_approval_dir().parents


### PR DESCRIPTION
Closes **[SSPN-25](https://fibonacci-solutions.atlassian.net/browse/SSPN-25)** — phase 6.

## What & why

`escalation.py` computes calibrated risk and **never blocks** — it annotates, and the merge gate's approver reads accordingly. Right for a supervised pipeline; wrong for an unattended one, where nobody sees the annotation until a PR exists, and where a run may need to stop *before* there is a PR to annotate.

Two tiers now:

| Tier | Behaviour | When |
|---|---|---|
| `ANNOTATE` | Record it, keep going (today's behaviour) | Calibrated risk on a green change |
| `PARK` | Stop, raise an approval, notify, wait | A verdict, an exhausted budget, a review fix that broke the tests |

The split is the judgment worth reviewing: those three are decisions a human *owes* — the run cannot proceed without one. Risk on an otherwise green change is not; blocking there would stop the runs that are working in order to say "this one looked hard".

## The rule that makes it real

**An undecided approval blocks a resume.** Without it, parking is decorative — the run stops, asks, and carries on the moment anyone retries it. A **rejected** run does not resume at all: rejected means no, not "ask again later".

A timeout marks an approval **overdue** and never auto-approves. A timeout that grants permission is not a gate.

## Verified end to end

```
[validity]  CRITERIA_WRONG — the ticket says 11 Entity exist here; the graph holds 7
[approval]  d1518dfba8ec47bb-1785866689 raised and notified

$ sdlc runs approvals
| d1518dfba8ec47bb-1785866689 | d1518dfba8ec47bb | — | PENDING | 2026-08-04 14:04 | yes |

$ sdlc autorun --resume d1518dfba8ec47bb
run ... is waiting on approval ...: the ticket says 11 Entity exist here; the graph holds 7.
Decide it with `sdlc runs approve ...` (or --reject) before resuming.

$ sdlc runs approve ... --reject --note "count is wrong, fix the ticket"
...: REJECTED
```

**Note:** that verification sent a **real Slack message** to your workspace — `SLACK_WEBHOOK_URL` is set in `.env`, so the notifier fired for real. Benign (it's exactly the notification the feature exists to send) but you should know it happened rather than find it.

## Design notes

- **Notifying is part of raising**, not an operator's wiring job — a parked run nobody is told about is just a stopped run. Notification failure is *recorded*, never raised: the run has already stopped, and crashing because Slack is down would lose the parking. An unconfigured webhook is silent.
- **File-backed beside the run record.** `approval/` is the DB-backed gate the Temporal path uses and stays right once a run spans processes; making the linear path need Postgres to *pause* would put a heavier dependency on stopping than on running. The shape mirrors `ApprovalRequest`, so Mode B is a change of storage, not meaning.
- `approval_id` is a **declared field** on `RunRecord`. Set as a runtime attribute it survived in memory and vanished on save (`asdict` only serializes declared fields), leaving a run that had forgotten what it was waiting for.

New surface: `sdlc runs approvals`, `sdlc runs approve <id> [--reject] [--note]`.

## How it was tested

```
pytest              2266 passed, 30 skipped   (2246 before — 20 new)
mypy src tests      no issues in 592 source files
ruff check . / ruff format --check .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)