### PR TITLE
release: 3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
-## Unreleased — A green suite is not a working change
+## 3.13.0 — A green suite is not a working change
 
 Found by running one ticket end to end a dozen times. Every stage of the build loop was
 working from an input it could not see, and reporting the gap as a defect in the work
@@ -34,6 +34,12 @@ useless change now fail with a reason.
   the test author by name.
 - **`sdlc autorun` is documented** in `CLI_REFERENCE.md`, including what each bracketed
   stage line means. It was the primary entry point and had no reference entry.
+- **`orchestrator mcp contracts` labels every argument with its declared type**, read from
+  the server's own JSON Schema at display time — `string`, `string|null` for a union, and
+  `any` when the schema gives no top-level type (`anyOf`, `$ref`, or no schema at all). A
+  parallel `input_types` map carries the same labels keyed by name. Display-only: nothing is
+  stored and `mcp call` is unaffected. **Note:** the existing `inputs` field changed shape
+  from `["name"]` to `["name (type)"]` — if you parse that output, this is a break.
 - **`orchestrator models`** — every model the pipeline can be pointed at, with context
   window, price per million tokens, and whether it supports tool calling, plus what
   each stage is resolving to right now. Read from the installed LiteLLM's own catalog
@@ -75,6 +81,29 @@ useless change now fail with a reason.
   lists the alternatives with prices. Codegen's output cap also rises 16k → 32k
   tokens: on the current Claude models thinking is on unless disabled and shares that
   budget, so a cap sized around the JSON payload alone truncates mid-object.
+- **Generated Python is parsed before it is written.** A file that does not compile used to
+  reach disk and surface three stages later as an opaque pytest `rc=2`, with the real
+  `SyntaxError` buried in an importlib traceback. It is now refused at the write with the
+  file, line, and offending text, and takes a corrective retry.
+- **Each kind of failure gets its own corrective attempt.** Unparseable JSON, a failed edit
+  anchor, an empty submission and unparseable Python previously shared a single retry, so
+  whichever failed first consumed it. A kind that fails twice still stops.
+- **No context builder drops a file silently.** Four separate loops — the files fed to
+  refine, the acceptance judge's reader, the anchor-repair block, and PKG grounding — stopped
+  at the first item too large for the budget and dropped everything after it. A 91 KB
+  `cli.py` could hide a 1.8 KB module the model then edited blind and could not repair. All
+  four now allocate fairly and name what they omit.
+- **Editing the repo's own docs is not inventing a path.** The layout guidance banned every
+  file outside the source and test directories, which made any documentation criterion
+  impossible to satisfy. New code and tests are still confined; changing a file the repo
+  already has — README, USER_GUIDE, CHANGELOG, pyproject.toml — is allowed.
+- **A criterion the judge cannot verify no longer ships.** An `uncertain` verdict stays a
+  comment, but now carries a blocker and enters the revision loop like any other, instead of
+  passing straight through because it was not `request_changes`.
+- **The type check no longer discards codes the target repo enforces.** Only `import-not-found`
+  and `import-untyped` are filtered, since a generated worktree carries runtime deps only.
+  Everything else is the repo's own mypy policy — filtering it made "clean" mean less than
+  CI clean.
 - **A safe-mode rehearsal no longer counts as a duplicate.** The check refused any second
   run on a ticket whose first run finished, so a ticket became unworkable after its first
   dry run. Only a run that reached a PR blocks another.

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -124,10 +124,11 @@ generating + testing code is **one LLM key**:
 ```bash
 # .env  (the bare minimum)
 OPENAI_API_KEY=sk-...                  # or ANTHROPIC_API_KEY=sk-ant-... (or an Ollama endpoint)
-ORCHESTRATOR_INTAKE_MODEL=gpt-4o       # one model drives everything; set it explicitly
+ORCHESTRATOR_MODEL=claude-opus-5       # one model for every stage (this is the default)
 ```
 
