### PR TITLE
fix(sdlc): CI green is the only green, and doubt is a finding

### DIFF
--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -302,20 +302,27 @@ async def _untracked_python_files(path: Path) -> list[str]:
     return [f for f in out.decode("utf-8", "replace").split("\n") if f.endswith(".py")]
 
 
-# Codes that say "this annotation could be tidier", not "this code is wrong". A worktree venv
-# has runtime deps only, so `import-*` there reports the environment rather than the change;
-# the rest are hygiene. A run spent two of its three refine passes chasing an unused
-# `type: ignore` in a generated test while the real `attr-defined` bug went unfixed.
+# Codes that report the *worktree environment* rather than the change. The generated venv
+# carries runtime deps only, so a changed import line can fail to resolve here and resolve
+# perfectly in CI — that is noise about the sandbox, not a defect.
+#
+# Nothing else belongs here. The list used to hold `unused-ignore`, `no-untyped-def`,
+# `type-arg`, `no-any-return` and `misc` as "hygiene", and the cost was immediate: a live
+# run shipped a PR that CI rejected with
+#
+#     tests/test_mcp_schema_types.py:49: error: Unused "type: ignore"  [unused-ignore]
+#
+# The pipeline had seen that error, discarded it, printed "clean on the changed lines", and
+# opened the PR. Whether a code is enforced is the target repo's policy, expressed in its
+# own mypy config; deciding here that some of its rules do not count makes green mean less
+# than CI green, which is the only definition that matters.
+#
+# The noise this list originally guarded against is already handled by scoping to changed
+# lines — pre-existing errors elsewhere never reach the filter.
 _TYPING_HYGIENE = frozenset(
     {
-        "unused-ignore",
-        "no-untyped-def",
-        "no-untyped-call",
-        "no-any-return",
-        "type-arg",
         "import-not-found",
         "import-untyped",
-        "misc",
     }
 )
 
@@ -403,7 +410,20 @@ async def _satisfy_the_ticket(
                 "this change is unreviewed. Not proceeding.",
                 code=1,
             )
-        if verdict.verdict != "request_changes":
+        # `request_changes` means a criterion is unmet. `comment` with blockers means one
+        # could not be *verified* — and that is not a pass either.
+        #
+        # A run shipped a PR whose single doubt was "all existing output fields remain
+        # unchanged in format", on a change that had rewritten `inputs` from `["name"]` to
+        # `["name (type)"]`. The judge saw it, said so, and the verdict mapping sent it
+        # straight through because `comment` is not `request_changes`. The doubt was the
+        # finding.
+        #
+        # Both now enter the same loop. An unverified criterion is usually the most
+        # actionable feedback in the run — the judge says what it could not confirm and
+        # why — so it gets the same bounded chance to be answered, and if it survives, the
+        # run stops rather than shipping acceptance nobody established.
+        if verdict.verdict != "request_changes" and not verdict.blockers:
             return
         blockers = list(verdict.blockers) or [verdict.summary]
         if attempt >= max_revisions:

--- a/src/orchestrator/sdlc/review.py
+++ b/src/orchestrator/sdlc/review.py
@@ -252,8 +252,21 @@ class SemanticReviewAdapter:
             return ReviewResult(verdict="request_changes", blockers=blockers, summary=summary)
         if uncertain:
             names = [str(r.get("criterion")) for r in uncertain]
+            # An uncertain criterion is a judgement — "I looked and cannot tell" — and one
+            # of those among many met ones is a note for a human, not a stop. It stays a
+            # `comment`, deliberately: a gate that cries wolf gets switched off.
+            #
+            # But it is evidence, and it was ignored once too often. A run shipped a PR
+            # whose only doubt was "existing output fields remain unchanged in format" —
+            # and the change had in fact rewritten `inputs` from `["name"]` to
+            # `["name (type)"]`. The judge saw it, said so, and the verdict mapping
+            # overruled it. So the blockers list now carries the doubt: the caller decides
+            # what to do with a change whose acceptance could not be established, instead
+            # of the mapping deciding for it by returning something that is not
+            # `request_changes`.
             return ReviewResult(
                 verdict="comment",
+                blockers=[f"acceptance criterion unverified: {n}" for n in names],
                 summary=f"{summary} · uncertain: {', '.join(names)}".strip(" ·"),
                 uncertain=names,
             )

