### PR TITLE
fix(sdlc): a check that cannot run must not look like a check that passed

### DIFF
--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -99,9 +99,9 @@ async def _prove_the_tests_test_something(
     if not production or not any(_is_test_path(f) for f in files):
         return
 
-    stashed = await _git(path, "stash", "push", "--include-untracked", "--quiet", "--", *production)
+    stashed, why = await _git_out(path, "stash", "push", "--include-untracked", "--quiet", "--", *production)
     if not stashed:
-        emit("[proof] could not set the change aside — skipping the without-it test run")
+        emit(f"[proof] could not set the change aside — skipping the without-it test run: {why}")
         return
     try:
         result = await runner.run(path=str(path))
@@ -144,8 +144,14 @@ async def _files_no_test_exercises(
         production = production[:_MAX_COVERAGE_PROBES]
 
     unexercised: list[str] = []
+    unprobed: list[str] = []
     for target in production:
-        if not await _git(path, "stash", "push", "--include-untracked", "--quiet", "--", target):
+        stashed, why = await _git_out(path, "stash", "push", "--include-untracked", "--quiet", "--", target)
+        if not stashed:
+            # Never a silent skip. This exact path reported "every changed file is
+            # exercised" for a whole run while stashing nothing, because an earlier
+            # stage had left intent-to-add entries in the index and every push failed.
+            unprobed.append(f"{Path(target).name} ({why.splitlines()[0] if why else 'stash failed'})")
             continue
         try:
             result = await runner.run(path=str(path))
@@ -153,10 +159,12 @@ async def _files_no_test_exercises(
             await _git(path, "stash", "pop", "--quiet")
         if getattr(result, "passed", False):
             unexercised.append(target)
+    if unprobed:
+        emit(f"[coverage] COULD NOT probe {len(unprobed)} file(s) — not a pass: {'; '.join(unprobed)}")
     if unexercised:
         names = ", ".join(Path(f).name for f in unexercised)
         emit(f"[coverage] nothing exercises the change in: {names}")
-    else:
+    elif not unprobed:
         emit("[coverage] every changed file is exercised by a test")
     return unexercised
 
@@ -218,8 +226,17 @@ async def _exec(path: Path, *argv: str) -> tuple[bool, str]:
 
 
 async def _changed_line_ranges(path: Path) -> dict[str, set[int]]:
-    """``{relative path: {line numbers this change added}}``, from the worktree diff."""
-    await _git(path, "add", "-N", "-A")
+    """``{relative path: {line numbers this change added}}``, from the worktree diff.
+
+    Reads the index; never writes it. The first version ran ``git add -N -A`` so untracked
+    files would appear in ``git diff``, and intent-to-add entries make every subsequent
+    ``git stash push`` fail with *"Entry ... not uptodate. Cannot merge."* That silently
+    disabled both checks that stash — the proof pass reported "could not set the change
+    aside" for three runs, and the coverage probe skipped every file and announced that all
+    of them were exercised. A check that cannot run must never look like a check that
+    passed, and the surest way to avoid it is not to touch shared state at all.
+    """
+    untracked = await _untracked_python_files(path)
     proc = await asyncio.create_subprocess_exec(
         "git",
         "diff",
@@ -245,7 +262,30 @@ async def _changed_line_ranges(path: Path) -> dict[str, set[int]]:
             if match:
                 start = int(match.group(1))
                 ranges[current].update(range(start, start + int(match.group(2) or 1)))
+    # A brand-new file has no diff against HEAD, and it is exactly where generated code
+    # lands — so every line of it counts as changed.
+    for rel in untracked:
+        try:
+            total = len((path / rel).read_text(encoding="utf-8").splitlines())
+        except (OSError, UnicodeDecodeError):
+            continue
+        if total:
+            ranges[rel] = set(range(1, total + 1))
     return {k: v for k, v in ranges.items() if v}
+
+
+async def _untracked_python_files(path: Path) -> list[str]:
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        cwd=str(path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    out, _ = await proc.communicate()
+    return [f for f in out.decode("utf-8", "replace").split("\n") if f.endswith(".py")]
 
 
 # Codes that say "this annotation could be tidier", not "this code is wrong". A worktree venv
@@ -435,15 +475,25 @@ def _is_test_path(rel: str) -> bool:
 
 
 async def _git(path: Path, *args: str) -> bool:
+    ok, _ = await _git_out(path, *args)
+    return ok
+
+
+async def _git_out(path: Path, *args: str) -> tuple[bool, str]:
+    """Run git, and keep what it said when it failed.
+
+    stderr used to go to ``DEVNULL``, so "could not set the change aside" was the whole
+    diagnosis for three runs. Git's own message named the cause in one line.
+    """
     proc = await asyncio.create_subprocess_exec(
         "git",
         *args,
         cwd=str(path),
         stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
     )
-    await proc.communicate()
-    return proc.returncode == 0
+    _, err = await proc.communicate()
+    return proc.returncode == 0, err.decode("utf-8", "replace").strip()
 
 
 async def _local_commit(path: Path, message: str) -> None:

--- a/tests/sdlc/test_feature_runner.py
+++ b/tests/sdlc/test_feature_runner.py
@@ -1143,3 +1143,72 @@ async def test_a_coverage_gap_asks_for_tests_not_an_implementation_change(
     assert result.passed
     assert created[0].gaps_seen == [["src/orchestrator/cli.py"]]
     assert created[0].refine_calls == 0  # the implementation was never blamed for a test gap
+
+
+# ---- a check that cannot run must not look like a check that passed (SSPN-14) ----
+
+
+def _seeded_repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "seed"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+async def test_reading_the_diff_leaves_the_index_alone(tmp_path: Path) -> None:
+    """`git add -N -A` made untracked files visible to `git diff` and made every later
+    `git stash push` fail with "Entry ... not uptodate. Cannot merge." That silently
+    disabled the proof pass for three runs and made the coverage probe skip every file
+    while announcing that all of them were exercised."""
+    from orchestrator.sdlc.feature_runner import _changed_line_ranges, _git_out
+
+    root = _seeded_repo(tmp_path)
+    (root / "src" / "mod.py").write_text("x = 2\n", encoding="utf-8")
+    (root / "src" / "brand_new.py").write_text("y = 1\ny = 2\n", encoding="utf-8")
+
+    ranges = await _changed_line_ranges(root)
+
+    assert ranges["src/mod.py"] == {1}
+    assert ranges["src/brand_new.py"] == {1, 2}  # a new file has no diff; every line counts
+
+    # The check that regressed: stashing must still work afterwards.
+    stashed, why = await _git_out(root, "stash", "push", "--include-untracked", "--quiet", "--", "src/mod.py")
+    assert stashed, f"reading the diff broke the stash: {why}"
+    await _git_out(root, "stash", "pop", "--quiet")
+
+
+async def test_git_failures_say_why() -> None:
+    """ "could not set the change aside" was the entire diagnosis for three runs, because
+    stderr went to DEVNULL. Git names the cause in one line."""
+    from orchestrator.sdlc.feature_runner import _git_out
+
+    ok, why = await _git_out(Path("/"), "stash", "push", "--", "nope.py")
+
+    assert not ok
+    assert why  # whatever git said, we kept it
+
+
+async def test_an_unprobed_file_is_not_reported_as_covered(tmp_path: Path) -> None:
+    """The bug this check had itself: a failed stash `continue`d, so a run in which nothing
+    could be probed printed "every changed file is exercised by a test"."""
+    from orchestrator.sdlc.feature_runner import _files_no_test_exercises
+
+    root = _seeded_repo(tmp_path)
+    (root / "tests").mkdir()
+    (root / "tests" / "test_it.py").write_text("def test_x() -> None:\n    assert True\n", encoding="utf-8")
+    (root / "src" / "mod.py").write_text("x = 2\n", encoding="utf-8")
+    # Make the stash fail the way intent-to-add did.
+    subprocess.run(["git", "add", "-N", "-A"], cwd=root, check=True)
+
+    said: list[str] = []
+    gaps = await _files_no_test_exercises(
+        root, ["src/mod.py", "tests/test_it.py"], _PassingRunner(), said.append
+    )
+
+    assert gaps == []  # nothing was proven unexercised...
+    assert any("COULD NOT probe" in m for m in said)  # ...because nothing was probed
+    assert not any("every changed file is exercised" in m for m in said)


### PR DESCRIPTION
The type checker added in #115 reads the diff, and to make untracked files visible to `git diff` it ran `git add -N -A`. Intent-to-add entries make every subsequent `git stash push` fail:

```
error: Entry 'tests/test_mcp_contract_arg_types.py' not uptodate. Cannot merge.
```

Both of the remaining checks stash. So for three runs:

- the proof pass printed `could not set the change aside` and skipped, and
- the coverage probe `continue`d past every file and printed **`every changed file is exercised by a test`** — having stashed nothing and run nothing.

The second is the serious one. A run reported that check passing for the first time; it had not run at all. It is exactly the failure this cycle has been about — a check that measures nothing looking identical to a check that passes — introduced by one of its own fixes.

### Reading the diff no longer writes the index

Untracked files come from `git ls-files --others`, and every line of a new file counts as changed: a new file has no diff against `HEAD`, and that is precisely where generated code lands. Nothing shared is mutated, so nothing downstream can be broken by it.

Verified in a clean repo — ranges come out correct (`src/mod.py: {1}`, `src/brand_new.py: {1, 2}`) and the `git stash push` that follows now succeeds.

### Failures say why

`_git` sent stderr to `DEVNULL`, so `could not set the change aside` was the entire diagnosis for three runs. Git named the cause in one line, and we were discarding it.

### A probe that cannot probe reports that, loudly

`[coverage] COULD NOT probe N file(s) — not a pass: …` instead of falling through to the success message. Previously "no gaps found" and "no gaps looked for" were distinguishable only by reading the source.

### Tests

Three regressions, including one that reproduces the intent-to-add state directly and asserts the probe refuses to claim coverage it did not measure.

---

This is the third time in this cycle a check silently measured nothing: `mypy` absent from the worktree venv, a verification harness missing `pytest`, and now this. Each looked identical to passing. The `COULD NOT probe` line and the stderr capture are the general fix; any future check with a "skip" path should be treated as suspect until it can distinguish the two.

**Gate:** `mypy src tests` clean (595 files), `ruff format --check` and `ruff check` clean, 2339 passed / 30 skipped.

Refs SSPN-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
