### PR TITLE
fix(sdlc): give each check its own allowance, and hand the ticket back

### DIFF
--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -678,7 +678,7 @@ orchestrator sdlc autorun --source jira://PROJ-14 --issue PROJ-14 --path . --saf
 | `--repo` | Git URL to branch from (default `$SDLC_REPO_URL`). |
 | `--path` | Repo to reason about — the graph the run is grounded in. (default: `.`) |
 | `--live` / `--safe` | Write for real, or make no external write. (default: `--safe`) |
-| `--max-refine` | Max test→refine loops. Tests and type errors share it. (default: `5`) |
+| `--max-refine` | Correction attempts allowed **per check** — a red suite, a type error and a coverage gap each get their own allowance, so one cannot starve another. (default: `5`) |
 | `--review` / `--no-review` | Show the diff and ask before committing or pushing anything. (default: `--no-review`) |
 | `--base` | PR target branch. |
 | `--language` | Target language (auto detects). (default: `auto`) |
@@ -736,7 +736,7 @@ orchestrator sdlc feature [OPTIONS]
 | `--intent` | Intent id to implement (default: first derived intent). |
 | `--repo` | Git URL to branch from (default $SDLC_REPO_URL; scratch if unset). |
 | `--model` | Codegen model (default: $SDLC_CODEGEN_MODEL or the adapter default). |
