### PR TITLE
fix(mcp): honour a server that declares a structured argument as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## Unreleased
+
+### Fixed
+
+- **A server that declares a structured argument as a JSON string now gets one.**
+  `mcp-atlassian` types `jira_create_issue.additional_fields` as `string` rather than
+  `object`, so every caller had to `json.dumps` it first and a governed create encoded
+  twice — once for the field, once for the transport. `MCPRegistry.call` reads the tool's
+  declared type and encodes on the caller's behalf. Narrow on purpose: only when the
+  declared type is exactly `string` (or `string|null`) *and* the value is an object or
+  array. A declared `object`, an undeclared argument, or an unreadable schema passes
+  through untouched, and a caller that already encoded still works. The schema round-trip
+  is skipped entirely when every argument is a scalar, and a discovery failure falls back
+  to the raw call rather than becoming a new way to fail.
+
 ## 3.13.0 — A green suite is not a working change
 
 Found by running one ticket end to end a dozen times. Every stage of the build loop was

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -787,10 +787,10 @@ You extend the catalog with new skills/tools/run-shapes via a selector
 
 `orchestrator mcp contracts` shows the governed ToolContract derived for each
 onboarded MCP tool, and labels every argument with its **declared type**, read
-from the server's own JSON Schema at display time (nothing is stored, and
-`mcp call` is unaffected). A union type is joined with `|`, and an argument the
-schema doesn't give a top-level `type` (an `anyOf`, a `$ref`, or a tool with no
-schema at all) is labelled `any`:
+from the server's own JSON Schema (nothing is stored — the labels are derived on
+every read). A union type is joined with `|`, and an argument the schema doesn't
+give a top-level `type` (an `anyOf`, a `$ref`, or a tool with no schema at all)
+is labelled `any`:
 
 ```json
 {
@@ -802,6 +802,24 @@ schema at all) is labelled `any`:
 
 Use it to see an argument's expected shape *before* a call fails on a type
 mismatch.
+
+**Stringly-typed arguments are encoded for you.** Some servers type a structured
+argument as a *string of JSON* rather than an object — Atlassian's
+`jira_create_issue.additional_fields` is the one you'll hit first. Pass the
+natural object; `mcp call` reads the declared type and encodes it:
+
+```bash
+orchestrator mcp call atlassian:jira_create_issue --args '{"project_key":"SSPN","additional_fields":{"labels":["dogfood"]}}'
+```
+
+Without this you'd have to embed a JSON document inside a JSON document. If you
+already encode it yourself, that still works — both spellings are accepted.
+
+The coercion is deliberately narrow: it applies only where the schema says
+`string` (or `string|null`) and you passed an object or array. An argument the
+server declares as `object`, one it doesn't declare at all, or a tool whose
+schema can't be read is sent exactly as you wrote it — Spine won't guess at a
+type the server never stated.
 
 Spine can use external **[MCP](https://modelcontextprotocol.io)
 servers** — read Confluence/Jira through Atlassian's MCP server, introspect a

--- a/src/orchestrator/mcp/registry.py
+++ b/src/orchestrator/mcp/registry.py
@@ -20,6 +20,7 @@ from typing import Any
 from orchestrator.mcp.client import MCPClient, SessionMCPClient
 from orchestrator.mcp.config import MCPServerConfig, load_mcp_configs
 from orchestrator.mcp.models import MCPServerStatus, MCPTool, MCPToolResult
+from orchestrator.mcp.schema_types import encode_for_schema, needs_schema_lookup
 
 logger = logging.getLogger("orchestrator.mcp")
 
@@ -112,7 +113,25 @@ class MCPRegistry:
             raise KeyError(f"unknown MCP server {server!r} (known: {known})")
         if not tool or not cfg.allows(tool):
             raise PermissionError(f"tool {qualified_name!r} is not allow-listed on server {server!r}")
-        return await self._factory(cfg).call_tool(tool, arguments)
+        client = self._factory(cfg)
+        return await client.call_tool(tool, await self._encoded(client, tool, arguments))
+
+    async def _encoded(self, client: MCPClient, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Honour a server that declares a structured argument as a JSON string.
+
+        Skipped entirely unless some argument is a ``dict``/``list``, so the common
+        all-scalar call pays nothing for the schema round-trip. A discovery failure
+        passes the arguments through untouched: this is a convenience over the raw
+        call, and it must never be the reason one fails.
+        """
+        if not needs_schema_lookup(arguments):
+            return arguments
+        try:
+            schema = next((t.input_schema for t in await client.list_tools() if t.name == tool), None)
+        except Exception as exc:  # noqa: BLE001 — the call itself is still worth attempting
+            logger.warning("mcp.schema_lookup_failed", extra={"tool": tool, "error": str(exc)[:200]})
+            return arguments
+        return encode_for_schema(schema, arguments)
 
 
 __all__ = ["ClientFactory", "MCPRegistry"]

--- a/src/orchestrator/mcp/schema_types.py
+++ b/src/orchestrator/mcp/schema_types.py
@@ -1,16 +1,27 @@
-"""Human-readable type labels for MCP tool arguments.
+"""Read an MCP tool's declared argument types — to show them, and to honour them.
 
 An MCP server describes each tool's arguments as a JSON Schema
 (``MCPTool.input_schema``). The registry's ``ToolContract`` keeps only a
 normalised field list, so the raw declared type (unions, ``anyOf``, ``$ref``)
 is lost by the time ``orchestrator mcp contracts`` renders it. These helpers
-read the schema at *display time* and derive a short scannable label such as
-``string`` or ``string|null`` — nothing here mutates stored state or affects
-how ``mcp call`` serialises arguments.
+read the schema directly and derive a short scannable label such as ``string``
+or ``string|null``.
+
+Two callers, from the same reading:
+
+- **Display** (``argument_type_label``) — ``mcp contracts`` shows the declared
+  shape so a caller sees it before a call fails.
+- **Call** (``encode_for_schema``) — a server that types a structured argument
+  as a JSON *string* gets one, so callers pass the natural object and no one
+  double-encodes.
+
+Neither mutates stored state; the labels are derived on every read.
 """
 
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
 from typing import Any
 
 # Shown when the schema declares no usable top-level ``type`` (``anyOf``,
@@ -58,9 +69,48 @@ def format_argument(name: str, label: str) -> str:
     return f"{name} ({label})"
 
 
+def needs_schema_lookup(arguments: Mapping[str, Any]) -> bool:
+    """Whether any argument is structured, so coercion could apply.
+
+    Fetching a tool's schema costs a round-trip (:class:`SessionMCPClient` opens a
+    fresh session per operation). Only a ``dict``/``list`` value can ever need
+    encoding, so a call passing scalars alone skips discovery entirely.
+    """
+    return any(isinstance(v, dict | list) for v in arguments.values())
+
+
+def encode_for_schema(schema: dict[str, Any] | None, arguments: Mapping[str, Any]) -> dict[str, Any]:
+    """JSON-encode arguments the server declares as ``string`` but were passed structured.
+
+    Some servers type a structured argument as a *string* of JSON rather than an
+    object — ``mcp-atlassian`` does this for ``jira_create_issue.additional_fields``.
+    Without this, every caller has to ``json.dumps`` before calling, so a governed
+    create double-encodes: once for the field, once for the transport. Callers that
+    already pass a string are untouched, so both spellings work.
+
+    Deliberately narrow. It encodes only when the declared type is exactly
+    ``string`` (or ``string|null``) *and* the value is a ``dict``/``list``. A
+    declared ``object``, an undeclared argument, or an unreadable schema is passed
+    through as-is — guessing at a type the server did not state is how you corrupt
+    a payload that was already correct.
+    """
+    if not isinstance(schema, dict):
+        return dict(arguments)
+    out = dict(arguments)
+    for name, value in arguments.items():
+        if not isinstance(value, dict | list):
+            continue
+        parts = {p for p in argument_type_label(schema, name).split("|") if p != "null"}
+        if parts == {"string"}:
+            out[name] = json.dumps(value)
+    return out
+
+
 __all__ = [
     "UNKNOWN_TYPE",
     "argument_type_label",
     "argument_type_labels",
+    "encode_for_schema",
     "format_argument",
+    "needs_schema_lookup",
 ]

--- a/tests/mcp/test_registry.py
+++ b/tests/mcp/test_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -12,16 +13,29 @@ from orchestrator.mcp.registry import MCPRegistry
 
 
 class _FakeClient:
-    def __init__(self, server: str, tools: list[tuple[str, bool | None]], *, down: bool = False) -> None:
+    def __init__(
+        self,
+        server: str,
+        tools: list[tuple[str, bool | None]],
+        *,
+        down: bool = False,
+        schemas: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
         self._server = server
         self._tools = tools
         self._down = down
+        self._schemas = schemas or {}
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.list_count = 0  # so a test can prove the schema lookup was skipped
 
     async def list_tools(self) -> list[MCPTool]:
+        self.list_count += 1
         if self._down:
             raise RuntimeError("server down")
-        return [MCPTool(server=self._server, name=n, read_only=ro) for n, ro in self._tools]
+        return [
+            MCPTool(server=self._server, name=n, read_only=ro, input_schema=self._schemas.get(n, {}))
+            for n, ro in self._tools
+        ]
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
         self.calls.append((name, arguments))
@@ -82,3 +96,89 @@ async def test_down_server_is_skipped_not_fatal() -> None:
 def test_disabled_server_is_excluded() -> None:
     reg = MCPRegistry([MCPServerConfig(name="off", command="x", enabled=False)])
     assert reg.server_names() == []
+
+
+# --- A server that declares a structured argument as a JSON string (SSPN-14) ---------
+#
+# mcp-atlassian types `jira_create_issue.additional_fields` as `string`, not `object`.
+# Every caller therefore had to json.dumps it first, which meant a governed create
+# encoded twice: once for the field, once for the transport. The registry now honours
+# the declared type, so callers pass the natural object.
+
+_ATLASSIAN = {
+    "jira_create_issue": {
+        "properties": {
+            "project_key": {"type": "string"},
+            "additional_fields": {"type": "string"},
+            "components": {"type": ["string", "null"]},
+            "labels": {"type": "array"},
+            "payload": {"type": "object"},
+        }
+    }
+}
+
+
+def _atlassian_registry() -> tuple[MCPRegistry, _FakeClient]:
+    client = _FakeClient("atlassian", [("jira_create_issue", False)], schemas=_ATLASSIAN)
+    configs = [MCPServerConfig(name="atlassian", command="x")]
+    return _registry({"atlassian": client}, configs), client
+
+
+async def test_object_argument_declared_as_string_is_encoded_once() -> None:
+    registry, client = _atlassian_registry()
+    await registry.call(
+        "atlassian:jira_create_issue",
+        {"project_key": "SSPN", "additional_fields": {"priority": {"name": "High"}}},
+    )
+    _, sent = client.calls[0]
+    assert sent["additional_fields"] == '{"priority": {"name": "High"}}'
+    # Encoded exactly once: it round-trips back to the object the caller passed.
+    assert json.loads(sent["additional_fields"]) == {"priority": {"name": "High"}}
+    assert sent["project_key"] == "SSPN", "a scalar argument is untouched"
+
+
+async def test_a_caller_that_already_encoded_is_left_alone() -> None:
+    """Both spellings work, so this is not a breaking change for existing callers."""
+    registry, client = _atlassian_registry()
+    await registry.call(
+        "atlassian:jira_create_issue",
+        {"project_key": "SSPN", "additional_fields": '{"priority": {"name": "High"}}'},
+    )
+    _, sent = client.calls[0]
+    assert sent["additional_fields"] == '{"priority": {"name": "High"}}'
+
+
+async def test_only_string_declared_arguments_are_encoded() -> None:
+    """A declared array/object is passed through — the server asked for structure."""
+    registry, client = _atlassian_registry()
+    await registry.call(
+        "atlassian:jira_create_issue",
+        {"labels": ["a", "b"], "payload": {"k": "v"}, "components": {"nullable": True}},
+    )
+    _, sent = client.calls[0]
+    assert sent["labels"] == ["a", "b"]
+    assert sent["payload"] == {"k": "v"}
+    # `string|null` is still a string type, so it is encoded.
+    assert sent["components"] == '{"nullable": true}'
+
+
+async def test_an_undeclared_argument_is_never_guessed_at() -> None:
+    registry, client = _atlassian_registry()
+    await registry.call("atlassian:jira_create_issue", {"mystery": {"k": "v"}})
+    assert client.calls[0][1]["mystery"] == {"k": "v"}
+
+
+async def test_all_scalar_call_skips_the_schema_round_trip() -> None:
+    """Discovery costs a session; nothing structured means nothing to encode."""
+    registry, client = _atlassian_registry()
+    await registry.call("atlassian:jira_create_issue", {"project_key": "SSPN"})
+    assert client.list_count == 0
+
+
+async def test_a_failed_schema_lookup_still_makes_the_call() -> None:
+    """The coercion is a convenience over the raw call, never a new way to fail."""
+    client = _FakeClient("atlassian", [("jira_create_issue", False)], down=True)
+    registry = _registry({"atlassian": client}, [MCPServerConfig(name="atlassian", command="x")])
+    result = await registry.call("atlassian:jira_create_issue", {"additional_fields": {"k": "v"}})
+    assert not result.is_error
+    assert client.calls[0][1]["additional_fields"] == {"k": "v"}


### PR DESCRIPTION
Closes the half of SSPN-14 that 3.13.0 left open.

## The bug

`mcp-atlassian` declares `jira_create_issue.additional_fields` as `string`, not `object`. So every caller had to `json.dumps` it first, and a governed create encoded twice — once for the field, once for the transport.

3.13.0 shipped the *visibility* half (`mcp contracts` now prints `additional_fields (string)`), and its spec said explicitly that call serialisation was out of scope. Seeing the trap is not avoiding it. This is the other half.

## The change

`MCPRegistry.call` reads the same schema at call time and encodes on the caller's behalf, so the natural object works.

Narrow on purpose — guessing at a type the server did not state is how you corrupt a payload that was already correct:

- encodes **only** when the declared type is exactly `string` (or `string|null`) **and** the value is a `dict`/`list`
- a declared `object`/`array`, an undeclared argument, or an unreadable schema passes through untouched
- a caller that already encoded is left alone, so **both spellings work** — not a breaking change

Cost: the schema lookup needs a session, so it's skipped entirely unless some argument is structured. An all-scalar call pays nothing. A discovery failure logs and falls back to the raw call — this is a convenience over calling directly, never a new way to fail.

## Files

- `src/orchestrator/mcp/schema_types.py` — `encode_for_schema` + `needs_schema_lookup`; the module docstring claimed nothing here affects `mcp call` serialisation, which this makes false, so it's rewritten
- `src/orchestrator/mcp/registry.py` — `_encoded` wired into `call`
- `tests/mcp/test_registry.py` — 6 tests

## Verification

Full gate green; **2389 passed** (up 6).

The new tests were checked against a reverted fix: `test_object_argument_declared_as_string_is_encoded_once` and `test_only_string_declared_arguments_are_encoded` **fail** without it. The other four assert pass-through behaviour and hold either way — they're guardrails against over-reach, not proofs of the fix, and are included as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)