### PR TITLE
docs: a re-run cannot fix a failure that came from the base branch

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -50,9 +50,23 @@ jobs:
       # This list must only ever SHRINK. Adding an ID is a PR-review decision, never a
       # drive-by — and each addition needs a reachability/trade-off note like the above.
       - name: Audit locked dependencies (fails on any NEW advisory)
+        id: audit
         run: |
           uv run --with pip-audit pip-audit -r requirements-audit.txt \
             --ignore-vuln PYSEC-2026-2132
+
+      # This job resolves from the *merge ref computed at push time*, so a bump that has
+      # already landed on the base is not in the tree it audits. Re-running replays that
+      # same ref and reports the same advisory, which makes "merge the fix, then re-run"
+      # the natural and wrong instinct. Say so where the failure is read.
+      - name: Why a re-run will not clear this
+        if: failure() && steps.audit.outcome == 'failure'
+        run: |
+          echo "::notice::If this advisory is already fixed on the base branch, a re-run"
+          echo "::notice::cannot pick it up — this job audits the merge ref computed when"
+          echo "::notice::you pushed. Rebase to get a fresh one:"
+          echo "::notice::  git fetch origin && git rebase origin/${{ github.base_ref || 'develop' }} && git push --force-with-lease"
+          echo "::notice::See CONTRIBUTING.md — 'When a check fails on something you didn't change'."
 
       # Always visible, never blocking: the full picture including the backlog above,
       # so the ignore list can't quietly become the place findings go to die.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,31 @@ them on a release cadence — so opening an issue first avoids duplicated effort
 4. Open the PR with a clear description of **what** and **why**, linking any issue.
 5. A maintainer reviews; the `security scan` check must pass.
 
+### When a check fails on something you didn't change
+
+**A re-run cannot fix a failure that came from the base branch. Push to your branch
+instead.**
+
+`gh run rerun` replays a run against the commit it was created for. For a
+`pull_request` workflow that commit is the *merge ref computed when you pushed* — not
+the base branch as it stands now. So merging a fix into `develop` and re-running your
+PR re-audits the same stale tree, and reports the same failure. Only a new merge ref
+clears it, which means pushing to the branch: a rebase onto the current base, or an
+empty commit if you have nothing to change.
+
+```bash
+git fetch origin && git rebase origin/develop && git push --force-with-lease
+```
+
+This bites hardest on `dependency audit`, which resolves the dependency tree from the
+merge ref. A vulnerable version pinned on `develop` keeps failing every open PR until
+each one is rebased past the bump — re-running looks like the obvious fix and is the
+one thing that cannot work. It applies equally to any check reading state your branch
+does not own.
+
+Re-running *is* the right move for a genuinely flaky failure — a network timeout, a
+cache miss, a runner dying. The distinction is whether the failure depends on the tree.
+
 We use [Conventional Commits](https://www.conventionalcommits.org/) for commit
 messages (e.g. `fix(planner): handle empty claims list`).
 


### PR DESCRIPTION
Closes SSPN-16.

## The trap

`gh run rerun` replays a run against the commit it was created for. For a `pull_request` workflow that is the **merge ref computed when you pushed** — not the base branch as it stands now. So merging a fix into `develop` and re-running your PR re-audits the same stale tree and reports the same failure.

Observed twice in one session: PR #89's `dependency audit` failed on `cryptography 49.0.0`, #91 bumped `develop` to 50.0.0, and the re-run still reported 49.0.0. Only a rebase produced a fresh merge ref and a passing run.

"Merge the fix, then re-run" is the natural instinct and the one thing that cannot work. As the ticket puts it, documenting the rule is the cheaper, honest fix — resolving from the base at run time would just trade one surprise for another.

## Where it's written

Two places, because a rule nobody reads at the moment of failure isn't documented:

- **`CONTRIBUTING.md`** — new *"When a check fails on something you didn't change"* section: the rule, the rebase command, why `dependency audit` hits it hardest, and the distinction from a genuinely flaky failure (timeout, cache miss, dead runner) where a re-run **is** correct.
- **`.github/workflows/dependency-audit.yml`** — an `if: failure()` step that prints the same guidance with the rebase command, at the point where someone is actually looking when they reach for the re-run button.

That covers both acceptance criteria — the second one asks that *anywhere* the process tells someone to re-run says which failures a re-run can't fix, and the audit job's failure output is where that decision gets made.

## Note on the sibling ticket

SSPN-15 is closed as obsolete rather than fixed. The `episteme-current` hook it describes was deleted by `4aeb6d5` ("regenerate episteme after merge instead of on every branch") as part of SSPN-20 — there's no `files:` pattern left to widen, and the replacement design means local and CI can't disagree about `episteme/` at all.

## Verification

YAML parses; `check-yaml` and the rest of pre-commit pass. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)