### PR TITLE
fix(sdlc): make codegen retries compose, and record what a failed run spent

### DIFF
--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -108,6 +108,10 @@ class RunContext:
         """
         from orchestrator.obs import tracing
 
+        # The phase is stamped on entry, not on result: a run that died inside `implement`
+        # reported `design` — the last stage that managed to *finish* — so the record named
+        # the wrong stage for the failure and nobody could tell where the money went.
+        self.checkpoint(phase=name)
         with tracing.span(
             "autorun.stage",
             **{"autorun.run_id": self.run_id, "autorun.stage": name, "autorun.issue": self.issue_key},
@@ -315,7 +319,10 @@ async def autorun(
             # for the reaper to find hours later, and a traceback where a verdict belongs.
             phase = ctx.record.phase if ctx.record is not None else "run"
             ctx.record_stage(phase or "run", "failed", f"unexpected {type(exc).__name__}: {exc}")
-            ctx.checkpoint(status="failed")
+            # Spend, on the way out. A run that died is exactly the one whose cost you need:
+            # the record used to say $0.00 for a run that had made three LLM calls, which
+            # makes "what does this cost" unanswerable from the thing built to answer it.
+            ctx.checkpoint(status="failed", spent_usd=_spent(budget, ctx.run_id))
             emit(f"[autorun] {type(exc).__name__}: {exc}")
             await _log_run_cost(ctx, ledger=ledger, started=started, verdict="FAILED", emit=emit)
             raise AutorunError(f"{type(exc).__name__}: {exc}", code=1) from exc

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -1279,26 +1279,35 @@ class LLMCodegenAdapter:
         nothing there is a real failure.
         """
         text = await self._complete(system, user)
-        try:
-            return self._apply(text, root, allow_empty=allow_empty)
-        except CodegenError as exc:
-            if exc.parse_detail:
-                # The model returned something that is not JSON. Models routinely fix their
-                # own JSON when shown where it broke, and this failure killed a real run
-                # outright — the edit-repair retry beside it had simply never been extended
-                # to cover it. One retry, never a loop: a second failure raises.
-                logger.warning("sdlc.codegen.parse_retry detail=%r", exc.parse_detail[:160])
-                text = await self._complete(system, f"{user}{_parse_repair_block(exc.parse_detail)}")
+        # One corrective retry, whichever way the first attempt failed. Written as a loop
+        # rather than two nested handlers because the nested form only guarded the *first*
+        # apply: a real run hit failed edits, took the repair retry, and the repaired
+        # response was unparseable JSON — which escaped, because nothing was watching the
+        # second apply. Two failure kinds, one retry budget, one guarded call site.
+        for attempt in range(2):
+            try:
                 return self._apply(text, root, allow_empty=allow_empty)
-            if not exc.failed_edit_paths and not exc.missing_edit_paths:
-                raise
+            except CodegenError as exc:
+                if attempt:  # the retry itself failed — a third attempt is a loop, not a fix
+                    raise
+                suffix = self._corrective_suffix(exc, root)
+                if suffix is None:
+                    raise
+                text = await self._complete(system, f"{user}{suffix}")
+        raise CodegenError("codegen retry did not produce a usable change")  # unreachable
+
+    def _corrective_suffix(self, exc: CodegenError, root: Path) -> str | None:
+        """What to tell the model about its last attempt, or ``None`` if nothing can help."""
+        if exc.parse_detail:
+            logger.warning("sdlc.codegen.parse_retry detail=%r", exc.parse_detail[:160])
+            return _parse_repair_block(exc.parse_detail)
+        if exc.failed_edit_paths or exc.missing_edit_paths:
             logger.warning(
                 "sdlc.codegen.repair_retry",
                 extra={"failed": exc.failed_edit_paths, "missing": exc.missing_edit_paths},
             )
