### PR TITLE
fix(sdlc): branch the work from the PR target, not the remote default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Fixed
 
+- **A run branches from the branch it will open a PR into.** A clone with no `--branch`
+  checks out the remote's *default* branch, so a run targeting `develop` still built on
+  `main` — the generated change was written against a tree predating everything merged to
+  develop since the last release, and could revert it with nothing noticing. Found when a
+  run silently reverted a fix merged two hours earlier. The base branch is now part of the
+  cached base repo's identity too, so a base cloned for `main` is rebuilt rather than reused
+  for a `develop` run. With no target given, the default branch is still used — this is not
+  a silent switch.
+
 - **Intake constrains its output the way codegen and the judge do.** Intent extraction and
   spec writing both asked for JSON with `json_object=True`. `response_format` is
   OpenAI/Ollama-only — Anthropic drops it, and the default model is `claude-opus-5`, so both

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -841,7 +841,13 @@ async def run_feature(
     # 3. worktree branch off the real repo (or a scratch repo in safe/no-repo mode).
     sdlc_id = uuid.uuid4().hex[:16]
     ws_root = Path(os.getenv("SDLC_WORKSPACE_ROOT", "/tmp/sdlc-workspaces"))
-    path = await WorkspaceManager(root=ws_root, repo_url=repo_url).create(sdlc_id, issue_key)
+    # Branch from the PR target, not the remote's default: a run opening a PR into
+    # `develop` must build on `develop`, or it is written against a tree that predates
+    # everything merged there since the last release.
+    work_base = base_branch or os.getenv("SDLC_PR_BASE") or None
+    path = await WorkspaceManager(root=ws_root, repo_url=repo_url, base_branch=work_base).create(
+        sdlc_id, issue_key
+    )
     branch = f"feat/{sdlc_id}/{issue_key}"
     emit(f"[workspace] worktree {path} on {branch}")
 

--- a/src/orchestrator/sdlc/workspace.py
+++ b/src/orchestrator/sdlc/workspace.py
@@ -64,9 +64,14 @@ class WorkspaceManager:
     initialised scratch repo; otherwise Block D clones ``repo_url``.
     """
 
-    def __init__(self, root: Path, repo_url: str | None = None) -> None:
+    def __init__(self, root: Path, repo_url: str | None = None, base_branch: str | None = None) -> None:
         self._root = Path(root)
         self._repo_url = repo_url
+        # Branch the work from here. Without it a clone checks out the remote's
+        # *default* branch, so a run targeting `develop` still built on `main` —
+        # the generated change was written against code that predated everything
+        # merged to develop since the last release, and could silently revert it.
+        self._base_branch = base_branch or None
         self._base = self._root / "_base"
         self._marker = self._root / _BASE_MARKER
         self._init_lock = asyncio.Lock()
@@ -86,8 +91,14 @@ class WorkspaceManager:
         return self._base
 
     def _desired_source(self) -> str:
-        """Identity of the base this manager wants — the repo URL, or scratch."""
-        return self._repo_url or "(scratch)"
+        """Identity of the base this manager wants — repo URL + branch, or scratch.
+
+        The branch is part of the identity: a base cloned for ``main`` cannot be
+        reused for a run branching from ``develop``, and reusing it is exactly how
+        a run silently built on the wrong tree.
+        """
+        source = self._repo_url or "(scratch)"
+        return f"{source}#{self._base_branch}" if self._base_branch else source
 
     def _base_matches(self) -> bool:
         """True when an existing base was built for the source we want now."""
@@ -123,7 +134,11 @@ class WorkspaceManager:
                 # against a private repo without an ambient credential helper.
                 # Falls back to the bare URL when no token is configured.
                 clone_url = await authenticate_repo_url(self._repo_url)
-                await _run_git("clone", clone_url or self._repo_url, str(self._base))
+                clone_args = ["clone"]
+                if self._base_branch:
+                    clone_args += ["--branch", self._base_branch]
+                clone_args += [clone_url or self._repo_url, str(self._base)]
+                await _run_git(*clone_args)
                 # Same neutral identity as the scratch path: worktrees inherit
                 # the clone's local config, and without this the feature
                 # commits pick up the machine's global email — which GitHub

--- a/tests/sdlc/test_workspace.py
+++ b/tests/sdlc/test_workspace.py
@@ -106,6 +106,23 @@ async def _seed_remote(remote: Path) -> None:
     await _run_git("commit", "-m", "seed", cwd=remote)
 
 
+async def _seed_origin_with_branch(origin: Path, *, branch: str, marker: str) -> None:
+    """A remote whose default branch is `main`, plus a second branch that has moved on."""
+    origin.mkdir()
+    await _run_git("init", "--initial-branch", "main", cwd=origin)
+    await _run_git("config", "user.email", "seed@example.com", cwd=origin)
+    await _run_git("config", "user.name", "Seed", cwd=origin)
+    (origin / "marker.txt").write_text("on-main\n", encoding="utf-8")
+    await _run_git("add", "marker.txt", cwd=origin)
+    await _run_git("commit", "-m", "main", cwd=origin)
+    await _run_git("checkout", "-b", branch, cwd=origin)
+    (origin / "marker.txt").write_text(f"{marker}\n", encoding="utf-8")
+    await _run_git("add", "marker.txt", cwd=origin)
+    await _run_git("commit", "-m", branch, cwd=origin)
+    # Leave the remote's HEAD on main, so a plain clone gets main.
+    await _run_git("checkout", "main", cwd=origin)
+
+
 async def test_stale_scratch_base_is_rebuilt_for_clone(tmp_path: Path) -> None:
     """A scratch base left by a --safe run must NOT be reused for a clone run:
     the reused base has no `origin`, so the eventual push fails. The manager
@@ -161,3 +178,47 @@ async def test_matching_base_is_reused_not_rebuilt(tmp_path: Path) -> None:
     # Second create with the same source must not rebuild (sentinel survives).
     await WorkspaceManager(root=root, repo_url=str(remote)).create("s2", "ISSUE-2")
     assert sentinel.exists()
+
+
+# --- The work branches from the PR target, not the remote's default -----------------
+#
+# A clone with no --branch checks out the remote's *default* branch. A run opening a PR
+# into `develop` therefore built on `main`, so the generated change was written against a
+# tree predating everything merged to develop since the last release — and could revert it
+# without anything noticing. Caught when a run reverted the change merged two hours earlier.
+
+
+async def test_the_base_is_cloned_at_the_requested_branch(tmp_path: Path) -> None:
+    origin = tmp_path / "origin"
+    await _seed_origin_with_branch(origin, branch="develop", marker="on-develop")
+
+    mgr = WorkspaceManager(root=tmp_path / "ws", repo_url=str(origin), base_branch="develop")
+    work = await mgr.create("sdlc1", "KEY-1")
+
+    assert (work / "marker.txt").read_text().strip() == "on-develop"
+
+
+async def test_without_a_base_branch_the_default_is_used(tmp_path: Path) -> None:
+    """Unchanged behaviour when no target is given — this is not a silent switch."""
+    origin = tmp_path / "origin"
+    await _seed_origin_with_branch(origin, branch="develop", marker="on-develop")
+
+    mgr = WorkspaceManager(root=tmp_path / "ws", repo_url=str(origin))
+    work = await mgr.create("sdlc1", "KEY-1")
+
+    assert (work / "marker.txt").read_text().strip() == "on-main"
+
+
+async def test_a_base_built_for_another_branch_is_not_reused(tmp_path: Path) -> None:
+    """The branch is part of the base's identity; reuse is how a run builds on the wrong tree."""
+    origin = tmp_path / "origin"
+    await _seed_origin_with_branch(origin, branch="develop", marker="on-develop")
+    root = tmp_path / "ws"
+
+    first = await WorkspaceManager(root=root, repo_url=str(origin)).create("sdlc1", "KEY-1")
+    assert (first / "marker.txt").read_text().strip() == "on-main"
+
+    second = await WorkspaceManager(root=root, repo_url=str(origin), base_branch="develop").create(
+        "sdlc2", "KEY-2"
+    )
+    assert (second / "marker.txt").read_text().strip() == "on-develop"


### PR DESCRIPTION
Found by a failed slice-2 run. This is the more important finding of the two.

## The bug

`git clone` with no `--branch` checks out the remote's **default** branch. Nothing ever overrode it, and `--base` only ever set the *PR target*. So **every run opening a PR into `develop` was built on `main`.**

Verified on the failed run's base clone:

```
checked-out branch: main
at:             2175781 Merge pull request #129 from synaptixs/develop
origin/develop: af0bf9f chore(episteme): regenerate for 56508be
```

That is not merely a stale tree. Codegen edits files it was shown, so a run can **revert work it never knew existed**, and the resulting diff looks deliberate.

## How it surfaced

A run against a spec that depended on [#134](https://github.com/synaptixs/spine/pull/134) — merged two hours earlier — produced a `src/orchestrator/intake/specs.py` with that fix *removed*: back to `json_object=True`, no forced tool call. The worktree base was `main` at the v3.13.0 tag, which predates it.

The run failed for an unrelated reason (a broken test fake), so this never reached a PR. Had the tests passed, it would have been a clean, plausible-looking revert of a security-relevant fix.

Earlier runs escaped only by luck: slice 1 touched a file where `main` and `develop` did not yet differ.

## The change

- `WorkspaceManager` takes `base_branch` and clones with `--branch`
- `feature_runner` passes the PR target (`--base`, else `$SDLC_PR_BASE`)
- The base branch is part of the cached base repo's **identity**, so a base cloned for `main` is torn down rather than reused for a `develop` run — reuse is the other way to end up on the wrong tree
- **With no target given, the default branch is still used.** This is not a silent switch.

## Verification

3 tests, against a seeded remote whose default branch is `main` and whose `develop` has moved on. Checked against a reverted fix: `test_the_base_is_cloned_at_the_requested_branch` and `test_a_base_built_for_another_branch_is_not_reused` both fail without it.

Full gate green, **2402 passed**.

## Note

Existing base clones under `/tmp/sdlc-workspaces/_base` were built for `main` and carry the old marker, so the first run after this lands rebuilds the base. That is the intended behaviour, and it costs one clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)