### PR TITLE
fix(sdlc): a stage failure must reach the supervisor, and bad JSON gets one retry

### DIFF
--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -269,25 +269,56 @@ async def autorun(
     if budget is not None:
         emit(f"[budget] cap ${max_cost_usd:.2f} for this run")
 
-    with ctx.stage_span("intake"):
-        await _stage_intake(ctx, intent_id=intent_id, emit=emit)
-    store, overview = _load_graph(ctx, emit=emit)
-    _stage_investigate(ctx, store=store, emit=emit)
-    _stage_validity(ctx, store=store, issue_type=issue_type, emit=emit)
-    await _stage_design(ctx, store=store, overview=overview, emit=emit)
-    await _stage_implement(
-        ctx,
-        issue=issue,
-        intent_id=intent_id,
-        repo=repo,
-        max_refine=max_refine,
-        base_branch=base_branch,
-        language=language,
-        budget=budget,
-        ledger=ledger,
-        emit=emit,
-    )
-    await _stage_review(ctx, fixer=ctx.fixer, tests=ctx.tests, max_rounds=review_rounds, emit=emit)
+    from orchestrator.obs import tracing
+
+    # One span for the run, one per stage beneath it. Every LLM call already emitted a span;
+    # what was missing was the thing that joins them — without a parent, a run that went
+    # wrong is a scatter of calls with no story.
+    with tracing.span(
+        "autorun.run", **{"autorun.run_id": run_id, "autorun.source": source, "autorun.live": live}
+    ):
+        try:
+            with ctx.stage_span("intake"):
+                await _stage_intake(ctx, intent_id=intent_id, emit=emit)
+            store_graph, overview = _load_graph(ctx, emit=emit)
+            with ctx.stage_span("investigate"):
+                _stage_investigate(ctx, store=store_graph, emit=emit)
+            with ctx.stage_span("validity"):
+                _stage_validity(ctx, store=store_graph, issue_type=issue_type, emit=emit)
+            with ctx.stage_span("design"):
+                await _stage_design(ctx, store=store_graph, overview=overview, emit=emit)
+            with ctx.stage_span("implement"):
+                await _stage_implement(
+                    ctx,
+                    issue=issue,
+                    intent_id=intent_id,
+                    repo=repo,
+                    max_refine=max_refine,
+                    base_branch=base_branch,
+                    language=language,
+                    budget=budget,
+                    ledger=ledger,
+                    emit=emit,
+                )
+            with ctx.stage_span("review"):
+                await _stage_review(
+                    ctx, fixer=ctx.fixer, tests=ctx.tests, max_rounds=review_rounds, emit=emit
+                )
+        except AutorunError:
+            # Already recorded by the stage that raised it: re-raise untouched so exit codes,
+            # parking and approvals survive.
+            raise
+        except Exception as exc:
+            # Everything nobody anticipated — a model returning unparseable JSON, a git
+            # failure, a network blip. Without this the error escapes the supervisor
+            # entirely: no stage recorded, no checkpoint, a run left claiming to be running
+            # for the reaper to find hours later, and a traceback where a verdict belongs.
+            phase = ctx.record.phase if ctx.record is not None else "run"
+            ctx.record_stage(phase or "run", "failed", f"unexpected {type(exc).__name__}: {exc}")
+            ctx.checkpoint(status="failed")
+            emit(f"[autorun] {type(exc).__name__}: {exc}")
+            await _log_run_cost(ctx, ledger=ledger, started=started, verdict="FAILED", emit=emit)
+            raise AutorunError(f"{type(exc).__name__}: {exc}", code=1) from exc
 
     ctx.checkpoint(phase="done", status="done", spent_usd=_spent(budget, run_id))
     await _log_run_cost(ctx, ledger=ledger, started=started, verdict="PASSED", emit=emit)

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -248,10 +248,15 @@ class CodegenError(RuntimeError):
         *,
         failed_edit_paths: list[str] | None = None,
         missing_edit_paths: list[str] | None = None,
+        parse_detail: str = "",
     ) -> None:
         super().__init__(message)
         self.failed_edit_paths = list(failed_edit_paths or [])
         self.missing_edit_paths = list(missing_edit_paths or [])
+        # Set when the output was not valid JSON at all. Carried explicitly rather than
+        # inferred from two empty path lists: "no edits failed" and "nothing parsed" are
+        # different failures and want different retries.
+        self.parse_detail = parse_detail
 
 
 @runtime_checkable
@@ -1277,6 +1282,14 @@ class LLMCodegenAdapter:
         try:
             return self._apply(text, root, allow_empty=allow_empty)
         except CodegenError as exc:
+            if exc.parse_detail:
+                # The model returned something that is not JSON. Models routinely fix their
+                # own JSON when shown where it broke, and this failure killed a real run
+                # outright — the edit-repair retry beside it had simply never been extended
+                # to cover it. One retry, never a loop: a second failure raises.
+                logger.warning("sdlc.codegen.parse_retry detail=%r", exc.parse_detail[:160])
+                text = await self._complete(system, f"{user}{_parse_repair_block(exc.parse_detail)}")
+                return self._apply(text, root, allow_empty=allow_empty)
             if not exc.failed_edit_paths and not exc.missing_edit_paths:
                 raise
             logger.warning(
@@ -1366,7 +1379,10 @@ class LLMCodegenAdapter:
             logger.warning("sdlc.codegen.unparseable_output len=%d tail=%r", len(text), text[-160:])
             if allow_empty:
                 return CodeChange()
-            raise CodegenError("model output was not a JSON object")
+            raise CodegenError(
+                "model output was not a JSON object",
+                parse_detail=_parse_detail(text),
+            )
         files = payload.get("files")
         if not isinstance(files, list) or not files:
             if allow_empty:
@@ -1596,6 +1612,35 @@ def _shadows_stdlib(root: Path, target: Path) -> bool:
     if target.suffix != ".py" or target.parent != root.resolve():
         return False
     return target.stem in sys.stdlib_module_names
+
+
+def _parse_detail(text: str) -> str:
+    """Why the output was not JSON, in the terms a model can act on.
+
+    The offset matters more than the message: "Expecting ',' delimiter" is useless without
+    knowing that it happened 2,294 characters in, inside a string full of backticks.
+    """
+    import json as _json
+
+    try:
+        _json.loads(text)
+    except _json.JSONDecodeError as exc:
+        start = max(0, exc.pos - 80)
+        return f"{exc.msg} at position {exc.pos} of {len(text)}, near: {text[start : exc.pos + 40]!r}"
+    except Exception as exc:  # noqa: BLE001 — any other reason is still "not usable JSON"
+        return f"the response could not be read as JSON ({type(exc).__name__}: {exc})"
+    return "the response parsed, but not as a single JSON object of files"
+
+
+def _parse_repair_block(detail: str) -> str:
+    """The corrective suffix for a parse retry. Names the break rather than saying 'try again'."""
+    return (
+        "\n\nYOUR PREVIOUS RESPONSE WAS NOT VALID JSON and could not be used.\n"
+        f"The parser failed: {detail}\n"
+        "Return the same work again as a SINGLE valid JSON object and nothing else. Escape "
+        "every quote, newline and backslash inside string values. Do not wrap the JSON in "
+        "markdown fences, and do not add commentary before or after it."
+    )
 
 
 def _shadows_first_party(root: Path, target: Path) -> Path | None:

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -465,7 +465,7 @@ def test_the_run_shares_one_ledger_with_the_implement_stage(
 
 def test_a_safe_run_posts_no_worklog(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Safe mode makes no external write, and telemetry is no exception."""
-    posted: list[Any] = []
+    posted: list[str] = []
 
     class _Jira:
         def __init__(self, *a: Any, **k: Any) -> None:
@@ -483,6 +483,58 @@ def test_a_safe_run_posts_no_worklog(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     _run(tmp_path)
 
     assert posted == []
+
+
+# ---- a stage failure must reach the supervisor (SSPN-32) -------------------
+
+
+def test_an_unanticipated_error_is_recorded_not_lost(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The first real run died on `CodegenError`, which no handler caught: the stage was
+    never recorded, the run stayed `running` for a reaper to find hours later, and the
+    operator got a traceback where a verdict belongs.
+
+    The supervisor's promise is that a crash is recoverable. This is the case where it wasn't.
+    """
+    _install(monkeypatch, tmp_path, feature=RuntimeError("model output was not a JSON object"))
+    store = RunStore(root=tmp_path / "state")
+
+    with pytest.raises(AutorunError, match="RuntimeError: model output") as exc:
+        _run(tmp_path, store=store)
+
+    assert exc.value.code == 1
+    (record,) = store.all()
+    assert record.status == "failed"  # never left claiming to be running for a reaper to find
+
+
+def test_a_recorded_failure_names_the_phase_it_died_in(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A run that failed somewhere is far less useful than one that failed *here*."""
+    _install(monkeypatch, tmp_path, feature=RuntimeError("boom"))
+    store = RunStore(root=tmp_path / "state")
+
+    with pytest.raises(AutorunError):
+        _run(tmp_path, store=store)
+
+    (record,) = store.all()
+    assert record.phase in {"design", "implement"}  # the last stage that started
+
+
+def test_errors_that_already_carry_meaning_keep_their_handling(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The catch-all must not swallow the specific handlers: a budget exhaustion still
+    parks and still exits 4, rather than becoming a generic failure."""
+    from orchestrator.core.llm import BudgetExceededError
+
+    _install(monkeypatch, tmp_path, feature=BudgetExceededError("cap exhausted"))
+    store = RunStore(root=tmp_path / "state")
+
+    with pytest.raises(AutorunError, match="budget exhausted") as exc:
+        _run(tmp_path, store=store, max_cost_usd=1.0)
+
+    assert exc.value.code == 4
+    assert store.all()[0].status == "parked"
 
 
 # ---- helper ----------------------------------------------------------------

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1047,3 +1047,47 @@ async def test_the_design_also_reaches_the_refine_prompt(tmp_path: Path) -> None
     )
 
     assert "Edit cli.py, not a new package." in "\n".join(m.content for m in llm.calls[0])
+
+
+# ---- unparseable output gets one corrective retry (SSPN-33) -----------------
+
+
+async def test_malformed_json_is_retried_once_and_recovers(tmp_path: Path) -> None:
+    """The failure that killed the first real end-to-end run. The model emitted a string
+    containing an unescaped quote 2,294 characters in; there was no retry, so the run died.
+    Models routinely fix their own JSON when shown where it broke."""
+    broken = '{"files": [{"path": "src/x.py", "content": "he said "hi""}]}'
+    good = _files_response({"src/x.py": "x = 1\n"})
+    llm = _ScriptedLLM([broken, good])
+
+    change = await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
+
+    assert change.files == [str(tmp_path / "src" / "x.py")]
+    assert len(llm.calls) == 2
+    # The retry names the break rather than saying "try again".
+    retry_prompt = "\n".join(m.content for m in llm.calls[1])
+    assert "NOT VALID JSON" in retry_prompt
+    assert "position" in retry_prompt
+
+
+async def test_a_second_parse_failure_raises(tmp_path: Path) -> None:
+    """One retry, never a loop: a model that cannot produce JSON twice will not on the third."""
+    broken = '{"files": [{"path": "src/x.py", "content": "oops"'
+    llm = _ScriptedLLM([broken, broken])
+
+    with pytest.raises(CodegenError, match="not a JSON object"):
+        await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
+
+    assert len(llm.calls) == 2
+
+
+async def test_the_parse_retry_does_not_stack_with_the_edit_repair(tmp_path: Path) -> None:
+    """Two recoveries for one generation would double the cost of a bad response. A parse
+    failure carries no edit paths, so only the parse retry fires."""
+    broken = "not json at all"
+    good = _files_response({"src/x.py": "x = 1\n"})
+    llm = _ScriptedLLM([broken, good])
+
+    await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
+
+    assert len(llm.calls) == 2  # not 3


### PR DESCRIPTION
Closes **[SSPN-32](https://fibonacci-solutions.atlassian.net/browse/SSPN-32)** and **[SSPN-33](https://fibonacci-solutions.atlassian.net/browse/SSPN-33)**.

Both found by the **first end-to-end `autorun` run against a real ticket** (SSPN-14, safe mode). Fixed together because the first has to exist before the second can be observed: until an error reaches the supervisor, every attempt dies the same undiagnosable way.

## 1 — A stage failure bypassed everything

`_stage_implement` caught `BudgetExceededError` and `FeatureRunError`. Codegen raised `CodegenError`, which is neither, so:

- the stage was never recorded as failed
- the run was never checkpointed — its record still said `running`, for the reaper to find hours later
- no worklog, no approval, no summary
- the operator got a Python traceback where a verdict belongs

Structural, not a one-off: *any* unanticipated error — a git failure, a full disk, a network blip — walked past the state machine. The supervisor's promise is that a crash is recoverable, and this was the case where it wasn't.

The guard now wraps the **sequence**, not each stage, so it covers the ones nobody thought about. Errors that already carry meaning re-raise untouched, so parking and exit codes survive. A crash **fails** rather than parks — it's a bug, not a decision a human owes — and it posts the run's worklog on the way out, because a run that spent money and died is exactly the one whose cost you want recorded.

## 2 — Codegen never retried unparseable output

```
json_parse_failed msg="Expecting ',' delimiter" line=1 col=2295 pos=2294/6231
```

`_generate` retried only when the error named failed or missing *edit paths*, so a parse failure re-raised immediately. Models routinely fix their own JSON when shown where it broke, and the anchored-edit repair sitting beside it had simply never been extended to cover this.

One retry, never a loop — the second failure raises. The corrective prompt **names the offset and surrounding text**, because *"Expecting ',' delimiter"* is useless without knowing it happened 2,294 characters in, inside a string full of backticks.

`parse_detail` is carried on the error rather than inferred from two empty path lists: *"no edits failed"* and *"nothing parsed"* are different failures wanting different retries, and conflating them is exactly how this case was missed.

## Correction to PR #109

**#109 claimed a per-run span with a span per stage. It shipped `stage_span` and one call site.** The `_drive` extraction and the run span were written, silently failed to apply, and I didn't verify — mypy and the tests passed either way. The run span and all six stage spans are in this PR, this time asserted at edit time rather than assumed.

## How it was tested

```
pytest              2284 passed, 30 skipped   (2278 before — 6 new)
mypy src tests      no issues in 594 source files
ruff check . / ruff format --check .
```

Tests: an unanticipated exception is recorded rather than lost; the record says `failed`, never `running`; a budget exhaustion still parks and still exits 4; malformed JSON recovers on retry; a second failure raises; the two retries don't stack into two recoveries for one generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)