### PR TITLE
fix(sdlc): prove each changed file is tested, not just the change as a whole

### DIFF
--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -121,7 +121,11 @@ class CodegenAdapter(Protocol):
         mcp_servers: list[str] | None = None,
     ) -> CodeChange: ...
 
-    async def author_tests(self, *, spec: dict[str, Any], path: str, issue_key: str) -> CodeChange: ...
+    async def author_tests(
+        self, *, spec: dict[str, Any], path: str, issue_key: str, gaps: list[str] | None = None
+    ) -> CodeChange:
+        """``gaps`` names changed files no test exercises — write tests that reach them."""
+        ...
 
     async def refine(
         self, *, spec: dict[str, Any], path: str, issue_key: str, failures: str
@@ -196,8 +200,10 @@ class StubCodegenAdapter:
         )
         return CodeChange(files=[str(module)], summary=f"wrote {_GENERATED_MODULE}")
 
-    async def author_tests(self, *, spec: dict[str, Any], path: str, issue_key: str) -> CodeChange:
-        _ = spec
+    async def author_tests(
+        self, *, spec: dict[str, Any], path: str, issue_key: str, gaps: list[str] | None = None
+    ) -> CodeChange:
+        _ = (spec, gaps)
         test = Path(path) / _GENERATED_TEST
         test.write_text(
             "from generated import feature\n\n\n"
@@ -432,8 +438,17 @@ _TESTS_SYSTEM = (
     "the SPEC names one) uses `edits` — typically anchoring on the file's "
     "final lines and appending the new test functions. Import the source by "
     "its top-level module name. Each acceptance criterion should map to at "
-    "least one assertion. Tests must pass against the given source."
+    "least one assertion. Tests must pass against the given source.\n\n"
+    "A criterion phrased as behaviour — *when the user runs `some command`, the output "
+    "shows …* — must be exercised through THAT entry point: invoke the command or "
+    "function the criterion names and assert on what it returns or prints. A test that "
+    "calls an internal helper directly does not test the criterion, however thorough it "
+    "is; the wiring between the entry point and the helper is where the bug lives."
 )
+# The rule above is not style advice. A change shipped with a correct, exhaustively tested
+# helper wired into the CLI through a guard that was always false, so every argument printed
+# `any` — and the suite was green, because every test called the helper directly and nothing
+# ever called the command. `_files_no_test_exercises` is the enforcement; this is the ask.
 
 _REFINE_SYSTEM = (
     "You are fixing failing tests. You are given the SPEC, the CURRENT FILES, "
@@ -1346,14 +1361,16 @@ class LLMCodegenAdapter:
         """The agentic implement system prompt, persona/skill-conditioned (implement phase)."""
         return self._condition_system(_AGENTIC_IMPLEMENT_SYSTEM, skills, phase="implement")
 
-    async def author_tests(self, *, spec: dict[str, Any], path: str, issue_key: str) -> CodeChange:
+    async def author_tests(
+        self, *, spec: dict[str, Any], path: str, issue_key: str, gaps: list[str] | None = None
+    ) -> CodeChange:
         root = Path(path)
         return await self._generate(
             self._condition_system(self._tests_system(), self._skills, phase="author_tests"),
             f"{self._layout_block()}{self._grounding(spec, root)}{self._design_block()}Issue: {issue_key}\n\n"
             f"SPEC:\n{_spec_text(spec)}\n\n"
             f"CURRENT SOURCE FILES:\n{self._session_files(root, include_tests=False)}"
-            f"{self._convention_block(root)}",
+            f"{self._convention_block(root)}{_coverage_gap_block(gaps or [])}",
             root,
         )
 
@@ -1867,6 +1884,25 @@ def _safe_target(root: Path, rel: str) -> Path:
 
 
 _PATH_RE = re.compile(r"\b((?:src/|tests/)[\w./-]+\.py)\b")
+
+
+def _coverage_gap_block(gaps: list[str]) -> str:
+    """Name the files whose changes no test reaches, or ''.
+
+    Deterministic evidence, not a hunch: each of these was reverted on its own and the suite
+    stayed green, which means nothing in it depends on the change.
+    """
+    if not gaps:
+        return ""
+    names = "\n".join(f"- {g}" for g in gaps)
+    return (
+        "\n\nNOT YET EXERCISED — each file below was reverted on its own and the tests still "
+        "passed, so nothing you have written depends on its change:\n"
+        f"{names}\n"
+        "Write tests that fail if those specific changes are reverted. Reach them the way a "
+        "user does — through the command or public function that was changed, not through a "
+        "helper it calls, or the same gap will still be there.\n"
+    )
 
 
 def _named_existing_files(spec: dict[str, Any], root: Path, design: str = "") -> str:

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -116,6 +116,51 @@ async def _prove_the_tests_test_something(
         await _git(path, "stash", "pop", "--quiet")
 
 
+_MAX_COVERAGE_PROBES = 4  # test runs this check may spend
+
+
+async def _files_no_test_exercises(
+    path: Path, files: list[str], runner: Any, emit: Callable[[str], None]
+) -> list[str]:
+    """Revert each changed production file **on its own**. Any that leaves the suite green
+    is a file nothing tests.
+
+    ``_prove_the_tests_test_something`` reverts the whole change at once, which only proves
+    the tests depend on *some* part of it. That passed on a change whose helper was correct,
+    fully tested, and wired into the CLI through ``hasattr(t.handler, "tool")`` — a guard
+    that is always False, so every argument printed ``any``. Reverting everything broke the
+    helper's import and the suite went red, so the proof "held" while the line that mattered
+    was covered by nothing.
+
+    Per-file is the version that catches it: revert ``cli.py`` alone, and if the tests still
+    pass, the wiring in ``cli.py`` is untested — which is exactly what "the criteria are
+    behavioural and nothing runs the command" looks like from the outside.
+    """
+    production = [f for f in files if not _is_test_path(f)]
+    if not production or not any(_is_test_path(f) for f in files):
+        return []
+    if len(production) > _MAX_COVERAGE_PROBES:
+        emit(f"[coverage] {len(production)} production files — probing the first {_MAX_COVERAGE_PROBES}")
+        production = production[:_MAX_COVERAGE_PROBES]
+
+    unexercised: list[str] = []
+    for target in production:
+        if not await _git(path, "stash", "push", "--include-untracked", "--quiet", "--", target):
+            continue
+        try:
+            result = await runner.run(path=str(path))
+        finally:
+            await _git(path, "stash", "pop", "--quiet")
+        if getattr(result, "passed", False):
+            unexercised.append(target)
+    if unexercised:
+        names = ", ".join(Path(f).name for f in unexercised)
+        emit(f"[coverage] nothing exercises the change in: {names}")
+    else:
+        emit("[coverage] every changed file is exercised by a test")
+    return unexercised
+
+
 async def _typecheck_the_change(
     path: Path, testenv: Any, files: list[str], emit: Callable[[str], None]
 ) -> str:
@@ -872,10 +917,27 @@ async def run_feature(
             # same model as the code and routinely exercise a new helper directly while never
             # importing the module the ticket was about — so they pass over a NameError or a
             # wrong attribute sitting on the line that matters. The type checker does not.
-            failures = await _typecheck_the_change(path, testenv, await _changed_files(path), emit)
+            changed = await _changed_files(path)
+            failures = await _typecheck_the_change(path, testenv, changed, emit)
             if not failures:
-                passed = True
-                break
+                # Type-clean and green still allows a change nothing tests. Probe each
+                # production file on its own; a gap is answered by writing the missing
+                # test, not by editing the implementation, so it goes to author_tests.
+                gaps = await _files_no_test_exercises(path, changed, runner, emit)
+                if not gaps:
+                    passed = True
+                    break
+                if iterations >= max_refine:
+                    break
+                with llm.stage("author_tests"):
+                    covered = await codegen.author_tests(
+                        spec=spec, path=str(path), issue_key=issue_key, gaps=gaps
+                    )
+                emit(f"[cover] {[Path(f).name for f in covered.files]} - {covered.summary}")
+                if not covered.files:
+                    emit("[cover] no tests written for the gap — stopping rather than looping")
+                    break
+                continue
         if iterations >= max_refine:
             break
         with llm.stage("refine"):

--- a/tests/sdlc/test_feature_runner.py
+++ b/tests/sdlc/test_feature_runner.py
@@ -101,6 +101,7 @@ class _StubCodegen:
         self.refine_calls = 0
         self.revise_calls = 0
         self.blockers_seen: list[list[str]] = []
+        self.gaps_seen: list[list[str]] = []
         self.layout = kwargs.get("layout")
 
     async def implement(self, **kwargs: Any) -> CodeChange:
@@ -1063,3 +1064,82 @@ def test_only_errors_on_changed_lines_count() -> None:
     assert _error_is_on_a_changed_line("src/a.py:10: error: boom  [attr-defined]", touched)
     assert not _error_is_on_a_changed_line("src/a.py:99: error: pre-existing  [attr-defined]", touched)
     assert not _error_is_on_a_changed_line("src/other.py:10: error: untouched  [attr-defined]", touched)
+
+
+# ---- a change nothing tests is not a tested change (SSPN-14) ----
+
+
+class _PerFileRunner:
+    """A suite that depends on one file's change and no other.
+
+    Stashing a tracked file reverts its *content*; it does not remove the file. So the
+    dependency is expressed the way a real test does — by what the file says.
+    """
+
+    depends_on = "src/orchestrator/mcp/contract.py"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    async def run(self, *, path: str) -> SimpleNamespace:
+        changed = (Path(path) / _PerFileRunner.depends_on).read_text(encoding="utf-8").strip() == "x = 2"
+        return SimpleNamespace(passed=changed, returncode=0 if changed else 1, output="E   assert 1 == 2")
+
+
+async def test_a_file_no_test_reaches_is_reported(tmp_path: Path) -> None:
+    """The live miss: the helper in contract.py was correct and exhaustively tested, and the
+    cli.py wiring that called it passed `{}` on every call. Reverting the whole change broke
+    the helper's import so the suite went red and the old proof check "held" — while the line
+    that actually mattered was covered by nothing."""
+    from orchestrator.sdlc.feature_runner import _files_no_test_exercises
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    for rel in ("src/orchestrator/mcp/contract.py", "src/orchestrator/cli.py", "tests/test_it.py"):
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "seed"], cwd=tmp_path, check=True)
+    # Both production files change; only contract.py is depended on by the suite.
+    (tmp_path / "src/orchestrator/mcp/contract.py").write_text("x = 2\n", encoding="utf-8")
+    (tmp_path / "src/orchestrator/cli.py").write_text("x = 2\n", encoding="utf-8")
+
+    files = ["src/orchestrator/mcp/contract.py", "src/orchestrator/cli.py", "tests/test_it.py"]
+    gaps = await _files_no_test_exercises(tmp_path, files, _PerFileRunner(), lambda _m: None)
+
+    assert gaps == ["src/orchestrator/cli.py"]  # the wiring, exactly
+
+
+async def test_a_coverage_gap_asks_for_tests_not_an_implementation_change(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A gap means the tests are wrong, not the code — so it goes to author_tests, and
+    refine is never asked to change an implementation that is already correct."""
+    from orchestrator.sdlc import feature_runner as fr
+
+    probes = {"n": 0}
+
+    async def _probe(path: Path, files: list[str], runner: Any, emit: Any) -> list[str]:
+        probes["n"] += 1
+        return ["src/orchestrator/cli.py"] if probes["n"] == 1 else []
+
+    class _CoveringCodegen(_StubCodegen):
+        async def author_tests(self, **kwargs: Any) -> CodeChange:
+            gaps = kwargs.get("gaps")
+            if gaps:
+                self.gaps_seen.append(list(gaps))
+                return CodeChange(files=["tests/test_cli.py"], summary="cover the wiring")
+            return CodeChange(files=[], summary="tests")
+
+    monkeypatch.setattr(fr, "_files_no_test_exercises", _probe)
+    monkeypatch.setattr(fr, "_typecheck_the_change", lambda *a, **k: _aresult(""))
+    created = _install_pipeline(monkeypatch, tmp_path, runner=_PassingRunner, codegen=_CoveringCodegen)
+    monkeypatch.setattr("orchestrator.sdlc.review.SemanticReviewAdapter", _Judge("approve"))
+
+    result = await run_feature("file://./spec.md", intent_id="intent-a", repo="https://x/widget")
+
+    assert result.passed
+    assert created[0].gaps_seen == [["src/orchestrator/cli.py"]]
+    assert created[0].refine_calls == 0  # the implementation was never blamed for a test gap


### PR DESCRIPTION
A run produced a correct helper, an exhaustive test file for it, a clean type check, and an approving judge — and shipped a feature that does nothing:

```python
t.handler.tool.input_schema if hasattr(t.handler, "tool") else {}
```

`MCPToolHandler` has no `tool`, so the guard is always false, the schema is always `{}`, and every argument in `mcp contracts` prints `any`. Given the graph definition of the class, the model had stopped guessing attribute names and started defending against their absence.

Every check in the pipeline inspects code or types. The criteria are behavioural — *when the user runs `orchestrator mcp contracts`, the output includes the type label `string`* — and nothing ran the command.

### Why the existing proof check could not catch it

`_prove_the_tests_test_something` reverts the whole change at once, which only proves the tests depend on *some* part of it. Reverting everything broke the helper's import, the suite went red, and the proof "held" while the line that mattered was covered by nothing.

### Per-file is the version that catches it

Each changed production file is reverted on its own; any that leaves the suite green is a file nothing tests. Against that exact worktree:

```
[coverage] nothing exercises the change in: cli.py
```

A gap goes to `author_tests` with the files named — not to `refine`. The code was right and the tests were wrong, and blaming the implementation for a coverage hole is how a correct change gets edited into a broken one. There's a test asserting `refine_calls == 0` on that path. Bounded by `max_refine`, capped at four probes, and it stops rather than looping when no tests come back.

The `author_tests` prompt now carries the rest: a criterion phrased as behaviour must be exercised through the entry point it names, because the wiring between a command and the helper it calls is exactly where this bug lived.

### Observed effect

The next run's refine passes were all about `CliRunner` — the tests moved to the entry point, which is the intent. It then failed on repo mechanics (the Typer app is `app`, not `cli`), which is a separate gap: codegen isn't shown the repo's own CLI tests. Not addressed here.

---

**Gate:** `mypy src tests` clean (595 files), `ruff format --check` and `ruff check` clean, 2333 passed / 30 skipped.

Refs SSPN-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
