### PR TITLE
fix(sdlc): an empty submission is not an answer, and a raised error still owes the ticket back

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,11 +24,16 @@ ANTHROPIC_API_KEY=sk-ant-...
 # ollama/* model below. Local: http://localhost:11434
 # OLLAMA_API_BASE=http://localhost:11434
 
-# Model selection — one model drives everything unless overridden. Set this
-# explicitly: a slow default can time out on large generations.
-# ORCHESTRATOR_INTAKE_MODEL=gpt-4o
-# SDLC_CODEGEN_MODEL=gpt-4o            # codegen; inherits INTAKE_MODEL if unset
-# SDLC_REVIEW_MODEL=gpt-4o            # PR review; inherits INTAKE_MODEL if unset
+# Model selection — every stage resolves independently: its own variable, then
+# ORCHESTRATOR_MODEL, then the built-in default. `orchestrator models` lists the
+# ids with context windows and prices, and marks the ones that CANNOT do the
+# forced tool call that codegen and the acceptance judge both require — on those,
+# both silently fall back to parsing prose out of a text reply.
+# ORCHESTRATOR_MODEL=claude-opus-5     # one knob for every stage (the default)
+# SDLC_CODEGEN_MODEL=                  # codegen only; falls back to INTAKE_MODEL
+# SDLC_JUDGE_MODEL=                    # the acceptance judge only
+# ORCHESTRATOR_INTAKE_MODEL=           # intent extraction + spec writing
+# SDLC_REVIEW_MODEL=                   # PR review; inherits INTAKE_MODEL if unset
 
 
 # ============================================================================

--- a/src/orchestrator/init_scaffold.py
+++ b/src/orchestrator/init_scaffold.py
@@ -15,11 +15,23 @@ from __future__ import annotations
 from collections.abc import Mapping
 from pathlib import Path
 
+from orchestrator.core.llm import catalog
 from orchestrator.doctor import ENV_GROUPS
 
 # Known-useful optional vars worth scaffolding as commented hints, beyond the
 # required groups doctor enforces.
 _OPTIONAL_HINTS: tuple[tuple[str, str], ...] = (
+    # Model selection was scaffolded nowhere, so the only way to learn a stage could be
+    # pointed somewhere else was to read the source — and three of the four stages could
+    # not be pointed anywhere at all. `orchestrator models` lists the ids with prices and
+    # marks the ones that cannot do the forced tool call codegen and the judge require.
+    (
+        "ORCHESTRATOR_MODEL",
+        f"Model for every stage (default {catalog.DEFAULT_MODEL}); see `orchestrator models`",
+    ),
+    ("SDLC_CODEGEN_MODEL", "Model for codegen only — implement / refine / revise / author_tests"),
+    ("SDLC_JUDGE_MODEL", "Model for the acceptance judge only"),
+    ("ORCHESTRATOR_INTAKE_MODEL", "Model for intake only — intent extraction and spec writing"),
     ("ORCHESTRATOR_DATABASE_URL", "Postgres URL (defaults to the docker-compose dev DB)"),
     ("SLACK_WEBHOOK_URL", "Slack incoming-webhook for approval-gate alerts (optional)"),
     ("SDLC_RUN_BUDGET_USD", "Per-run LLM spend cap; 0 disables enforcement (default 25)"),

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -282,6 +282,7 @@ class CodegenError(RuntimeError):
         missing_edit_paths: list[str] | None = None,
         failed_anchors: dict[str, list[str]] | None = None,
         parse_detail: str = "",
+        empty_summary: str = "",
     ) -> None:
         super().__init__(message)
         self.failed_edit_paths = list(failed_edit_paths or [])
@@ -294,6 +295,9 @@ class CodegenError(RuntimeError):
         # inferred from two empty path lists: "no edits failed" and "nothing parsed" are
         # different failures and want different retries.
         self.parse_detail = parse_detail
