### PR TITLE
feat(sdlc): refuse a criterion that contradicts a documented invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Added
+
+- **The validity gate refuses a criterion that contradicts a documented invariant.** The run
+  that started SSPN-31 produced a criterion requiring an ISO-8601 `meta.generated_at`
+  timestamp in a comprehension command's JSON — nobody asked for it, and it breaks CLAUDE.md
+  invariant 2 (`understand` / `state` are deterministic; never a clock, an LLM call, or
+  randomness). An agent building to it would have shipped non-diffable output and passed its
+  own tests. `assess()` now returns `CRITERIA_WRONG` with evidence naming the invariant.
+  Deterministic string matching, no LLM call — an LLM asked whether an LLM invented a
+  requirement is not an answer. Proposed criteria are checked too, since an invented
+  criterion is the kind most likely to break a rule. A timestamp in a log line, an HTTP
+  header or a tracker comment is untouched: determinism is a property of specific outputs,
+  not a ban on the word.
+
 ### Fixed
 
 - **A failure kind is now advised about the thing it was charged for.** `_failure_kind`

--- a/src/orchestrator/sdlc/validity.py
+++ b/src/orchestrator/sdlc/validity.py
@@ -112,6 +112,24 @@ def _criteria_text(spec: dict[str, Any]) -> list[str]:
     return [str(a) for a in (spec.get("acceptance_criteria") or [])]
 
 
+def _all_criteria_text(spec: dict[str, Any]) -> list[str]:
+    """Stated criteria **and** proposed ones (``proposed_criteria``, #137).
+
+    A proposed criterion is the kind most likely to contradict an invariant — nobody asked
+    for it — and it is still handed to codegen, so the gate has to read it too.
+    """
+    criteria = _criteria_text(spec)
+    for proposed in spec.get("proposed_criteria") or []:
+        # A proposal may be a plain string or a {"criterion": ..., "why": ...} record.
+        if isinstance(proposed, dict):
+            text = str(proposed.get("criterion") or proposed.get("text") or "").strip()
+        else:
+            text = str(proposed).strip()
+        if text:
+            criteria.append(text)
+    return criteria
+
+
 def _count_of(store: FactStore, kind: NodeKind) -> int:
     """Grounded nodes only: an external placeholder is a table someone else owns, not one
     this repo has."""
@@ -149,6 +167,103 @@ def _check_countable_claims(spec: dict[str, Any], store: FactStore) -> list[Find
                     evidence=criterion.strip(),
                 )
             )
