### PR TITLE
feat(sdlc): carry criteria provenance to the judge, codegen and the views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **`FeatureSpec.acceptance_criteria` has narrowed to the criteria the source
+  *stated*.** Criteria the spec writer infers now go to `FeatureSpec.proposed_criteria`
+  instead of being concatenated into `acceptance_criteria`, so anything reading that
+  field sees **fewer entries than before**. The acceptance judge
+  (`orchestrator.sdlc.review.SemanticReviewAdapter`) verifies only the stated set — a
+  change can no longer be rejected for failing a criterion nobody asked for — while the
+  codegen SPEC banner (`orchestrator.sdlc.feature_runner.run_feature`) and every human
+  render surface (`intake.service.spec_to_issue_request`, `intake.report`,
+  `intake.web.app`) show the proposed set under its own label rather than dropping it.
+  Specs with no proposed criteria render exactly as before.
+
 All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).

--- a/src/orchestrator/intake/report.py
+++ b/src/orchestrator/intake/report.py
@@ -33,6 +33,20 @@ def _ul(items: Sequence[Any]) -> str:
     return "<ul>" + "".join(rows) + "</ul>" if rows else ""
 
 
+def _criteria_cell(spec: Mapping[str, Any]) -> str:
+    """Stated criteria, then any the spec writer proposed — labelled, never merged.
+
+    ``acceptance_criteria`` now holds only what the source stated; the inferred ones live
+    in ``proposed_criteria``. Rendering the stated list alone would drop them silently, so
+    they get their own labelled block — and no label at all when there are none.
+    """
+    cell = _ul(spec.get("acceptance_criteria") or [])
+    proposed = _ul(spec.get("proposed_criteria") or [])
+    if proposed:
+        cell += "<p><em>Proposed (inferred, not stated by the source):</em></p>" + proposed
+    return cell
+
+
 def intent_number(index: int) -> str:
     return f"I-{index:02d}"
 
@@ -113,7 +127,7 @@ def _design_specs_table(
             f"<td><strong>{_esc(spec.get('title') or it.get('title'))}</strong></td>"
             f"<td>{intent_number(idx)}, {requirement_number(idx)}</td>"
             f"<td>{_esc(spec.get('summary'))}</td>"
-            f"<td>{_ul(spec.get('acceptance_criteria') or [])}</td>"
+            f"<td>{_criteria_cell(spec)}</td>"
             f"<td>{_esc(spec.get('estimate') or '—')}</td>"
             f"<td>{jira_cell}</td></tr>"
         )

