### PR TITLE
release: 3.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.14.0 — The pipeline can be trusted about its own output
 
 ### Added
 
@@ -16,16 +16,14 @@
   header or a tracker comment is untouched: determinism is a property of specific outputs,
   not a ban on the word.
 
-### Fixed
-
-- **A failure kind is now advised about the thing it was charged for.** `_failure_kind`
-  ordered syntax before anchors; `_corrective_suffix` ordered anchors before syntax. An
-  attempt producing both — a stray `</content>` in a new file *and* an edit whose anchor
-  missed — was recorded as `syntax` while the model was handed the anchor-repair block, so
-  the syntax kind's one correction was spent on advice about something else and the next
-  failure had nothing left. The same shape as the shared-retry-pool bug the per-kind budget
-  replaced, arriving through misclassification instead. A test now fails if the two
-  orderings drift again.
+- **`--spec` on `sdlc autorun` and `sdlc feature`** — implement a spec you wrote instead of
+  one derived from the source. Intake is skipped entirely and the `[intake]` line reports
+  `skipped`, so a run summary never implies a source document was read when none was. For a
+  settled spec (a remediation, something agreed in review) — or when intake itself is what
+  the ticket is about, where letting a defective stage specify its own repair is circular.
+  The file is JSON validated against `FeatureSpec` rather than markdown: a misspelled
+  `acceptance-criteria` is an error naming the valid fields, not a run that proceeds with no
+  criteria and passes by default. An empty criteria list is refused for the same reason.
 
 ### Changed
 
@@ -46,8 +44,6 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## Unreleased
 
-### Changed
-
 - **Codegen's source-context budget goes from 40 KB to 200 KB.** 40 KB is ~10k tokens —
   about 1% of the default model's window, and a leftover rather than a limit. It shaped
   work instead of bounding it: a change spanning five files totalled 113 KB, so every file
@@ -55,16 +51,16 @@ All notable changes to this project are documented here. Format loosely follows
   Failure output stays at 40 KB under its own constant — a pytest dump is not source, and
   refine re-sends context every attempt.
 
-- **`FeatureSpec.acceptance_criteria` has narrowed to the criteria the source actually
-  stated.** Anything the spec writer inferred now lands in a new `proposed_criteria` field
-  instead of being appended to the same list. Readers of `acceptance_criteria` will see
-  fewer entries than before — that is the point: they were previously indistinguishable, so
-  a run could be held to a requirement nobody asked for. `_merge_criteria` returns
-  `(stated, proposed)` rather than one merged list. The judge, the codegen prompt and the
-  spec views still read the stated set; carrying the distinction through to them is
-  separate work.
-
 ### Fixed
+
+- **A failure kind is now advised about the thing it was charged for.** `_failure_kind`
+  ordered syntax before anchors; `_corrective_suffix` ordered anchors before syntax. An
+  attempt producing both — a stray `</content>` in a new file *and* an edit whose anchor
+  missed — was recorded as `syntax` while the model was handed the anchor-repair block, so
+  the syntax kind's one correction was spent on advice about something else and the next
+  failure had nothing left. The same shape as the shared-retry-pool bug the per-kind budget
+  replaced, arriving through misclassification instead. A test now fails if the two
+  orderings drift again.
 
 - **A run branches from the branch it will open a PR into.** A clone with no `--branch`
   checks out the remote's *default* branch, so a run targeting `develop` still built on
@@ -82,19 +78,6 @@ All notable changes to this project are documented here. Format loosely follows
   exactly this for codegen and the acceptance judge; intake was never converted. Both now
   emit through a forced tool call. The text path remains as the degradation route, since a
   forced call constrains shape but a provider can still answer in prose.
-
-### Added
-
-- **`--spec` on `sdlc autorun` and `sdlc feature`** — implement a spec you wrote instead of
-  one derived from the source. Intake is skipped entirely and the `[intake]` line reports
-  `skipped`, so a run summary never implies a source document was read when none was. For a
-  settled spec (a remediation, something agreed in review) — or when intake itself is what
-  the ticket is about, where letting a defective stage specify its own repair is circular.
-  The file is JSON validated against `FeatureSpec` rather than markdown: a misspelled
-  `acceptance-criteria` is an error naming the valid fields, not a run that proceeds with no
-  criteria and passes by default. An empty criteria list is refused for the same reason.
-
-### Fixed
 
 - **A server that declares a structured argument as a JSON string now gets one.**
   `mcp-atlassian` types `jira_create_issue.additional_fields` as `string` rather than

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.13.0"
+version = "3.14.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -3690,7 +3690,7 @@ wheels = [
 
 [[package]]
 name = "synaptixs-spine"
-version = "3.13.0"
+version = "3.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Cuts 3.14.0. Version bump, `uv.lock`, and a changelog tidy.

## What's in it

3.13.0 could open a PR and tell whether it did what the ticket asked. It could not tell whether the ticket was worth asking — or whether it was working from the right tree.

- **Intake emits through a forced tool call.** It was the last stage still passing `json_object=True`, which Anthropic drops — so it ran unconstrained and its specs were salvaged rather than parsed.
- **Criteria are partitioned by provenance.** An invented criterion was indistinguishable from one the source stated. The judge now requires only the stated set, and *enforces* it by narrowing verdict rows rather than just asking the model.
- **The validity gate refuses a criterion that contradicts a documented invariant** — the `meta.generated_at` case that would have shipped non-diffable output and passed its own tests.
- **A run branches from the branch it will open a PR into.** Every run previously branched from the remote default, so a change could revert work it never knew existed.
- **Codegen's context budget was ~1% of the model's window.** Now 200 KB.
- **`--spec`**, to implement a spec you wrote instead of one derived.

## Changelog tidy

Each PR prepended its own `### Added/Changed/Fixed` block, so those headings appeared several times in `## Unreleased` and the `acceptance_criteria` narrowing was listed twice. Regrouped into one of each; 9 entries → 8.

## Verification

- `ruff format --check .`, `ruff check src tests`, `mypy src tests` — clean
- `pytest -q` — **2459 passed**, 30 skipped
- `uv build` — `synaptixs_spine-3.14.0` sdist + wheel

## Known gap, filed not hidden

SSPN-39: the new invariant check does not fire on SSPN-31's own verbatim criterion, because that text names the JSON key `"regressions"` and never the command. The check works when a surface is named; the corpus fixture is a paraphrase that is easier than the real case. Filed with a reproduction rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)