### PR TITLE
fix(sdlc): show the test author how this repo tests the module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,72 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## Unreleased — A green suite is not a working change
+
+Found by running one ticket end to end a dozen times. Every stage of the build loop was
+working from an input it could not see, and reporting the gap as a defect in the work
+rather than in its own view. Three separate runs committed code that did nothing: a helper
+appended and never called, a file missing its `typing` import, a command wired through an
+attribute its class does not have. All three had green tests.
+
+**Behaviour change:** a run is now stopped by things that previously passed. Type errors on
+changed lines, a changed file no test exercises, and an acceptance verdict that cannot be
+read all block a commit where they used to be silent. Runs that used to finish with a
+useless change now fail with a reason.
+
+### Added
+
+- **`orchestrator sdlc autorun --review`** — prints the full diff and asks before the run's
+  first write. The last gate before anything is committed or pushed, and the only one that
+  is a person rather than a model. Fails closed when there is no terminal to ask on, so an
+  unattended run declines rather than assuming yes.
+- **The repo's own type checker runs inside the test loop.** Scoped to the lines the change
+  touched, so pre-existing errors elsewhere don't block a run, and its output goes back to
+  the refine loop exactly like a test failure. Typing-hygiene codes (`unused-ignore`,
+  `no-untyped-def`, `import-*`) are ignored — in a generated worktree those report the
+  environment, not the change.
+- **Per-file coverage proof.** The existing check reverts the whole change at once, which
+  only proves the tests depend on *some* part of it. Each changed file is now reverted on
+  its own; anything that leaves the suite green is a file nothing tests, and goes back to
+  the test author by name.
+- **`sdlc autorun` is documented** in `CLI_REFERENCE.md`, including what each bracketed
+  stage line means. It was the primary entry point and had no reference entry.
+
+### Changed
+
+- **The acceptance judge can ask for a correction, not only refuse.** A rejection used to
+  end the run, which made any criterion the generator was never told to satisfy an
+  unwinnable ticket — most visibly a documentation criterion, which every codegen prompt
+  forbids and the judge then failed the run for missing. Blockers now go back for revision,
+  bounded; a revision that breaks the suite is repaired rather than fatal.
+- **The judge reads documentation and config, not just `.py`.** A run wrote the
+  `USER_GUIDE.md` its ticket demanded, twice, and was told both times that no documentation
+  was present — true of its input, and unfixable by any change. The same hole meant a Java
+  or Go change was judged on its Python files, of which there are none.
+- **Codegen is shown the files it is changing.** Paths came only from the spec text, so a
+  ticket phrased in behaviour named none and codegen received zero bytes of existing source.
+  Paths now come from the spec *and* the design, which knew them all along.
+- **A file too large for the prompt budget is excerpted, not dropped.** It used to vanish in
+  silence, so a repair prompt could say "copy this snippet verbatim from the content below"
+  and then include nothing. Windows are placed by anchor and sized by what is left, and
+  whatever is not shown is named.
+- **Codegen and the judge both emit through a forced tool call.** `response_format`
+  is an OpenAI/Ollama concept that Anthropic drops, so on Anthropic models nothing
+  constrained the output and replies arrived wrapped in prose.
+- **`--max-refine` now defaults to 5** (was 3) on `sdlc autorun` and `sdlc feature`: tests
+  and type errors draw on the same budget.
+- **A safe-mode rehearsal no longer counts as a duplicate.** The check refused any second
+  run on a ticket whose first run finished, so a ticket became unworkable after its first
+  dry run. Only a run that reached a PR blocks another.
+
+### Known limitations
+
+- A run parked at the validity gate holds its ticket until its approval is decided; there is
+  no reaper for parked runs.
+- `--resume` re-runs its stages and builds a fresh worktree rather than continuing the
+  previous one, so approve-then-resume regenerates the change instead of committing the diff
+  that was approved.
+
 ## 3.12.0 — Read your tracker through a server, not a token
 
 **Behaviour change:** where an MCP server is onboarded that can serve them, `jira://` and

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -656,6 +656,61 @@ orchestrator openspec draft [OPTIONS]
 
 The autonomous build path: requirements → code → tests → reviewed PR, with human gates.
 
