### PR TITLE
feat(intake): partition acceptance criteria by provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## Unreleased
 
+### Changed
+
+- **`FeatureSpec.acceptance_criteria` has narrowed to the criteria the source actually
+  stated.** Anything the spec writer inferred now lands in a new `proposed_criteria` field
+  instead of being appended to the same list. Readers of `acceptance_criteria` will see
+  fewer entries than before — that is the point: they were previously indistinguishable, so
+  a run could be held to a requirement nobody asked for. `_merge_criteria` returns
+  `(stated, proposed)` rather than one merged list. The judge, the codegen prompt and the
+  spec views still read the stated set; carrying the distinction through to them is
+  separate work.
+
 ### Fixed
 
 - **A run branches from the branch it will open a PR into.** A clone with no `--branch`

--- a/src/orchestrator/intake/specs.py
+++ b/src/orchestrator/intake/specs.py
@@ -98,6 +98,10 @@ class FeatureSpec(BaseModel):
     summary: str = ""
     user_story: str = ""
     acceptance_criteria: list[str] = Field(default_factory=list)
+    # Criteria the model produced that the source never stated. Kept apart from
+    # acceptance_criteria so a reader (and, later, the judge) can tell a contract
+    # the ticket signed from a suggestion the spec writer inferred.
+    proposed_criteria: list[str] = Field(default_factory=list)
     technical_notes: str = ""
     nfrs: list[str] = Field(default_factory=list)
     dependencies: list[str] = Field(default_factory=list)
@@ -168,15 +172,18 @@ class SpecWriter:
                 nfrs=list(intent.nfrs),
                 dependencies=list(intent.dependencies),
             )
-        # Stated criteria are the contract: keep them even if the model dropped
-        # them, and ensure they lead (verbatim) before any the model inferred.
-        criteria = _merge_criteria(intent.acceptance_criteria, _str_list(payload.get("acceptance_criteria")))
+        # Stated criteria are the contract: keep them verbatim and alone in
+        # acceptance_criteria; whatever the model added lands in proposed_criteria.
+        stated, proposed = _merge_criteria(
+            intent.acceptance_criteria, _str_list(payload.get("acceptance_criteria"))
+        )
         return FeatureSpec(
             intent_id=intent.id,
             title=intent.title,
             summary=str(payload.get("summary") or intent.description).strip(),
             user_story=str(payload.get("user_story") or "").strip(),
-            acceptance_criteria=criteria,
+            acceptance_criteria=stated,
+            proposed_criteria=proposed,
             technical_notes=str(payload.get("technical_notes") or "").strip(),
             nfrs=_str_list(payload.get("nfrs")) or list(intent.nfrs),
             dependencies=_str_list(payload.get("dependencies")) or list(intent.dependencies),
@@ -184,21 +191,29 @@ class SpecWriter:
         )
 
 
-def _merge_criteria(stated: list[str], produced: list[str]) -> list[str]:
-    """Stated criteria lead (verbatim); the model's extras follow, de-duped.
+def _merge_criteria(stated: list[str], produced: list[str]) -> tuple[list[str], list[str]]:
+    """Partition criteria by provenance: ``(stated, proposed)``.
 
