### PR TITLE
fix(sdlc): editing the repo's own docs is not inventing a path

### DIFF
--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -1052,8 +1052,17 @@ class LLMCodegenAdapter:
             f"- Import source as `from {layout.package_name}.<module> import ...` "
             "(the test runner puts the source root on the path).\n"
             f"- Put tests under `{layout.tests_dir}/` as `{layout.tests_dir}/test_<name>.py`.\n"
-            f"- Do NOT create files outside `{layout.source_dir}/` and `{layout.tests_dir}/`, "
-            "and do NOT invent unrelated top-level paths.\n\n"
+            f"- Put NEW code and tests under `{layout.source_dir}/` and `{layout.tests_dir}/` "
+            "only, and do NOT invent unrelated top-level paths or parallel package trees.\n"
+            # The ban used to be absolute — "do NOT create files outside src/ and tests/" —
+            # which is right about invented paths and wrong about the repo's own docs. It
+            # made every documentation criterion unsatisfiable: the judge required a
+            # USER_GUIDE note, this line forbade touching USER_GUIDE.md, and the model
+            # obeyed and said so ("outside the allowed src/tests paths so the doc note was
+            # not added"). Editing a file the repo already has is not inventing a path.
+            "- You MAY edit files that already exist elsewhere in the repo — README, "
+            "USER_GUIDE, CHANGELOG, pyproject.toml — when the ticket calls for it. Changing "
+            "an existing file is not inventing a path; creating a new top-level one is.\n\n"
         )
 
     def _language(self) -> str:

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1424,3 +1424,28 @@ async def test_no_existing_tests_is_not_an_error(tmp_path: Path) -> None:
     from orchestrator.sdlc.codegen import _existing_test_examples
 
     assert _existing_test_examples({"summary": "x"}, tmp_path, "touch src/app/nothing.py") == ""
+
+
+async def test_the_layout_permits_editing_the_repo_s_own_docs(tmp_path: Path) -> None:
+    """The layout block is stamped "authoritative — overrides any default path guidance"
+    and leads every phase prompt, so its absolute ban on files outside src/ and tests/
+    beat the revise prompt's explicit permission to write documentation. A run said so in
+    its own summary: "USER_GUIDE.md is outside the allowed src/tests paths so the doc note
+    was not added" — while the judge was failing the ticket for the missing doc."""
+    from orchestrator.sdlc.codegen import LLMCodegenAdapter
+    from orchestrator.sdlc.layout import TargetLayout
+
+    layout = TargetLayout(
+        package_name="app",
+        source_dir="src/app",
+        tests_dir="tests",
+        src_layout=True,
+        mode="existing",
+        language="python",
+    )
+    block = LLMCodegenAdapter(_ScriptedLLM([]), layout=layout)._layout_block()
+
+    assert "MAY edit files that already exist" in block
+    assert "USER_GUIDE" in block
+    # The part that was right stays: invented paths are still refused.
+    assert "do NOT invent unrelated top-level paths" in block


### PR DESCRIPTION
The documentation criterion has now been unwinnable three times for three different reasons. This is the third, and it is the one that silently overrode the fix for the first.

The layout block is stamped **"authoritative — overrides any default path guidance"** and leads every phase prompt. It said:

```
Do NOT create files outside `src/orchestrator/` and `tests/`, and do NOT invent
unrelated top-level paths.
```

So the explicit permission to write documentation — added to the `revise` prompt precisely because the judge kept failing tickets for a missing doc — lost to a line that outranks it. The model obeyed and said so in its own summary, in the same run the judge was failing for the missing note:

> `USER_GUIDE.md is outside the allowed src/tests paths so the doc note was not added`

### What changed

The ban is right about what it was written for. Leaked `src/orchestrator/pkg/...` paths in unrelated repos are a real failure, and inventing a parallel package tree is still refused. It was simply overbroad: a repo's `README`, `USER_GUIDE`, `CHANGELOG` and `pyproject.toml` are files that already exist, and changing one is not inventing a path.

New code and tests stay confined to the source and test directories. Editing what the repo already has is now explicitly allowed, with the four common cases named so the permission is concrete rather than a hedge.

### Worth noting

The layout block outranks every other prompt by its own wording, and nothing tested what it forbade. That is now three cycles lost to a fence nobody checked — a test pins this one, but any future "the model won't do X" is worth treating as a layout-block question first.

It also remains a prompt, not a check. This should let the model write the doc; nothing here guarantees it will.

---

**Gate:** `mypy src tests` clean (597 files), `ruff check` clean, sdlc suite 589 passed.

Refs SSPN-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