+### `orchestrator sdlc autorun`
+
+One ticket, all the way through: research → design → validity gate → code → tests
+→ review → PR. The stages are the commands below, called in order with the same
+spec, and each result recorded.
+
+Default `--safe` makes no external write anywhere in the chain: a local branch and
+commit, dry-run tracker, no push. `--live` creates or adopts the issue, pushes the
+branch, and opens a PR.
+
+```
+orchestrator sdlc autorun --source jira://PROJ-14 --issue PROJ-14 --path . --safe --max-cost 10
+```
+
+| Option | Description |
+|---|---|
+| `--source` | Source root, e.g. `jira://<issue-key>`, `confluence://<page_id>`, `file://./spec.md`. **Required.** |
+| `--issue` | Adopt an existing tracker issue instead of creating one. |
+| `--intent` | Intent id to implement (default: the first). |
+| `--repo` | Git URL to branch from (default `$SDLC_REPO_URL`). |
+| `--path` | Repo to reason about — the graph the run is grounded in. (default: `.`) |
+| `--live` / `--safe` | Write for real, or make no external write. (default: `--safe`) |
+| `--max-refine` | Max test→refine loops. Tests and type errors share it. (default: `5`) |
+| `--review` / `--no-review` | Show the diff and ask before committing or pushing anything. (default: `--no-review`) |
+| `--base` | PR target branch. |
+| `--language` | Target language (auto detects). (default: `auto`) |
+| `--out` | Where run artifacts go (default: a run dir under the temp dir). |
+| `--resume` | Continue a run by id — adopts the issue it already created. |
+| `--max-cost` | Cap LLM spend (USD) for this run; exhausting it parks the run. |
+
+**Reading the output.** Each stage prints a bracketed line. The ones that decide
+whether a change ships:
+
+| Line | What it means |
+|---|---|
+| `[validity]` | The gate's verdict. Only `PROCEED` continues; `DUPLICATE`, `CRITERIA_WRONG`, `UNLOCALIZED` and `TOO_BIG` park the run with evidence. |
+| `[run_tests #N]` | A pytest run. `refine` follows a red one. |
+| `[typecheck]` | The repo's own type checker, over the lines this change touched. Errors go back to `refine` exactly like a test failure. |
+| `[proof]` | The generated tests are re-run with the change reverted. They must fail — tests that pass without the change do not exercise it. |
+| `[coverage]` | Each changed file is reverted on its own. Anything that leaves the suite green is a file no test reaches, and goes back to `author_tests`. |
+| `[judge]` | Does the change satisfy the ticket's acceptance criteria? `REQUEST_CHANGES` sends the blockers back through `revise`; a verdict that cannot be read blocks the run rather than passing it. |
+| `[gate]` | `--review` only: waiting for you. Nothing has been committed yet. |
+
+**`--review` is the last gate before the first write.** It prints the full diff,
+asks once, and defaults to no. Every other check above is a model or a heuristic;
+this one is you. It **fails closed** when there is no terminal to ask on, so an
+unattended run (cron, a background shell, the MCP server) stops rather than
+assuming yes — pass `--review` only from an interactive session.
+
+**Resuming.** A parked or failed run continues with `--resume <run-id>`, keeping
+its id and adopting the issue it already created. A run parked on an approval
+resumes only after the approval is decided (`orchestrator sdlc runs approve`).
+Note that a resumed run re-runs its stages and builds a **fresh worktree** — it
+does not continue editing the previous one.
+
 ### `orchestrator sdlc feature`
 
 Linear pipeline for ONE intent, end to end.
@@ -681,7 +736,7 @@ orchestrator sdlc feature [OPTIONS]
 | `--intent` | Intent id to implement (default: first derived intent). |
 | `--repo` | Git URL to branch from (default $SDLC_REPO_URL; scratch if unset). |
 | `--model` | Codegen model (default: $SDLC_CODEGEN_MODEL or the adapter default). |
