### PR TITLE
fix(intake): constrain output the way codegen and the judge do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## Unreleased
 
+### Fixed
+
+- **Intake constrains its output the way codegen and the judge do.** Intent extraction and
+  spec writing both asked for JSON with `json_object=True`. `response_format` is
+  OpenAI/Ollama-only — Anthropic drops it, and the default model is `claude-opus-5`, so both
+  stages ran completely unconstrained and relied on brace-scanning salvage. 3.13.0 fixed
+  exactly this for codegen and the acceptance judge; intake was never converted. Both now
+  emit through a forced tool call. The text path remains as the degradation route, since a
+  forced call constrains shape but a provider can still answer in prose.
+
 ### Added
 
 - **`--spec` on `sdlc autorun` and `sdlc feature`** — implement a spec you wrote instead of

--- a/src/orchestrator/intake/intents.py
+++ b/src/orchestrator/intake/intents.py
@@ -26,7 +26,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from orchestrator.core.llm import CompletionResult, LLMClient, Message, catalog
+from orchestrator.core.llm import CompletionResult, LLMClient, Message, ToolSpec, catalog
 from orchestrator.intake.source import SourceDocument
 
 logger = logging.getLogger("orchestrator.intake.intents")
@@ -72,6 +72,50 @@ _SYSTEM_PROMPT = (
     "of 'async notify_approval_raised(...) -> bool returns True on 2xx' lets "
     "the implementation invent its own API. Leave the array empty only when "
     "the document states no criteria."
+)
+
+# The same contract as the prompt, as a tool the provider makes the model call.
+#
+# `json_object=True` was doing the constraining here, and `response_format` is an
+# OpenAI/Ollama-only lever — Anthropic drops it, and the default intake model is an
+# Anthropic one, so extraction ran completely unconstrained and leaned on the
+# brace-scanning salvage in `_loads_json_object`. Codegen and the acceptance judge
+# were converted to a forced tool call for exactly this; intake was not. The prompt
+# still spells the contract out, because the schema says nothing about fidelity.
+_SUBMIT_TOOL = ToolSpec(
+    name="submit_intents",
+    description=(
+        "Submit the discrete, buildable intents derived from the source documents. "
+        "Call this exactly once, with every intent you found."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "intents": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string", "description": "Short imperative capability name."},
+                        "description": {"type": "string"},
+                        "scope": {"type": "string"},
+                        "acceptance_criteria": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Criteria the document states, copied VERBATIM.",
+                        },
+                        "dependencies": {"type": "array", "items": {"type": "string"}},
+                        "nfrs": {"type": "array", "items": {"type": "string"}},
+                        "open_questions": {"type": "array", "items": {"type": "string"}},
+                        "source_titles": {"type": "array", "items": {"type": "string"}},
+                        "confidence": {"type": "number"},
+                    },
+                    "required": ["title", "description"],
+                },
+            }
+        },
+        "required": ["intents"],
+    },
 )
 
 
@@ -136,9 +180,20 @@ class IntentExtractor:
         # temperature=0: intent extraction must be deterministic so a pinned
         # --intent id stays addressable across runs (paired with the intake cache).
         result: CompletionResult = await self._llm.complete(
-            messages, model=self._model, json_object=True, temperature=0.0
+            messages,
+            model=self._model,
+            temperature=0.0,
+            tools=[_SUBMIT_TOOL],
+            tool_choice=_SUBMIT_TOOL.name,
         )
-        return self._parse(result.text, title_to_id, fallback_doc_ids=[d.id for d in usable])
+        fallback_doc_ids = [d.id for d in usable]
+        for call in result.tool_calls:
+            if call.name == _SUBMIT_TOOL.name:
+                # Re-serialized so a forced call and a hand-parsed answer reach the same
+                # parser — the graceful-degradation path below stays the only one.
+                return self._parse(json.dumps(call.arguments), title_to_id, fallback_doc_ids=fallback_doc_ids)
+        # A provider that ignored the tool still answers in text — the old path, unchanged.
+        return self._parse(result.text, title_to_id, fallback_doc_ids=fallback_doc_ids)
 
     def _build_user_message(self, documents: list[SourceDocument]) -> str:
         parts: list[str] = []

--- a/src/orchestrator/intake/specs.py
+++ b/src/orchestrator/intake/specs.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from orchestrator.core.llm import CompletionResult, LLMClient, Message, catalog
+from orchestrator.core.llm import CompletionResult, LLMClient, Message, ToolSpec, catalog
 from orchestrator.intake.intents import Intent
 
 logger = logging.getLogger("orchestrator.intake.specs")
