### PR TITLE
fix(sdlc): move the ticket when the work moves

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -459,6 +459,12 @@ figures rather than an estimate. A failed run logs one too; that is where the sp
 needs explaining. `--safe` posts nothing, and a tracker that rejects the worklog leaves a
 line in the log without changing the run's verdict.
 
+**The ticket's status follows the work.** A live run moves it to *In Progress* when it
+starts — not when it finishes, so a run that dies halfway still shows that something picked
+the ticket up — and to *In Review* when the PR opens. **Done is never set by the agent**: it
+means a human looked at the change. A board whose workflow uses different status names logs
+a line and carries on rather than failing the run.
+
 A human reviews and merges the PR (it never merges on its own). After the merge,
 close the loop so the tracker issue moves to Done:
 

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -331,6 +331,23 @@ async def run_feature(
         )
     issue_key = tracker_issue.key
 
+    async def move(status: str) -> None:
+        """Drive the ticket's status. Never fatal: a tracker's workflow is not the run's to
+        fail on, and a missing status says something about the board rather than the work."""
+        if not live:
+            return
+        try:
+            moved = await jira.transition_issue(issue_key, status)
+            if moved:
+                emit(f"[jira] moved {issue_key} → {moved}")
+        except IssueTrackerError as exc:
+            emit(f"[jira] could not move {issue_key} to {status}: {exc}")
+
+    # In Progress *now*, not when the work is finished. A ticket that sits in To Do through
+    # design, codegen and the whole test loop tells nobody that anything is happening — and
+    # a run that dies at codegen leaves no sign it was ever picked up.
+    await move("In Progress")
+
     async def log_run_cost(verdict: str) -> None:
         """Post what this run spent onto the issue it was working.
 
@@ -563,12 +580,9 @@ async def run_feature(
         write_backlog(local_backlog, source, plan, load_progress(source))
         await jira.comment_issue(issue_key, f"PR opened for this story: {pr.url}")
         emit(f"[jira] commented PR link on {issue_key}")
-        try:
-            moved = await jira.transition_issue(issue_key, "In Progress")
-            if moved:
-                emit(f"[jira] moved {issue_key} → {moved}")
-        except IssueTrackerError as exc:
-            emit(f"[jira] could not move {issue_key} to In Progress: {exc}")
+        # The work is done and waiting on a human. Done is never the agent's to set —
+        # that is `sdlc complete`, after someone has actually looked at the change.
+        await move("In Review")
         await log_run_cost("PASSED")
     else:
         await _local_commit(path, title)

--- a/tests/sdlc/test_feature_runner.py
+++ b/tests/sdlc/test_feature_runner.py
@@ -145,10 +145,15 @@ class _FakeJira:
     """Records whether the run created an issue or adopted one. ``missing``
     makes ``get_issue`` fail the way an unknown key does."""
 
-    def __init__(self, *, missing: bool = False, worklog_fails: bool = False) -> None:
+    def __init__(
+        self, *, missing: bool = False, worklog_fails: bool = False, transition_fails: bool = False
+    ) -> None:
+        self._transition_fails = transition_fails
         self.created: list[Any] = []
         self.adopted: list[str] = []
         self.worklogs: list[tuple[str, str, str]] = []
+        # Ordered, because *when* a ticket moves is the thing being fixed.
+        self.transitions: list[str] = []
         self._missing = missing
         self._worklog_fails = worklog_fails
 
@@ -171,6 +176,9 @@ class _FakeJira:
         return None
 
     async def transition_issue(self, issue_key: str, target: str) -> str:
+        if self._transition_fails:
+            raise IssueTrackerError(f"no transition to {target!r} available for {issue_key}")
+        self.transitions.append(target)
         return target
 
 
@@ -202,6 +210,17 @@ def _install_pipeline(
     monkeypatch.setattr("orchestrator.sdlc.codegen.resolve_codegen_model", lambda *a, **k: None)
     monkeypatch.setattr("orchestrator.sdlc.testrunner.SubprocessTestRunner", runner)
     monkeypatch.setattr("orchestrator.intake.jira.JiraAdapter", lambda *a, **k: jira or _FakeJira())
+
+    class _Forge:
+        """A PR without a forge: the live path needs one to reach the In Review transition."""
+
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        async def open_pr(self, **kwargs: Any) -> Any:
+            return SimpleNamespace(url="https://github.com/x/y/pull/7")
+
+    monkeypatch.setattr("orchestrator.sdlc.forge.GhPRAdapter", _Forge)
     monkeypatch.setattr(
         "orchestrator.sdlc.grounding.PKGCodegenGrounder",
         SimpleNamespace(from_repo=lambda path: SimpleNamespace(context_for_spec=lambda spec: "")),
@@ -501,3 +520,78 @@ async def test_missing_pytest_fails_fast_with_actionable_message(
     with pytest.raises(FeatureRunError, match="pytest is required") as exc:
         await run_feature("file://./spec.md", intent_id="intent-a")
     assert exc.value.code == 2
+
+
+# ---- the ticket's status follows the work (SSPN-34) -------------------------
+
+
+async def test_a_live_run_moves_the_ticket_in_progress_before_writing_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """It used to move to In Progress *after* the PR was opened — so a ticket sat in To Do
+    through design, codegen and the whole test loop, and a run that died at codegen left no
+    sign it had ever been picked up."""
+    jira = _FakeJira()
+    _install_pipeline(monkeypatch, tmp_path, runner=_FailingRunner, jira=jira)
+
+    with pytest.raises(FeatureRunError, match="VERDICT: FAILED"):
+        await run_feature(
+            "file://./spec.md", intent_id="intent-a", repo="https://x/widget", live=True, issue="SSPN-1"
+        )
+
+    # The run never reached a PR, and the ticket still shows that work started.
+    assert jira.transitions == ["In Progress"]
+
+
+async def test_a_safe_run_moves_nothing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    jira = _FakeJira()
+    _install_pipeline(monkeypatch, tmp_path, runner=_FailingRunner, jira=jira)
+
+    with pytest.raises(FeatureRunError):
+        await run_feature("file://./spec.md", intent_id="intent-a")
+
+    assert jira.transitions == []
+
+
+async def test_a_workflow_without_the_status_does_not_fail_the_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A tracker's workflow is not the run's to fail on: a board with different status names
+    should still get its code."""
+    jira = _FakeJira(transition_fails=True)
+    _install_pipeline(monkeypatch, tmp_path, runner=_FailingRunner, jira=jira)
+
+    with pytest.raises(FeatureRunError, match="VERDICT: FAILED"):  # the test verdict, not a tracker error
+        await run_feature(
+            "file://./spec.md", intent_id="intent-a", repo="https://x/widget", live=True, issue="SSPN-1"
+        )
+
+
+async def test_done_is_never_set_by_the_agent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Done means a human looked at it. `sdlc complete` is where that lives."""
+    jira = _FakeJira()
+    _install_pipeline(monkeypatch, tmp_path, runner=_FailingRunner, jira=jira)
+
+    with pytest.raises(FeatureRunError):
+        await run_feature(
+            "file://./spec.md", intent_id="intent-a", repo="https://x/widget", live=True, issue="SSPN-1"
+        )
+
+    assert "Done" not in jira.transitions
+
+
+async def test_a_live_run_moves_the_ticket_to_in_review_when_the_pr_opens(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The step the workflow described and the code never had: the change is written, tested
+    and waiting on a human. Order matters as much as the transitions — In Progress at the
+    start, In Review at the end."""
+    jira = _FakeJira()
+    _install_pipeline(monkeypatch, tmp_path, runner=_PassingRunner, jira=jira)
+
+    result = await run_feature(
+        "file://./spec.md", intent_id="intent-a", repo="https://x/widget", live=True, issue="SSPN-1"
+    )
+
+    assert result.pr_url == "https://github.com/x/y/pull/7"
+    assert jira.transitions == ["In Progress", "In Review"]