-| `--max-refine` | Max implement→test→refine iterations. (default: `3`) |
+| `--max-refine` | Max test→refine loops. Tests and type errors share it. (default: `5`) |
 | `--live` | Write for real: create the Jira issue, push the branch + open a PR, comment on Jira. Default --safe stays local (branch + commit + diff, dry-run Jira, no push). |
 | `--issue` | Adopt an existing tracker issue (e.g. SSPN-9) instead of creating one — the branch, PR, comment and transition all land on it. |
 | `--base` | PR target branch (default: $SDLC_PR_BASE, else the repo's default branch). |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -431,6 +431,61 @@ made and read the diff.
 
 ---
 
+## Step 3.5 — What stops a bad change from shipping
+
+A model writes the code **and** the tests that judge it, so "the tests pass" only
+means its tests agree with its code. Between a green suite and a commit sit several
+checks that don't take the model's word for it. You'll see each as a bracketed line.
+
+```bash
+orchestrator sdlc autorun --source jira://PROJ-14 --issue PROJ-14 --path . --safe --max-cost 10
+```
+
+**Before any code is written — `[validity]`.** The ticket is checked against the
+graph. A criterion asserting *"11 Entity nodes on this repo"* when the source has 7
+is a false premise, and building to it produces code that passes its own tests and
+is still wrong. Verdicts other than `PROCEED` park the run with evidence rather than
+guessing.
+
+**`[typecheck]`** runs your repo's own type checker over the lines the change
+touched, and any error goes back to the refine loop like a test failure. This is not
+redundant with the tests: generated tests routinely exercise a new helper directly
+and never import the module the ticket was about, so they sail past a missing import
+or an attribute that doesn't exist on the line that matters. Scoped to changed
+lines, so pre-existing errors elsewhere in your repo don't block the run.
+
+**`[proof]`** reverts the change and re-runs the generated tests. They must fail. A
+suite that passes *without* the change is not testing it.
+
+**`[coverage]`** reverts each changed file **on its own**. Anything that leaves the
+suite green is a file no test reaches — the classic shape being a correct, fully
+tested helper wired into a command by a line nothing ever calls. Gaps go back to the
+test author, naming the files.
+
+**`[judge]`** asks the one question the others can't: does this change satisfy the
+ticket's acceptance criteria? It reads the spec and the code, never the codegen
+conversation, so it can't rationalise the generator's choices. `REQUEST_CHANGES`
+sends the specific blockers back for revision; a reply that can't be read stops the
+run rather than passing it.
+
+### And then you
+
+```bash
+orchestrator sdlc autorun --source jira://PROJ-14 --issue PROJ-14 --safe --review
+```
+
+`--review` prints the full diff and asks, once, after every check above and before
+the first write. Declining commits nothing and pushes nothing.
+
+Everything above is a model or a heuristic. `--review` is the only gate that is a
+person, and it's the one worth using the first few times you point Spine at a repo
+you care about — and on your first `--live` run.
+
+It **fails closed**: with no terminal to ask on, it declines rather than assuming
+yes. Pass it from an interactive shell, not from cron or a background job.
+
+---
+
 ## Step 4 — Go live: a real issue + pull request
 
 When the local result looks right, let it do the real thing — file a Jira issue,

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -920,8 +920,11 @@ def sdlc_feature(
     ] = None,
     max_refine: Annotated[
         int,
-        typer.Option("--max-refine", help="Max implement→test→refine iterations."),
-    ] = 3,
+        # Matches `sdlc autorun`: the type checker draws on this budget too, so a run that
+        # greens its suite on the first pass still has the checker to satisfy. Left at 3, this
+        # flag silently overrode the raise and reintroduced the shortfall on this path only.
+        typer.Option("--max-refine", help="Max test→refine loops (tests and type errors share it)."),
+    ] = 5,
     live: Annotated[
         bool,
         typer.Option(

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -1370,7 +1370,9 @@ class LLMCodegenAdapter:
             f"{self._layout_block()}{self._grounding(spec, root)}{self._design_block()}Issue: {issue_key}\n\n"
             f"SPEC:\n{_spec_text(spec)}\n\n"
             f"CURRENT SOURCE FILES:\n{self._session_files(root, include_tests=False)}"
-            f"{self._convention_block(root)}{_coverage_gap_block(gaps or [])}",
+            f"{self._convention_block(root)}"
+            f"{_existing_test_examples(spec, root, self._design)}"
+            f"{_coverage_gap_block(gaps or [])}",
             root,
         )
 
@@ -1886,6 +1888,104 @@ def _safe_target(root: Path, rel: str) -> Path:
 _PATH_RE = re.compile(r"\b((?:src/|tests/)[\w./-]+\.py)\b")
 
 
+_MAX_TEST_EXAMPLE_BYTES = 12_000  # supplementary to the source block, so a fraction of it
+
+
+def _existing_test_examples(spec: dict[str, Any], root: Path, design: str = "") -> str:
+    """Tests this repo already has for the modules this change touches, or ''.
+
+    Told to exercise a criterion through the entry point it names, a run reached for
+    ``CliRunner`` — the right instinct — and then spent its whole budget on mechanics: it
+    guessed the Typer app was called ``cli``, and when the import failed it edited *production*
+    ``cli.py`` to add a ``cli`` alias so its test would work. It also passed a ``mix_stderr``
+    kwarg Typer's runner does not take, and patched the wrong import paths.
+
+    Every one of those answers is in the repo's own suite, two files of it::
+
+        tests/test_cli.py:9       from orchestrator.cli import app
+        tests/test_launch.py:172  result = CliRunner().invoke(app, ["up", "--help"])
+
+    Nothing was showing them. Written for a specific failure and general by construction: the
+    convention for invoking *any* entry point under test is best stated by the tests that
+    already do it.
+    """
+    targets = _paths_from(spec, design)
+    if not targets:
+        return ""
+    modules = {_module_path_of(rel) for rel in targets if _module_path_of(rel)}
+    if not modules:
+        return ""
+
+    scored: list[tuple[int, str]] = []
+    for candidate in sorted(root.rglob("test_*.py")):
+        if ".git" in candidate.parts or not candidate.is_file():
+            continue
+        try:
+            body = candidate.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        hits = sum(_exercises_module(body, module) for module in modules)
+        if hits:
+            scored.append((hits, str(candidate.resolve().relative_to(root.resolve()))))
+    if not scored:
+        return ""
+    scored.sort(key=lambda pair: -pair[0])
+    chosen = [rel for _, rel in scored[:2]]
+    body = _excerpt_files(
+        root,
+        chosen,
+        budget=_MAX_TEST_EXAMPLE_BYTES,
+        anchors_by_path={rel: sorted(modules) for rel in chosen},
+        label="an existing test for this module",
+    )
+    if not body:
+        return ""
+    return (
+        "\n\nHOW THIS REPO ALREADY TESTS THESE MODULES — copy these mechanics rather than "
+        "inventing them: the import path the entry point is reached by, the runner and the "
+        "arguments it takes, and how collaborators are patched. If your test cannot import "
+        "something, the fix is in your test, never a new alias in the production module:\n" + body
+    )
+
+
+def _paths_from(spec: dict[str, Any], design: str) -> list[str]:
+    """Repo-relative source paths this ticket is about — spec first, then the design."""
+    blob = " ".join(
+        [
+            str(spec.get("summary") or ""),
+            str(spec.get("technical_notes") or ""),
+            *_str_list(spec.get("acceptance_criteria")),
+        ]
+    )
+    seen: list[str] = []
+    for rel in _PATH_RE.findall(blob) + _PATH_RE.findall(design):
+        if rel not in seen:
+            seen.append(rel)
+    return seen
+
+
+def _exercises_module(body: str, module: str) -> int:
+    """How strongly a test file reaches ``module`` — imports and patch targets only.
+
+    Counting bare occurrences ranked a wikilink test above ``tests/test_cli.py`` for
+    ``orchestrator.cli``, because it names the doc file ``orchestrator.cli.md`` six times.
+    Mentioning a module is not testing it; importing or patching it is.
+    """
+    escaped = re.escape(module)
+    imports = re.findall(rf"^\s*(?:from\s+{escaped}\s+import|import\s+{escaped})\b", body, re.MULTILINE)
+    patches = re.findall(rf"""(?:setattr|patch)\(\s*["']{escaped}[."']""", body)
+    return len(imports) * 3 + len(patches)
+
+
+def _module_path_of(rel: str) -> str:
+    """``src/orchestrator/cli.py`` → ``orchestrator.cli``; '' when it isn't a source path."""
+    parts = Path(rel).with_suffix("").parts
+    if not parts or parts[0] not in {"src", "tests"}:
+        return ""
+    trimmed = [p for p in parts[1:] if p != "__init__"]
+    return ".".join(trimmed)
+
+
 def _coverage_gap_block(gaps: list[str]) -> str:
     """Name the files whose changes no test reaches, or ''.
 
@@ -1924,6 +2024,9 @@ def _named_existing_files(spec: dict[str, Any], root: Path, design: str = "") ->
     helper it never wired in and never touched the display layer at all — not a
     judgement failure downstream, a generator working blind.
     """
+    # Spec first: when a ticket does name its files, that is the sharpest statement of
+    # intent there is. The design follows, and fills the common case where it does not.
+    seen = _paths_from(spec, design)
     blob = " ".join(
         [
             str(spec.get("summary") or ""),
@@ -1931,12 +2034,6 @@ def _named_existing_files(spec: dict[str, Any], root: Path, design: str = "") ->
             *_str_list(spec.get("acceptance_criteria")),
         ]
     )
-    seen: list[str] = []
-    # Spec first: when a ticket does name its files, that is the sharpest statement of
-    # intent there is. The design follows, and fills the common case where it does not.
-    for rel in _PATH_RE.findall(blob) + _PATH_RE.findall(design):
-        if rel not in seen:
-            seen.append(rel)
     # The spec's own words are the anchors here: a criterion naming `_type_label` or
     # `mcp contracts` says which part of a large module the ticket is about, which is
     # what decides where the window lands when the file cannot be shown whole.

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1366,3 +1366,38 @@ async def test_a_type_error_pulls_in_the_definition_it_names(tmp_path: Path) -> 
 async def test_a_failure_naming_nothing_adds_no_definitions(tmp_path: Path) -> None:
     adapter = LLMCodegenAdapter(_ScriptedLLM([]))
     assert adapter._definitions_for("E   assert 1 == 2", tmp_path) == ""
+
+
+async def test_author_tests_is_shown_how_this_repo_tests_the_module(tmp_path: Path) -> None:
+    """Told to reach the entry point, a run reached for CliRunner — right instinct — then
+    spent its budget guessing the Typer app was named `cli`, and edited *production* cli.py
+    to add an alias so its own test would import. The answer was in tests/test_cli.py."""
+    from orchestrator.sdlc.codegen import _existing_test_examples
+
+    (tmp_path / "src" / "app").mkdir(parents=True)
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "src" / "app" / "cli.py").write_text("entry = 1\n", encoding="utf-8")
+    (tmp_path / "tests" / "test_cli.py").write_text(
+        "from app.cli import entry\n\n\ndef test_entry() -> None:\n    assert entry == 1\n",
+        encoding="utf-8",
+    )
+
+    block = _existing_test_examples({"summary": "change it"}, tmp_path, "touch src/app/cli.py")
+
+    assert "from app.cli import entry" in block
+
+
+async def test_a_file_that_only_mentions_the_module_does_not_count(tmp_path: Path) -> None:
+    """Mentioning a module is not testing it: a wikilink test naming `orchestrator.cli.md`
+    six times outranked tests/test_cli.py, which imports the app."""
+    from orchestrator.sdlc.codegen import _exercises_module
+
+    assert _exercises_module("from orchestrator.cli import app\n", "orchestrator.cli") > 0
+    assert _exercises_module('monkeypatch.setattr("orchestrator.cli.thing", x)\n', "orchestrator.cli") > 0
+    assert _exercises_module('doc = "orchestrator.cli.md"\n' * 6, "orchestrator.cli") == 0
+
+
+async def test_no_existing_tests_is_not_an_error(tmp_path: Path) -> None:
+    from orchestrator.sdlc.codegen import _existing_test_examples
+
+    assert _existing_test_examples({"summary": "x"}, tmp_path, "touch src/app/nothing.py") == ""


