### PR TITLE
fix(sdlc): no context builder drops a file silently

### DIFF
--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -1402,6 +1402,7 @@ class LLMCodegenAdapter:
 
     async def refine(self, *, spec: dict[str, Any], path: str, issue_key: str, failures: str) -> CodeChange:
         root = Path(path)
+        fail_anchors = _spec_anchors(failures)
         return await self._generate(
             self._condition_system(self._refine_system(), self._skills, phase="refine"),
             f"{self._layout_block()}{self._grounding(spec, root)}{self._design_block()}Issue: {issue_key}\n\n"
@@ -1409,7 +1410,9 @@ class LLMCodegenAdapter:
             "IMPORTANT: Fix the IMPLEMENTATION files only. Do NOT modify test files to "
             "make them match a broken implementation — fix the source code so the tests "
             "pass as written.\n\n"
-            f"CURRENT FILES:\n{self._session_files(root, include_tests=True)}"
+            # Aim the windows at whatever the traceback names: on a big file the excerpt
+            # should cover the line that failed, not the top of the module.
+            f"CURRENT FILES:\n{self._session_files(root, include_tests=True, anchors=fail_anchors)}"
             f"{_named_existing_files(spec, root, self._design)}{self._convention_block(root)}\n\n"
             f"FAILURE OUTPUT:\n{_truncate(failures, _MAX_CONTEXT_BYTES)}\n\n"
             f"{self._definitions_for(failures, root)}",
@@ -1569,7 +1572,7 @@ class LLMCodegenAdapter:
             )
         return "".join(chunks)
 
-    def _session_files(self, root: Path, *, include_tests: bool) -> str:
+    def _session_files(self, root: Path, *, include_tests: bool, anchors: list[str] | None = None) -> str:
         """The files this adapter wrote under ``root``, as a labeled prompt block.
 
         In Block C the worktree starts empty, so "everything in the worktree"
@@ -1583,16 +1586,20 @@ class LLMCodegenAdapter:
             written = [p for p in written if not p.name.startswith("test_")]
         if not written:
             return _read_worktree(root, include_tests=include_tests)
-        chunks: list[str] = []
-        budget = _MAX_CONTEXT_BYTES
-        for file in written:
-            block = f"--- {file.resolve().relative_to(root.resolve())} ---\n"
-            block += file.read_text(encoding="utf-8") + "\n"
-            if len(block) > budget:
-                break
-            budget -= len(block)
-            chunks.append(block)
-        return "".join(chunks)
+        # Fair allocation, never a `break`. This loop used to stop at the first file that
+        # did not fit, dropping every file after it — and a live run edited `models.py`
+        # (1.8 KB), broke it, and then could not repair it because `cli.py` (91 KB) came
+        # earlier in the list and ended the loop. The model said so plainly: "that file's
+        # current content was not provided, so I have no verbatim anchor to edit it
+        # safely." It was right. Third copy of this bug; the other two were the judge's
+        # reader and the anchor-repair block.
+        return _excerpt_files(
+            root,
+            [str(f.resolve().relative_to(root.resolve())) for f in written],
+            budget=_MAX_CONTEXT_BYTES,
+            anchors_by_path={str(f.resolve().relative_to(root.resolve())): anchors or [] for f in written},
+            label="written this session",
+        )
 
     async def _complete(self, system: str, user: str) -> str:
         result = await self._llm.complete(
@@ -2199,7 +2206,10 @@ def _read_worktree(root: Path, *, include_tests: bool) -> str:
     Skips ``.git`` and (optionally) ``test_*`` files; caps the total size so a
     big worktree can't blow past the model's context.
     """
+    # Skip-don't-break, for the same reason as everywhere else in this module: one big
+    # module must not hide every file sorted after it.
     chunks: list[str] = []
+    skipped: list[str] = []
     budget = _MAX_CONTEXT_BYTES
     for file in sorted(root.rglob("*.py")):
         if ".git" in file.parts:
@@ -2213,9 +2223,12 @@ def _read_worktree(root: Path, *, include_tests: bool) -> str:
         rel = file.relative_to(root)
         block = f"--- {rel} ---\n{body}\n"
         if len(block) > budget:
-            break
+            skipped.append(str(rel))
+            continue
         budget -= len(block)
         chunks.append(block)
+    if skipped:
+        chunks.append(f"--- [{len(skipped)} file(s) omitted for size: {', '.join(skipped)}] ---\n")
     return "".join(chunks) if chunks else "(worktree is empty)"
 
 

--- a/src/orchestrator/sdlc/grounding.py
+++ b/src/orchestrator/sdlc/grounding.py
@@ -80,12 +80,22 @@ class PKGCodegenGrounder:
         symbols = self._retriever.api_surface(_spec_query(spec))
         blocks: list[str] = []
         budget = _MAX_CONTEXT_CHARS
+        # Skip what does not fit; never stop. `break` here means one oversized symbol
+        # hides every symbol ranked below it — the same silent-drop that cost three
+        # separate runs in the codegen context builders.
+        skipped = 0
         for symbol in symbols:
             block = self._symbol_block(symbol)
             if len(block) > budget:
-                break
+                skipped += 1
+                continue
             budget -= len(block)
             blocks.append(block)
+        if skipped:
+            blocks.append(
+                f"\n[{skipped} further symbol(s) omitted for size — their absence is not "
+                "evidence they do not exist.]\n"
+            )
         if blocks:
             sections.append(
                 "EXISTING CODEBASE CONTEXT (from the Product Knowledge Graph — real "

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1534,3 +1534,50 @@ def test_each_failure_kind_is_classified_apart() -> None:
     assert _failure_kind(CodegenError("x", syntax_errors=["a.py: line 1"])) == "syntax"
     assert _failure_kind(CodegenError("x", failed_edit_paths=["a.py"])) == "anchors"
     assert _failure_kind(CodegenError("x", empty_summary="did nothing")) == "empty"
+
+
+async def test_a_big_file_no_longer_hides_the_small_ones_from_refine(tmp_path: Path) -> None:
+    """The live failure, stated by the model itself: "the failure is in models.py … but
+    that file's current content was not provided, so I have no verbatim anchor to edit it
+    safely." It was right — `cli.py` was 91 KB against a 40 KB budget, the loop hit
+    `break`, and every file after it was dropped. `models.py` was 1.8 KB."""
+    from orchestrator.sdlc.codegen import _MAX_CONTEXT_BYTES
+
+    for rel, body in (
+        ("small_first.py", "a = 1\n"),
+        ("huge.py", "# " + "x" * (_MAX_CONTEXT_BYTES + 5_000)),
+        ("tiny_last.py", "class MCPTool:\n    server: str\n"),
+    ):
+        target = tmp_path / rel
+        target.write_text(body, encoding="utf-8")
+
+    adapter = LLMCodegenAdapter(_ScriptedLLM([]))
+    adapter._written[tmp_path.resolve()] = [
+        tmp_path / r for r in ("small_first.py", "huge.py", "tiny_last.py")
+    ]
+
+    block = adapter._session_files(tmp_path, include_tests=True)
+
+    # The file *after* the oversized one is the whole point.
+    assert "tiny_last.py" in block
+    assert "class MCPTool" in block
+    assert "small_first.py" in block
+    assert "huge.py" in block  # windowed, not dropped
+
+
+async def test_refine_windows_land_on_what_the_traceback_names(tmp_path: Path) -> None:
+    """On a file too big to show whole, the excerpt should cover the failing line rather
+    than the top of the module."""
+    from orchestrator.sdlc.codegen import _MAX_CONTEXT_BYTES
+
+    needle = "def the_function_that_broke() -> None:"
+    filler = "\n".join(f"def pad_{i}() -> int:\n    return {i}\n" for i in range(_MAX_CONTEXT_BYTES // 18))
+    half = len(filler) // 2
+    (tmp_path / "big.py").write_text(filler[:half] + f"\n{needle}\n" + filler[half:], encoding="utf-8")
+
+    adapter = LLMCodegenAdapter(_ScriptedLLM([]))
+    adapter._written[tmp_path.resolve()] = [tmp_path / "big.py"]
+
+    block = adapter._session_files(tmp_path, include_tests=True, anchors=["the_function_that_broke"])
+
+    assert needle in block


### PR DESCRIPTION
The model said exactly what was wrong, in English:

> Cannot proceed: the failure is in `src/orchestrator/mcp/models.py` (MCPTool dataclass has a non-default field after a defaulted one), but **that file's current content was not provided, so I have no verbatim anchor to edit it safely**.

It was right.

### The arithmetic

`_session_files` — the block `refine` reads — walked the files written this session and stopped at the first one that did not fit:

```
cli.py              91,544 bytes
_MAX_CONTEXT_BYTES  40,000 bytes
models.py            1,819 bytes   ← after cli.py in the list, dropped
```

So refine edited `models.py` blind, broke it, and then could not repair it, because a 91 KB file earlier in the list had ended the loop. Three test runs and the entire correction budget went on a file the model had never been shown.

### The third copy of one bug

This is the same `break` twice fixed already: the acceptance judge's reader dropped a 100 KB `cli.py` and reported the change absent; the anchor-repair block promised *"copy every `find` snippet VERBATIM from this content"* above nothing. Both were fixed at the time. This loop was not — and it is the one `refine` depends on.

`_session_files` now goes through the same fair allocation as the rest: smallest first, each taking an equal share of what remains, nothing dropped without a note. `refine` also aims the windows at whatever its traceback names, so on a large file the excerpt covers the failing line rather than the top of the module.

### A sweep, not another one-at-a-time fix

Fixing these as each run surfaced them is why this looked like it would never converge. So this time every context builder was checked, and two more of the same shape were found and fixed:

- **PKG grounding** dropped every symbol ranked below an oversized one.
- **The worktree fallback scan** dropped every file sorted after a big module.

Both now skip and say what they skipped. The remaining `break`s in these modules are loop control or already carry an omission note.

### Verified against the failing worktree

Run against the actual artifact from the failed run, not a fixture written to match a guess — all four files reach the model, and `class MCPTool` with them.

---

**Gate:** `mypy src tests` clean (597 files), `ruff check` clean, 2366 passed / 30 skipped.

Refs SSPN-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
