### PR TITLE
fix(codegen): advise the failure kind that was actually charged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Fixed
+
+- **A failure kind is now advised about the thing it was charged for.** `_failure_kind`
+  ordered syntax before anchors; `_corrective_suffix` ordered anchors before syntax. An
+  attempt producing both — a stray `</content>` in a new file *and* an edit whose anchor
+  missed — was recorded as `syntax` while the model was handed the anchor-repair block, so
+  the syntax kind's one correction was spent on advice about something else and the next
+  failure had nothing left. The same shape as the shared-retry-pool bug the per-kind budget
+  replaced, arriving through misclassification instead. A test now fails if the two
+  orderings drift again.
+
 ### Changed
 
 - **`FeatureSpec.acceptance_criteria` has narrowed to the criteria the source

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -1525,12 +1525,12 @@ class LLMCodegenAdapter:
         if exc.parse_detail:
             logger.warning("sdlc.codegen.parse_retry detail=%r", exc.parse_detail[:160])
             return _parse_repair_block(exc.parse_detail)
-        if exc.failed_edit_paths or exc.missing_edit_paths:
-            logger.warning(
-                "sdlc.codegen.repair_retry",
-                extra={"failed": exc.failed_edit_paths, "missing": exc.missing_edit_paths},
-            )
-            return self._repair_block(exc, root)
+        # Syntax before anchors, matching `_failure_kind`. When one attempt produces both —
+        # a stray `</content>` in a new file *and* an edit whose anchor missed — the kind is
+        # recorded as "syntax", so handing back the anchor-repair block spends that kind's
+        # one correction on advice about something else. A live run died that way: the model
+        # was told its anchors failed, never told to stop emitting markup wrappers, and the
+        # retry it needed was already marked used. The two orderings must not drift again.
         if exc.syntax_errors:
             logger.warning("sdlc.codegen.syntax_retry", extra={"errors": exc.syntax_errors[:3]})
             listed = "\n".join(f"  - {m}" for m in exc.syntax_errors)
@@ -1542,6 +1542,12 @@ class LLMCodegenAdapter:
                 "own source — no XML or markup wrappers, no `<content>` tags, no fences, "
                 "nothing after the final line of code.\n"
             )
+        if exc.failed_edit_paths or exc.missing_edit_paths:
+            logger.warning(
+                "sdlc.codegen.repair_retry",
+                extra={"failed": exc.failed_edit_paths, "missing": exc.missing_edit_paths},
+            )
+            return self._repair_block(exc, root)
         if exc.empty_summary:
             logger.warning("sdlc.codegen.empty_retry summary=%r", exc.empty_summary[:160])
             return (

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1579,3 +1579,51 @@ async def test_refine_windows_land_on_what_the_traceback_names(tmp_path: Path) -
     block = adapter._session_files(tmp_path, include_tests=True, anchors=["the_function_that_broke"])
 
     assert needle in block
+
+
+# --- the classifier and the corrector must agree on priority ------------------------
+#
+# `_failure_kind` decides which kind's one correction is being spent; `_corrective_suffix`
+# decides what the model is actually told. When they disagree, an attempt is charged to one
+# kind and spent advising about another. A live run died that way: a stray `</content>` in a
+# new file arrived alongside an edit whose anchor missed, the kind was recorded as "syntax",
+# and the model was handed the anchor-repair block — so it was never told to stop emitting
+# markup wrappers, and by the next failure "syntax" was already marked used.
+
+
+async def test_a_syntax_error_gets_syntax_advice_even_alongside_a_failed_edit(
+    tmp_path: Path,
+) -> None:
+    from orchestrator.sdlc.codegen import CodegenError, _failure_kind
+
+    exc = CodegenError(
+        "both at once",
+        syntax_errors=["t.py: line 219: invalid syntax — '</content>'"],
+        failed_edit_paths=["src/a.py"],
+    )
+    assert _failure_kind(exc) == "syntax"
+
+    gen = LLMCodegenAdapter(_ScriptedLLM([]))
+    suffix = gen._corrective_suffix(exc, tmp_path)
+
+    assert suffix is not None
+    assert "DOES NOT PARSE" in suffix, "the advice must address the kind that was charged"
+    assert "</content>" in suffix or "`<content>` tags" in suffix
+
+
+def test_every_failure_kind_has_advice_that_matches_it(tmp_path: Path) -> None:
+    """Each kind, alone, must produce advice — and the same kind the classifier names."""
+    from orchestrator.sdlc.codegen import CodegenError, _failure_kind
+
+    gen = LLMCodegenAdapter(_ScriptedLLM([]))
+    cases = [
+        ("parse", CodegenError("x", parse_detail="not an object"), "JSON"),
+        ("syntax", CodegenError("x", syntax_errors=["a.py: line 1: bad"]), "DOES NOT PARSE"),
+        ("anchors", CodegenError("x", failed_edit_paths=["a.py"]), "CURRENT"),
+        ("empty", CodegenError("x", empty_summary="nothing submitted"), "submit"),
+    ]
+    for expected_kind, exc, marker in cases:
+        assert _failure_kind(exc) == expected_kind
+        suffix = gen._corrective_suffix(exc, tmp_path)
+        assert suffix is not None, f"{expected_kind} has no advice"
+        assert marker.lower() in suffix.lower(), f"{expected_kind} advice does not address it"


### PR DESCRIPTION
Found by diagnosing the `</content>` failure on the last SSPN-31 run.

## The bug

Two functions disagreed on priority:

| | order |
|---|---|
| `_failure_kind` | parse → **syntax** → anchors → empty |
| `_corrective_suffix` | parse → **anchors** → syntax → empty |

When one attempt produced **both** a syntax error and a failed edit anchor, the kind was recorded as `"syntax"` while the model was handed the **anchor-repair** block. So:

1. The syntax kind's single correction was spent on advice about edit anchors.
2. The model was never told the thing that would have helped — *"no XML or markup wrappers, no `<content>` tags"* — even though that text exists for exactly this.
3. By the next failure, `"syntax"` was already marked used, so it raised.

The run's own log is the evidence: it died on `tests/...: line 219: invalid syntax — '</content>'` having logged `repair_retry`, not `syntax_retry`.

This is the shared-retry-pool bug again — *"whichever failed first consumed it"* — arriving through misclassification rather than a shared pool. The comment above the retry loop describes the earlier version of the same failure.

## Verification

Two tests. One asserts a syntax error alongside a failed edit still receives syntax advice; the other asserts every kind's advice addresses that kind, so the orderings cannot drift apart again.

Checked against the original ordering by actually swapping the branches back: `test_a_syntax_error_gets_syntax_advice_even_alongside_a_failed_edit` **fails**, logging `repair_retry` — the same line your run printed.

Full gate green, **2426 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)