### PR TITLE
ci: a release promotion is not a branch carrying the bank

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,16 @@ jobs:
 
       # And a PR must not carry the artifact. Two branches that both regenerate conflict on
       # every merge; that is the whole failure this design removes.
+      #
+      # Except when promoting develop to main. That PR's episteme/ diff is nothing *but*
+      # this design working: every one of those commits is the bot's, made on develop after
+      # a merge, and the two-dot diff against a main that is behind shows all of them at
+      # once. The guard asks "did a contributor carry the artifact?" — on a promotion the
+      # answer is structurally no, and there is no way to make it pass without reverting
+      # the bank main is owed. Regeneration runs on main too, so main rebuilds from its own
+      # tree after this lands regardless.
       - name: PR does not modify episteme/
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.base_ref != 'main'
         run: |
           # Two-dot, against a freshly fetched base: the question is whether this branch's
           # committed bank differs from the base's, which is answerable in a shallow clone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,11 @@ them on a release cadence — so opening an issue first avoids duplicated effort
    it. Regenerating after merge, where the tree is stable, removes the conflict entirely.
 
    If you have local `episteme/` changes, drop them: `git checkout origin/develop -- episteme/`.
+
+   The one exemption is a **release promotion** — a `develop` → `main` PR. Its `episteme/`
+   diff is every bot commit made on `develop` since `main` last moved, which is the design
+   working rather than a contributor carrying the artifact, so the check skips when the base
+   is `main`. `main` regenerates from its own tree after the merge either way.
 4. Open the PR with a clear description of **what** and **why**, linking any issue.
 5. A maintainer reviews; the `security scan` check must pass.
 


### PR DESCRIPTION
Found while opening [#129](https://github.com/synaptixs/spine/pull/129) (the 3.13.0 promotion): the `PR does not modify episteme/` check fails on every `develop` → `main` PR, and cannot be made to pass.

## Why it can't pass

The guard does a two-dot diff of `episteme/` against a freshly fetched base. That is exactly right for a contributor branch — it answers "did you commit the generated bank?". On a promotion PR the base is a `main` that is 129 commits behind, so the diff shows **every bot commit made on `develop` since `main` last moved** — 76 files, +2549/−1899. All of it is `episteme.yml`'s own output.

So the check reports the design working as a violation, and the only way to satisfy it would be to revert the bank `main` is owed.

## The change

Skip the step when `github.base_ref == 'main'`. Everything else about the guard is unchanged: a feature branch that carries `episteme/` still fails.

This costs nothing, because `episteme.yml` triggers on pushes to **both** `main` and `develop` — `main` regenerates from its own tree after the merge no matter what rides in.

`CONTRIBUTING.md` documents the exemption next to the existing rule.

## Files

- `.github/workflows/ci.yml` — the `if:` condition, plus a comment explaining why a promotion is structurally exempt
- `CONTRIBUTING.md` — the exemption, under the existing "Do not commit `episteme/`" note

🤖 Generated with [Claude Code](https://claude.com/claude-code)