--- a/src/orchestrator/intake/service.py
+++ b/src/orchestrator/intake/service.py
@@ -129,6 +129,10 @@ def spec_to_issue_request(
             lines.extend([f"## {title}", *(f"- {item}" for item in items), ""])
 
     section("Acceptance criteria", _spec_list(spec, "acceptance_criteria"))
+    # Kept visible but kept apart: a criterion the spec writer inferred is a suggestion,
+    # not something the ticket signed up to. Dropping it would lose work; merging it would
+    # make the reader unable to tell which half the source actually asked for.
+    section("Proposed criteria (inferred, not stated by the source)", _spec_list(spec, "proposed_criteria"))
     notes = _spec_str(spec, "technical_notes")
     if notes:
         lines += ["## Technical notes", notes, ""]

--- a/src/orchestrator/intake/web/app.py
+++ b/src/orchestrator/intake/web/app.py
@@ -71,6 +71,9 @@ def _plan_to_dict(plan: BacklogPlan) -> dict[str, object]:
                 "summary": s.summary,
                 "user_story": s.user_story,
                 "acceptance_criteria": list(s.acceptance_criteria),
+                # Carried separately, not merged: the preview labels them so a reader can
+                # tell the source's contract from the spec writer's inference.
+                "proposed_criteria": list(s.proposed_criteria),
                 "technical_notes": s.technical_notes,
                 "nfrs": list(s.nfrs),
                 "dependencies": list(s.dependencies),
@@ -235,6 +238,8 @@ function render(d) {
     if (s.summary) h += '<p>' + esc(s.summary) + '</p>';
     if (s.user_story) h += '<p><em>' + esc(s.user_story) + '</em></p>';
     if (s.acceptance_criteria.length) h += '<p>Acceptance criteria:</p>' + list(s.acceptance_criteria);
+    if (s.proposed_criteria && s.proposed_criteria.length)
+      h += '<p>Proposed criteria (inferred, not stated by the source):</p>' + list(s.proposed_criteria);
     if (s.dependencies.length) h += '<p>Dependencies:</p>' + list(s.dependencies);
     h += '</div>';
   }

--- a/src/orchestrator/sdlc/feature_runner.py
+++ b/src/orchestrator/sdlc/feature_runner.py
@@ -766,6 +766,14 @@ async def run_feature(
     emit(f"  summary: {spec['summary']}")
     for criterion in spec["acceptance_criteria"]:
         emit(f"    - {criterion}")
+    # Proposed criteria are still built — printing only the stated set would silently
+    # shrink what a run delivers — but they are labelled, so the reader can tell the
+    # contract from what the spec writer inferred. No heading when there are none.
+    proposed_criteria = [str(c) for c in (spec.get("proposed_criteria") or []) if str(c).strip()]
+    if proposed_criteria:
+        emit("  proposed (inferred by the spec writer, not stated by the source):")
+        for criterion in proposed_criteria:
+            emit(f"    - {criterion}")
     emit("=" * 70)
 
     # 2. Jira issue (real only with live; otherwise a synthetic dry-run key).

--- a/src/orchestrator/sdlc/review.py
+++ b/src/orchestrator/sdlc/review.py
@@ -192,7 +192,11 @@ class SemanticReviewAdapter:
         self._model = model or catalog.resolve("judge")
 
     async def review(self, *, path: str, issue_key: str, spec: dict[str, Any] | None = None) -> ReviewResult:
+        # Only the criteria the *source stated* bind the change. ``proposed_criteria`` are
+        # what the spec writer inferred — building them is welcome, being rejected for them
+        # is not: a run must never fail for missing something nobody asked for.
         criteria = [str(c) for c in ((spec or {}).get("acceptance_criteria") or []) if str(c).strip()]
+        proposed = [str(c) for c in ((spec or {}).get("proposed_criteria") or []) if str(c).strip()]
         if not criteria:
             return ReviewResult(
                 verdict="comment",
@@ -209,6 +213,15 @@ class SemanticReviewAdapter:
         user = (
             f"Issue: {issue_key}\n\nSPEC ACCEPTANCE CRITERIA:\n"
             + "\n".join(f"- {c}" for c in criteria)
+            # Context, not contract: the judge is told these exist so it doesn't read their
+            # implementation as scope creep, and told explicitly not to judge against them.
+            + (
+                "\n\nPROPOSED CRITERIA (context only — the source never stated these; do NOT "
+                "judge the change against them and do NOT include them in your verdict):\n"
+                + "\n".join(f"- {c}" for c in proposed)
+                if proposed
+                else ""
+            )
             # `source` is the cloned repo's file contents — untrusted. Fence it so an
             # injected "approve this" can't coerce the gate. See core.prompt_safety.
             + "\n\nCHANGED FILES:\n"
@@ -226,14 +239,14 @@ class SemanticReviewAdapter:
         )
         for call in result.tool_calls:
             if call.name == _VERDICT_TOOL.name:
-                return self._verdict_from(call.arguments)
+                return self._verdict_from(call.arguments, stated=criteria)
         # A provider that ignored the tool still answers in text — the old path, unchanged.
-        return self._parse(result.text)
+        return self._parse(result.text, stated=criteria)
 
-    def _parse(self, text: str) -> ReviewResult:
-        return self._verdict_from(_loads_json_object(text) or {})
+    def _parse(self, text: str, *, stated: list[str] | None = None) -> ReviewResult:
+        return self._verdict_from(_loads_json_object(text) or {}, stated=stated)
 
-    def _verdict_from(self, payload: dict[str, Any]) -> ReviewResult:
+    def _verdict_from(self, payload: dict[str, Any], *, stated: list[str] | None = None) -> ReviewResult:
         rows = payload.get("criteria")
         if not isinstance(rows, list) or not rows:
             logger.warning("sdlc.review.unparseable_judge_output")
@@ -242,6 +255,10 @@ class SemanticReviewAdapter:
                 summary="semantic review: judge output unparseable — needs human review",
                 unreviewed=True,
             )
+        # A judge that answers about a criterion it was told was context-only cannot make it
+        # binding: rows are narrowed to the stated set before the verdict is computed. The
+        # prompt asks; this enforces.
+        rows = _only_stated(rows, stated)
         unmet = [r for r in rows if isinstance(r, dict) and r.get("status") == "unmet"]
         uncertain = [r for r in rows if isinstance(r, dict) and r.get("status") == "uncertain"]
         summary = str((payload or {}).get("summary") or "").strip()
@@ -271,6 +288,22 @@ class SemanticReviewAdapter:
                 uncertain=names,
             )
         return ReviewResult(verdict="approve", summary=summary or "all acceptance criteria met")
+
+
+def _only_stated(rows: list[Any], stated: list[str] | None) -> list[Any]:
+    """Drop verdict rows that don't correspond to a stated criterion.
+
+    Whitespace-insensitive, matching ``intake.specs._merge_criteria`` — a judge that
+    re-spaces a criterion is still talking about the stated one. With no stated list
+    (a caller that never had one) every row is kept, so behaviour is unchanged.
+    """
+    if not stated:
+        return rows
+    keys = {" ".join(c.split()) for c in stated}
+    kept = [r for r in rows if isinstance(r, dict) and " ".join(str(r.get("criterion", "")).split()) in keys]
+    # A judge that renamed every criterion would otherwise leave nothing to judge; keeping
+    # the rows is the fail-closed choice (an unmet one still blocks).
+    return kept or rows
 
 
 def _read_source(root: Path, criteria: list[str]) -> str:

--- a/tests/sdlc/test_criteria_provenance.py
+++ b/tests/sdlc/test_criteria_provenance.py
@@ -1,0 +1,153 @@
+"""Provenance carried past the spec writer: the judge, the SPEC banner, the views.
+
+`FeatureSpec` separates the criteria a source stated from the ones the spec writer
+inferred. These tests are about everything *downstream* of that split honouring it —
+the failure being guarded is a run rejected for missing a requirement nobody asked for.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from orchestrator.core.llm import CompletionResult, Message
+from orchestrator.sdlc.review import SemanticReviewAdapter, _only_stated
+
+_STATED = ["exports a CSV file", "handles empty input"]
+_PROPOSED = ["emits a generated_at timestamp"]
+
+SPEC: dict[str, Any] = {
+    "title": "CSV export",
+    "acceptance_criteria": list(_STATED),
+    "proposed_criteria": list(_PROPOSED),
+}
+
+
+class _JudgeLLM:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+        self.last_user = ""
+
+    async def complete(self, messages: list[Message], **_: Any) -> CompletionResult:
+        self.last_user = messages[-1].content
+        text = self._payload if isinstance(self._payload, str) else json.dumps(self._payload)
+        return CompletionResult(text, "m", 1, 1, 0.0, 1.0)
+
+
+def _worktree(tmp_path: Path) -> Path:
+    (tmp_path / "export.py").write_text("def export_csv(rows):\n    return 'a,b'\n", encoding="utf-8")
+    return tmp_path
+
+
+def _rows(*pairs: tuple[str, str]) -> dict[str, Any]:
+    return {"criteria": [{"criterion": c, "status": s} for c, s in pairs], "summary": "s"}
+
+
+# ---- the judge: proposed criteria are context, never contract ----------------------
+
+
+async def test_an_unmet_proposed_criterion_does_not_block(tmp_path: Path) -> None:
+    """The whole point: a change is not rejected for missing what nobody asked for."""
+    llm = _JudgeLLM(_rows((_STATED[0], "met"), (_STATED[1], "met"), (_PROPOSED[0], "unmet")))
+
+    result = await SemanticReviewAdapter(llm).review(
+        path=str(_worktree(tmp_path)), issue_key="S-1", spec=SPEC
+    )
+
+    assert result.verdict == "approve"
+    assert not result.blockers
+
+
+async def test_an_unmet_stated_criterion_still_blocks(tmp_path: Path) -> None:
+    """Narrowing must not have disarmed the gate."""
+    llm = _JudgeLLM(_rows((_STATED[0], "unmet"), (_STATED[1], "met")))
+
+    result = await SemanticReviewAdapter(llm).review(
+        path=str(_worktree(tmp_path)), issue_key="S-1", spec=SPEC
+    )
+
+    assert result.verdict == "request_changes"
+    assert result.blockers
+
+
+async def test_proposed_criteria_reach_the_prompt_as_context(tmp_path: Path) -> None:
+    """Told they exist, so their implementation doesn't read as scope creep."""
+    llm = _JudgeLLM(_rows((_STATED[0], "met"), (_STATED[1], "met")))
+
+    await SemanticReviewAdapter(llm).review(path=str(_worktree(tmp_path)), issue_key="S-1", spec=SPEC)
+
+    assert _PROPOSED[0] in llm.last_user
+    assert "do NOT" in llm.last_user, "and told plainly not to judge against them"
+
+
+async def test_a_spec_with_no_proposed_criteria_prompts_exactly_as_before(tmp_path: Path) -> None:
+    llm = _JudgeLLM(_rows((_STATED[0], "met"), (_STATED[1], "met")))
+    spec = {"title": "CSV export", "acceptance_criteria": list(_STATED)}
+
+    await SemanticReviewAdapter(llm).review(path=str(_worktree(tmp_path)), issue_key="S-1", spec=spec)
+
+    assert "PROPOSED CRITERIA" not in llm.last_user
+
+
+# ---- the narrowing itself -----------------------------------------------------------
+
+
+def test_only_stated_drops_rows_for_criteria_the_source_never_stated() -> None:
+    rows = [{"criterion": _STATED[0], "status": "met"}, {"criterion": _PROPOSED[0], "status": "unmet"}]
+    assert _only_stated(rows, _STATED) == [rows[0]]
+
+
+def test_only_stated_is_whitespace_insensitive() -> None:
+    """Matching intake.specs._merge_criteria: a re-spaced criterion is the stated one."""
+    rows = [{"criterion": "exports   a  CSV file", "status": "unmet"}]
+    assert _only_stated(rows, _STATED) == rows
+
+
+def test_only_stated_keeps_everything_when_nothing_matches() -> None:
+    """Fail closed: a judge that renamed every criterion must not approve vacuously."""
+    rows = [{"criterion": "something else entirely", "status": "unmet"}]
+    assert _only_stated(rows, _STATED) == rows
+
+
+def test_only_stated_is_a_no_op_without_a_stated_list() -> None:
+    rows = [{"criterion": "anything", "status": "unmet"}]
+    assert _only_stated(rows, None) == rows
+
+
+# ---- the surfaces a human reads ----------------------------------------------------
+
+
+def test_the_issue_body_labels_proposed_criteria_apart_from_stated() -> None:
+    from orchestrator.intake.service import spec_to_issue_request
+
+    body = spec_to_issue_request(SPEC).description
+
+    assert _STATED[0] in body and _PROPOSED[0] in body
+    assert "Proposed criteria" in body
+    # And the reader can tell which is which: the proposed heading comes after the stated one.
+    assert body.index("Acceptance criteria") < body.index("Proposed criteria")
+
+
+def test_the_issue_body_has_no_proposed_heading_when_there_are_none() -> None:
+    from orchestrator.intake.service import spec_to_issue_request
+
+    spec = {"title": "CSV export", "acceptance_criteria": list(_STATED)}
+    body = spec_to_issue_request(spec).description
+
+    assert "Proposed criteria" not in body
+
+
+def test_the_report_cell_labels_proposed_criteria() -> None:
+    from orchestrator.intake.report import _criteria_cell
+
+    cell = _criteria_cell(SPEC)
+
+    assert _STATED[0] in cell and _PROPOSED[0] in cell
+    assert "Proposed" in cell
+
+
+def test_the_report_cell_is_unchanged_without_proposed_criteria() -> None:
+    from orchestrator.intake.report import _criteria_cell
+
+    assert "Proposed" not in _criteria_cell({"acceptance_criteria": list(_STATED)})


### PR DESCRIPTION
SSPN-31, slices 2b+2c+2d as one change. **All six source files are the model's, unmodified.** The tests are mine — see below.

## What it does

`FeatureSpec` has separated stated from inferred criteria since [#137](https://github.com/synaptixs/spine/pull/137), but only the spec writer knew it.

- **The judge verifies the stated set.** A change can no longer be rejected for missing a requirement nobody asked for.
- **Codegen still sees the proposed set, labelled.** Printing only the stated criteria would silently shrink what a run delivers; merging them back would undo the distinction.
- **The three render surfaces label them apart** — issue body, HTML report, web preview — with no heading at all when there are none.

## The part worth reading

The judge doesn't merely *ask* the model to ignore proposed criteria. It **enforces**:

```python
# A judge that answers about a criterion it was told was context-only cannot make it
# binding: rows are narrowed to the stated set before the verdict is computed. The
# prompt asks; this enforces.
rows = _only_stated(rows, stated)
```

`_only_stated` is whitespace-insensitive to match `intake.specs._merge_criteria`, and **fails closed** — `return kept or rows`, so a judge that renamed every criterion keeps its rows rather than approving vacuously. That is better than the spec asked for.

## What was the model's and what was mine

The run (`2692592326af4fc3`) wrote all six source files, then **failed writing its test module**: `</content>` markup at line 219.

That failure is the 3.13.0 syntax check working — the file was refused *at the write*, with its line and the offending text, instead of surfacing as an opaque pytest `rc=2` three stages later. What it could not do was recover inside one repair attempt.

So the 12 tests are hand-written.

## Verification

- `test_an_unmet_proposed_criterion_does_not_block` **fails** with the row-narrowing disabled and passes with it — checked by isolating that call, not just by reverting the file (which only produces an ImportError and proves less).
- Full gate green: `ruff format --check .`, `ruff check src tests`, `mypy src tests`, **2424 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)