+        # Set when the model answered in the right shape but submitted no files. Its own
+        # summary is the useful part — it usually says why it thought nothing was needed.
+        self.empty_summary = empty_summary
 
 
 @runtime_checkable
@@ -1485,6 +1489,16 @@ class LLMCodegenAdapter:
                 extra={"failed": exc.failed_edit_paths, "missing": exc.missing_edit_paths},
             )
             return self._repair_block(exc, root)
+        if exc.empty_summary:
+            logger.warning("sdlc.codegen.empty_retry summary=%r", exc.empty_summary[:160])
+            return (
+                "\n\nYOUR PREVIOUS ATTEMPT SUBMITTED NO FILES. You said:\n"
+                f"  {exc.empty_summary}\n"
+                "That is not an answer this stage can use — it needs at least one file. If "
+                "you believe the work is already done, you are looking at the wrong thing: "
+                "say what you would write and write it. Re-emit with a non-empty `files` "
+                "list.\n"
+            )
         return None
 
     def _repair_block(self, exc: CodegenError, root: Path) -> str:
@@ -1587,7 +1601,15 @@ class LLMCodegenAdapter:
             if allow_empty:
                 logger.info("sdlc.codegen.empty_refine summary=%r", str(payload.get("summary") or "")[:160])
                 return CodeChange(summary=str(payload.get("summary") or "").strip())