-| `--max-refine` | Max test→refine loops. Tests and type errors share it. (default: `5`) |
+| `--max-refine` | Correction attempts allowed **per check** — a red suite, a type error and a coverage gap each get their own allowance, so one cannot starve another. (default: `5`) |
 | `--live` | Write for real: create the Jira issue, push the branch + open a PR, comment on Jira. Default --safe stays local (branch + commit + diff, dry-run Jira, no push). |
 | `--issue` | Adopt an existing tracker issue (e.g. SSPN-9) instead of creating one — the branch, PR, comment and transition all land on it. |
 | `--base` | PR target branch (default: $SDLC_PR_BASE, else the repo's default branch). |

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -832,7 +832,11 @@ def sdlc_autorun(
         typer.Option("--live/--safe", help="Write for real. Default --safe makes no external write."),
     ] = False,
     max_refine: Annotated[
-        int, typer.Option("--max-refine", help="Max test→refine loops (tests and type errors share it).")
+        int,
+        typer.Option(
+            "--max-refine",
+            help="Correction attempts allowed per check — tests, types and coverage each get their own.",
+        ),
     ] = 5,
     review: Annotated[
         bool,
@@ -923,7 +927,10 @@ def sdlc_feature(
         # Matches `sdlc autorun`: the type checker draws on this budget too, so a run that
         # greens its suite on the first pass still has the checker to satisfy. Left at 3, this
         # flag silently overrode the raise and reintroduced the shortfall on this path only.
-        typer.Option("--max-refine", help="Max test→refine loops (tests and type errors share it)."),
+        typer.Option(
+            "--max-refine",
+            help="Correction attempts allowed per check — tests, types and coverage each get their own.",
+        ),
     ] = 5,
     live: Annotated[
         bool,

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -116,7 +116,8 @@ async def _prove_the_tests_test_something(
         await _git(path, "stash", "pop", "--quiet")
 
 
-_MAX_COVERAGE_PROBES = 4  # test runs this check may spend
+_MAX_COVERAGE_PROBES = 4  # files this check may probe in one pass
+_MAX_COVERAGE_FIXES = 2  # attempts at writing the missing test before giving up
 
 
 async def _files_no_test_exercises(
@@ -167,6 +168,19 @@ async def _files_no_test_exercises(
     elif not unprobed:
         emit("[coverage] every changed file is exercised by a test")
     return unexercised
+
+
+async def _release_the_ticket(move: Callable[[str], Any], emit: Callable[[str], None]) -> None:
+    """Hand a ticket back after a run that produced nothing.
+
+    Best-effort and never fatal, like every other transition: a board that has no "To Do"
+    to return to is a fact about the board, not a reason to fail work that already failed.
+    Says plainly when it could not, so nobody assumes the ticket was tidied up.
+    """
+    try:
+        await move("To Do")
+    except Exception as exc:  # noqa: BLE001 — a tracker quirk must not mask the real failure
+        emit(f"[jira] left In Progress — could not hand the ticket back: {exc}")
 
 
 async def _typecheck_the_change(
@@ -957,11 +971,20 @@ async def run_feature(
 
     passed = False
     iterations = 0
-    while iterations < max_refine:
+    # One allowance per kind of problem, not one pool for all three. A live run spent
+    # iterations 1-2 on real test failures and 3-4 on type errors, so when the coverage
+    # probe found its gap on iteration 5 there was nothing left to answer it with — the
+    # change was fixable and the run reported FAILED. Each check now gets guaranteed room,
+    # with a hard ceiling so a pathological run still terminates.
+    spent = {"tests": 0, "types": 0, "coverage": 0}
+    budgets = {"tests": max_refine, "types": max_refine, "coverage": _MAX_COVERAGE_FIXES}
+    ceiling = sum(budgets.values()) + 1
+    while iterations < ceiling:
         result = await run_with_autoheal(runner, testenv, str(path), emit=emit)
         iterations += 1
         emit(f"[run_tests #{iterations}] passed={result.passed} rc={result.returncode}")
         failures = result.output
+        kind = "tests"
         if result.passed:
             # Green is necessary and not sufficient. The generated tests are written by the
             # same model as the code and routinely exercise a new helper directly while never
@@ -969,6 +992,7 @@ async def run_feature(
             # wrong attribute sitting on the line that matters. The type checker does not.
             changed = await _changed_files(path)
             failures = await _typecheck_the_change(path, testenv, changed, emit)
+            kind = "types"
             if not failures:
                 # Type-clean and green still allows a change nothing tests. Probe each
                 # production file on its own; a gap is answered by writing the missing
@@ -977,8 +1001,10 @@ async def run_feature(
                 if not gaps:
                     passed = True
                     break
-                if iterations >= max_refine:
+                if spent["coverage"] >= budgets["coverage"]:
+                    emit("[cover] out of coverage attempts — the change is not proven tested")
                     break
+                spent["coverage"] += 1
                 with llm.stage("author_tests"):
                     covered = await codegen.author_tests(
                         spec=spec, path=str(path), issue_key=issue_key, gaps=gaps
@@ -988,8 +1014,10 @@ async def run_feature(
                     emit("[cover] no tests written for the gap — stopping rather than looping")
                     break
                 continue
-        if iterations >= max_refine:
+        if spent[kind] >= budgets[kind]:
+            emit(f"[refine] out of {kind} attempts — stopping")
             break
+        spent[kind] += 1
         with llm.stage("refine"):
             change = await codegen.refine(spec=spec, path=str(path), issue_key=issue_key, failures=failures)
         emit(f"[refine] {[Path(f).name for f in change.files]} - {change.summary}")
@@ -1026,6 +1054,11 @@ async def run_feature(
     if not passed:
         # A failed run is where the spend most needs explaining — it bought no PR.
         await log_run_cost("FAILED")
+        # Put the ticket back. It was moved to In Progress before codegen so the board would
+        # show the work being picked up; a run that then fails has produced no branch and no
+        # PR, and leaving the ticket In Progress tells everyone looking at the board that
+        # someone is on it. A live run did exactly this and the ticket sat there afterwards.
+        await _release_the_ticket(move, emit)
         raise FeatureRunError(f"VERDICT: FAILED after {iterations} test run(s) — not opening a PR.", code=1)
 
     # The last gate before anything is written, and the only one that is not a model. Every

--- a/tests/sdlc/test_feature_runner.py
+++ b/tests/sdlc/test_feature_runner.py
@@ -322,8 +322,9 @@ async def test_refine_that_changes_files_still_uses_the_whole_budget(
     with pytest.raises(FeatureRunError, match="VERDICT: FAILED"):
         await run_feature("file://./spec.md", intent_id="intent-a", max_refine=3)
 
-    # max_refine=3 → run/refine/run/refine/run.
-    assert created and created[0].refine_calls == 2
+    # max_refine is an allowance of *correction attempts*, per kind of problem: three
+    # refines, each followed by a run, then a fourth run that finds the budget spent.
+    assert created and created[0].refine_calls == 3
 
 
 async def test_greenfield_run_scaffolds_and_passes_layout_to_codegen(
@@ -587,8 +588,9 @@ async def test_a_live_run_moves_the_ticket_in_progress_before_writing_code(
             "file://./spec.md", intent_id="intent-a", repo="https://x/widget", live=True, issue="SSPN-1"
         )
 
-    # The run never reached a PR, and the ticket still shows that work started.
-    assert jira.transitions == ["In Progress"]
+    # In Progress before codegen so the board shows the work being picked up — and handed
+    # back when the run produces nothing, rather than left claiming someone is on it.
+    assert jira.transitions == ["In Progress", "To Do"]
 
 
 async def test_a_safe_run_moves_nothing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1212,3 +1214,44 @@ async def test_an_unprobed_file_is_not_reported_as_covered(tmp_path: Path) -> No
     assert gaps == []  # nothing was proven unexercised...
     assert any("COULD NOT probe" in m for m in said)  # ...because nothing was probed
     assert not any("every changed file is exercised" in m for m in said)
+
+
+async def test_each_check_gets_its_own_allowance(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A live run spent iterations 1-2 on test failures and 3-4 on type errors, so when the
+    coverage probe found its gap on iteration 5 there was nothing left to answer it. The
+    change was fixable; the run reported FAILED because three checks shared one pool."""
+    from orchestrator.sdlc import feature_runner as fr
+
+    types_seen = {"n": 0}
+    gaps_seen = {"n": 0}
+
+    async def _typecheck(path: Path, testenv: Any, files: list[str], emit: Any) -> str:
+        types_seen["n"] += 1
+        return "cli.py:1: error: boom  [attr-defined]" if types_seen["n"] <= 2 else ""
+
+    async def _probe(path: Path, files: list[str], runner: Any, emit: Any) -> list[str]:
+        gaps_seen["n"] += 1
+        return ["src/orchestrator/cli.py"] if gaps_seen["n"] == 1 else []
+
+    class _Covering(_StubCodegen):
+        async def refine(self, **kwargs: Any) -> CodeChange:
+            self.refine_calls += 1
+            return CodeChange(files=["src/x.py"], summary="fixed the type error")
+
+        async def author_tests(self, **kwargs: Any) -> CodeChange:
+            if kwargs.get("gaps"):
+                self.gaps_seen.append(list(kwargs["gaps"]))
+                return CodeChange(files=["tests/test_cli.py"], summary="cover the wiring")
+            return CodeChange(files=[], summary="tests")
+
+    monkeypatch.setattr(fr, "_typecheck_the_change", _typecheck)
+    monkeypatch.setattr(fr, "_files_no_test_exercises", _probe)
+    created = _install_pipeline(monkeypatch, tmp_path, runner=_PassingRunner, codegen=_Covering)
+    monkeypatch.setattr("orchestrator.sdlc.review.SemanticReviewAdapter", _Judge("approve"))
+
+    # Two type errors consume the type allowance; the coverage gap must still be answerable.
+    result = await run_feature("file://./spec.md", intent_id="intent-a", max_refine=2)
+
+    assert result.passed
+    assert created[0].refine_calls == 2  # both type errors corrected
+    assert created[0].gaps_seen == [["src/orchestrator/cli.py"]]  # and the gap still got its turn


### PR DESCRIPTION
The first `--live` run failed on a change that was fixable. It spent iterations 1–2 on real test failures and 3–4 on type errors, so when the coverage probe found its gap on iteration 5 there was nothing left to answer it with:

```
[typecheck] clean on the changed lines
[coverage] nothing exercises the change in: cli.py
VERDICT: FAILED after 5 test run(s) — not opening a PR
```

Three checks were drawing on one pool. `--max-refine` went 3 → 5 when the type checker joined the loop, then the coverage probe was added without revisiting it — so the newest check is the one that never gets its turn.

### Each kind of problem gets its own allowance

A red suite, a type error and a coverage gap can no longer starve one another, under a hard ceiling so a pathological run still terminates. `--max-refine` accordingly means **correction attempts per check** rather than total test runs — it always read as "test→refine loops", and now it is one.

A new test pins it: two type errors consume the type allowance and the coverage gap still gets its turn.

### A failed live run hands its ticket back

The ticket is moved to In Progress before codegen so the board shows the work being picked up. A run that then fails has produced no branch and no PR, and leaving it In Progress tells everyone looking at the board that someone is on it — SSPN-14 sat exactly like that after the run above.

Best-effort and never fatal, like every other transition, and it says plainly when it could not, so nobody assumes the ticket was tidied up.

---

**Gate:** `mypy src tests` clean (595 files), `ruff check` clean, full sdlc suite 586 passed.

Refs SSPN-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