@@ -54,6 +54,39 @@ _SYSTEM_PROMPT = (
     "'src/orchestrator/pkg/stats.py' makes it guess."
 )
 
+# The same contract as the prompt, as a tool the provider makes the model call.
+#
+# `json_object=True` only constrains providers that have a JSON mode; Anthropic
+# drops `response_format`, and the default intake model is an Anthropic one — so the
+# spec arrived as whatever the model felt like emitting and `_loads_json_object`
+# salvaged it. Codegen and the acceptance judge already force a tool call for this;
+# spec writing now does the same. The prompt still states the fidelity rules, which
+# no schema can express.
+_SUBMIT_TOOL = ToolSpec(
+    name="submit_feature_spec",
+    description=("Submit the implementation-ready feature spec for this intent. Call this exactly once."),
+    parameters={
+        "type": "object",
+        "properties": {
+            "summary": {"type": "string", "description": "2-4 sentence what + why."},
+            "user_story": {
+                "type": "string",
+                "description": "As a <role>, I want <capability>, so that <benefit>.",
+            },
+            "acceptance_criteria": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Testable criteria; stated ones copied VERBATIM and first.",
+            },
+            "technical_notes": {"type": "string"},
+            "nfrs": {"type": "array", "items": {"type": "string"}},
+            "dependencies": {"type": "array", "items": {"type": "string"}},
+            "estimate": {"type": "string", "enum": ["S", "M", "L", "XL"]},
+        },
+        "required": ["summary", "acceptance_criteria"],
+    },
+)
+
 
 class FeatureSpec(BaseModel):
     """An implementation-ready spec derived from one intent → one Jira issue."""
@@ -86,8 +119,18 @@ class SpecWriter:
         # temperature=0: a spec must be stable for a given intent so the same
         # --intent yields the same acceptance criteria (and cached) run to run.
         result: CompletionResult = await self._llm.complete(
-            messages, model=self._model, json_object=True, temperature=0.0
+            messages,
+            model=self._model,
+            temperature=0.0,
+            tools=[_SUBMIT_TOOL],
+            tool_choice=_SUBMIT_TOOL.name,
         )
+        for call in result.tool_calls:
+            if call.name == _SUBMIT_TOOL.name:
+                # Re-serialized so the forced call and a text answer share one parser,
+                # keeping the minimal-spec degradation path the only fallback.
+                return self._parse(json.dumps(call.arguments), intent)
+        # A provider that ignored the tool still answers in text — the old path, unchanged.
         return self._parse(result.text, intent)
 
     async def write_all(self, intents: list[Intent]) -> list[FeatureSpec]:

--- a/tests/intake/test_intake_tool_choice.py
+++ b/tests/intake/test_intake_tool_choice.py
@@ -1,0 +1,251 @@
+"""Intake constrains its output with a forced tool call (SSPN-31).
+
+A scripted fake ``LLMClient`` records the kwargs each stage sends, so these tests
+assert on the *request* — a `tool_choice` naming the submit tool and no
+`json_object=True` — not just on the parsed result, which would pass either way.
+The graceful-degradation paths (unparseable output) and the `_merge_criteria`
+guarantee are pinned here too, since this change routes through them.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from orchestrator.core.llm import CompletionResult, Message, ToolCall
+from orchestrator.intake.intents import Intent, IntentExtractor
+from orchestrator.intake.source import SourceDocument
+from orchestrator.intake.specs import SpecWriter, _merge_criteria
+
+
+class _ScriptedLLM:
+    """Records every ``complete`` kwarg and replays queued responses in order."""
+
+    def __init__(self, responses: list[CompletionResult]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def complete(
+        self,
+        messages: list[Message],
+        *,
+        model: str,
+        response_format: type[BaseModel] | None = None,
+        json_object: bool = False,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: object = None,
+        tool_choice: str | None = None,
+    ) -> CompletionResult:
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "model": model,
+                "response_format": response_format,
+                "json_object": json_object,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "tools": tools,
+                "tool_choice": tool_choice,
+            }
+        )
+        return self._responses.pop(0)
+
+
+def _result(text: str = "", tool_calls: list[ToolCall] | None = None) -> CompletionResult:
+    return CompletionResult(
+        text=text,
+        model="fake",
+        prompt_tokens=0,
+        completion_tokens=0,
+        cost_usd=0.0,
+        latency_ms=0.0,
+        tool_calls=tuple(tool_calls or []),
+    )
+
+
+def _docs() -> list[SourceDocument]:
+    return [SourceDocument(id="doc-1", title="Export", body="Users need CSV export of invoices.")]
+
+
+def _intent() -> Intent:
+    return Intent(
+        id="intent-add-csv-export",
+        title="Add CSV export",
+        description="Let users download invoices as CSV.",
+        acceptance_criteria=["async export_csv(invoice_id: str) -> bytes returns the file body"],
+        nfrs=["p95 under 500ms"],
+        dependencies=["billing service"],
+    )
+
+
+def _names(tools: object) -> list[str]:
+    assert isinstance(tools, list)
+    return [t.name for t in tools]
+
+
+# ---- the request the model receives (the bug this replaces) ----
+
+
+async def test_intent_extraction_forces_the_submit_tool_call() -> None:
+    llm = _ScriptedLLM(
+        [_result(tool_calls=[ToolCall(id="1", name="submit_intents", arguments={"intents": []})])]
+    )
+
+    await IntentExtractor(llm, model="claude-opus-5").extract(_docs())
+
+    (call,) = llm.calls
+    assert call["tool_choice"] == "submit_intents"
+    assert "submit_intents" in _names(call["tools"])
+    # `response_format` is OpenAI/Ollama-only, so JSON mode is not the constraint any more.
+    assert call["json_object"] is False
+
+
+async def test_spec_writing_forces_the_submit_tool_call() -> None:
+    llm = _ScriptedLLM(
+        [_result(tool_calls=[ToolCall(id="1", name="submit_feature_spec", arguments={"summary": "s"})])]
+    )
+
+    await SpecWriter(llm, model="claude-opus-5").write(_intent())
+
+    (call,) = llm.calls
+    assert call["tool_choice"] == "submit_feature_spec"
+    assert "submit_feature_spec" in _names(call["tools"])
+    assert call["json_object"] is False
+
+
+# ---- the forced call's arguments are parsed, not salvaged ----
+
+
+async def test_intents_come_from_the_forced_call_arguments() -> None:
+    args = {
+        "intents": [
+            {
+                "title": "Add CSV export",
+                "description": "Download invoices as CSV.",
+                "scope": "src/orchestrator/pkg/stats.py only",
+                "acceptance_criteria": ["export_csv returns bytes"],
+                "source_title": "Export",
+            }
+        ]
+    }
+    llm = _ScriptedLLM(
+        [_result(text="", tool_calls=[ToolCall(id="1", name="submit_intents", arguments=args)])]
+    )
+
+    intents = await IntentExtractor(llm).extract(_docs())
+
+    assert [i.title for i in intents] == ["Add CSV export"]
+    assert intents[0].id == "intent-add-csv-export"
+    assert intents[0].scope == "src/orchestrator/pkg/stats.py only"
+    assert intents[0].source_doc_ids == ["doc-1"]
+
+
+async def test_spec_comes_from_the_forced_call_arguments() -> None:
+    args = {
+        "summary": "Export invoices as CSV.",
+        "user_story": "As a user, I want CSV, so that I can reconcile.",
+        "acceptance_criteria": ["headers are written first"],
+        "technical_notes": "streams the response",
+        "estimate": "m",
+    }
+    llm = _ScriptedLLM(
+        [_result(text="", tool_calls=[ToolCall(id="1", name="submit_feature_spec", arguments=args)])]
+    )
+
+    spec = await SpecWriter(llm).write(_intent())
+
+    assert spec.summary == "Export invoices as CSV."
+    assert spec.technical_notes == "streams the response"
+    assert spec.estimate == "M"
+    # Stated criteria still lead, verbatim, ahead of anything the model added.
+    assert spec.acceptance_criteria[0] == _intent().acceptance_criteria[0]
+    assert "headers are written first" in spec.acceptance_criteria
+
+
+# ---- a provider that ignores the tool still answers in text ----
+
+
+async def test_a_text_answer_is_still_parsed_for_intents() -> None:
+    payload = json.dumps({"intents": [{"title": "Add CSV export", "description": "d"}]})
+    llm = _ScriptedLLM([_result(text=f"```json\n{payload}\n```")])
+
+    intents = await IntentExtractor(llm).extract(_docs())
+
+    assert [i.title for i in intents] == ["Add CSV export"]
+
+
+async def test_a_text_answer_is_still_parsed_for_specs() -> None:
+    payload = json.dumps({"summary": "from text", "acceptance_criteria": []})
+    llm = _ScriptedLLM([_result(text=f"Here you go:\n{payload}")])
+
+    spec = await SpecWriter(llm).write(_intent())
+
+    assert spec.summary == "from text"
+
+
+# ---- graceful degradation is unchanged ----
+
+
+async def test_unparseable_output_yields_no_intents_rather_than_raising() -> None:
+    llm = _ScriptedLLM([_result(text="I could not do that.")])
+
+    assert await IntentExtractor(llm).extract(_docs()) == []
+
+
+async def test_unparseable_output_yields_a_minimal_spec_carried_by_the_intent() -> None:
+    intent = _intent()
+    llm = _ScriptedLLM([_result(text="sorry, no JSON here")])
+
+    spec = await SpecWriter(llm).write(intent)
+
+    assert spec.intent_id == intent.id
+    assert spec.title == intent.title
+    assert spec.summary == intent.description
+    assert spec.acceptance_criteria == intent.acceptance_criteria
+    assert spec.nfrs == intent.nfrs
+    assert spec.dependencies == intent.dependencies
+    assert spec.estimate == ""
+
+
+async def test_no_usable_documents_skips_the_llm_entirely() -> None:
+    llm = _ScriptedLLM([])
+
+    assert await IntentExtractor(llm).extract([SourceDocument(id="d", title="t", body="")]) == []
+    assert llm.calls == []
+
+
+# ---- _merge_criteria's guarantee is unchanged ----
+
+
+@pytest.mark.parametrize(
+    "produced",
+    [
+        [],
+        ["The exporter writes a CSV file"],
+    ],
+)
+async def test_a_stated_criterion_survives_a_model_that_drops_or_paraphrases_it(produced: list[str]) -> None:
+    intent = _intent()
+    stated = intent.acceptance_criteria[0]
+    args = {"summary": "s", "acceptance_criteria": produced}
+    llm = _ScriptedLLM([_result(tool_calls=[ToolCall(id="1", name="submit_feature_spec", arguments=args)])])
+
+    spec = await SpecWriter(llm).write(intent)
+
+    assert spec.acceptance_criteria[0] == stated
+    for c in produced:
+        assert c in spec.acceptance_criteria
+
+
+def test_merge_criteria_leads_with_stated_and_dedupes_on_whitespace() -> None:
+    stated = ["add(2, 3) returns 5", "raises TypeError on strings"]
+    produced = ["add(2,  3)   returns 5", "logs the call"]
+
+    merged = _merge_criteria(stated, produced)
+
+    assert merged[: len(stated)] == stated
+    assert merged == [*stated, "logs the call"]


### PR DESCRIPTION
SSPN-31, slice 1. **Generated by the pipeline** — `sdlc autorun --spec`, run `9c4b381b2a494d88` — and verified by hand before opening this.

## The bug

Intent extraction and spec writing both passed `json_object=True`. Verified against the installed LiteLLM, for the model these actually run on:

```
response_format survives to anthropic: False -> None
```

`response_format` is OpenAI/Ollama-only. The default model is `claude-opus-5`, so **both intake stages ran completely unconstrained**, leaning on `_loads_json_object`'s brace-scanning to recover a shape from whatever came back.

3.13.0 fixed exactly this for codegen and the acceptance judge. Intake was never converted.

## The change

Both stages force a named submit tool. Two details worth noting:

- The forced call's arguments are **re-serialised through the existing parser**, so there's one parse path rather than two.
- The text path **stays** as the degradation route. A forced call constrains shape, not sanity, and a provider that ignores the tool still answers in prose.

No change to `Intent` or `FeatureSpec` fields — provenance for invented criteria is a later slice.

## Why the spec was hand-written

Intake is the defective component. Running `autorun` normally would have intake write the specification for its own repair, and its characteristic failure is inventing criteria. `--spec` (#133) exists for this.

## Verification

I did not take the run's own `[proof]` stage at its word. Independently, in this repo:

- **12 pass** with the change
- **5 fail** without it — including both tests that assert `tool_choice` is on the request

That distinction is the point. Two of the spec's criteria demanded tests that assert on the *request kwargs*, not the parsed result, because a test checking only the parsed output passes identically with `json_object=True` — which is how this survived in the first place.

Full gate green: `ruff format --check .`, `ruff check src tests`, `mypy src tests`, **2414 passed**.

## Note on the run

Clean end to end: intake reported `skipped`, validity `PROCEED`, `[implement]` touched only the two files the spec named, one refine cycle for a typing slip in the test helper, and the judge verified the two regression criteria rather than only the new behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)