### PR DESCRIPTION
Told that a behavioural criterion must be exercised through the entry point it names, a run reached for `CliRunner` — exactly the intent — and then spent its entire budget on mechanics it had no way to know:

```
[refine] cli.py — Expose `cli` alias on the Typer app so tests can import it
[refine] test  — Fix CliRunner call by removing unsupported mix_stderr kwarg
[refine] test  — use `app` instead of `cli`, patch the right import paths
```

It guessed the Typer app was called `cli`, and when the import failed it edited **production** `cli.py` to add a `cli` alias so its own test would work.

Every one of those answers is in this repo's own suite:

```
tests/test_cli.py:9       from orchestrator.cli import app
tests/test_launch.py:172  result = CliRunner().invoke(app, ["up", "--help"])
```

Nothing was showing them.

### What changed

`author_tests` now receives the repo's existing tests for the modules the change touches, excerpted through the same windowing everything else uses, with the instruction that a failed import is a bug in the test and never a reason to add an alias to the production module.

Ranked by **imports and patch targets, not mentions**. Counting bare occurrences put a wikilink test above `tests/test_cli.py` for `orchestrator.cli`, because it names the doc file `orchestrator.cli.md` six times — and with only two slots, noise crowding out the answer is the original failure repeating one level up.

On this repo's own ticket the block now carries `from orchestrator.cli import app` and `CliRunner()`, the two facts the previous run guessed wrong.