-            repair = self._repair_block(exc, root)
-            text = await self._complete(system, f"{user}{repair}")
-            return self._apply(text, root, allow_empty=allow_empty)
+            return self._repair_block(exc, root)
+        return None
 
     def _repair_block(self, exc: CodegenError, root: Path) -> str:
         """The corrective prompt suffix for a repair retry. Two kinds of fix:
@@ -1813,6 +1822,9 @@ def _loads_json_object(text: str) -> dict[str, Any] | None:
     try:
         loaded = json.loads(stripped, strict=False)
     except json.JSONDecodeError as first:
+        merged = _merge_json_documents(stripped)
+        if merged is not None:
+            return merged
         start, end = stripped.find("{"), stripped.rfind("}")
         if start == -1 or end <= start:
             _log_json_failure(stripped, first)
@@ -1823,6 +1835,43 @@ def _loads_json_object(text: str) -> dict[str, Any] | None:
             _log_json_failure(stripped[start : end + 1], second)
             return None
     return loaded if isinstance(loaded, dict) else None
+
+
+def _merge_json_documents(text: str) -> dict[str, Any] | None:
+    """Several complete ``{"files": [...]}`` objects in a row → one object.
+
+    Observed twice on real runs: the model emits one JSON document per file and concatenates
+    them, so the decoder stops at the second with ``Extra data``. Every document is valid and
+    every one is a files-object — the intent is not in doubt, and stitching them is free where
+    a corrective retry costs another call.
+
+    Deliberately strict: *every* decoded document must be an object carrying a ``files`` list,
+    or this returns ``None`` and the caller falls back to retrying. Merging a files-object with
+    something else would be guessing at what the model meant.
+    """
+    decoder = json.JSONDecoder(strict=False)
+    documents: list[dict[str, Any]] = []
+    index = 0
+    while index < len(text):
+        while index < len(text) and text[index] in " \t\r\n,":
+            index += 1
+        if index >= len(text):
+            break
+        try:
+            value, index = decoder.raw_decode(text, index)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(value, dict) or not isinstance(value.get("files"), list):
+            return None
+        documents.append(value)
+    if len(documents) < 2:
+        return None
+    files: list[Any] = []
+    for document in documents:
+        files.extend(document["files"])
+    summaries = [str(d.get("summary") or "").strip() for d in documents]
+    logger.warning("sdlc.codegen.merged_json_documents count=%d files=%d", len(documents), len(files))
+    return {"files": files, "summary": " ".join(s for s in summaries if s)}
 
 
 def _log_json_failure(text: str, exc: json.JSONDecodeError) -> None:

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -517,7 +517,9 @@ def test_a_recorded_failure_names_the_phase_it_died_in(
         _run(tmp_path, store=store)
 
     (record,) = store.all()
-    assert record.phase in {"design", "implement"}  # the last stage that started
+    # The stage it *died in*, not the last one that managed to finish. The record used to say
+    # `design` for a run that failed inside `implement`.
+    assert record.phase == "implement"
 
 
 def test_errors_that_already_carry_meaning_keep_their_handling(

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1091,3 +1091,53 @@ async def test_the_parse_retry_does_not_stack_with_the_edit_repair(tmp_path: Pat
     await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
 
     assert len(llm.calls) == 2  # not 3
+
+
+async def test_a_parse_failure_after_an_edit_repair_still_retries(tmp_path: Path) -> None:
+    """The gap the first live-ish run fell through: failed edits took the repair path, the
+    repaired response was unparseable, and the second apply was outside the guard — so it
+    raised. One retry budget, whichever way the first attempt failed."""
+    (tmp_path / "existing.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    edits_that_fail = json.dumps(
+        {
+            "files": [{"path": "existing.py", "edits": [{"find": "NOT PRESENT ANYWHERE", "replace": "x"}]}],
+            "summary": "edit",
+        }
+    )
+    unparseable = "definitely not json"
+
+    llm = _ScriptedLLM([edits_that_fail, unparseable])
+
+    with pytest.raises(CodegenError):
+        await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
+
+    # Two calls, not three: the repair was spent, so the parse failure raises rather than
+    # buying a third attempt.
+    assert len(llm.calls) == 2
+
+
+async def test_two_concatenated_json_documents_are_merged(tmp_path: Path) -> None:
+    """Observed twice on real runs: the model emits one document per file and concatenates
+    them, so the decoder stops at the second with `Extra data`. Every document is valid and
+    every one is a files-object — stitching them is free where a retry costs a call."""
+    two_documents = (
+        '{"files": [{"path": "src/a.py", "content": "a = 1\\n"}], "summary": "first"}, '
+        '{"files": [{"path": "src/b.py", "content": "b = 2\\n"}], "summary": "second"}'
+    )
+    llm = _ScriptedLLM([two_documents])
+
+    change = await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
+
+    assert sorted(Path(f).name for f in change.files) == ["a.py", "b.py"]
+    assert len(llm.calls) == 1  # no retry needed
+
+
+async def test_a_files_object_next_to_something_else_is_not_merged(tmp_path: Path) -> None:
+    """Strict on purpose: merging a files-object with anything else would be guessing."""
+    mixed = '{"files": [{"path": "src/a.py", "content": "a = 1\\n"}]}, {"notes": "hello"}'
+    good = _files_response({"src/a.py": "a = 1\n"})
+    llm = _ScriptedLLM([mixed, good])
+
+    await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
+
+    assert len(llm.calls) == 2  # fell back to the corrective retry


### PR DESCRIPTION
Closes **[SSPN-36](https://fibonacci-solutions.atlassian.net/browse/SSPN-36)**. Three defects from the **second** end-to-end safe run against SSPN-14.

The supervisor guard from #110 held — clean verdict, no traceback, run recorded. But the run still died, and the record couldn't say what it cost.

## 1 — The retries didn't compose *(my bug from #110)*

```
sdlc.codegen.edit_failed
sdlc.codegen.repair_retry
sdlc.codegen.json_parse_failed msg='Extra data' pos=1583/5986
[autorun] CodegenError: model output was not a JSON object
```

Failed edits → repair retry → **that** response was unparseable → escaped, because only the *first* `_apply` was guarded. The parse retry I shipped in SSPN-33 covered a parse failure on the first attempt and nowhere else.

Rewritten as **one retry budget over one guarded call site**: two failure kinds, one corrective attempt, whichever way the first went wrong. A second failure raises — a third attempt is a loop, not a fix.

## 2 — The model emits concatenated JSON documents

`Extra data` at position 1,583: a complete `{"files": [...]}` object immediately followed by another. **Seen on both runs**, so it's the model's habit, not a fluke.

Every document is valid and every one carries a `files` list — the intent isn't in doubt, and stitching them is **free** where a corrective retry costs another call. Strict on purpose: every decoded document must be a files-object, or the merge is refused and the retry happens instead. Merging a files-object with something else would be guessing.

## 3 — A failed run couldn't say what it cost

```
{'status': 'failed', 'phase': 'design', 'spent_usd': 0.0}
```

It died inside **implement** after at least three LLM calls.

- The phase was stamped when a stage *finished*, so the record named the last stage that **succeeded** rather than the one that failed. Now stamped on entry.
- The failure path never wrote the spend. Now it does.

This is the one that mattered most: the run was made to answer *"what does this cost"*, and the artifact built to answer it said `$0.00`.

## How it was tested

```
pytest              2294 passed, 30 skipped   (2291 before — 3 new)
mypy src tests      no issues in 594 source files
ruff check . / ruff format --check .
```

New tests: a parse failure *after* an edit repair still retries once and no more; two concatenated documents merge with **no** extra model call; a files-object beside anything else falls back to the retry. The phase assertion tightened from `in {design, implement}` — which passed while hiding the bug — to `== implement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)