### PR TITLE
fix(sdlc): a live run with an injected spec reaches its PR

### DIFF
--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -259,6 +259,13 @@ async def run_feature(
     # 1. Obtain the spec. Normally: source → intents → specs (intake, cached +
     #    temperature-0 so a pinned --intent stays addressable). When a spec is
     #    injected (Spine remediation: drift → governed run), skip intake entirely.
+    # Bound before the branch, because the live path below reads them either way. An
+    # injected spec (Spine remediation, `sdlc autorun`) skips intake entirely, so there is no
+    # backlog *plan* behind it — the ledger is an intake artifact, and refreshing it from
+    # nothing would be inventing one.
+    local_backlog = backlog_path()
+    plan: Any = None
+
     if spec is None:
         parse_source_uri(source)  # validate the source URI early
         try:
@@ -269,7 +276,6 @@ async def run_feature(
         if not plan.specs:
             raise FeatureRunError("No specs derived from the source — nothing to implement.", code=3)
         # Refresh the local canonical backlog ledger (BACKLOG.md) with progress.
-        local_backlog = backlog_path()
         write_backlog(local_backlog, source, plan, load_progress(source))
         emit(f"[backlog] {local_backlog}")
         spec_obj = (
@@ -565,7 +571,8 @@ async def run_feature(
         # Mark in-progress and drop BACKLOG.md into the worktree BEFORE open_pr so
         # the PR carries the updated progress ledger (the "both locations" rule).
         set_progress(source, spec["intent_id"], status="in_progress", issue_key=issue_key)
-        write_backlog(path / local_backlog.name, source, plan, load_progress(source))
+        if plan is not None:
+            write_backlog(path / local_backlog.name, source, plan, load_progress(source))
         # Without an explicit base, ``gh`` targets the repo's *default* branch — which
         # for a repo whose contributing guide says "work off develop, never commit to
         # main" is precisely the wrong branch, with no way to say so from the CLI.
@@ -577,7 +584,8 @@ async def run_feature(
         emit(f"[pr] opened: {pr.url}")
         # Now that the PR URL is known, record it and refresh the local ledger.
         set_progress(source, spec["intent_id"], status="in_progress", issue_key=issue_key, pr_url=pr.url)
-        write_backlog(local_backlog, source, plan, load_progress(source))
+        if plan is not None:
+            write_backlog(local_backlog, source, plan, load_progress(source))
         await jira.comment_issue(issue_key, f"PR opened for this story: {pr.url}")
         emit(f"[jira] commented PR link on {issue_key}")
         # The work is done and waiting on a human. Done is never the agent's to set —

--- a/tests/sdlc/test_feature_runner.py
+++ b/tests/sdlc/test_feature_runner.py
@@ -595,3 +595,49 @@ async def test_a_live_run_moves_the_ticket_to_in_review_when_the_pr_opens(
 
     assert result.pr_url == "https://github.com/x/y/pull/7"
     assert jira.transitions == ["In Progress", "In Review"]
+
+
+async def test_a_live_run_with_an_injected_spec_reaches_the_pr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`autorun` always injects a spec — it does intake itself — and the live path then
+    reached for `local_backlog` and `plan`, which are only bound when this function does its
+    own intake. It fired *after* codegen and the whole test loop succeeded and immediately
+    before the PR opened: the worst possible moment, full spend and nothing to show."""
+    jira = _FakeJira()
+    _install_pipeline(monkeypatch, tmp_path, runner=_PassingRunner, jira=jira)
+
+    result = await run_feature(
+        "file://./spec.md",
+        repo="https://x/widget",
+        live=True,
+        issue="SSPN-1",
+        spec={
+            "title": "Injected",
+            "intent_id": "intent-a",
+            "summary": "s",
+            "acceptance_criteria": ["c"],
+        },
+    )
+
+    assert result.pr_url == "https://github.com/x/y/pull/7"
+    assert jira.transitions == ["In Progress", "In Review"]
+
+
+async def test_intake_driven_runs_still_write_the_backlog_ledger(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The guard must not cost the ledger its normal case: when this function does its own
+    intake there *is* a plan, and BACKLOG.md is still written in both places."""
+    written: list[str] = []
+    jira = _FakeJira()
+    _install_pipeline(monkeypatch, tmp_path, runner=_PassingRunner, jira=jira)
+    monkeypatch.setattr(
+        "orchestrator.intake.backlog_doc.write_backlog",
+        lambda path, *a, **k: written.append(str(path)),
+    )
+
+    await run_feature("file://./spec.md", intent_id="intent-a", repo="https://x/widget", live=True)
+
+    # Once for the local ledger during intake, then into the worktree and back locally.
+    assert len(written) >= 2


### PR DESCRIPTION
Closes **[SSPN-35](https://fibonacci-solutions.atlassian.net/browse/SSPN-35)**. **Blocker for the first live run** — found by reading the code before spending money on it, not by spending it.

## The failure

```
UnboundLocalError: cannot access local variable 'local_backlog'
  src/orchestrator/sdlc/feature_runner.py:568
```

`local_backlog` and `plan` are bound only inside `if spec is None:` — the branch that does intake. **`autorun` always injects a spec**, because it runs intake itself so the brief, design and implementation all describe the same thing. The live path then read both unconditionally.

It fires **immediately before the PR opens**, after codegen and the entire test loop have succeeded. The full spend, and nothing to show for it. Safe mode never reaches the line, which is why three rehearsal runs never saw it.

## The fix

Both names bound before the branch; the ledger writes **guarded rather than forced**. A backlog is an *intake* artifact — an injected spec has no plan behind it, and refreshing a ledger from nothing would be inventing one. A run that does its own intake writes BACKLOG.md in both places exactly as before.

## Reproduced first

The test was written to fail before the fix existed:

```
E  UnboundLocalError: cannot access local variable 'local_backlog'
   src/orchestrator/sdlc/feature_runner.py:568
```

and now asserts the run opens its PR and transitions `["In Progress", "In Review"]`. A second test covers the case the guard could have broken — an intake-driven run still writing the ledger.

## How it was tested

```
pytest              2291 passed, 30 skipped   (2289 before — 2 new)
mypy src tests      no issues in 594 source files
ruff check . / ruff format --check .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)