### PR DESCRIPTION
Closes **[SSPN-34](https://fibonacci-solutions.atlassian.net/browse/SSPN-34)**. Stacked on [#110](https://github.com/synaptixs/spine/pull/110).

## The bug

The only transition in the codebase moved the ticket to **In Progress after the PR was opened**. So a ticket sat in `To Do` through design, codegen and the whole test loop, and reached `In Progress` at the moment the work was finished. A run that died at codegen left it in `To Do` with no sign anyone had touched it.

And there was **no In Review transition at all** — every one on this board so far has been made by hand.

## Now

| Transition | When |
|---|---|
| `To Do` → `In Progress` | as soon as the ticket is known, **before** a line is generated |
| `In Progress` → `In Review` | the PR opens — work done, waiting on a human |
| `In Review` → `Done` | **never the agent.** `sdlc complete`, after someone looked |

Two deliberate choices:

- **A failed run leaves the ticket In Progress** rather than reverting it. Work did start, and pretending otherwise hides a run that needs attention — the reaper already reports tickets that may be left there.
- **Transitions are never fatal.** A board using different status names logs a line and the run carries on. A tracker's workflow is not the run's to fail on, and the change is worth more than the label.

## Scope note

Fixed in `feature_runner`, not `autorun`, so **`sdlc feature --live` standalone gets the same correction**. That's a deliberate behaviour change to an existing command: the ticket now moves earlier and gains an In Review step. Flagging it because "additive only" has been the rule everywhere else in this programme — here the existing behaviour was the bug.

## How it was tested

```
pytest              2289 passed, 30 skipped   (2284 before — 5 new)
mypy src tests      no issues in 594 source files
ruff check . / ruff format --check .
```

Order is asserted, not just presence: a failing run records `["In Progress"]`, a passing one `["In Progress", "In Review"]`, a safe run `[]`, and a board that rejects the transition still gets its `VERDICT: FAILED` rather than a tracker error. `USER_GUIDE.md` step 4 documents the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)