### PR TITLE
fix(codegen): the 40 KB context budget was a leftover, not a limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Changed
 
+- **Codegen's source-context budget goes from 40 KB to 200 KB.** 40 KB is ~10k tokens —
+  about 1% of the default model's window, and a leftover rather than a limit. It shaped
+  work instead of bounding it: a change spanning five files totalled 113 KB, so every file
+  was excerpted and codegen quoted an edit anchor from a region it had only partly seen.
+  Failure output stays at 40 KB under its own constant — a pytest dump is not source, and
+  refine re-sends context every attempt.
+
 - **`FeatureSpec.acceptance_criteria` has narrowed to the criteria the source actually
   stated.** Anything the spec writer inferred now lands in a new `proposed_criteria` field
   instead of being appended to the same list. Readers of `acceptance_criteria` will see

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -55,7 +55,23 @@ def resolve_codegen_model(override: str | None = None) -> str | None:
 
 _MAX_FILES = 20  # files the model may write in one pass
 _MAX_FILE_BYTES = 64_000  # per generated file
-_MAX_CONTEXT_BYTES = 40_000  # cap on existing source fed back to the model
+# Cap on existing source fed back to the model.
+#
+# Was 40_000 — about 10k tokens, or ~1% of the 1M-token window the default model has.
+# That is not a model limit, it is a leftover, and it shaped work rather than bounding
+# it: a change spanning `review.py`, `feature_runner.py` and three render surfaces
+# totalled 113 KB, so every file was excerpted, and codegen quoted an edit anchor from a
+# region it had only seen part of — `'find' text not found`. The change was then split
+# four ways to fit, which is designing around a constant nobody had justified.
+#
+# 200 KB is ~50k tokens: comfortable for the current models, and still a real bound.
+# It stays bounded on purpose — refine re-sends context on every attempt, so an
+# uncapped budget multiplies across a loop rather than being paid once.
+_MAX_CONTEXT_BYTES = 200_000
+# Pytest output is not source: a failing suite prints tracebacks, not the code that must
+# be read whole to be edited safely. It keeps the old bound so raising the *source* budget
+# does not quietly multiply every refine prompt by five.
+_MAX_FAILURE_BYTES = 40_000
 # The subject of a type error, as mypy names it: `"MCPToolHandler" has no attribute "tool"`,
 # `Name "Any" is not defined`, `Argument 1 to "_type_label" has incompatible type`. Quoted
 # CamelCase or identifier-shaped words — the things the graph can look up.
@@ -1414,7 +1430,7 @@ class LLMCodegenAdapter:
             # should cover the line that failed, not the top of the module.
             f"CURRENT FILES:\n{self._session_files(root, include_tests=True, anchors=fail_anchors)}"
             f"{_named_existing_files(spec, root, self._design)}{self._convention_block(root)}\n\n"
-            f"FAILURE OUTPUT:\n{_truncate(failures, _MAX_CONTEXT_BYTES)}\n\n"
+            f"FAILURE OUTPUT:\n{_truncate(failures, _MAX_FAILURE_BYTES)}\n\n"
             f"{self._definitions_for(failures, root)}",
             root,
             # A refine pass that yields no applicable edits is a legitimate

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1255,36 +1255,34 @@ async def test_a_file_larger_than_the_budget_is_excerpted_not_dropped(tmp_path: 
     """The live failure: `cli.py` is 100 KB against a 40 KB pool, so the repair block said
     "below is the CURRENT EXACT content" and then appended nothing. Every retry re-guessed
     the anchor and the run died having never seen a byte of the file it was editing."""
-    from orchestrator.sdlc.codegen import _MAX_CONTEXT_BYTES
     from orchestrator.sdlc.excerpt import _excerpt_files
 
+    # An explicit pool, not the global cap: this test is about what happens when a file
+    # exceeds its budget, and it must keep testing that however large the cap becomes.
+    pool = 40_000
     target = "def render_contract_types(schema: dict) -> str:"
     (tmp_path / "cli.py").write_text(_big_module(target), encoding="utf-8")
 
-    block = _excerpt_files(
-        tmp_path, ["cli.py"], budget=_MAX_CONTEXT_BYTES, anchors_by_path={"cli.py": [target]}, label="x"
-    )
+    block = _excerpt_files(tmp_path, ["cli.py"], budget=pool, anchors_by_path={"cli.py": [target]}, label="x")
 
     assert block, "an oversized file must still reach the prompt"
     assert target in block, "the window must cover the line the model was aiming at"
-    assert len(block) <= _MAX_CONTEXT_BYTES * 2  # bounded, not the whole 120 KB file
+    assert len(block) <= pool * 2  # bounded by the pool it was given
     assert "lines not shown" in block  # and honest about being partial
 
 
 async def test_a_near_miss_anchor_still_finds_its_neighbourhood(tmp_path: Path) -> None:
     """A `find` fails on whitespace or a renamed identifier as easily as on being wrong.
     The window should still land where the model was reaching."""
-    from orchestrator.sdlc.codegen import _MAX_CONTEXT_BYTES
     from orchestrator.sdlc.excerpt import _excerpt_files
 
+    pool = 40_000  # explicit, so the global cap can move without disarming this
     target = "def render_contract_types(schema: dict) -> str:"
     (tmp_path / "cli.py").write_text(_big_module(target), encoding="utf-8")
 
     # What the model guessed: right function, wrong signature.
     guess = "def render_contract_types(schema):"
-    block = _excerpt_files(
-        tmp_path, ["cli.py"], budget=_MAX_CONTEXT_BYTES, anchors_by_path={"cli.py": [guess]}, label="x"
-    )
+    block = _excerpt_files(tmp_path, ["cli.py"], budget=pool, anchors_by_path={"cli.py": [guess]}, label="x")
 
     assert target in block
 


### PR DESCRIPTION
`_MAX_CONTEXT_BYTES = 40_000` is about 10k tokens — roughly **1% of the window the default model has** — and it carried no justification, unlike every other cap around it.

It shaped work rather than bounding it. A change spanning `review.py`, `feature_runner.py` and three render surfaces totals 113 KB, so every file was excerpted and codegen quoted an edit anchor from a region it had only partly seen (`'find' text not found`). My response was to split the change four ways to fit — designing around a number nobody had defended.

## The change

**200 KB** (~50k tokens): comfortable for the current models, still a real bound. Bounded on purpose — refine re-sends context on every attempt, so the budget multiplies across a loop rather than being paid once.

**Failure output moves to its own `_MAX_FAILURE_BYTES`, still 40 KB.** A pytest dump is not source: it does not need to be read whole to be edited safely. Sharing the constant would have quietly 5×'d every refine prompt as a side effect of this change.

**The two excerpt tests now pass an explicit pool** instead of reading the global cap. They are about what happens when a file exceeds its budget — reading the cap meant raising it turned them into no-ops, which is how a raised limit silently disarms the tests that were guarding it.

## Verification

Full gate green: `ruff format --check .`, `ruff check src tests`, `mypy src tests`, **2412 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)