-            raise CodegenError("model output had no 'files' list")
+            # Recoverable, not fatal. The forced tool call means the model *did* answer in
+            # the right shape — it just submitted zero files, which the schema allows
+            # (`required` means present, not non-empty). A live run died here after a
+            # clean implement pass because author_tests came back empty and nothing asked
+            # it to try again.
+            raise CodegenError(
+                "model output had no 'files' list",
+                empty_summary=str(payload.get("summary") or "").strip() or "(no summary given)",
+            )
         return apply_files(
             files,
             root,

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -957,17 +957,28 @@ async def run_feature(
 
     # Attribute each leg's LLM spans + token ledger to a named stage, so the trace
     # reads implement / author_tests / refine instead of "unattributed".
-    with llm.stage("implement"):
-        impl = await codegen.implement(
-            spec=spec, path=str(path), issue_key=issue_key, skills=capability_plan.skills
-        )
-    emit(f"[implement] {[Path(f).name for f in impl.files]} - {impl.summary}")
-    # SQL is single-phase: the migration IS the artifact and is validated by applying
-    # it to an ephemeral database, so there is no separate test-authoring leg.
-    if lang != "sql":
-        with llm.stage("author_tests"):
-            tests = await codegen.author_tests(spec=spec, path=str(path), issue_key=issue_key)
-        emit(f"[author_tests] {[Path(f).name for f in tests.files]} - {tests.summary}")
+    #
+    # Everything from here to the PR runs inside the ticket-release guard. Handing the
+    # ticket back was wired only into the "tests stayed red" path, so a codegen error —
+    # the thing most likely to end a run early — sailed past it and left the ticket
+    # In Progress anyway. A live run did exactly that, twice.
+    try:
+        with llm.stage("implement"):
+            impl = await codegen.implement(
+                spec=spec, path=str(path), issue_key=issue_key, skills=capability_plan.skills
+            )
+        emit(f"[implement] {[Path(f).name for f in impl.files]} - {impl.summary}")
+        # SQL is single-phase: the migration IS the artifact and is validated by applying
+        # it to an ephemeral database, so there is no separate test-authoring leg.
+        if lang != "sql":
+            with llm.stage("author_tests"):
+                tests = await codegen.author_tests(spec=spec, path=str(path), issue_key=issue_key)
+            emit(f"[author_tests] {[Path(f).name for f in tests.files]} - {tests.summary}")
+    except Exception:
+        # Release and re-raise: the caller still sees the real failure, and the board no
+        # longer claims someone is working the ticket.
+        await _release_the_ticket(move, emit)
+        raise
 
     passed = False
     iterations = 0

--- a/tests/core/llm/test_catalog.py
+++ b/tests/core/llm/test_catalog.py
@@ -85,3 +85,22 @@ class TestToolCallingIsARequirement:
     def test_render_points_at_the_current_model(self) -> None:
         rows = [catalog.ModelInfo("a", "anthropic", 1, 1.0, 2.0, supports_tools=True)]
         assert "←" in catalog.render(rows, current="a")
+
+
+class TestTheScaffoldMentionsThem:
+    """A variable nobody can discover is not configuration. Model selection was
+    scaffolded nowhere, so `orchestrator init` produced a `.env` that never hinted a
+    stage could be pointed somewhere else."""
+
+    def test_every_stage_variable_reaches_the_env_template(self) -> None:
+        from orchestrator.init_scaffold import render_env_template
+
+        template = render_env_template({})
+        for stage, names in catalog.STAGE_ENV.items():
+            for name in names:
+                assert name in template, f"{name} ({stage}) missing from the .env scaffold"
+
+    def test_the_default_is_named_so_you_know_what_you_get(self) -> None:
+        from orchestrator.init_scaffold import render_env_template
+
+        assert catalog.DEFAULT_MODEL in render_env_template({})

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -207,11 +207,28 @@ async def test_rejects_absolute_path(tmp_path: Path) -> None:
         await adapter.implement(spec=_SPEC, path=str(tmp_path), issue_key="SDLC-1")
 
 
-async def test_rejects_output_with_no_files(tmp_path: Path) -> None:
-    llm = _ScriptedLLM(['{"summary": "I did nothing"}'])
+async def test_a_submission_with_no_files_is_retried_then_refused(tmp_path: Path) -> None:
+    """Empty is recoverable, not fatal. The forced tool call means the model answered in
+    the right shape and simply submitted nothing — the schema allows it, since `required`
+    means present, not non-empty. A live run died here after a clean implement pass
+    because author_tests came back empty and nothing asked it to try again."""
+    llm = _ScriptedLLM(['{"summary": "I did nothing"}', '{"summary": "still nothing"}'])
     adapter = LLMCodegenAdapter(llm)
+
     with pytest.raises(CodegenError):
         await adapter.implement(spec=_SPEC, path=str(tmp_path), issue_key="SDLC-1")
+
+    assert len(llm.calls) == 2  # one corrective retry, then it gives up
+    assert "SUBMITTED NO FILES" in llm.calls[1][1].content
+    assert "I did nothing" in llm.calls[1][1].content  # its own words, fed back
+
+
+async def test_a_retried_empty_submission_can_succeed(tmp_path: Path) -> None:
+    llm = _ScriptedLLM(['{"summary": "nothing to do"}', _files_response({"src/a.py": "a = 1\n"})])
+
+    change = await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="S-1")
+
+    assert [Path(f).name for f in change.files] == ["a.py"]
 
 
 async def test_refine_tolerates_a_no_op_response(tmp_path: Path) -> None:
@@ -807,14 +824,15 @@ async def test_anchor_repair_gives_up_after_one_retry(tmp_path: Path) -> None:
     assert len(llm.calls) == 2  # initial + exactly one repair
 
 
-async def test_no_repair_for_non_edit_failures(tmp_path: Path) -> None:
-    """A response with no files at all fails immediately — repair is only for
-    anchor misses."""
-    llm = _ScriptedLLM([json.dumps({"files": [], "summary": "nothing"})])
+async def test_the_empty_retry_is_spent_once(tmp_path: Path) -> None:
+    """One corrective pass, not a loop: a model that submits nothing twice has said its
+    piece, and a third call would just pay to watch it repeat."""
+    empty = json.dumps({"files": [], "summary": "nothing"})
+    llm = _ScriptedLLM([empty, empty])
     adapter = LLMCodegenAdapter(llm)
     with pytest.raises(CodegenError, match="no 'files'"):
         await adapter.implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
-    assert len(llm.calls) == 1
+    assert len(llm.calls) == 2
 
 
 async def test_new_root_module_shadowing_stdlib_is_rejected(tmp_path: Path) -> None:

--- a/tests/sdlc/test_feature_runner.py
+++ b/tests/sdlc/test_feature_runner.py
@@ -1255,3 +1255,24 @@ async def test_each_check_gets_its_own_allowance(monkeypatch: pytest.MonkeyPatch
     assert result.passed
     assert created[0].refine_calls == 2  # both type errors corrected
     assert created[0].gaps_seen == [["src/orchestrator/cli.py"]]  # and the gap still got its turn
+
+
+async def test_a_codegen_error_hands_the_ticket_back(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Releasing the ticket was wired only into the "tests stayed red" path, so a codegen
+    error — the thing most likely to end a run early — sailed past it. A live run failed
+    at author_tests and left SSPN-14 In Progress with no branch and no PR."""
+    from orchestrator.sdlc.codegen import CodegenError
+
+    class _ExplodingCodegen(_StubCodegen):
+        async def author_tests(self, **kwargs: Any) -> CodeChange:
+            raise CodegenError("model output had no 'files' list")
+
+    jira = _FakeJira()
+    _install_pipeline(monkeypatch, tmp_path, runner=_PassingRunner, codegen=_ExplodingCodegen, jira=jira)
+
+    with pytest.raises(CodegenError):
+        await run_feature(
+            "file://./spec.md", intent_id="intent-a", repo="https://x/widget", live=True, issue="SSPN-1"
+        )
+
+    assert jira.transitions == ["In Progress", "To Do"]


### PR DESCRIPTION
The first live run to clear codegen died one stage later:

```
[implement] ['contract.py', 'cli.py', 'USER_GUIDE.md'] — `mcp contracts` now renders
  inputs as `name (type)` … (models.py and core/llm/client.py needed no change — the
  plan was wrong there)
CodegenError: model output had no 'files' list
```

Implement was good: it wrote the change *and* rejected two files the design told it to touch. Then `author_tests` called `submit_files` with an empty array and the run ended.

### An empty submission is recoverable, not fatal

The forced tool call means the model answered in exactly the right shape — it just submitted nothing, which the schema permits, because `required` means present, not non-empty.

Nothing asked it to try again. `_corrective_suffix` had a branch for unparseable output and one for failed anchors, and returned `None` for this, so `_generate` re-raised on the first attempt. It now gets **one** corrective pass — quoting the model's own summary back at it, since that usually says why it thought nothing was needed — and gives up after that rather than looping.

### A raised error still owes the ticket back

Handing the ticket to To Do was wired only into the "tests stayed red" path, so a codegen error — the likeliest way for a run to end early — sailed straight past it. **Both** live runs left SSPN-14 In Progress with no branch and no PR.

The implement and author_tests legs now run inside a release-and-re-raise guard: the caller still sees the real failure, and the board no longer claims someone is working the ticket. This is a follow-up to a gap in #119, which introduced the hand-back and covered only one of the two ways a run ends.

### Also here

`orchestrator init` writes a `.env` from the same definitions `doctor` checks, and neither mentioned model selection at all — so the only way to learn a stage could be pointed somewhere else was to read the source. `.env.example` was worse than silent: it said *"one model drives everything unless overridden"* and listed three `gpt-4o` lines, describing a single-knob world that no longer exists and naming a model two generations old.

The repo's own `test_every_optional_hint_is_documented` caught the omission when I added hints to one file and not the other. A companion test now walks `STAGE_ENV` against the rendered template, so a stage variable added later without a scaffold entry fails rather than quietly becoming undiscoverable.

### Tests

Two asserted the old fail-immediately behaviour and now assert the retry; a third pins the exception path, which had no coverage at all.

---

**Gate:** `mypy src tests` clean (597 files), `ruff check` clean, 2356 passed / 30 skipped.

Refs SSPN-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