--- a/tests/sdlc/test_feature_runner.py
+++ b/tests/sdlc/test_feature_runner.py
@@ -1044,13 +1044,21 @@ async def test_the_type_errors_are_what_refine_is_given(
     assert seen and "cli.py:1117" in seen[0]
 
 
-def test_typing_hygiene_is_filtered_but_real_defects_are_not() -> None:
-    """A run spent two of its three refine passes chasing an unused `type: ignore` in a
-    generated test while the `attr-defined` bug that broke the command went unfixed."""
+def test_only_environment_codes_are_filtered() -> None:
+    """The worktree venv carries runtime deps only, so a changed import line can fail here
+    and resolve fine in CI. Nothing else belongs in the filter: it used to hold
+    `unused-ignore` and `misc` as "hygiene", and a live run shipped a PR that CI rejected
+    with `Unused "type: ignore"` — the pipeline had seen it, discarded it, and printed
+    "clean on the changed lines"."""
     from orchestrator.sdlc.feature_runner import _is_typing_hygiene
 
-    assert _is_typing_hygiene('t.py:1: error: Unused "type: ignore" comment  [unused-ignore]')
-    assert _is_typing_hygiene("t.py:1: error: Untyped decorator makes f untyped  [misc]")
+    # The sandbox, not the change.
+    assert _is_typing_hygiene("t.py:1: error: Cannot find implementation for x  [import-not-found]")
+    assert _is_typing_hygiene("t.py:1: error: Library stubs not installed  [import-untyped]")
+
+    # Everything else is the target repo's policy, and CI enforces it.
+    assert not _is_typing_hygiene('t.py:1: error: Unused "type: ignore" comment  [unused-ignore]')
+    assert not _is_typing_hygiene("t.py:1: error: Untyped decorator makes f untyped  [misc]")
     assert not _is_typing_hygiene(
         'c.py:1126: error: "MCPToolHandler" has no attribute "tool"  [attr-defined]'
     )
@@ -1276,3 +1284,41 @@ async def test_a_codegen_error_hands_the_ticket_back(monkeypatch: pytest.MonkeyP
         )
 
     assert jira.transitions == ["In Progress", "To Do"]
+
+
+async def test_an_unverified_criterion_does_not_ship(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The live PR: one criterion of seven came back uncertain — "all existing output
+    fields remain unchanged in format" — on a change that had rewritten `inputs` from
+    `["name"]` to `["name (type)"]`. `comment` is not `request_changes`, so the mapping
+    sent it straight to a real PR. The doubt was the finding."""
+
+    class _UncertainJudge(_Judge):
+        async def review(self, *, path: str, issue_key: str, spec: Any = None) -> Any:
+            self.calls += 1
+            return SimpleNamespace(
+                verdict="comment",
+                blockers=["acceptance criterion unverified: output format unchanged"],
+                summary="judged",
+                uncertain=["output format unchanged"],
+                unreviewed=False,
+            )
+
+    created = _install_pipeline(monkeypatch, tmp_path, runner=_PassingRunner)
+    monkeypatch.setattr("orchestrator.sdlc.review.SemanticReviewAdapter", _UncertainJudge())
+
+    with pytest.raises(FeatureRunError, match="does not satisfy the ticket"):
+        await run_feature("file://./spec.md", intent_id="intent-a", repo="https://x/widget")
+
+    # It went to revise like any other blocker, rather than through to a PR.
+    assert created[0].revise_calls == 1
+
+
+async def test_a_fully_met_verdict_still_ships(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The gate only tightened for doubt. An approving verdict is untouched."""
+    judge = _Judge("approve")
+    _install_pipeline(monkeypatch, tmp_path, runner=_PassingRunner)
+    monkeypatch.setattr("orchestrator.sdlc.review.SemanticReviewAdapter", judge)
+
+    result = await run_feature("file://./spec.md", intent_id="intent-a", repo="https://x/widget")
+
+    assert result.passed and judge.calls == 1

--- a/tests/sdlc/test_review.py
+++ b/tests/sdlc/test_review.py
@@ -112,7 +112,14 @@ async def test_uncertain_is_comment_not_block(tmp_path: Path) -> None:
         }
     )
     result = await adapter.review(path=str(_worktree(tmp_path)), issue_key="E-1", spec=SPEC)
-    assert result.verdict == "comment" and not result.has_blocker
+    # Still `comment` — an uncertain criterion is a judgement, not a refusal, and callers
+    # that read the verdict keep their existing behaviour. But it now carries a blocker,
+    # because a run shipped a PR whose single doubt was "existing output fields remain
+    # unchanged in format" on a change that had rewritten `inputs` from `["name"]` to
+    # `["name (type)"]`. The judge saw it and the verdict mapping overruled it.
+    assert result.verdict == "comment"
+    assert result.has_blocker
+    assert result.blockers == ["acceptance criterion unverified: handles empty input"]
     assert "uncertain" in result.summary
 
 


### PR DESCRIPTION
The first end-to-end live run opened a real PR (#126). CI rejected it:

```
tests/test_mcp_schema_types.py:49: error: Unused "type: ignore"  [unused-ignore]
```

The pipeline had **seen** that error, discarded it, printed `clean on the changed lines`, and shipped.

### CI green is the only green

`unused-ignore` was in the deny-list added with the type check, on the theory that those codes report the worktree environment rather than the change.

That is true of `import-not-found` and `import-untyped` — the generated venv carries runtime deps only, so a changed import can fail there and resolve fine in CI. It is not true of the rest. Whether a code is enforced is the **target repo's** policy, expressed in its own mypy config; deciding here that some of its rules do not count makes our green mean less than CI green, which is the only definition that matters.

The noise the list was guarding against is already handled by scoping to changed lines — pre-existing errors elsewhere never reach the filter. The list is now the two import codes and nothing else.

### Doubt is a finding

The judge caught the other defect in that same run and was overruled by the verdict mapping. Its one uncertain criterion was *"all existing output fields remain unchanged in format"* — on a change that had rewritten `inputs` from `["name"]` to `["name (type)"]`. It said exactly that in its summary. `comment` is not `request_changes`, so the run went straight to a PR.

An uncertain criterion **stays** a `comment` — it is a judgement, not a refusal, and a gate that cries wolf gets switched off. But it now carries a blocker, and a blocker enters the revise loop like any other. Unverified acceptance gets the same bounded chance to be answered, and if it survives, the run stops rather than shipping acceptance nobody established.

### One correction to the plan

This is stricter than the *majority*-uncertain rule floated when the problem was first described, and deliberately so: **one criterion of seven** was uncertain here, so a majority rule would have shipped this PR too.

Expect this to fail more runs. That is the intent — every alternative discussed leaves a path where an unverified criterion reaches a PR.

### Tests

Two asserted the old behaviour and now assert the new. Two more pin the live cases: an unverified criterion goes to revise instead of a PR, and an approving verdict still ships untouched.

---

**Gate:** `mypy src tests` clean (597 files), `ruff check` clean, 2368 passed / 30 skipped.

Refs SSPN-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
