### PR TITLE
fix(deps): langgraph-checkpoint-postgres 3.1.0 → 3.1.1 (CVE-2026-71433)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1445,7 +1445,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint-postgres"
-version = "3.1.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langgraph-checkpoint" },
@@ -1453,9 +1453,9 @@ dependencies = [
     { name = "psycopg" },
     { name = "psycopg-pool" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/51/5a2dc42e8b5d5942b933b5b7237eae5a4dbc92508a04727c263dd383ad8a/langgraph_checkpoint_postgres-3.1.0.tar.gz", hash = "sha256:02bff4ab63d9dae8eab3a9640fce1d479da8965c9fba7b0dc04cb1f7c56f0a55", size = 148473, upload-time = "2026-05-12T03:40:10.599Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/92/1e8959f8cd1b56e672fde3227f6fd642be85af6c5fd662d73921074aa39d/langgraph_checkpoint_postgres-3.1.1.tar.gz", hash = "sha256:d320e147ddad8c374cd546df0b52b532dd54d0541dd9fd23fc738cbd5de76f41", size = 150413, upload-time = "2026-07-30T19:15:39.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/cd/eff9b82bc3b5f62d481b437099f44f3ef7b1d907f166fb4ee25e8f84a1e7/langgraph_checkpoint_postgres-3.1.0-py3-none-any.whl", hash = "sha256:814cce2ef35d792bf07b090a95eed004f1acac0724fe6605536b13f6d1e7032c", size = 48988, upload-time = "2026-05-12T03:40:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/03/32/ba457698a48a0e18d786caa770033067049fbe36d6846f8e50f13b594b51/langgraph_checkpoint_postgres-3.1.1-py3-none-any.whl", hash = "sha256:6e353aecd8150de144fef8e51a49076f58b7d6830d4cf51392b7ad4d79832ba7", size = 50778, upload-time = "2026-07-30T19:15:37.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A newly published advisory. **Not introduced by any branch** — `develop`'s lock carries the same 3.1.0. It surfaced on [#134](https://github.com/synaptixs/spine/pull/134) only because that is what happened to run after the CVE was published.

```
Name                          Version ID             Fix Versions
----------------------------- ------- -------------- ------------
langgraph-checkpoint-postgres 3.1.0   CVE-2026-71433 3.1.1
```

`pyproject.toml` already allows it (`>=2.0`), so this is the lock only — 3 lines.

## Verification

```
No known vulnerabilities found, 1 ignored
```

Full suite passes on the bumped dependency: **2387 passed, 35 skipped**.

## Why this is separate from #134

Per the rule documented in `CONTRIBUTING.md` (SSPN-16, merged in #132): a check failing on base-branch state needs the base fixed and the branch rebased — re-running replays the same stale merge ref. Folding a security bump into an unrelated feature PR would also make both harder to revert.

Merge this, then #134 rebases past it.

## Footnote

This run is the first time the `if: failure()` guidance step from #132 fired in the wild. It printed the rebase instructions directly in the failing job, which is exactly what that change was for — though in this case the advisory was new everywhere, so the base needed fixing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)