-Use any LiteLLM‑supported model string here (e.g. `gpt-4o`, an Anthropic
+Use any LiteLLM‑supported model string here (run `orchestrator models` to list
+them with prices and tool-calling support; e.g. an Anthropic
 `claude-*` id, or `ollama/<model>` with `OLLAMA_API_BASE`) — match it to the key you set.
 
 Add more only for what you do:
@@ -236,7 +237,7 @@ Checks what's wired up. Run this first.
 // tool: doctor   (no arguments)
 {}
 ```
-**Returns:** `{ "all_passed": false, "checks": [ { "name": "llm", "passed": true, "detail": "openai/gpt-4o" }, … ] }`
+**Returns:** `{ "all_passed": false, "checks": [ { "name": "llm", "passed": true, "detail": "anthropic/claude-opus-5" }, … ] }`
 
 ---
 

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -3,12 +3,12 @@
 > **Spine** is the product; the command is **`orchestrator`** (package `synaptixs-spine`).
 > Auto-generated from the CLI — run `orchestrator <command> --help` for the live version.
 
-**43 commands** across 7 areas. Every command supports `--help`; repo-analysis commands accept a local path or a git URL.
+**48 commands** across 7 areas. Every command supports `--help`; repo-analysis commands accept a local path or a git URL.
 
 ## Command map
 
 **Getting started & operations** — Set up your environment and run the platform.  
-`init` · `doctor` · `up` · `tui` · `task submit`
+`init` · `doctor` · `models` · `up` · `tui` · `task submit`
 
 **Understand a codebase — the Knowledge Graph** — Extract and read the Product Knowledge Graph (PKG). Deterministic, no LLM. All accept a local path OR a git URL.  
 `understand` · `state` · `profile` · `catalog list` · `catalog plan` · `pkg extract` · `pkg export` · `pkg docs` · `pkg capabilities` · `media extract`
@@ -20,7 +20,7 @@
 `ingest` · `backlog` · `openspec draft`
 
 **The SDLC pipeline — build features** — The autonomous build path: requirements → code → tests → reviewed PR, with human gates.  
-`sdlc feature` · `sdlc run` · `sdlc complete` · `sdlc address-review` · `sdlc remediate`
+`sdlc autorun` · `sdlc feature` · `sdlc run` · `sdlc runs` · `sdlc complete` · `sdlc address-review` · `sdlc remediate`
 
 **MCP — external tools** — Consume onboarded Model Context Protocol servers (governed, audited).  
 `mcp list` · `mcp contracts` · `mcp call` · `mcp ingest-db`
@@ -892,6 +892,12 @@ orchestrator mcp list [OPTIONS]
 ### `orchestrator mcp contracts`
 
 Show the ToolContract derived for each onboarded MCP tool (governance view).
+
+Each input is rendered `name (type)`, with the type read from the server's own
+JSON Schema at display time — `string|null` for a union, and `any` when the
+schema declares no top-level type (an `anyOf`, a `$ref`, or a tool with no
+schema). A parallel `input_types` map carries the same labels keyed by argument
+name. Display-only: nothing is stored, and `mcp call` serialisation is unchanged.
 
 ```
 orchestrator mcp contracts [OPTIONS]

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -111,10 +111,11 @@ generating + testing code is **one LLM key**:
 ```bash
 # .env  (the bare minimum)
 OPENAI_API_KEY=sk-...                  # or ANTHROPIC_API_KEY=sk-ant-... (or an Ollama endpoint)
-ORCHESTRATOR_INTAKE_MODEL=gpt-4o       # one model drives everything; set it explicitly
+ORCHESTRATOR_MODEL=claude-opus-5       # one model for every stage (this is the default)
 ```
 
-Use any LiteLLM‑supported model string here (e.g. `gpt-4o`, an Anthropic
+Use any LiteLLM‑supported model string here (run `orchestrator models` to list
+them with prices and tool-calling support; e.g. an Anthropic
 `claude-*` id, or `ollama/<model>` with `OLLAMA_API_BASE`) — match it to the key you set.
 
 Add more only for what you do:
@@ -202,7 +203,7 @@ Checks what's wired up. Run this first.
 // tool: doctor   (no arguments)
 {}
 ```
-**Returns:** `{ "all_passed": false, "checks": [ { "name": "llm", "passed": true, "detail": "openai/gpt-4o" }, … ] }`
+**Returns:** `{ "all_passed": false, "checks": [ { "name": "llm", "passed": true, "detail": "anthropic/claude-opus-5" }, … ] }`
 
 ---
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -111,14 +111,37 @@ orchestrator doctor    # readiness report — tells you exactly what's set and w
 | Setting | What it's for | Needed by |
 |---|---|---|
 | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` | Your LLM provider | Step 3 |
-| `ORCHESTRATOR_INTAKE_MODEL` | One model for everything, e.g. `gpt-4o` | Step 3 |
+| `ORCHESTRATOR_MODEL` | One model for every stage (optional — defaults to `claude-opus-5`) | Step 3 |
 | `CONFLUENCE_*`, `JIRA_*` | Read requirements / file issues | Step 4 |
 | `SDLC_REPO_URL` | The repo it builds **into** | Step 4 |
 | `GITHUB_TOKEN` *(or `GITHUB_APP_*`)* | Auth for a private target repo | Step 4 |
 
-> **Tip:** set `ORCHESTRATOR_INTAKE_MODEL` explicitly (e.g. `gpt-4o`). One model
-> then drives every stage. A heavyweight default can time out on large code
-> generations.
+### Choosing a model
+
+Every stage runs on `claude-opus-5` unless you say otherwise. To see what you can
+point it at — with context windows, prices, and which models support the tool
+calling the pipeline requires:
+
+```bash
+orchestrator models                    # everything, plus what each stage uses now
+orchestrator models --provider openai  # just one vendor
+```
+
+Set one knob for everything, or a model per stage:
+
+| Variable | Drives |
+|---|---|
+| `ORCHESTRATOR_MODEL` | every stage |
+| `SDLC_CODEGEN_MODEL` | codegen — implement, refine, revise, author_tests |
+| `SDLC_JUDGE_MODEL` | the acceptance judge |
+| `ORCHESTRATOR_INTAKE_MODEL` | intent extraction and spec writing |
+
+A stage's own variable wins over `ORCHESTRATOR_MODEL`, which wins over the default.
+Pointing a stage at another vendor needs that vendor's key in the environment.
+
+> **Tool calling is required, not preferred.** Codegen and the judge both force a
+> tool call. On a model without it they fall back to reading prose out of a text
+> reply, which is far less reliable — `orchestrator models` marks those.
 
 ---
 
@@ -569,7 +592,7 @@ edits — use a **coder** model there. You can even mix local and cloud per stag
 
 ```bash
 ORCHESTRATOR_INTAKE_MODEL=ollama/qwen2.5-coder   # cheap stages, local
-SDLC_CODEGEN_MODEL=gpt-4o                         # codegen, cloud quality
+SDLC_CODEGEN_MODEL=claude-opus-5                  # codegen, cloud quality
 SDLC_REVIEW_MODEL=ollama/qwen2.5-coder            # the review judge
 ```
 
@@ -748,7 +771,7 @@ writes, runs the tests, and fixes — and (Step 9) calls approved external tools
 
 - **Off by default** — single-shot stays default until you're happy with cost
   (the loop makes several model calls per feature).
-- **Needs a tool-calling model** (`gpt-4o`, `claude-*`); otherwise it falls back
+- **Needs a tool-calling model** (`claude-*`, `gpt-5*`); otherwise it falls back
   to single-shot.
 - **Safe by construction** — a hard step cap, a per-run spend budget
   (`SDLC_RUN_BUDGET_USD`), the same write guards as single-shot, and external
@@ -987,7 +1010,7 @@ Destructive tools stay gated regardless of auth: `sdlc_feature(live=true)` and
 | Symptom | Fix |
 |---|---|
 | `doctor` shows everything missing | Run it from the folder that has your `.env`. |
-| Codegen times out | Set `ORCHESTRATOR_INTAKE_MODEL=gpt-4o` (or another fast model). |
+| Codegen times out | Set `ORCHESTRATOR_MODEL` to a faster model (see `orchestrator models`). |
 | Private repo clone fails | Set `GITHUB_TOKEN` (PAT) or the GitHub App (`GITHUB_APP_*`). |
 | Console asks for an API key | Paste the `ORCHESTRATOR_API_KEY` you started the server with (`dev-key` above). |
 | `sdlc run` hangs at a gate | Approve it in the console or via `/v1/approvals/.../approve`. |
@@ -995,7 +1018,7 @@ Destructive tools stay gated regardless of auth: `sdlc_feature(live=true)` and
 | `mcp list` shows no servers | Add an `mcpServers` file (`--config`, `$ORCHESTRATOR_MCP_CONFIG`, or `./mcp.json`). |
 | `mcp` commands fail to import | Install the extra: `pip install 'synaptixs-spine[mcp]'` (or `uv sync --extra mcp`). |
 | An MCP tool is "not allow-listed" / write-gated | Add it to the server's `allow`; for mutating tools set `write_enabled: true`. |
-| Agentic loop falls back to single-shot | Use a tool-calling model (`gpt-4o`, `claude-*`) and set `SDLC_CODEGEN=llm`. |
+| Agentic loop falls back to single-shot | Use a tool-calling model (see `orchestrator models`) and set `SDLC_CODEGEN=llm`. |
 | `orchestrator-mcp --http` refuses to start | Set `ORCHESTRATOR_MCP_TOKEN` or `…_INTROSPECTION_URL`, bind `127.0.0.1`, or pass `--allow-unauthenticated` on a trusted net. |
 | Remote client gets 401 | Send `Authorization: Bearer <token>`; for introspection confirm the token is active and carries the required scope. |
 | `Nondeterminism error` on replay | An in-flight workflow predates a code change. Terminate the stale run (Temporal UI); new runs are unaffected. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.12.0"
+version = "3.13.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -3690,7 +3690,7 @@ wheels = [
 
 [[package]]
 name = "synaptixs-spine"
-version = "3.12.0"
+version = "3.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Cuts 3.13.0: version bump, changelog release heading, and a user-facing documentation pass.

## What's in the release

Everything merged since 3.12.0 (#115–#127). The theme: the SDLC pipeline could open a PR, but could not tell whether the PR did what the ticket asked. The changelog entry lists each gap that closed.

## Documentation audit

- `USER_GUIDE.md` — new **Choosing a model** section (`orchestrator models`, the per-stage variable table, and the tool-calling requirement); the model table row now documents `ORCHESTRATOR_MODEL`
- `CLI_REFERENCE.md` — 43 → **48 commands**; `models` and the full `sdlc` surface added to the command map; `mcp contracts` now documents the `name (type)` labels
- `CLAUDE_GUIDE.md` / `CODEX_GUIDE.md` — model examples point at `claude-opus-5`

No `gpt-4o` references remain in any user-facing document. The three left in `docs/specs/` are design records — they describe what was decided at the time and are deliberately unchanged.

## Verification

- `ruff format --check .` · `ruff check src tests` · `mypy src tests` — clean
- `pytest -q` — 2383 passed, 30 skipped
- `uv build` produces `synaptixs_spine-3.13.0` (sdist + wheel)

Not published to PyPI — this only makes the tree ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)