### PR TITLE
fix(sdlc): generated Python that does not parse never reaches disk

### DIFF
--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -16,6 +16,7 @@ they may do real I/O; the workflow only ever sees the returned dataclasses.
 
 from __future__ import annotations
 
+import ast
 import json
 import logging
 import os
@@ -1651,6 +1652,7 @@ def apply_files(
     edit_failures: list[str] = []
     edit_failure_paths: list[str] = []
     attempted_anchors: dict[str, list[str]] = {}
+    syntax_failures: list[str] = []
     missing_targets: list[str] = []  # edits aimed at a file that doesn't exist yet
     tracked_now = written_tracker.get(root.resolve(), [])
     for entry in files:
@@ -1687,6 +1689,11 @@ def apply_files(
                 continue
             if len(patched.encode("utf-8")) > _MAX_PATCHED_FILE_BYTES:
                 edit_failures.append(f"{rel}: patched file exceeds {_MAX_PATCHED_FILE_BYTES} bytes")
+                continue
+            broken = _python_syntax_error(rel, patched)
+            if broken:
+                edit_failures.append(broken)
+                syntax_failures.append(rel)
                 continue
             target.write_text(patched, encoding="utf-8")
             written.append(str(target))
@@ -1725,6 +1732,14 @@ def apply_files(
             continue
         if len(content.encode("utf-8")) > _MAX_FILE_BYTES:
             raise CodegenError(f"generated file {rel!r} exceeds {_MAX_FILE_BYTES} bytes")
+        broken = _python_syntax_error(rel, content)
+        if broken:
+            # Never write it. A file that does not parse turns the whole suite into a
+            # collection error, and every later stage then reads an unrelated wall of
+            # pytest traceback instead of one line naming the problem.
+            edit_failures.append(broken)
+            syntax_failures.append(rel)
+            continue
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
         written.append(str(target))
@@ -1749,7 +1764,7 @@ def apply_files(
     # (skipped), an edit that failed to anchor, or edits aimed at a file that
     # doesn't exist yet — all trigger ONE repair retry (even when other files
     # landed), so a create+edit feature never silently ships half the change.
-    unmodified_existing = edit_failure_paths + skipped
+    unmodified_existing = edit_failure_paths + skipped + syntax_failures
     if unmodified_existing or missing_targets:
         notes = [
             f"skipped existing (use edits, not full content): {', '.join(skipped)}" if skipped else "",
@@ -2039,6 +2054,31 @@ def _coverage_gap_block(gaps: list[str]) -> str:
         "user does — through the command or public function that was changed, not through a "
         "helper it calls, or the same gap will still be there.\n"
     )
+
+
+def _python_syntax_error(rel: str, source: str) -> str:
+    """``""`` when this parses, otherwise one line naming exactly what is wrong.
+
+    Generated Python is checked before it reaches disk. A live run wrote a test file
+    ending in a stray ``</content>`` — markup that leaked out of the tool payload into
+    the file body — and the only symptom anyone saw was ``rc=2`` from pytest three
+    stages later, buried in an importlib traceback. The refine loop spent both of its
+    attempts on that and never found the line.
+
+    ``ast.parse`` costs nothing, runs no model, and turns the whole thing into a
+    sentence: file, line, and the offending text.
+    """
+    if not rel.endswith(".py"):
+        return ""
+    try:
+        ast.parse(source)
+    except SyntaxError as exc:
+        offending = (exc.text or "").strip()
+        where = f"{rel}: line {exc.lineno}"
+        return f"{where}: {exc.msg}" + (f" — {offending!r}" if offending else "")
+    except ValueError as exc:  # e.g. a NUL byte in the payload
+        return f"{rel}: not parseable as Python ({exc})"
+    return ""
 
 
 def _named_existing_files(spec: dict[str, Any], root: Path, design: str = "") -> str:

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1449,3 +1449,50 @@ async def test_the_layout_permits_editing_the_repo_s_own_docs(tmp_path: Path) ->
     assert "USER_GUIDE" in block
     # The part that was right stays: invented paths are still refused.
     assert "do NOT invent unrelated top-level paths" in block
+
+
+# ---- generated Python that does not parse never reaches disk (SSPN-14) ----
+
+
+async def test_unparseable_generated_python_is_refused_and_repaired(tmp_path: Path) -> None:
+    """A live run wrote a test file ending in a stray `</content>` — markup that leaked
+    out of the tool payload into the file body. The only symptom was `rc=2` from pytest
+    three stages later, buried in an importlib traceback; refine spent both attempts on
+    that and never found the line."""
+    broken = _files_response({"src/a.py": "def f():\n    return 1\n</content>\n"})
+    good = _files_response({"src/a.py": "def f():\n    return 1\n"})
+    llm = _ScriptedLLM([broken, good])
+
+    change = await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="S-1")
+
+    assert len(llm.calls) == 2  # the syntax error bought a corrective retry
+    assert "</content>" not in (tmp_path / "src" / "a.py").read_text()
+    assert [Path(f).name for f in change.files] == ["a.py"]
+
+
+async def test_the_repair_names_the_line(tmp_path: Path) -> None:
+    from orchestrator.sdlc.codegen import _python_syntax_error
+
+    err = _python_syntax_error("tests/test_x.py", "def f():\n    return 1\n</content>\n")
+
+    assert "line 3" in err and "</content>" in err
+
+
+async def test_a_broken_file_is_never_written(tmp_path: Path) -> None:
+    """Not written, not left behind: an unparseable module turns the whole suite into a
+    collection error, so every later stage reads an unrelated traceback instead."""
+    llm = _ScriptedLLM([_files_response({"src/bad.py": "def f(\n"})] * 2)
+
+    with pytest.raises(CodegenError):
+        await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="S-2")
+
+    assert not (tmp_path / "src" / "bad.py").exists()
+
+
+async def test_non_python_files_are_not_syntax_checked(tmp_path: Path) -> None:
+    """Markdown is not Python. The doc a criterion demands must still get written."""
+    llm = _ScriptedLLM([_files_response({"USER_GUIDE.md": "# Step 9\n\nnot <<< python\n"})])
+
+    change = await LLMCodegenAdapter(llm).implement(spec=_SPEC, path=str(tmp_path), issue_key="S-3")
+
+    assert [Path(f).name for f in change.files] == ["USER_GUIDE.md"]


### PR DESCRIPTION
A live run wrote a test file ending in a stray `</content>` — markup that leaked out of the tool payload and into the file body. Nobody saw that. What they saw was:

```
[run_tests #1] passed=False rc=2
[refine] ['test_schema_types.py'] - placeholder
[run_tests #2] passed=False rc=2
[refine] [] -
[refine] no file changes — not fixable by editing code; stopping early
```

`rc=2` is pytest failing to **collect**, and the `SyntaxError` naming line 188 was buried in an importlib traceback. The refine loop spent both of its attempts on that and never found the line; the run then ended by calling a one-line syntax error *"not fixable by editing code"*.

### Generated Python is parsed before it is written

`ast.parse` costs nothing, runs no model, and turns the whole thing into a sentence:

```
tests/mcp/test_schema_types.py: line 188: invalid syntax — '</content>'
```

That is a repairable failure, so it takes the same corrective retry as a failed edit anchor — and arrives with the exact line instead of a wall of traceback.

### Not written, not left behind

An unparseable module turns the entire suite into a collection error, so every later stage — refine, the type check, the coverage probe — reads an unrelated failure rather than the real one. Refusing the write keeps the worktree usable for the retry.

Only `.py` is checked. Markdown is not Python, and the doc a criterion demands must still get written — there's a test for that, since forbidding the doc has already cost three cycles by other routes.

### Verified against the real file

The helper was run against the actual artifact from the failed run, which is how the line was found — not against a fixture written to match a guess.

---

**Gate:** `mypy src tests` clean (597 files), `ruff check` clean, 2361 passed / 30 skipped. Rebased onto develop after #122.

Refs SSPN-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
