### PR TITLE
feat(evals): score the run agent against a corpus with known answers

### DIFF
--- a/docs/specs/autonomous-run-agent.md
+++ b/docs/specs/autonomous-run-agent.md
@@ -206,6 +206,27 @@ and verify it in CI; regenerate post-merge; or serialize merges behind a queue.
 
 ---
 
+## 8a. The baseline
+
+Measured by `orchestrator sdlc baseline`, and held by `tests/evals/test_agent_corpus.py`.
+Raise these when the agent genuinely improves; **never lower one to make a change pass** —
+that edit is the whole thing this baseline exists to make uncomfortable.
+
+| Metric | Baseline | Why this bar |
+|---|---|---|
+| Validity-gate accuracy | **100%** (10/10) | Every case has an argued expected verdict; a corpus you cannot justify encodes yesterday's bugs |
+| False refusals | **0** | Refusing sound work teaches people to switch the gate off, and a gate that is off scores nothing |
+| Missed refusals | **0** | A run built on a false premise passes its own tests and is still wrong |
+
+The corpus is this board: SSPN-2, 3, 4, 9, 13 and 18, plus the two paired cases that differ
+only in what was wrong (SSPN-3 with its real number; SSPN-18 with a fault site) and two
+synthetic cases for size and for prose that merely contains digits.
+
+**Run metrics are observations, not simulations.** `score_runs` reads the durable run records
+— completion, parking, cost — so an empty store reports *nothing* rather than a zero that
+looks like a result. First-pass test success and cost per ticket fill in as real runs
+accumulate; publishing them from a handful of ad-hoc runs would dress anecdote as benchmark.
+
 ## 9. Open decisions
 
 1. **Durability.** Build the skeleton as a Temporal workflow from the start (durability and

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -655,6 +655,55 @@ async def _run_address_review(*, pr: str, repo: str | None, bot_login: str | Non
     _print(result.__dict__)
 
 
+@sdlc_app.command("baseline")
+def sdlc_baseline(
+    path: Annotated[str, typer.Option("--path", help="Repo whose graph the gate reads.")] = ".",
+    as_json: Annotated[bool, typer.Option("--json", help="Emit the numbers as JSON.")] = False,
+) -> None:
+    """Score the run agent against a corpus of tickets whose right answer is known.
+
+    Deterministic and free: the validity gate reads each ticket and a real graph, and every
+    case has an argued expected verdict. Run metrics come from the durable run records —
+    observations of what actually ran, not a simulation.
+
+    False refusals and missed refusals are counted separately. A single accuracy number would
+    let one hide behind the other, and they cost very different things.
+    """
+    import json as _json
+
+    from orchestrator.evals.agent_corpus import render_report, score_gate, score_runs
+    from orchestrator.pkg import FactStore, load_or_extract
+    from orchestrator.sdlc.runstate import RunStore
+
+    gate = score_gate(FactStore(load_or_extract(path)))
+    runs = score_runs(RunStore().all())
+    if as_json:
+        typer.echo(
+            _json.dumps(
+                {
+                    "gate": {
+                        "accuracy": gate.accuracy,
+                        "cases": len(gate.results),
+                        "false_refusals": gate.false_refusals,
+                        "missed_refusals": gate.missed_refusals,
+                    },
+                    "runs": {
+                        "runs": runs.runs,
+                        "completed": runs.completed,
+                        "parked": runs.parked,
+                        "failed": runs.failed,
+                        "completion_rate": runs.completion_rate,
+                        "intervention_rate": runs.intervention_rate,
+                        "mean_cost_usd": runs.mean_cost_usd,
+                    },
+                },
+                indent=2,
+            )
+        )
+        return
+    typer.echo(render_report(gate, runs))
+
+
 @sdlc_app.command("runs")
 def sdlc_runs(
     action: Annotated[

--- a/src/orchestrator/evals/agent_corpus.py
+++ b/src/orchestrator/evals/agent_corpus.py
@@ -1,0 +1,313 @@
+"""A scored corpus for the run agent, drawn from tickets whose right answer is known.
+
+Everything the agent does is tested as *parts*. None of it is measured as a *system*, and
+without measurement there is no way to tell whether a change made it better — the failure
+mode that let a hand-authored capability matrix be 22% wrong with nothing failing.
+
+The corpus is this project's own board. That is not a convenience: these are real tickets,
+written by the real pipeline, with outcomes already argued out in review. Two of them shipped
+with criteria that contradicted the source, and one is a design defect with no traceback —
+cases nobody would have thought to invent.
+
+**Two scorers, because two different things are knowable.**
+
+* :func:`score_gate` is deterministic and free. The validity gate reads a ticket and a graph
+  and returns a verdict; every case here has a known-correct one, so accuracy is a fact, and
+  a regression test can hold it.
+* :func:`score_runs` reads what actually ran — the durable run records — for cost, parking
+  and human interventions. It reports on the runs that exist rather than simulating any.
+
+**The bar is asymmetric and the score says so.** A false refusal (`PROCEED` → refused) wastes
+a human's attention and teaches people to switch the gate off; a missed refusal lets a run
+build to a false premise. They are counted separately, because a single accuracy number would
+let one hide behind the other.
+
+What is deliberately *not* scored here: first-pass test success and cost per ticket cannot be
+had without spending real money on real runs. The fields exist in :class:`RunMetrics` and are
+filled from run records as runs accumulate — reporting them from a handful of ad-hoc runs
+would dress anecdote as benchmark.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from orchestrator.pkg import FactStore
+from orchestrator.sdlc.validity import Verdict, assess
+
+
+@dataclass(frozen=True)
+class Case:
+    """One ticket with a known-correct verdict, and why it is known."""
+
+    # Named `ticket`, not `key`: a field called `key` holding "SSPN-18-located" trips the
+    # secret scanner's generic-api-key rule on entropy. Renaming beats allowlisting — the
+    # scanner keeps its teeth, and `ticket` says what it holds anyway.
+    ticket: str
+    title: str
+    criteria: tuple[str, ...]
+    expected: Verdict
+    why: str
+    summary: str = ""
+    issue_type: str = "Story"
+    landing: tuple[str, ...] = ()
+
+    def spec(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "summary": self.summary,
+            "acceptance_criteria": list(self.criteria),
+        }
+
+
+# Real tickets. The `why` is the record of how each answer is known — a corpus whose expected
+# answers cannot be justified is a corpus that encodes yesterday's bugs.
+CORPUS: tuple[Case, ...] = (
+    Case(
+        ticket="SSPN-3",
+        title="Add Entity, Field, and REFERENCES detection for Python",
+        criteria=("11 `Entity` nodes on this repo, one per `__tablename__`.",),
+        expected=Verdict.CRITERIA_WRONG,
+        why="shipped claiming 11; the source has 7 __tablename__ declarations, found in review",
+    ),
+    Case(
+        ticket="SSPN-3-fixed",
+        title="Add Entity, Field, and REFERENCES detection for Python",
+        criteria=("7 `Entity` nodes on this repo, one per `__tablename__`.",),
+        expected=Verdict.PROCEED,
+        why="the same ticket with the number the source supports",
+    ),
+    Case(
+        ticket="SSPN-2",
+        title="Add Endpoint and EXPOSES detection for Python",
+        criteria=(
+            "On this repo, at least 70 route handlers carry an inbound `EXPOSES` edge.",
+            "No endpoint is emitted for a route whose path is not a string literal.",
+        ),
+        expected=Verdict.PROCEED,
+        why="delivered 77 of 77 against a >= 70 target; refusing it would be a false refusal",
+    ),
+    Case(
+        ticket="SSPN-4",
+        title="Add READS and WRITES detection for Python",
+        criteria=(
+            "`select(X)` with X a bare name bound to an ORM class yields a READS edge.",
+            "No edge is emitted for `text()` SQL or a non-literal table argument.",
+        ),
+        expected=Verdict.PROCEED,
+        why="delivered as written; nothing in it asserts a count",
+    ),
+    Case(
+        ticket="SSPN-18",
+        title="The graph cache is not keyed on the extractor",
+        summary="a warm cache serves a pre-endpoint graph after an upgrade",
+        criteria=("The cache key includes a fingerprint of the extraction code.",),
+        expected=Verdict.UNLOCALIZED,
+        why="a Bug in prose with no traceback; rca reported 'fault site: unresolved'",
+        issue_type="Bug",
+    ),
+    Case(
+        ticket="SSPN-18-located",
+        title="The graph cache is not keyed on the extractor",
+        summary="persistence keys the cache on HEAD plus a hand-bumped format version",
+        criteria=("The cache key includes a fingerprint of the extraction code.",),
+        expected=Verdict.PROCEED,
+        why="the same Bug once a fault site is known — localization is what was missing",
+        issue_type="Bug",
+        landing=("src/orchestrator/pkg/persistence.py",),
+    ),
+    Case(
+        ticket="SSPN-13",
+        title="Log run telemetry as a Jira worklog",
+        criteria=(
+            "A live run posts exactly one worklog on the issue it worked.",
+            "A safe run posts nothing and makes no API call.",
+        ),
+        expected=Verdict.PROCEED,
+        why=(
+            "delivered as written, and its criteria assert behaviour rather than counts — "
+            "nothing in it can be contradicted by the graph"
+        ),
+    ),
+    Case(
+        ticket="SSPN-9",
+        title="sdlc feature --live always creates a new issue",
+        summary="create_issue is unconditional, so every run mints a ticket",
+        criteria=("`--issue <KEY>` adopts an existing issue and creates none.",),
+        expected=Verdict.PROCEED,
+        why="a Bug that localizes: feature_runner.py:261 was named in the ticket",
+        issue_type="Bug",
+        landing=("src/orchestrator/sdlc/feature_runner.py",),
+    ),
+    Case(
+        ticket="synthetic-oversized",
+        title="Rewrite the SDLC pipeline",
+        criteria=tuple(f"criterion {i}" for i in range(15)),
+        expected=Verdict.TOO_BIG,
+        why="15 criteria is more than one change's worth, whatever the words say",
+    ),
+    Case(
+        ticket="synthetic-prose-numbers",
+        title="Add a --format json flag to `orchestrator regression`",
+        criteria=(
+            "An unknown --format value exits 2 with a message naming the valid values.",
+            "The default output is unchanged.",
+        ),
+        expected=Verdict.PROCEED,
+        why="digits that are not claims about the repo; the gate must not fire on ordinary prose",
+    ),
+)
+
+
+@dataclass
+class CaseResult:
+    case: Case
+    actual: Verdict
+    detail: str = ""
+
+    @property
+    def correct(self) -> bool:
+        return self.actual is self.case.expected
+
+    @property
+    def false_refusal(self) -> bool:
+        """Refused something that should have proceeded — the expensive kind of wrong."""
+        return self.case.expected is Verdict.PROCEED and self.actual is not Verdict.PROCEED
+
+    @property
+    def missed_refusal(self) -> bool:
+        """Proceeded on something that should have been refused."""
+        return self.case.expected is not Verdict.PROCEED and self.actual is Verdict.PROCEED
+
+
+@dataclass
+class GateScore:
+    results: list[CaseResult] = field(default_factory=list)
+
+    @property
+    def accuracy(self) -> float:
+        return round(sum(r.correct for r in self.results) / len(self.results), 3) if self.results else 0.0
+
+    @property
+    def false_refusals(self) -> int:
+        return sum(r.false_refusal for r in self.results)
+
+    @property
+    def missed_refusals(self) -> int:
+        return sum(r.missed_refusal for r in self.results)
+
+    def render(self) -> str:
+        lines = [
+            "## Validity gate",
+            "",
+            f"- **accuracy** {self.accuracy:.0%} ({sum(r.correct for r in self.results)}"
+            f"/{len(self.results)} cases)",
+            f"- **false refusals** {self.false_refusals} — refused work that was sound",
+            f"- **missed refusals** {self.missed_refusals} — proceeded on a false premise",
+            "",
+            "| Case | Expected | Actual | |",
+            "|---|---|---|---|",
+        ]
+        for r in self.results:
+            mark = "✓" if r.correct else "✗"
+            lines.append(f"| {r.case.ticket} | {r.case.expected.value} | {r.actual.value} | {mark} |")
+        return "\n".join(lines)
+
+
+def score_gate(store: FactStore, *, corpus: tuple[Case, ...] = CORPUS) -> GateScore:
+    """Run every case through the gate. Deterministic, no LLM, no network."""
+    score = GateScore()
+    for case in corpus:
+        assessment = assess(
+            case.spec(),
+            store=store,
+            landing=list(case.landing),
+            issue_type=case.issue_type,
+        )
+        detail = "; ".join(f.detail for f in assessment.findings)
+        score.results.append(CaseResult(case=case, actual=assessment.verdict, detail=detail))
+    return score
+
+
+@dataclass
+class RunMetrics:
+    """What the runs that actually happened cost and needed.
+
+    Read from the durable run records rather than simulated: these are observations, and an
+    empty store honestly reports nothing rather than a zero that looks like a result.
+    """
+
+    runs: int = 0
+    completed: int = 0
+    parked: int = 0
+    failed: int = 0
+    abandoned: int = 0
+    # Counted, not dropped. Without it the categories do not sum to the total and the report
+    # quietly loses runs — a table whose numbers do not add up teaches nobody to trust it.
+    running: int = 0
+    total_cost_usd: float = 0.0
+
+    @property
+    def completion_rate(self) -> float:
+        return round(self.completed / self.runs, 3) if self.runs else 0.0
+
+    @property
+    def intervention_rate(self) -> float:
+        """Runs that stopped and asked a human. The number that decides whether unattended
+        operation is real or aspirational."""
+        return round(self.parked / self.runs, 3) if self.runs else 0.0
+
+    @property
+    def mean_cost_usd(self) -> float:
+        return round(self.total_cost_usd / self.runs, 4) if self.runs else 0.0
+
+    def render(self) -> str:
+        if not self.runs:
+            return "## Runs\n\n_No runs recorded yet — nothing to report._"
+        return "\n".join(
+            [
+                "## Runs",
+                "",
+                f"- **runs** {self.runs}",
+                f"- **completed** {self.completed} ({self.completion_rate:.0%})",
+                f"- **needed a human** {self.parked} ({self.intervention_rate:.0%})",
+                f"- **failed** {self.failed} · **abandoned** {self.abandoned}"
+                + (f" · **still running** {self.running}" if self.running else ""),
+                f"- **cost** ${self.total_cost_usd:.2f} total · ${self.mean_cost_usd:.4f} mean",
+            ]
+        )
+
+
+def score_runs(records: list[Any]) -> RunMetrics:
+    metrics = RunMetrics(runs=len(records))
+    for record in records:
+        metrics.total_cost_usd += float(getattr(record, "spent_usd", 0.0) or 0.0)
+        status = getattr(record, "status", "")
+        if status == "done":
+            metrics.completed += 1
+        elif status == "parked":
+            metrics.parked += 1
+        elif status == "failed":
+            metrics.failed += 1
+        elif status == "abandoned":
+            metrics.abandoned += 1
+        elif status == "running":
+            metrics.running += 1
+    return metrics
+
+
+def render_report(gate: GateScore, runs: RunMetrics) -> str:
+    return "\n\n".join(["# Agent baseline", gate.render(), runs.render()])
+
+
+__all__ = [
+    "CORPUS",
+    "Case",
+    "CaseResult",
+    "GateScore",
+    "RunMetrics",
+    "render_report",
+    "score_gate",
+    "score_runs",
+]

--- a/tests/evals/test_agent_corpus.py
+++ b/tests/evals/test_agent_corpus.py
@@ -1,0 +1,122 @@
+"""The baseline the agent is held to.
+
+This is the test that turns "the gate seems to work" into a number a change can regress
+against. It runs the real gate over real tickets and a real graph — no stubs, because a
+corpus scored against a fake is a measurement of the fake.
+
+The bar is asymmetric on purpose and asserted that way: **zero false refusals** is
+non-negotiable, because refusing sound work teaches people to switch the gate off, and a gate
+that is switched off scores nothing at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from orchestrator.evals.agent_corpus import (
+    CORPUS,
+    render_report,
+    score_gate,
+    score_runs,
+)
+from orchestrator.pkg import FactStore, RepoCodeExtractor, load_or_extract
+from orchestrator.sdlc.validity import Verdict
+
+# The published baseline. Raise it when the gate genuinely improves; never lower it to make a
+# change pass — that is the one edit this file exists to make uncomfortable.
+BASELINE_ACCURACY = 1.0
+BASELINE_FALSE_REFUSALS = 0
+BASELINE_MISSED_REFUSALS = 0
+
+
+@pytest.fixture(scope="module")
+def repo_store() -> FactStore:
+    """This repo's real graph — the corpus asserts counts against it (7 entities, 71 routes)."""
+    root = Path(__file__).resolve().parents[2]
+    return FactStore(load_or_extract(root, extractor=RepoCodeExtractor()))
+
+
+def test_the_gate_meets_its_baseline(repo_store: FactStore) -> None:
+    score = score_gate(repo_store)
+
+    assert score.accuracy >= BASELINE_ACCURACY, score.render()
+    assert score.false_refusals <= BASELINE_FALSE_REFUSALS, score.render()
+    assert score.missed_refusals <= BASELINE_MISSED_REFUSALS, score.render()
+
+
+def test_every_case_carries_its_justification() -> None:
+    """A corpus whose expected answers cannot be justified encodes yesterday's bugs as truth."""
+    for case in CORPUS:
+        assert case.why.strip(), f"{case.ticket} has no recorded reason for its expected verdict"
+        assert len(case.why) > 20, f"{case.ticket}'s justification is too thin to audit"
+
+
+def test_the_corpus_covers_more_than_the_happy_path() -> None:
+    """A corpus of tickets that should all proceed measures nothing about refusing."""
+    expected = {case.expected for case in CORPUS}
+
+    assert Verdict.PROCEED in expected
+    assert Verdict.CRITERIA_WRONG in expected
+    assert Verdict.UNLOCALIZED in expected
+    assert Verdict.TOO_BIG in expected
+    # And the two halves of the asymmetric bar are both represented.
+    assert sum(c.expected is Verdict.PROCEED for c in CORPUS) >= 4
+    assert sum(c.expected is not Verdict.PROCEED for c in CORPUS) >= 3
+
+
+def test_the_paired_cases_differ_only_in_what_was_wrong(repo_store: FactStore) -> None:
+    """SSPN-3 and SSPN-3-fixed are the same ticket with one number changed; SSPN-18 and
+    SSPN-18-located the same bug with a fault site. If the gate scored the pairs the same,
+    it would be reading something other than what we think."""
+    results = {r.case.ticket: r.actual for r in score_gate(repo_store).results}
+
+    assert results["SSPN-3"] is Verdict.CRITERIA_WRONG
+    assert results["SSPN-3-fixed"] is Verdict.PROCEED
+    assert results["SSPN-18"] is Verdict.UNLOCALIZED
+    assert results["SSPN-18-located"] is Verdict.PROCEED
+
+
+# ---- run metrics: observations, not simulations ----------------------------
+
+
+def _record(status: str, cost: float = 0.0) -> SimpleNamespace:
+    return SimpleNamespace(status=status, spent_usd=cost)
+
+
+def test_run_metrics_count_every_run() -> None:
+    """The categories must sum to the total. A report that quietly loses runs teaches nobody
+    to trust it — an earlier version dropped `running` and showed 3 runs adding up to 1."""
+    metrics = score_runs(
+        [
+            _record("done", 1.0),
+            _record("parked", 0.5),
+            _record("failed"),
+            _record("abandoned"),
+            _record("running"),
+        ]
+    )
+
+    assert metrics.runs == 5
+    assert (
+        metrics.completed + metrics.parked + metrics.failed + metrics.abandoned + metrics.running
+    ) == metrics.runs
+    assert metrics.total_cost_usd == 1.5
+    assert metrics.intervention_rate == 0.2
+
+
+def test_no_runs_reports_nothing_rather_than_zero() -> None:
+    """A 0% completion rate over no runs looks like a result. It is an absence."""
+    metrics = score_runs([])
+
+    assert metrics.runs == 0
+    assert "No runs recorded yet" in metrics.render()
+
+
+def test_the_report_names_both_halves(repo_store: FactStore) -> None:
+    report = render_report(score_gate(repo_store), score_runs([_record("done", 2.0)]))
+
+    assert "## Validity gate" in report and "## Runs" in report
+    assert "false refusals" in report and "missed refusals" in report


### PR DESCRIPTION
Closes **[SSPN-27](https://fibonacci-solutions.atlassian.net/browse/SSPN-27)** — phase 8, the last of the programme.

## Why

Everything the agent does is tested as *parts*. None of it was measured as a *system* — so nobody, including me, could tell you whether the validity gate is accurate, how often a run needs a human, or what one costs. That's the failure mode that let a hand-authored capability matrix be 22% wrong with nothing failing.

## The corpus is this board

Not for convenience. These are real tickets written by the real pipeline, with outcomes already argued out in review: **two shipped with criteria that contradicted the source**, and one is a design defect with no traceback. Nobody would have thought to invent those cases.

It includes two **paired** cases that differ only in what was wrong — SSPN-3 with its real number, SSPN-18 with a fault site — so the gate can't score the pair identically and still look right.

## Two scorers, because two things are knowable

| | |
|---|---|
| `score_gate` | Deterministic and free. Real gate, real graph, argued expected verdicts. Accuracy is a fact a test can hold. |
| `score_runs` | Reads the durable run records — what ran, what it cost, how often a human was needed. An empty store reports **nothing**, not a zero that looks like a result. |

**The bar is asymmetric and the score says so.** False refusals and missed refusals are counted separately: one number lets each hide behind the other, and they cost different things. Refusing sound work teaches people to switch the gate off — and a gate that's off scores nothing at all.

## The baseline

```
accuracy         100%  (10/10 cases)
false refusals   0     refused work that was sound
missed refusals  0     proceeded on a false premise
```

Published in [`docs/specs/autonomous-run-agent.md`](docs/specs/autonomous-run-agent.md) as a commitment, not left as a number in a test — with the note that **lowering one to make a change pass is the edit this exists to make uncomfortable**.

New surface: `orchestrator sdlc baseline [--json]`.

## Three things caught while building it

- **`score_runs` dropped runs whose status was `running`** — a report showed 3 runs whose categories summed to 1. A table whose numbers don't add up teaches nobody to trust it.
- **A corpus case justified itself with "delivered as written"** — twenty characters, too thin to audit. The test asserts every case carries a checkable reason; I rewrote the case rather than lowering the bar.
- **The field was named `key`**, and `key="SSPN-18-located"` trips gitleaks' generic-api-key rule on entropy. The pre-commit hook **blocked the commit**; renamed to `ticket` rather than allowlisted, so the scanner keeps its teeth.

## Deliberately not reported

First-pass test success and cost per ticket need real runs. Publishing them from a handful of ad-hoc ones would dress anecdote as benchmark — the fields exist and fill in as runs accumulate.

## How it was tested

```
pytest              2273 passed, 30 skipped   (2266 before — 7 new)
mypy src tests      no issues in 594 source files
ruff check . / ruff format --check .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)