### PR TITLE
fix(sdlc): the invariant check catches the criterion it was built from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The repo-invariant check now catches the criterion it was built from.** It needed both a
+  nondeterminism word and a named deterministic surface; SSPN-31's own criterion is phrased
+  entirely as output shape, naming the JSON key `"regressions"` and never the `regression`
+  command, so no surface matched and the gate returned `PROCEED`. Surface names now match a
+  trailing `s`/`es` and a possessive. The corpus fixture asserts the verbatim criterion
+  rather than a reworded one that names the command — a fixture easier than the real case
+  makes a check read as working while doing less.
+
 ## 3.14.0 — The pipeline can be trusted about its own output
 
 ### Added

--- a/src/orchestrator/sdlc/validity.py
+++ b/src/orchestrator/sdlc/validity.py
@@ -220,12 +220,29 @@ _OUTPUT_WORDS = re.compile(
 )
 
 
+def _surface_pattern(alias: str) -> str:
+    """A regex for one surface alias, tolerating a plural ``s`` and a possessive.
+
+    SSPN-31's own criterion is phrased entirely as output shape — it names the JSON key
+    ``"regressions"`` and never the ``regression`` command — so an exact-word match found no
+    surface and the check that was written for it returned PROCEED. The inflection rule is
+    deliberately tiny (an optional ``'``/``’`` possessive, an optional trailing ``s``): a
+    stemmer would start matching words nobody wrote, and the two-signal design (a
+    nondeterminism word **and** a named surface) is what keeps `timestamp` alone harmless.
+    """
+    return rf"(?<![a-z0-9_]){re.escape(alias)}(?:['\u2019]s|s|es)?(?![a-z0-9_])"
+
+
 def _named_surface(text: str) -> str | None:
-    """The deterministic surface a criterion talks about, if any."""
+    """The deterministic surface a criterion talks about, if any.
+
+    Matches simple inflections of each alias, so ``regressions`` and ``the regression's
+    output`` both resolve to the ``regression`` surface.
+    """
     lowered = text.lower()
     for aliases in _DETERMINISTIC_SURFACES:
         for alias in aliases:
-            if re.search(rf"(?<![a-z0-9_]){re.escape(alias)}(?![a-z0-9_])", lowered):
+            if re.search(_surface_pattern(alias), lowered):
                 return aliases[0]
     return None
 

--- a/tests/sdlc/test_validity_invariants.py
+++ b/tests/sdlc/test_validity_invariants.py
@@ -27,8 +27,18 @@ def _spec(*criteria: str, proposed: list[Any] | None = None) -> dict[str, Any]:
     return spec
 
 
-# The criterion that started the ticket, verbatim in spirit.
+# The criterion that started the ticket, VERBATIM — phrased entirely as output shape, so it
+# names the JSON key "regressions" and never the `regression` command. This is the case the
+# check must refuse; the reworded one below is kept as an extra, never as the only case.
 _GENERATED_AT = (
+    "Given `--format json` is passed, the JSON output is a top-level object with two keys: "
+    '"meta" (object containing at minimum "generated_at" as an ISO-8601 UTC timestamp string) '
+    'and "regressions" (array of objects)'
+)
+
+# The same requirement reworded to name the command — the fixture the check used to be tested
+# against. Kept so both phrasings stay covered.
+_GENERATED_AT_NAMING_THE_COMMAND = (
     "`orchestrator regression --format json` includes `meta.generated_at` as an "
     "ISO-8601 UTC timestamp in its JSON output"
 )
@@ -42,8 +52,38 @@ def test_generated_at_criterion_is_refused_as_criteria_wrong() -> None:
     assert [f.check for f in result.findings] == ["repo-invariant"]
 
 
+def test_the_reworded_criterion_naming_the_command_is_refused_too() -> None:
+    result = assess(_spec(_GENERATED_AT_NAMING_THE_COMMAND), store=_store())
+
+    assert result.verdict is Verdict.CRITERIA_WRONG
+    assert [f.check for f in result.findings] == ["repo-invariant"]
+
+
+@pytest.mark.parametrize(
+    "criterion",
+    [
+        'the JSON output lists the "regressions" array with a generated_at timestamp',
+        "the regression's JSON report carries a generated_at timestamp",
+        "the regressions' report payload includes the current time",
+    ],
+)
+def test_surface_names_match_plural_and_possessive_inflections(criterion: str) -> None:
+    result = assess(_spec(criterion), store=_store())
+
+    assert result.verdict is Verdict.CRITERIA_WRONG
+    assert result.findings[0].check == "repo-invariant"
+
+
+def test_a_nondeterminism_word_alone_still_proceeds() -> None:
+    """The two-signal design stays: 'timestamp' with no named surface is not a breach."""
+    result = assess(_spec("the JSON output includes a generated_at timestamp"), store=_store())
+
+    assert result.verdict is Verdict.PROCEED
+    assert result.findings == []
+
+
 def test_finding_evidence_names_the_invariant_it_breaks() -> None:
-    result = assess(_spec(_GENERATED_AT), store=_store())
+    result = assess(_spec(_GENERATED_AT_NAMING_THE_COMMAND), store=_store())
 
     evidence = result.findings[0].evidence
     assert "CLAUDE.md invariant 2" in evidence
@@ -103,7 +143,7 @@ def test_proposed_criteria_are_checked_too() -> None:
     result = assess(spec, store=_store())
 
     assert result.verdict is Verdict.CRITERIA_WRONG
-    assert "meta.generated_at" in result.findings[0].evidence
+    assert "generated_at" in result.findings[0].evidence
 
 
 def test_proposed_criteria_may_be_plain_strings() -> None:


### PR DESCRIPTION
Closes SSPN-39. **Both files are the model's, unmodified** (`sdlc autorun --spec`, run `099b43cf82a54589`, live).

## The gap

The check needs **both** a nondeterminism word and a named deterministic surface. SSPN-31's own criterion is phrased entirely as output shape — it names the JSON key `"regressions"` and never the `regression` command:

```
nondeterminism : True      ← generated_at, ISO-8601, timestamp
named surface  : None      ← the failure
```

So `assess()` returned `PROCEED` on the exact input the check exists for. And the corpus fixture was a *reworded* version naming the command, so it passed — a fixture easier than the real case makes a check read as working while doing less than its ticket claims. Which is the same failure SSPN-31 is about.

## The change

Surface aliases match a trailing `s`/`es` and a possessive. Deliberately tiny — a stemmer would start matching words nobody wrote, and the two-signal design is what keeps a bare `timestamp` harmless.

The fixture now asserts the **verbatim** criterion; the reworded one stays as an additional case, never the only one.

## Verification

```
verbatim SSPN-31 criterion -> CRITERIA_WRONG   (was PROCEED)
jira comment timestamp     -> PROCEED          (exemptions intact)
```

Full gate green, **2464 passed**.

## A real bug this run exposed

The run reported `edit 0 'find' text not found` — but **both files had already been written completely on the first attempt**. `apply_files` is per-file atomic, not per-batch: successful files are written as it goes. When a later file fails, `_repair_block` says *"Re-emit the full JSON object"* and shows current content **only for the files that failed**. So the model re-sends edits for files that already applied, whose anchors it has itself consumed.

Filing separately — it makes any partially-successful attempt unrecoverable, and it is why this run failed despite producing a complete, correct change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)