### PR TITLE
feat(sdlc): --spec, to implement a spec you wrote instead of one derived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## Unreleased
 
+### Added
+
+- **`--spec` on `sdlc autorun` and `sdlc feature`** — implement a spec you wrote instead of
+  one derived from the source. Intake is skipped entirely and the `[intake]` line reports
+  `skipped`, so a run summary never implies a source document was read when none was. For a
+  settled spec (a remediation, something agreed in review) — or when intake itself is what
+  the ticket is about, where letting a defective stage specify its own repair is circular.
+  The file is JSON validated against `FeatureSpec` rather than markdown: a misspelled
+  `acceptance-criteria` is an error naming the valid fields, not a run that proceeds with no
+  criteria and passes by default. An empty criteria list is refused for the same reason.
+
 ### Fixed
 
 - **A server that declares a structured argument as a JSON string now gets one.**

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -722,6 +722,36 @@ orchestrator sdlc autorun --source jira://PROJ-14 --issue PROJ-14 --path . --saf
 | `--out` | Where run artifacts go (default: a run dir under the temp dir). |
 | `--resume` | Continue a run by id — adopts the issue it already created. |
 | `--max-cost` | Cap LLM spend (USD) for this run; exhausting it parks the run. |
+| `--spec` | Implement a hand-written spec (JSON) instead of deriving one from the source. Intake is skipped entirely and recorded as `skipped`. |
+
+**Implementing a spec you wrote (`--spec`).** Normally intake derives the spec from
+the source document. Pass `--spec path.json` to supply it directly — the pipeline
+builds exactly what the file says, and the `[intake]` line reports `skipped` rather
+than implying a document was read.
+
+Use it when the spec is already settled (a remediation, something agreed in review),
+or when intake itself is what the ticket is about — letting a defective stage write
+the specification for its own repair is circular.
+
+```json
+{
+  "title": "Keep invented criteria separable",
+  "intent_id": "SSPN-31",
+  "summary": "Intake appends inferred criteria to the stated ones, losing provenance.",
+  "acceptance_criteria": [
+    "A criterion the source did not state is emitted as proposed, not as fact."
+  ],
+  "technical_notes": "FeatureSpec gains a proposed_criteria field."
+}
+```
+
+Only `title` and `acceptance_criteria` are required; `intent_id` defaults to the
+filename stem. The file is JSON rather than markdown on purpose — it is validated
+strictly, so a misspelled `acceptance-criteria` is an error naming the valid fields
+instead of a run that proceeds with no criteria and passes by default. An empty
+criteria list is refused for the same reason.
+
+The `--source` argument is still required and still what the run is filed against.
 
 **Reading the output.** Each stage prints a bracketed line. The ones that decide
 whether a change ships:
@@ -779,6 +809,7 @@ orchestrator sdlc feature [OPTIONS]
 | `--base` | PR target branch (default: $SDLC_PR_BASE, else the repo's default branch). |
 | `--layout` | Target structure: auto (scaffold only empty repos), new (always scaffold a src/<pkg>/ skeleton), or existing (follow the repo's layout). (default: `auto`) |
 | `--package-name` | Override the scaffold package name (default: derived from repo). |
+| `--spec` | Implement a hand-written spec (JSON) instead of deriving one from the source — see `sdlc autorun` above for the format. |
 | `--refresh` | Re-extract intents from the source (default: reuse the cached, deterministic backlog). |
 | `--language` | Target language: auto (detect), python, java, typescript, csharp, c, cpp, go, or sql. (default: `auto`) |
 

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -880,6 +880,13 @@ def sdlc_autorun(
         float | None,
         typer.Option("--max-cost", help="Cap LLM spend (USD) for this run; exhausting it parks it."),
     ] = None,
+    spec: Annotated[
+        Path | None,
+        typer.Option(
+            "--spec",
+            help="Implement a hand-written spec (JSON) instead of deriving one from the source.",
+        ),
+    ] = None,
 ) -> None:
     """Drive ONE ticket through the whole happy path: research → design → code → tests → PR.
 
@@ -894,6 +901,14 @@ def sdlc_autorun(
     import asyncio
 
     from orchestrator.sdlc.autorun import AutorunError, autorun, render_summary
+    from orchestrator.sdlc.spec_file import SpecFileError, load_spec_file
+
+    # Before any work starts: a bad spec file should cost nothing to discover.
+    try:
+        injected = load_spec_file(spec) if spec else None
+    except SpecFileError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
 
     async def _go() -> None:
         try:
@@ -911,6 +926,7 @@ def sdlc_autorun(
                 artifacts_dir=out,
                 resume=resume,
                 max_cost_usd=max_cost,
+                spec=injected,
                 log=typer.echo,
             )
         except AutorunError as exc:
@@ -1004,6 +1020,13 @@ def sdlc_feature(
             help="Target language: auto (detect), python, java, typescript, csharp, c, cpp, go, or sql.",
         ),
     ] = "auto",
+    spec: Annotated[
+        Path | None,
+        typer.Option(
+            "--spec",
+            help="Implement a hand-written spec (JSON) instead of deriving one from the source.",
+        ),
+    ] = None,
 ) -> None:
     """Linear pipeline for ONE intent, end to end.
 
@@ -1021,15 +1044,24 @@ def sdlc_feature(
     import asyncio
 
     from orchestrator.sdlc.feature_runner import unsupported_language_error
+    from orchestrator.sdlc.spec_file import SpecFileError, load_spec_file
 
     lang_error = unsupported_language_error(language)
     if lang_error is not None:
         typer.echo(f"ERROR: {lang_error}", err=True)
         raise typer.Exit(code=2)
 
+    # Before any work starts: a bad spec file should cost nothing to discover.
+    try:
+        injected = load_spec_file(spec) if spec else None
+    except SpecFileError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
+
     asyncio.run(
         _run_sdlc_feature(
             source,
+            spec=injected,
             intent_id=intent,
             repo=repo,
             model=model,
@@ -1059,12 +1091,14 @@ async def _run_sdlc_feature(
     package_name: str | None,
     refresh: bool,
     language: str,
+    spec: dict[str, Any] | None = None,
 ) -> None:
     from orchestrator.sdlc.feature_runner import FeatureRunError, run_feature
 
     try:
         result = await run_feature(
             source,
+            spec=spec,
             intent_id=intent_id,
             repo=repo,
             model=model,

--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -195,6 +195,7 @@ async def autorun(
     approvals_dir: Path | None = None,
     resume: str | None = None,
     max_cost_usd: float | None = None,
+    spec: dict[str, Any] | None = None,
     store: Any = None,
     log: Callable[[str], None] | None = None,
 ) -> RunContext:
@@ -284,7 +285,7 @@ async def autorun(
     ):
         try:
             with ctx.stage_span("intake"):
-                await _stage_intake(ctx, intent_id=intent_id, emit=emit)
+                await _stage_intake(ctx, intent_id=intent_id, spec=spec, emit=emit)
             store_graph, overview = _load_graph(ctx, emit=emit)
             with ctx.stage_span("investigate"):
                 _stage_investigate(ctx, store=store_graph, emit=emit)
@@ -400,13 +401,30 @@ def _refuse_undecided_resume(record: Any, approvals_dir: Path | None, emit: Call
 # ---- stages ----------------------------------------------------------------
 
 
-async def _stage_intake(ctx: RunContext, *, intent_id: str | None, emit: Callable[[str], None]) -> None:
+async def _stage_intake(
+    ctx: RunContext,
+    *,
+    intent_id: str | None,
+    spec: dict[str, Any] | None = None,
+    emit: Callable[[str], None],
+) -> None:
     """Resolve the source to one spec, once, and hand it to every later stage.
 
     ``run_feature`` can do its own intake, but then the brief and design would be written for
     a spec the implementation stage might re-derive differently. Resolving here and injecting
     it keeps all four stages talking about the same thing.
+
+    A caller-supplied ``spec`` replaces that derivation outright: intake does not run, and
+    the stage records *skipped* rather than *ok*, so the summary never implies a source
+    document was read. The source URI is still what the run is filed against.
     """
+    if spec is not None:
+        ctx.spec = dict(spec)
+        ctx.spec.setdefault("intent_id", intent_id or "injected")
+        ctx.record_stage("intake", "skipped", "spec supplied by the caller")
+        emit(f"[intake] skipped — spec supplied: {ctx.spec.get('title', '')}")
+        return
+
     from orchestrator.core.env import load_local_env
     from orchestrator.intake.cache import analyze_cached
     from orchestrator.intake.factory import IntakeNotConfiguredError, build_service_for

--- a/src/orchestrator/sdlc/spec_file.py
+++ b/src/orchestrator/sdlc/spec_file.py
@@ -1,0 +1,70 @@
+"""Load a hand-written feature spec from disk, in place of intake.
+
+Intake derives a spec from a source document. Sometimes you already know what the
+spec is and want the pipeline to build *that* — a remediation, a spec agreed in
+review, or a ticket whose repair is a defect in intake itself, where letting the
+broken stage write the specification for its own fix is circular.
+
+The injection path already exists (``run_feature(spec=...)``, ``autorun(spec=...)``);
+this is the file format that reaches it.
+
+**JSON, validated strictly.** A markdown spec would be friendlier to write and worse
+to trust: a criterion the parser silently misses is indistinguishable from one you
+never wrote, which is the failure this pipeline keeps having. ``FeatureSpec`` forbids
+extra keys, so ``acceptance-criteria`` or ``acceptanceCriteria`` is an error naming
+the valid fields rather than a run that quietly proceeds with none.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from orchestrator.intake.specs import FeatureSpec
+
+
+class SpecFileError(ValueError):
+    """A spec file could not be read, parsed, or validated."""
+
+
+def load_spec_file(path: Path | str) -> dict[str, Any]:
+    """Read and validate a spec file, returning the dict the pipeline expects.
+
+    Raises :class:`SpecFileError` with a message naming the file and the specific
+    problem — this runs before any work starts, so it is the cheapest place to be
+    told the spec is wrong.
+    """
+    p = Path(path)
+    try:
+        raw = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SpecFileError(f"cannot read spec file {p}: {exc}") from exc
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SpecFileError(f"{p} is not valid JSON: line {exc.lineno}: {exc.msg}") from exc
+
+    if not isinstance(payload, dict):
+        raise SpecFileError(f"{p} must contain a JSON object, got {type(payload).__name__}")
+
+    payload.setdefault("intent_id", p.stem)
+    try:
+        spec = FeatureSpec.model_validate(payload)
+    except Exception as exc:  # pydantic ValidationError — reported, not re-raised raw
+        raise SpecFileError(f"{p} is not a valid spec:\n{exc}") from exc
+
+    if not spec.title.strip():
+        raise SpecFileError(f"{p}: 'title' is required and cannot be empty")
+    if not spec.acceptance_criteria:
+        # Not fatal upstream, but a spec with nothing to satisfy gives the judge
+        # nothing to judge — the run would report success having proved nothing.
+        raise SpecFileError(
+            f"{p}: 'acceptance_criteria' is empty — there would be nothing for the "
+            "acceptance judge to verify, and the run would pass by default."
+        )
+    return spec.model_dump()
+
+
+__all__ = ["SpecFileError", "load_spec_file"]

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -551,6 +551,7 @@ def _run(
     resume: str | None = None,
     issue: str | None = None,
     max_cost_usd: float | None = None,
+    spec: dict[str, Any] | None = None,
 ) -> RunContext:
     """Run the skeleton against a tiny real repo, so the graph stages do real work."""
     import asyncio
@@ -571,5 +572,71 @@ def _run(
             resume=resume,
             issue=issue,
             max_cost_usd=max_cost_usd,
+            spec=spec,
         )
     )
+
+
+# --- A hand-written spec replaces intake (--spec) -----------------------------------
+#
+# Intake derives a spec from a source document. When the ticket's repair is a defect in
+# intake itself, letting it write the specification for its own fix is circular — so the
+# stage has to be skippable, and visibly so.
+
+_INJECTED = {
+    "title": "Keep invented criteria separable",
+    "intent_id": "SSPN-31",
+    "summary": "Intake appends inferred criteria to the stated ones.",
+    "acceptance_criteria": ["A criterion the source did not state is emitted as proposed."],
+}
+
+
+def test_an_injected_spec_is_what_every_later_stage_sees(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    seen = _install(monkeypatch, tmp_path)
+
+    ctx = _run(tmp_path, spec=dict(_INJECTED))
+
+    assert ctx.spec is not None and ctx.spec["title"] == _INJECTED["title"]
+    assert ctx.spec["acceptance_criteria"] == _INJECTED["acceptance_criteria"]
+    assert seen["feature_kwargs"]["spec"] == ctx.spec, "the implement stage gets the same spec"
+
+
+def test_an_injected_spec_records_intake_as_skipped_not_ok(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A run summary must never imply a source document was read when none was."""
+    _install(monkeypatch, tmp_path)
+
+    ctx = _run(tmp_path, spec=dict(_INJECTED))
+
+    intake = next(s for s in ctx.stages if s.name == "intake")
+    assert intake.status == "skipped"
+    assert "spec supplied" in (intake.detail or "")
+
+
+def test_intake_does_not_run_at_all_when_a_spec_is_given(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The point of --spec for SSPN-31: the defective stage must not execute."""
+    _install(monkeypatch, tmp_path)
+
+    def _boom(*a: Any, **k: Any) -> Any:
+        raise AssertionError("intake ran despite an injected spec")
+
+    monkeypatch.setattr("orchestrator.intake.cache.analyze_cached", _boom)
+
+    ctx = _run(tmp_path, spec=dict(_INJECTED))
+    assert ctx.passed
+
+
+def test_an_injected_spec_without_an_intent_id_still_gets_one(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install(monkeypatch, tmp_path)
+    spec = {k: v for k, v in _INJECTED.items() if k != "intent_id"}
+
+    ctx = _run(tmp_path, spec=spec)
+
+    assert ctx.spec is not None and ctx.spec["intent_id"] == "injected"

--- a/tests/sdlc/test_spec_file.py
+++ b/tests/sdlc/test_spec_file.py
@@ -1,0 +1,79 @@
+"""Loading a hand-written spec, in place of intake.
+
+The point of the format is that a spec you wrote is the spec that runs. Every test
+here is about a way that could quietly not be true.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orchestrator.sdlc.spec_file import SpecFileError, load_spec_file
+
+_VALID = {
+    "title": "Keep invented criteria separable",
+    "summary": "Intake appends inferred criteria to the stated ones.",
+    "acceptance_criteria": ["A criterion the source did not state is emitted as proposed."],
+}
+
+
+def _write(tmp_path: Path, payload: object, name: str = "spec.json") -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps(payload) if not isinstance(payload, str) else payload, encoding="utf-8")
+    return p
+
+
+def test_a_valid_spec_round_trips(tmp_path: Path) -> None:
+    spec = load_spec_file(_write(tmp_path, _VALID))
+    assert spec["title"] == _VALID["title"]
+    assert spec["acceptance_criteria"] == _VALID["acceptance_criteria"]
+
+
+def test_intent_id_defaults_to_the_filename(tmp_path: Path) -> None:
+    """So a spec file is addressable without repeating its own name inside it."""
+    assert load_spec_file(_write(tmp_path, _VALID, "SSPN-31.json"))["intent_id"] == "SSPN-31"
+
+
+def test_an_explicit_intent_id_wins(tmp_path: Path) -> None:
+    spec = load_spec_file(_write(tmp_path, {**_VALID, "intent_id": "chosen"}, "ignored.json"))
+    assert spec["intent_id"] == "chosen"
+
+
+def test_a_misspelled_field_is_an_error_not_a_silent_drop(tmp_path: Path) -> None:
+    """The whole reason for JSON-with-validation over a markdown parser.
+
+    `acceptance-criteria` would otherwise leave the run with zero criteria, which
+    the judge passes by default — a spec that proves nothing, reported as success.
+    """
+    bad = {"title": _VALID["title"], "acceptance-criteria": ["something"]}
+    with pytest.raises(SpecFileError) as exc:
+        load_spec_file(_write(tmp_path, bad))
+    assert "not a valid spec" in str(exc.value)
+
+
+def test_an_empty_criteria_list_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(SpecFileError, match="nothing for the acceptance judge to verify"):
+        load_spec_file(_write(tmp_path, {**_VALID, "acceptance_criteria": []}))
+
+
+def test_an_empty_title_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(SpecFileError, match="'title' is required"):
+        load_spec_file(_write(tmp_path, {**_VALID, "title": "   "}))
+
+
+def test_malformed_json_names_the_line(tmp_path: Path) -> None:
+    with pytest.raises(SpecFileError, match="not valid JSON"):
+        load_spec_file(_write(tmp_path, '{"title": "x",}'))
+
+
+def test_a_json_array_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(SpecFileError, match="must contain a JSON object"):
+        load_spec_file(_write(tmp_path, [_VALID]))
+
+
+def test_a_missing_file_names_itself(tmp_path: Path) -> None:
+    with pytest.raises(SpecFileError, match="cannot read spec file"):
+        load_spec_file(tmp_path / "nope.json")


### PR DESCRIPTION
Prerequisite for SSPN-31.

## Why

The injection path already existed — `run_feature(spec=...)`, and `autorun`'s intake stage hands a resolved spec to every stage downstream. Nothing on the CLI could reach it. A spec agreed in review, or written by hand, had no way in.

The immediate need is SSPN-31, *"intake invents acceptance criteria"*. Running `autorun` against that ticket means the defective stage writes the specification for its own repair — and its characteristic failure is inventing criteria. You'd get invented acceptance criteria for the invented-acceptance-criteria bug, with no clean signal about which were real. The stage has to be skippable.

## What

`--spec path.json` on both `sdlc autorun` and `sdlc feature`.

**Skipped, and visibly so.** Intake records `skipped`, not `ok`, and prints `[intake] skipped — spec supplied: <title>`. A run summary must never imply a source document was read when none was. `--source` is still required and still what the run is filed against.

**JSON validated against `FeatureSpec`, not markdown.** Markdown would be friendlier to write and worse to trust: a criterion the parser silently misses is indistinguishable from one you never wrote, which is precisely the failure this pipeline keeps having. `extra="forbid"` turns `acceptance-criteria` into an error naming the valid fields:

```
bad.json is not a valid spec:
1 validation error for FeatureSpec
acceptance-criteria
  Extra inputs are not permitted [type=extra_forbidden, ...]
```

An empty `acceptance_criteria` is refused outright — the judge would have nothing to verify, and the run would report success having proved nothing. `intent_id` defaults to the filename stem. Validation runs before any work starts, so a bad spec costs nothing to discover; both commands exit `2`.

## Files

- `src/orchestrator/sdlc/spec_file.py` *(new)* — load + validate
- `src/orchestrator/sdlc/autorun.py` — `spec=` param; `_stage_intake` returns early and records `skipped`
- `src/orchestrator/cli.py` — the flag on both commands, validated before the async entry
- `tests/sdlc/test_spec_file.py` *(new, 9)* and `tests/sdlc/test_autorun.py` *(+4)*
- `CLI_REFERENCE.md`, `CHANGELOG.md`

## Verification

Full gate green; **2402 passed** (up 13).

The four `autorun` tests were checked against a reverted skip — all four fail without it, including the one asserting intake does not execute at all. End-to-end: a valid file loads with `intent_id` from the filename, and a misspelled field is rejected by both commands with exit `2` before any work begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)