### Result

The next run implemented the ticket correctly, verified against the real code path:

```
query   -> 'string'          declared type, surfaced
n       -> 'integer|null'    list types joined
ref     -> 'any'             $ref falls back, as the criteria require
absent  -> 'any'             no crash
```

The type checker caught an attribute error twice and refused to let it through; `[coverage]` ran for the first time and passed; the judge caught the missing documentation and `revise` wrote it. It needed **5 test runs** — under the old `max_refine=3` it would have failed exactly where the budget raise was made for.

### Documentation

`sdlc autorun` had **no entry in CLI_REFERENCE.md at all** — no description, no options — despite being the primary entry point. Added, with a table of what each bracketed stage line means, because that output is how a user tells a run that *refused to ship* from a run that *failed to work*.

`USER_GUIDE.md` gains a step between "your first build" and "go live", where the question actually arises: a model writes the code *and* the tests that judge it, so a green suite only means its tests agree with its code. `--review` is presented as the one gate that is a person, including that it fails closed with no terminal.

The CHANGELOG entry leads with the behaviour change rather than the feature list — runs that used to finish with a useless change now fail with a reason — and records two limitations a user will meet: a parked run holds its ticket until its approval is decided, and `--resume` regenerates rather than continuing, so approve-then-resume does not commit the diff that was approved.

Writing the docs caught a real inconsistency: `sdlc feature` still hard-coded `--max-refine 3`, overriding the raise to 5 and reintroducing on that path the shortfall the type checker caused on `autorun`. Fixed, so the documented default is the one both commands use.

### Worth a reviewer's eye

The successful run edited `src/orchestrator/mcp/handler.py` (`self._tool = tool`) — outside the ticket's stated scope, though it is the honest fix, since the schema genuinely was not reachable otherwise. The judge approved it. That is exactly the case `--review` exists for, and an argument for using it on live runs.

---

**Gate:** `mypy src tests` clean (595 files), `ruff format --check` and `ruff check` clean, 2336 passed / 30 skipped. `scripts/check-mermaid.js` confirms the guide's diagram still renders as inline SVG.

Refs SSPN-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