+    return findings
+
+
+# --- documented invariants -------------------------------------------------------------
+# Hand-maintained on purpose. Parsing CLAUDE.md at runtime would make the gate depend on
+# prose formatting — a worse contract than a short explicit list that a reviewer can read.
+# Keep in sync with CLAUDE.md "Invariants" (invariant 2: `understand` / `state` and the
+# episteme knowledge base are deterministic — no LLM call, no clock, no randomness).
+_DETERMINISTIC_SURFACES: tuple[tuple[str, ...], ...] = (
+    ("understand",),
+    ("state",),
+    ("episteme",),
+    ("memory bank", "memory-bank"),
+    ("knowledge base", "knowledge-base"),
+    ("comprehension",),
+    ("regression",),
+)
+
+_INVARIANT_REF = (
+    "CLAUDE.md invariant 2: `understand` / `state` and the episteme knowledge base are "
+    "deterministic — never add an LLM call, a clock read, or randomness to their output"
+)
+
+# Words that mean "read the clock" or "roll a die" in an output. Matched on word boundaries
+# so `generated_at` and `uuid4` hit while `timestamped log line` only hits via `timestamp`.
+_NONDETERMINISM = re.compile(
+    r"\b("
+    r"timestamps?|timestamped|generated_at|created_at|updated_at|generation[_ ]time"
+    r"|iso[- ]?8601|utcnow|datetime\.now|time\.time|current time|wall[- ]clock|clock read"
+    r"|random(?:ly|ness|ised|ized)?|uuid4?|nondeterministic|non-deterministic"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Places a timestamp is perfectly fine: they are not the deterministic artifacts. A log line,
+# an HTTP header, or a tracker comment may carry a clock read without breaking anything.
+_EXEMPT_SINKS = re.compile(
+    r"\b(log(?:s|ged|ging|ger|-line|\sline|\smessage|\srecord)?|stderr|stdout\slog"
+    r"|http\s*(?:response\s*)?header|response\s*header|header|audit\s*(?:log|row|record)"
+    r"|jira|tracker|issue\s*comment|pr\s*(?:comment|body|description)|slack|notification"
+    r"|database\s*(?:row|column)|db\s*row|metric|telemetry|trace)\b",
+    re.IGNORECASE,
+)
+
+# Words that mean "this lands in what the surface emits" — the part invariant 2 pins down.
+_OUTPUT_WORDS = re.compile(
+    r"\b(output|outputs|json|report|artifact|artifacts|payload|meta|manifest|markdown|md"
+    r"|file|files|document|snapshot|response|result|emit|emits|emitted|render|rendered"
+    r"|write|writes|written|include|includes|including|contains?|carry|carries)\b",
+    re.IGNORECASE,
+)
+
+
+def _named_surface(text: str) -> str | None:
+    """The deterministic surface a criterion talks about, if any."""
+    lowered = text.lower()
+    for aliases in _DETERMINISTIC_SURFACES:
+        for alias in aliases:
+            if re.search(rf"(?<![a-z0-9_]){re.escape(alias)}(?![a-z0-9_])", lowered):
+                return aliases[0]
+    return None
+
+
+def _check_invariants(spec: dict[str, Any]) -> list[Finding]:
+    """A criterion that contradicts a documented repo invariant (SSPN-31).
+
+    The run that produced this check invented *"`meta.generated_at` as an ISO-8601 UTC
+    timestamp in the JSON output of `orchestrator regression --format json`"*. Nobody asked
+    for it, and it contradicts invariant 2: those surfaces are byte-stable so their output can
+    be diffed. An agent building to it would have shipped non-diffable output and passed its
+    own tests. Provenance makes an invented criterion visible; this makes a dangerous one stop.
+
+    Deterministic string matching, like every other check here — no LLM, no network. Asking a
+    model whether a model invented a requirement is not an answer.
+    """
+    findings: list[Finding] = []
+    for criterion in _all_criteria_text(spec):
+        match = _NONDETERMINISM.search(criterion)
+        if match is None:
+            continue
+        surface = _named_surface(criterion)
+        if surface is None:
+            continue
+        # Determinism is a property of these outputs, not a ban on the word: a log line, an
+        # HTTP header, or a tracker comment may carry a clock read.
+        if _EXEMPT_SINKS.search(criterion) or not _OUTPUT_WORDS.search(criterion):
+            continue
+        findings.append(
+            Finding(
+                check="repo-invariant",
+                detail=(
+                    f"the criterion puts {match.group(0)!r} in {surface!r} output, which is a "
+                    "deterministic surface — its output must be byte-stable so it can be diffed"
+                ),
+                evidence=f"{_INVARIANT_REF} — criterion: {criterion.strip()}",
+            )
+        )
     return findings
 
 
@@ -237,6 +352,12 @@ def assess(
     duplicate = _check_prior_runs(issue_key, prior_runs or [])
     if duplicate:
         return Assessment(verdict=Verdict.DUPLICATE, findings=duplicate)
+
+    breaks_invariant = _check_invariants(spec)
+    if breaks_invariant:
+        # Same reason as a false countable claim: code built to a criterion that contradicts
+        # the repo's own rules passes its own tests and is still wrong.
+        return Assessment(verdict=Verdict.CRITERIA_WRONG, findings=breaks_invariant)
 
     wrong = _check_countable_claims(spec, store)
     if wrong:

--- a/tests/sdlc/test_validity_invariants.py
+++ b/tests/sdlc/test_validity_invariants.py
@@ -1,0 +1,172 @@
+"""The validity gate refuses a criterion that contradicts a documented repo invariant (SSPN-31).
+
+Every case goes through ``assess()`` — the entry point the run agent calls — so the wiring
+between the new ``_check_invariants`` check and the verdict is exercised, not just the helper.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+import pytest
+
+from orchestrator.pkg import FactBatch, FactStore
+from orchestrator.sdlc.validity import Verdict, assess
+
+
+def _store() -> FactStore:
+    """An empty graph: these cases are about the criteria text, not what the repo contains."""
+    return FactStore(FactBatch())
+
+
+def _spec(*criteria: str, proposed: list[Any] | None = None) -> dict[str, Any]:
+    spec: dict[str, Any] = {"acceptance_criteria": list(criteria)}
+    if proposed is not None:
+        spec["proposed_criteria"] = proposed
+    return spec
+
+
+# The criterion that started the ticket, verbatim in spirit.
+_GENERATED_AT = (
+    "`orchestrator regression --format json` includes `meta.generated_at` as an "
+    "ISO-8601 UTC timestamp in its JSON output"
+)
+
+
+def test_generated_at_criterion_is_refused_as_criteria_wrong() -> None:
+    result = assess(_spec(_GENERATED_AT), store=_store())
+
+    assert result.verdict is Verdict.CRITERIA_WRONG
+    assert result.proceed is False
+    assert [f.check for f in result.findings] == ["repo-invariant"]
+
+
+def test_finding_evidence_names_the_invariant_it_breaks() -> None:
+    result = assess(_spec(_GENERATED_AT), store=_store())
+
+    evidence = result.findings[0].evidence
+    assert "CLAUDE.md invariant 2" in evidence
+    assert "deterministic" in evidence
+    # The offending criterion travels with the evidence, so the reader sees what was refused.
+    assert "meta.generated_at" in evidence
+    assert "regression" in result.findings[0].detail
+
+
+@pytest.mark.parametrize(
+    "criterion",
+    [
+        "the `understand` command writes a `generated_at` timestamp into its JSON output",
+        "`orchestrator state` output includes the current time in its report",
+        "the episteme knowledge base markdown files contain a generated_at timestamp",
+        "the comprehension report payload includes a random uuid4 per run",
+    ],
+)
+def test_deterministic_surfaces_reject_clock_and_randomness(criterion: str) -> None:
+    result = assess(_spec(criterion), store=_store())
+
+    assert result.verdict is Verdict.CRITERIA_WRONG
+    assert result.findings[0].check == "repo-invariant"
+
+
+@pytest.mark.parametrize(
+    "criterion",
+    [
+        "the `understand` run emits a log line with a timestamp for each file scanned",
+        "the HTTP response header carries a generated_at timestamp",
+        "the Jira issue comment includes an ISO-8601 timestamp of the run",
+        "the audit log row records created_at for every state change",
+    ],
+)
+def test_non_deterministic_sinks_are_not_flagged(criterion: str) -> None:
+    result = assess(_spec(criterion), store=_store())
+
+    assert result.verdict is Verdict.PROCEED
+    assert result.findings == []
+
+
+def test_timestamp_without_a_deterministic_surface_is_fine() -> None:
+    result = assess(
+        _spec("the PR body includes an ISO-8601 timestamp of when the run finished"),
+        store=_store(),
+    )
+
+    assert result.verdict is Verdict.PROCEED
+
+
+def test_proposed_criteria_are_checked_too() -> None:
+    spec = _spec(
+        "`orchestrator understand` prints a module count",
+        proposed=[{"criterion": _GENERATED_AT, "why": "nice for cache busting"}],
+    )
+
+    result = assess(spec, store=_store())
+
+    assert result.verdict is Verdict.CRITERIA_WRONG
+    assert "meta.generated_at" in result.findings[0].evidence
+
+
+def test_proposed_criteria_may_be_plain_strings() -> None:
+    spec = _spec("something harmless", proposed=[_GENERATED_AT])
+
+    result = assess(spec, store=_store())
+
+    assert result.verdict is Verdict.CRITERIA_WRONG
+
+
+def test_clean_spec_still_proceeds_with_no_findings() -> None:
+    spec = _spec(
+        "`orchestrator understand` output is byte-identical across two runs on the same commit",
+        "the state file records the module count",
+        proposed=["the episteme index lists every table"],
+    )
+
+    result = assess(spec, store=_store())
+
+    assert result.verdict is Verdict.PROCEED
+    assert result.findings == []
+    assert result.proceed is True
+
+
+def test_check_makes_no_network_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deterministic string matching: no LLM, no socket. Opening one fails the test."""
+
+    def _no_network(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("the validity gate must not touch the network")
+
+    monkeypatch.setattr(socket.socket, "connect", _no_network)
+    monkeypatch.setattr(socket, "create_connection", _no_network)
+
+    result = assess(_spec(_GENERATED_AT), store=_store())
+
+    assert result.verdict is Verdict.CRITERIA_WRONG
+
+
+def test_verdict_is_stable_across_repeated_calls() -> None:
+    spec = _spec(_GENERATED_AT)
+    first = assess(spec, store=_store())
+    second = assess(spec, store=_store())
+
+    assert first.verdict is second.verdict
+    assert [(f.check, f.detail, f.evidence) for f in first.findings] == [
+        (f.check, f.detail, f.evidence) for f in second.findings
+    ]
+
+
+def test_render_shows_the_refusal_and_its_evidence() -> None:
+    rendered = assess(_spec(_GENERATED_AT), store=_store()).render()
+
+    assert "**Verdict:** CRITERIA_WRONG" in rendered
+    assert "repo-invariant" in rendered
+    assert "CLAUDE.md invariant 2" in rendered
+
+
+def test_invariant_check_runs_before_the_size_gate() -> None:
+    # Many criteria *and* an invariant breach: the invariant is the one that must be reported,
+    # because building to it is wrong however small the ticket is.
+    spec = _spec(*[f"criterion {i}" for i in range(20)], _GENERATED_AT)
+
+    result = assess(spec, store=_store(), max_criteria=2)
+
+    assert result.verdict is Verdict.CRITERIA_WRONG
+    assert result.findings[0].check == "repo-invariant"


### PR DESCRIPTION
SSPN-31, final slice — the check plus its corpus fixture. **The source change is the model's, unmodified** (`sdlc autorun --spec`, run `4010af9a26f14846`).

## Why

The run that started this ticket wrote a criterion requiring an ISO-8601 `meta.generated_at` timestamp in `orchestrator regression --format json`. Nobody asked for it, and it contradicts **CLAUDE.md invariant 2** — `understand` / `state` and the episteme bank are deterministic, never a clock read, an LLM call, or randomness. An agent building to it would have produced non-diffable output **and passed its own tests**.

[#137](https://github.com/synaptixs/spine/pull/137) and [#139](https://github.com/synaptixs/spine/pull/139) made an invented criterion visible and non-binding. Neither made a *dangerous* one stop.

## The change

One check beside the existing ones in `validity.py`. `Verdict.CRITERIA_WRONG` already meant "a criterion contradicts the source", so no new vocabulary was needed.

- **Deterministic string matching, no LLM call, no network.** An LLM asked whether an LLM invented a requirement is not an answer.
- **The invariant list is hand-maintained in code**, with a pointer to CLAUDE.md. Parsing prose at runtime would make the gate depend on markdown formatting — a worse contract than a short list a reviewer can read.
- **Proposed criteria are checked too.** An invented criterion is the kind most likely to break a rule, and codegen still sees it.
- **A timestamp in a log line, an HTTP header or a tracker comment is left alone.** Determinism is a property of those specific outputs, not a ban on the word.

Criterion 2 of the spec is the corpus fixture SSPN-31 asked for: this ticket's own `meta.generated_at` expansion, asserted against a known-correct verdict.

## Verification

- 18 tests; **11 fail** against the pre-change gate.
- Full gate green: **2444 passed**.

## Note on `pytesseract`

It is reported on every red run and is **not** a cause — `tests/pkg/test_media_extract.py` uses `pytest.importorskip`, and running it alone gives `11 passed, 1 skipped`. The missing-module scan only executes when a suite fails, so it is invisible on green runs and appears on red ones regardless of why.

The actual failure was `FactStore.__init__() missing 1 required positional argument: 'batch'`.

## The pattern worth fixing next

Three runs in a row have produced **correct source** and a **broken test module**, each time by constructing a type the spec never named — `CompletionResult` twice, now `FactStore`. `author_tests` writes fakes for types it has never been shown. That is mechanical and fixable, and it is now the single largest cost in this pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)