-    Guarantees a contract the source stated survives even if the spec writer
-    paraphrased or dropped it — the failure that let run #23 ship the wrong
-    API. Comparison is whitespace-insensitive so a re-emitted criterion isn't
-    double-listed.
+    The stated list is returned verbatim and in its original order — a contract
+    the source stated survives even if the spec writer paraphrased or dropped
+    it (the failure that let run #23 ship the wrong API). Everything the model
+    produced that isn't one of them is *proposed*, not accepted: concatenating
+    the two is how a three-criterion ticket became a nine-criterion spec with
+    nobody able to tell which three were real.
+
+    Comparison stays whitespace-insensitive, so a criterion the model re-emits
+    in a different whitespace form is recognised as the stated one rather than
+    listed a second time as proposed.
     """
-    out = list(stated)
+    stated_out = list(stated)
     seen = {" ".join(c.split()) for c in stated}
+    proposed: list[str] = []
     for c in produced:
-        if " ".join(c.split()) not in seen:
-            out.append(c)
-            seen.add(" ".join(c.split()))
-    return out
+        key = " ".join(c.split())
+        if key not in seen:
+            proposed.append(c)
+            seen.add(key)
+    return stated_out, proposed
 
 
 def _str_list(value: Any) -> list[str]:

--- a/src/orchestrator/sdlc/spec_file.py
+++ b/src/orchestrator/sdlc/spec_file.py
@@ -13,6 +13,10 @@ to trust: a criterion the parser silently misses is indistinguishable from one y
 never wrote, which is the failure this pipeline keeps having. ``FeatureSpec`` forbids
 extra keys, so ``acceptance-criteria`` or ``acceptanceCriteria`` is an error naming
 the valid fields rather than a run that quietly proceeds with none.
+
+``proposed_criteria`` is optional and defaults to empty: a file may carry criteria
+nobody stated (clearly marked as such), and a file that only supplies
+``acceptance_criteria`` keeps validating exactly as before.
 """
 
 from __future__ import annotations
@@ -60,6 +64,8 @@ def load_spec_file(path: Path | str) -> dict[str, Any]:
     if not spec.acceptance_criteria:
         # Not fatal upstream, but a spec with nothing to satisfy gives the judge
         # nothing to judge — the run would report success having proved nothing.
+        # 'proposed_criteria' deliberately doesn't count: unsourced criteria are
+        # suggestions, not a contract to pass a run against.
         raise SpecFileError(
             f"{p}: 'acceptance_criteria' is empty — there would be nothing for the "
             "acceptance judge to verify, and the run would pass by default."

--- a/tests/intake/test_intake_tool_choice.py
+++ b/tests/intake/test_intake_tool_choice.py
@@ -161,9 +161,10 @@ async def test_spec_comes_from_the_forced_call_arguments() -> None:
     assert spec.summary == "Export invoices as CSV."
     assert spec.technical_notes == "streams the response"
     assert spec.estimate == "M"
-    # Stated criteria still lead, verbatim, ahead of anything the model added.
-    assert spec.acceptance_criteria[0] == _intent().acceptance_criteria[0]
-    assert "headers are written first" in spec.acceptance_criteria
+    # Stated criteria are kept verbatim; what the model added is proposed, so the
+    # forced-tool-call path partitions exactly as the text path does.
+    assert spec.acceptance_criteria == _intent().acceptance_criteria
+    assert "headers are written first" in spec.proposed_criteria
 
 
 # ---- a provider that ignores the tool still answers in text ----
@@ -237,15 +238,19 @@ async def test_a_stated_criterion_survives_a_model_that_drops_or_paraphrases_it(
     spec = await SpecWriter(llm).write(intent)
 
     assert spec.acceptance_criteria[0] == stated
+    # The model's own criteria are kept, but as *proposed* — not silently promoted
+    # to the contract. Whichever list a produced criterion lands in, it survives.
     for c in produced:
-        assert c in spec.acceptance_criteria
+        assert c in spec.acceptance_criteria or c in spec.proposed_criteria
 
 
 def test_merge_criteria_leads_with_stated_and_dedupes_on_whitespace() -> None:
     stated = ["add(2, 3) returns 5", "raises TypeError on strings"]
     produced = ["add(2,  3)   returns 5", "logs the call"]
 
-    merged = _merge_criteria(stated, produced)
+    kept, proposed = _merge_criteria(stated, produced)
 
-    assert merged[: len(stated)] == stated
-    assert merged == [*stated, "logs the call"]
+    assert kept == stated, "stated criteria are returned verbatim and alone"
+    # 'add(2,  3)   returns 5' is the first stated criterion re-spaced, so it is
+    # recognised rather than proposed a second time.
+    assert proposed == ["logs the call"]

--- a/tests/intake/test_spec_criteria_provenance.py
+++ b/tests/intake/test_spec_criteria_provenance.py
@@ -1,0 +1,160 @@
+"""SSPN-31: the spec writer partitions criteria by provenance.
+
+Stated criteria stay in ``acceptance_criteria`` verbatim; anything the model
+added lands in ``proposed_criteria``. Exercised through ``SpecWriter.write``
+(and ``load_spec_file`` for the file path), not through ``_merge_criteria``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.core.llm import CompletionResult, LLMClient, Message, ToolSpec
+from orchestrator.intake.intents import Intent
+from orchestrator.intake.specs import FeatureSpec, SpecWriter
+from orchestrator.sdlc.spec_file import SpecFileError, load_spec_file
+
+
+class _ScriptedLLM:
+    """Returns one canned JSON payload as the assistant's text answer."""
+
+    def __init__(self, payload: dict[str, Any] | str) -> None:
+        self._text = payload if isinstance(payload, str) else json.dumps(payload)
+        self.calls: list[list[Message]] = []
+
+    async def complete(
+        self,
+        messages: list[Message],
+        *,
+        model: str = "",
+        temperature: float = 0.0,
+        tools: list[ToolSpec] | None = None,
+        tool_choice: str | None = None,
+        **_: Any,
+    ) -> CompletionResult:
+        self.calls.append(list(messages))
+        return CompletionResult(
+            text=self._text,
+            model=model or "fake",
+            prompt_tokens=0,
+            completion_tokens=0,
+            cost_usd=0.0,
+            latency_ms=0.0,
+        )
+
+
+def _writer(payload: dict[str, Any] | str) -> SpecWriter:
+    llm: LLMClient = _ScriptedLLM(payload)  # type: ignore[assignment]
+    return SpecWriter(llm, model="fake-model")
+
+
+def test_feature_spec_has_proposed_criteria_defaulting_to_empty() -> None:
+    spec = FeatureSpec(intent_id="i-1", title="T")
+    assert spec.proposed_criteria == []
+    assert "proposed_criteria" in spec.model_dump()
+
+
+async def test_stated_criteria_stay_verbatim_and_inferred_go_to_proposed() -> None:
+    intent = Intent(
+        id="i-1",
+        title="Add stats module",
+        description="d",
+        acceptance_criteria=["mean() returns a float", "median() raises on empty input"],
+    )
+    writer = _writer(
+        {
+            "summary": "s",
+            "acceptance_criteria": [
+                "mean() returns a float",
+                "median() raises on empty input",
+                "meta.generated_at is an ISO-8601 timestamp",
+            ],
+        }
+    )
+    spec = await writer.write(intent)
+    assert spec.acceptance_criteria == [
+        "mean() returns a float",
+        "median() raises on empty input",
+    ]
+    assert spec.proposed_criteria == ["meta.generated_at is an ISO-8601 timestamp"]
+
+
+async def test_three_stated_nine_produced_yields_three_and_at_most_six() -> None:
+    stated = ["c one", "c two", "c three"]
+    produced = stated + [f"inferred {n}" for n in range(1, 7)]
+    intent = Intent(id="i-2", title="Ticket", description="d", acceptance_criteria=list(stated))
+    spec = await _writer({"summary": "s", "acceptance_criteria": produced}).write(intent)
+    assert spec.acceptance_criteria == stated
+    assert len(spec.acceptance_criteria) == 3
+    assert len(spec.proposed_criteria) <= 6
+    assert not set(stated) & set(spec.proposed_criteria)
+
+
+async def test_unsourced_intent_puts_everything_in_proposed() -> None:
+    intent = Intent(id="i-3", title="No criteria", description="d")
+    spec = await _writer({"summary": "s", "acceptance_criteria": ["a", "b"]}).write(intent)
+    assert spec.acceptance_criteria == []
+    assert spec.proposed_criteria == ["a", "b"]
+
+
+async def test_whitespace_variant_of_a_stated_criterion_is_not_also_proposed() -> None:
+    intent = Intent(id="i-4", title="T", description="d", acceptance_criteria=["mean() returns a float"])
+    spec = await _writer(
+        {"summary": "s", "acceptance_criteria": ["mean()   returns\n a float", "extra one"]}
+    ).write(intent)
+    assert spec.acceptance_criteria == ["mean() returns a float"]
+    assert spec.proposed_criteria == ["extra one"]
+
+
+async def test_duplicate_inferred_criterion_is_listed_once() -> None:
+    intent = Intent(id="i-5", title="T", description="d", acceptance_criteria=["stated"])
+    spec = await _writer({"summary": "s", "acceptance_criteria": ["extra", "extra"]}).write(intent)
+    assert spec.acceptance_criteria == ["stated"]
+    assert spec.proposed_criteria == ["extra"]
+
+
+async def test_unparseable_output_keeps_stated_criteria_and_proposes_nothing() -> None:
+    intent = Intent(id="i-6", title="T", description="d", acceptance_criteria=["stated one"])
+    spec = await _writer("not json at all").write(intent)
+    assert spec.acceptance_criteria == ["stated one"]
+    assert spec.proposed_criteria == []
+
+
+def test_spec_file_accepts_proposed_criteria(tmp_path: Path) -> None:
+    path = tmp_path / "SSPN-31.json"
+    path.write_text(
+        json.dumps(
+            {
+                "title": "Partition criteria",
+                "acceptance_criteria": ["stated one"],
+                "proposed_criteria": ["inferred one"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    loaded = load_spec_file(path)
+    assert loaded["acceptance_criteria"] == ["stated one"]
+    assert loaded["proposed_criteria"] == ["inferred one"]
+    assert loaded["intent_id"] == "SSPN-31"
+
+
+def test_spec_file_without_proposed_criteria_still_loads(tmp_path: Path) -> None:
+    path = tmp_path / "legacy.json"
+    path.write_text(json.dumps({"title": "Legacy", "acceptance_criteria": ["only stated"]}), encoding="utf-8")
+    loaded = load_spec_file(path)
+    assert loaded["acceptance_criteria"] == ["only stated"]
+    assert loaded["proposed_criteria"] == []
+
+
+def test_spec_file_with_only_proposed_criteria_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "unsourced.json"
+    path.write_text(
+        json.dumps({"title": "Unsourced", "acceptance_criteria": [], "proposed_criteria": ["a"]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(SpecFileError, match="acceptance_criteria"):
+        load_spec_file(path)

--- a/tests/intake/test_specs.py
+++ b/tests/intake/test_specs.py
@@ -49,7 +49,9 @@ async def test_write_parses_spec_fields() -> None:
     assert spec.intent_id == "intent-add-export"
     assert spec.title == "Add CSV export"  # carried from intent, not LLM
     assert spec.summary == "Export grid data to CSV."
-    assert spec.acceptance_criteria[0].startswith("Given 10k rows")
+    # The intent states no criteria, so everything the model produced is proposed.
+    assert spec.acceptance_criteria == []
+    assert spec.proposed_criteria[0].startswith("Given 10k rows")
     assert spec.estimate == "M"  # upper-cased
 
 
@@ -100,9 +102,10 @@ async def test_stated_criteria_survive_when_llm_drops_them() -> None:
     payload = {"summary": "s", "acceptance_criteria": ["sends a notification"]}
     writer = SpecWriter(_llm_returning(jsonlib.dumps(payload)))
     spec = await writer.write(_intent_with_criteria())
-    # Stated criteria lead, verbatim; the model's extra follows.
-    assert spec.acceptance_criteria[:2] == _intent_with_criteria().acceptance_criteria
-    assert "sends a notification" in spec.acceptance_criteria
+    # Stated criteria are kept verbatim and alone; the model's extra is proposed,
+    # not presented as something the source asked for.
+    assert spec.acceptance_criteria == _intent_with_criteria().acceptance_criteria
+    assert spec.proposed_criteria == ["sends a notification"]
 
 
 async def test_stated_criteria_not_double_listed() -> None:


### PR DESCRIPTION
SSPN-31, slice 2a. **Generated by the pipeline** (`sdlc autorun --spec`, run `490e5e28c16e4825`), with the hand work called out below.

## The bug

`_merge_criteria` put the source's stated criteria first and verbatim, then appended whatever the model inferred **to the same flat list**. After that line provenance was gone — nothing downstream could tell a criterion the ticket asked for from one the spec writer invented.

That is how a three-criterion ticket became a nine-criterion spec, including a requirement for an ISO-8601 `meta.generated_at` timestamp nobody asked for — which would have violated CLAUDE.md invariant 2 had anything built to it.

It already computed both sets in order to de-duplicate. It just discarded the boundary.

## The change

`_merge_criteria` returns `(stated, proposed)`; `FeatureSpec` carries both.

**`acceptance_criteria` narrows to what the source stated.** Readers see fewer entries than before — that is the point. Recorded in the changelog under *Changed*.

## What was the model's, and what was mine

The **source change is the model's and is unmodified.** It is good: the partition is right, and the docstring explains why concatenating was wrong.

Mine:
- **One fix to its test module.** The fake built `CompletionResult` without its four required fields (`prompt_tokens`, `completion_tokens`, `cost_usd`, `latency_ms`). The same class of error appeared in the previous run under a different spelling — `author_tests` writes fakes for types it is never shown, since the spec names only `specs.py` and `spec_file.py`.
- **The existing-test updates.** Five tests asserted the merged behaviour. The run stopped before reaching them.

Those tests are updated to the new contract, **not relaxed**. Each still asserts that a stated criterion survives a model that drops or paraphrases it, and that a re-spaced echo is recognised rather than listed twice.

## Verification

- The generated tests **fail against the pre-change source** (10 of 10) and pass after — checked here, not taken from the run's `[proof]` stage, which it never reached.
- Full gate green: `ruff format --check .`, `ruff check src tests`, `mypy src tests`, **2412 passed**.

## Note on `pytesseract`

The run printed `[testenv] missing module 'pytesseract'`. It is a bystander: the missing-module scan only runs when a suite fails (`if result.passed: return result`), so it is invisible on green runs and appears on red ones regardless of cause. The actual failure was the `CompletionResult` constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)