### PR TITLE
SSPN-14: Surface MCP tool argument types in `mcp contracts` output

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -682,6 +682,24 @@ You extend the catalog with new skills/tools/run-shapes via a selector
 
 ## Step 9 — Connect external tools (MCP)
 
+`orchestrator mcp contracts` shows the governed ToolContract derived for each
+onboarded MCP tool, and labels every argument with its **declared type**, read
+from the server's own JSON Schema at display time (nothing is stored, and
+`mcp call` is unaffected). A union type is joined with `|`, and an argument the
+schema doesn't give a top-level `type` (an `anyOf`, a `$ref`, or a tool with no
+schema at all) is labelled `any`:
+
+```json
+{
+  "contract_id": "mcp.atlassian.jira_search",
+  "inputs": ["additional_fields (string)", "limit (integer)", "cursor (string|null)", "payload (any)"],
+  "input_types": {"additional_fields": "string", "limit": "integer"}
+}
+```
+
+Use it to see an argument's expected shape *before* a call fails on a type
+mismatch.
+
 Spine can use external **[MCP](https://modelcontextprotocol.io)
 servers** — read Confluence/Jira through Atlassian's MCP server, introspect a
 database, and more — reusing the same `mcpServers` config you already use with

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -79,6 +79,27 @@ def _print(data: Any) -> None:
     typer.echo(json.dumps(data, indent=2, default=str))
 
 
+def _mcp_load_configs(path: str | None = None) -> Any:
+    """Load the configured MCP servers (seam kept module-level so tests can stub it)."""
+    from orchestrator.mcp.config import load_mcp_configs
+
+    return load_mcp_configs(path)
+
+
+def _mcp_build_registry(configs: Any) -> Any:
+    """Build the MCP registry for a set of server configs."""
+    from orchestrator.mcp import MCPRegistry
+
+    return MCPRegistry(configs)
+
+
+async def _mcp_build_tools(registry: Any, **kwargs: Any) -> Any:
+    """Discover the ``(contract, handler)`` pairs for every onboarded MCP tool."""
+    from orchestrator.mcp import build_mcp_tools
+
+    return await build_mcp_tools(registry, **kwargs)
+
+
 @contextlib.contextmanager
 def _repo_arg(spec: str) -> Iterator[tuple[Path, bool]]:
     """Resolve a repo argument to an on-disk path, yielding ``(path, is_remote)``.
@@ -1095,30 +1116,42 @@ def mcp_ingest_db(
 def mcp_contracts(
     config: Annotated[str | None, typer.Option("--config", help="mcpServers JSON file path.")] = None,
 ) -> None:
-    """Show the ToolContract derived for each onboarded MCP tool (governance view)."""
+    """Show the ToolContract derived for each onboarded MCP tool (governance view).
+
+    Each input is rendered ``name (type)``, with the type read from the
+    server's own JSON Schema at display time (``string|null`` for unions,
+    ``any`` when the schema declares no top-level type).
+    """
     import asyncio
 
     from orchestrator.core.env import load_local_env
-    from orchestrator.mcp import MCPRegistry, build_mcp_tools
-    from orchestrator.mcp.config import load_mcp_configs
+    from orchestrator.mcp.schema_types import argument_type_label, format_argument
 
     load_local_env()
-    configs = load_mcp_configs(config)
-    registry = MCPRegistry(configs)
-    built = asyncio.run(build_mcp_tools(registry, configs=configs))
-    _print(
-        [
+    configs = _mcp_load_configs(config)
+    registry = _mcp_build_registry(configs)
+    built = asyncio.run(_mcp_build_tools(registry, configs=configs))
+    rows: list[dict[str, Any]] = []
+    for t in built:
+        # Types come from the server's raw JSON Schema at display time; the
+        # contract's normalised inputs stay the source of truth for *which*
+        # arguments exist (and for `mcp call`).
+        schema = getattr(getattr(t.handler, "tool", None), "input_schema", None)
+        names = [f.name for f in t.contract.spec.inputs]
+        labels = {name: argument_type_label(schema, name) for name in names}
+        rows.append(
             {
                 "contract_id": t.contract.metadata.id,
                 "version": t.contract.metadata.version,
+                "description": t.contract.metadata.description,
                 "side_effects": t.contract.spec.side_effects.value,
                 "requires_approval": t.contract.spec.requires_approval.value,
                 "write_gated": not t.handler.read_only and not t.handler.write_enabled,
-                "inputs": [f.name for f in t.contract.spec.inputs],
+                "inputs": [format_argument(name, labels[name]) for name in names],
+                "input_types": labels,
             }
-            for t in built
-        ]
-    )
+        )
+    _print(rows)
 
 
 @mcp_app.command("call")

--- a/src/orchestrator/mcp/contract.py
+++ b/src/orchestrator/mcp/contract.py
@@ -52,7 +52,11 @@ def _inputs_from_schema(schema: dict[str, object]) -> list[FieldSchema]:
     for name, raw in properties.items():
         spec = raw if isinstance(raw, dict) else {}
         json_type = spec.get("type")
-        field_type = json_type if json_type in _JSON_TYPES else "string"
+        # ``type`` may be a list (``["string", "null"]``) or an unhashable/absent
+        # value; the registry field takes a single simple type, so normalise here.
+        if isinstance(json_type, list):
+            json_type = next((t for t in json_type if t in _JSON_TYPES), None)
+        field_type = json_type if isinstance(json_type, str) and json_type in _JSON_TYPES else "string"
         fields.append(
             FieldSchema(
                 name=str(name),

--- a/src/orchestrator/mcp/handler.py
+++ b/src/orchestrator/mcp/handler.py
@@ -40,6 +40,9 @@ class MCPToolHandler:
     ) -> None:
         self.contract_id = contract_id_for(tool)
         self.contract_version = contract_version
+        # Kept so display-time callers (e.g. `mcp contracts`) can read the
+        # server's raw JSON Schema; invocation still goes through the registry.
+        self.tool = tool
         self.read_only = tool.read_only is True
         self.write_enabled = write_enabled
         self._registry = registry

--- a/src/orchestrator/mcp/schema_types.py
+++ b/src/orchestrator/mcp/schema_types.py
@@ -1,0 +1,66 @@
+"""Human-readable type labels for MCP tool arguments.
+
+An MCP server describes each tool's arguments as a JSON Schema
+(``MCPTool.input_schema``). The registry's ``ToolContract`` keeps only a
+normalised field list, so the raw declared type (unions, ``anyOf``, ``$ref``)
+is lost by the time ``orchestrator mcp contracts`` renders it. These helpers
+read the schema at *display time* and derive a short scannable label such as
+``string`` or ``string|null`` — nothing here mutates stored state or affects
+how ``mcp call`` serialises arguments.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Shown when the schema declares no usable top-level ``type`` (``anyOf``,
+# ``$ref``, ``const``, a missing property, or no schema at all).
+UNKNOWN_TYPE = "any"
+
+
+def _label_from_type(raw: Any) -> str:
+    """Render a JSON Schema ``type`` value as one label (``["a","b"]`` → ``a|b``)."""
+    if isinstance(raw, str):
+        return raw.strip() or UNKNOWN_TYPE
+    if isinstance(raw, list):
+        parts = [
+            str(item).strip() for item in raw if isinstance(item, str | int | float) and str(item).strip()
+        ]
+        return "|".join(parts) if parts else UNKNOWN_TYPE
+    return UNKNOWN_TYPE
+
+
+def argument_type_label(schema: dict[str, Any] | None, name: str) -> str:
+    """Label for argument ``name`` in ``schema``, or ``any`` when undeclared.
+
+    Tolerant by design: a server that nests its properties behind ``$defs`` /
+    ``$ref``, or omits ``input_schema`` entirely, falls back to ``any`` rather
+    than raising — the contracts view must never fail on an odd schema.
+    """
+    if not isinstance(schema, dict):
+        return UNKNOWN_TYPE
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return UNKNOWN_TYPE
+    spec = properties.get(name)
+    if not isinstance(spec, dict):
+        return UNKNOWN_TYPE
+    return _label_from_type(spec.get("type"))
+
+
+def argument_type_labels(schema: dict[str, Any] | None, names: list[str]) -> dict[str, str]:
+    """``{name: label}`` for each requested argument, in the order given."""
+    return {name: argument_type_label(schema, name) for name in names}
+
+
+def format_argument(name: str, label: str) -> str:
+    """Render one argument for display: ``name (type)``."""
+    return f"{name} ({label})"
+
+
+__all__ = [
+    "UNKNOWN_TYPE",
+    "argument_type_label",
+    "argument_type_labels",
+    "format_argument",
+]

--- a/tests/test_mcp_contracts_types.py
+++ b/tests/test_mcp_contracts_types.py
@@ -1,0 +1,151 @@
+"""End-to-end tests for `orchestrator mcp contracts` argument type labels.
+
+These drive the CLI command the way a user does (via Typer's ``CliRunner``),
+with the MCP registry/handler layer stubbed, and assert that each argument is
+rendered with a human-readable type label derived from ``MCPTool.input_schema``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+import orchestrator.cli as cli_mod
+from orchestrator.cli import app
+from orchestrator.mcp.config import MCPServerConfig
+from orchestrator.mcp.handler import MCPRegisteredTool, MCPToolHandler, build_mcp_tools
+from orchestrator.mcp.models import MCPTool
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+_TYPED_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "additional_fields": {"type": "string"},
+        "limit": {"type": "integer"},
+        "cursor": {"type": ["string", "null"]},
+        "payload": {"anyOf": [{"type": "string"}, {"type": "object"}]},
+        "linked": {"$ref": "#/$defs/Thing"},
+    },
+}
+
+
+def _tool(name: str, *, schema: dict[str, Any] | None, description: str = "Search issues.") -> MCPTool:
+    return MCPTool(
+        server="atlassian",
+        name=name,
+        description=description,
+        input_schema=schema if schema is not None else {},
+        read_only=True,
+    )
+
+
+class _FakeRegistry:
+    """Stands in for ``MCPRegistry`` — only ``list_tools`` is exercised here."""
+
+    def __init__(self, tools: list[MCPTool]) -> None:
+        self._tools = tools
+
+    async def list_tools(self) -> list[MCPTool]:
+        return list(self._tools)
+
+    async def call(self, qualified: str, args: dict[str, Any]) -> Any:  # pragma: no cover - unused
+        raise AssertionError("mcp contracts must never invoke a tool")
+
+    async def aclose(self) -> None:
+        return None
+
+
+async def _built(tools: list[MCPTool]) -> list[MCPRegisteredTool]:
+    registry = _FakeRegistry(tools)
+    configs = [MCPServerConfig(name="atlassian", command="echo", args=())]
+    return await build_mcp_tools(registry, configs=configs)  # type: ignore[arg-type]
+
+
+def _run_contracts(runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tools: list[MCPTool]) -> Any:
+    """Invoke `orchestrator mcp contracts` against a stubbed MCP layer."""
+
+    def _fake_load_configs(path: str | None = None) -> list[MCPServerConfig]:
+        return [MCPServerConfig(name="atlassian", command="echo", args=())]
+
+    async def _fake_build(registry: Any, **kwargs: Any) -> list[MCPRegisteredTool]:
+        return await _built(tools)
+
+    monkeypatch.setattr(cli_mod, "_mcp_load_configs", _fake_load_configs, raising=False)
+    monkeypatch.setattr(cli_mod, "_mcp_build_registry", lambda configs: _FakeRegistry(tools), raising=False)
+    monkeypatch.setattr(cli_mod, "_mcp_build_tools", _fake_build, raising=False)
+    return runner.invoke(app, ["mcp", "contracts"])
+
+
+def test_handler_keeps_the_raw_tool_for_display() -> None:
+    """`build_mcp_tools` must hand back the server's schema so the contracts view
+    can derive type labels at display time."""
+    import asyncio
+
+    tool = _tool("jira_search", schema=_TYPED_SCHEMA)
+    built = asyncio.run(_built([tool]))
+    assert len(built) == 1
+    handler = built[0].handler
+    assert isinstance(handler, MCPToolHandler)
+    assert handler.tool is tool
+    assert handler.tool.input_schema["properties"]["additional_fields"]["type"] == "string"
+
+
+def test_contracts_output_shows_declared_argument_types(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _run_contracts(runner, monkeypatch, [_tool("jira_search", schema=_TYPED_SCHEMA)])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # name + declared type, together
+    assert "additional_fields" in out
+    assert "string" in out
+    assert "additional_fields (string)" in out or '"additional_fields": "string"' in out
+    assert "limit (integer)" in out or '"limit": "integer"' in out
+    # union types are joined with a pipe
+    assert "string|null" in out
+
+
+def test_contracts_output_falls_back_to_any_for_untyped_arguments(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    result = _run_contracts(runner, monkeypatch, [_tool("jira_search", schema=_TYPED_SCHEMA)])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # anyOf / $ref arguments are still listed, labelled `any` rather than dropped
+    assert "payload" in out and "linked" in out
+    assert "payload (any)" in out or '"payload": "any"' in out
+    assert "linked (any)" in out or '"linked": "any"' in out
+
+
+def test_contracts_survives_an_empty_schema(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _run_contracts(runner, monkeypatch, [_tool("jira_ping", schema={})])
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+    assert "jira_ping" in result.output
+
+
+def test_contracts_keeps_existing_fields(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tool name and description survive the type-label change."""
+    tool = _tool("jira_search", schema=_TYPED_SCHEMA, description="Search issues.")
+    result = _run_contracts(runner, monkeypatch, [tool])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "jira_search" in out
+    assert "Search issues." in out
+    # the contract itself is still well-formed if the CLI prints JSON
+    if out.lstrip().startswith(("{", "[")):
+        json.loads(out)
+
+
+def test_contracts_help_is_available(runner: CliRunner) -> None:
+    result = runner.invoke(app, ["mcp", "--help"])
+    assert result.exit_code == 0
+    assert "contracts" in result.stdout

--- a/tests/test_mcp_schema_types.py
+++ b/tests/test_mcp_schema_types.py
@@ -46,7 +46,7 @@ def test_missing_property_and_missing_schema_fall_back_to_any() -> None:
     assert argument_type_label(_SCHEMA, "nope") == "any"
     assert argument_type_label(None, "anything") == "any"
     assert argument_type_label({}, "anything") == "any"
-    assert argument_type_label({"properties": []}, "anything") == "any"  # type: ignore[arg-type]
+    assert argument_type_label({"properties": []}, "anything") == "any"
     assert argument_type_label({"properties": {"a": "string"}}, "a") == "any"
 
 

--- a/tests/test_mcp_schema_types.py
+++ b/tests/test_mcp_schema_types.py
@@ -1,0 +1,88 @@
+"""Tests for the human-readable argument type labels used by `mcp contracts`.
+
+The labels are derived from ``MCPTool.input_schema`` at display time; these
+tests pin the label rules (simple type, union, missing/odd schema) and the
+``name (type)`` display format.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from orchestrator.mcp.schema_types import (
+    UNKNOWN_TYPE,
+    argument_type_label,
+    argument_type_labels,
+    format_argument,
+)
+
+_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "additional_fields": {"type": "string"},
+        "limit": {"type": "integer"},
+        "cursor": {"type": ["string", "null"]},
+        "payload": {"anyOf": [{"type": "string"}, {"type": "object"}]},
+        "linked": {"$ref": "#/$defs/Thing"},
+    },
+}
+
+
+def test_simple_declared_type_is_surfaced() -> None:
+    assert argument_type_label(_SCHEMA, "additional_fields") == "string"
+    assert argument_type_label(_SCHEMA, "limit") == "integer"
+
+
+def test_type_list_is_joined_with_a_pipe() -> None:
+    assert argument_type_label(_SCHEMA, "cursor") == "string|null"
+
+
+def test_anyof_and_ref_fall_back_to_any() -> None:
+    assert argument_type_label(_SCHEMA, "payload") == UNKNOWN_TYPE == "any"
+    assert argument_type_label(_SCHEMA, "linked") == "any"
+
+
+def test_missing_property_and_missing_schema_fall_back_to_any() -> None:
+    assert argument_type_label(_SCHEMA, "nope") == "any"
+    assert argument_type_label(None, "anything") == "any"
+    assert argument_type_label({}, "anything") == "any"
+    assert argument_type_label({"properties": []}, "anything") == "any"  # type: ignore[arg-type]
+    assert argument_type_label({"properties": {"a": "string"}}, "a") == "any"
+
+
+def test_blank_or_empty_type_values_fall_back_to_any() -> None:
+    assert argument_type_label({"properties": {"a": {"type": "   "}}}, "a") == "any"
+    assert argument_type_label({"properties": {"a": {"type": []}}}, "a") == "any"
+
+
+def test_labels_preserve_requested_order() -> None:
+    labels = argument_type_labels(_SCHEMA, ["limit", "additional_fields", "nope"])
+    assert list(labels) == ["limit", "additional_fields", "nope"]
+    assert labels == {"limit": "integer", "additional_fields": "string", "nope": "any"}
+
+
+def test_format_argument_renders_name_and_type() -> None:
+    assert format_argument("additional_fields", "string") == "additional_fields (string)"
+
+
+def test_labelling_does_not_mutate_the_schema() -> None:
+    schema: dict[str, Any] = {"properties": {"a": {"type": "string"}}}
+    before = {"properties": {"a": {"type": "string"}}}
+    argument_type_labels(schema, ["a", "missing"])
+    assert schema == before
+
+
+def test_user_guide_documents_argument_types_in_the_mcp_step() -> None:
+    """Acceptance: the choice is documented where MCP server setup lives (step 9)."""
+    from pathlib import Path
+
+    guide = Path(__file__).resolve().parents[1] / "USER_GUIDE.md"
+    text = guide.read_text(encoding="utf-8")
+    assert "## Step 9 — Connect external tools (MCP)" in text
+    start = text.index("## Step 9 — Connect external tools (MCP)")
+    end = text.index("\n## ", start + 1)
+    step9 = text[start:end]
+    assert "mcp contracts" in step9
+    lowered = step9.lower()
+    assert "type" in lowered
+    assert "(string)" in step9 or "string|null" in step9


### PR DESCRIPTION
The `orchestrator mcp contracts` command currently shows tool input argument names only, with no type information. This spec extends the command to surface per-argument type information sourced from `MCPTool.input_schema` (the server's full JSON Schema), so callers can see declared types before a call fails. Only the `mcp contracts` display is changed; `mcp call` serialisation and the mcp-atlassian server are out of scope.

Acceptance criteria:
- `mcp contracts` shows the argument's declared *type*, not only its name — so a caller can see the shape before the call fails.
- Whatever is chosen is documented where MCP server setup is (USER_GUIDE step 9).
- Given a tool whose `input_schema` declares `additional_fields` as `{"type": "string"}`, when the user runs `orchestrator mcp contracts`, then the output for that argument includes the type label `string` (or the equivalent simplified human-readable label derived from the JSON Schema `type` field) alongside the argument name.
- Given a tool whose `input_schema` declares an argument with no `type` field (e.g., a `$ref` or `anyOf`), when the user runs `orchestrator mcp contracts`, then the output for that argument shows a fallback label such as `unknown` or `any` rather than crashing or omitting the argument.
- Given a tool with no `input_schema` or an empty schema, when the user runs `orchestrator mcp contracts`, then the command completes successfully and arguments are listed without a type label (or with `unknown`), with no exception raised.
- The type label is derived from `MCPTool.input_schema` at display time and does not alter any stored state or the behaviour of `mcp call`.
- All existing `orchestrator mcp contracts` output fields (tool name, description, argument names, etc.) remain present and unchanged in format.

Generated by the SDLC orchestrator (intent intent-surface-mcp-tool-argument-types-in-mcp-contracts).