### PR TITLE
fix(codegen): a partially-applied attempt can be repaired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Fixed
 
+- **A partially-applied codegen attempt can now be repaired.** `apply_files` is per-file
+  atomic, not per-batch: a successful file is written before the rest are attempted, so a
+  later failure leaves earlier ones on disk. The repair then said "re-emit the full JSON
+  object" while showing current content only for the files that *failed* — so the model
+  resent edits whose `find` text its own previous attempt had replaced, and the retry could
+  not succeed. A live run produced a complete, correct change and failed anyway on `edit 0
+  'find' text not found`. The error now carries which files landed, and the repair tells the
+  model to omit them.
+
 - **`mcp` pinned below 2.0 until the v2 migration lands, and CI now installs the extra.**
   v2 renames what this package uses — `streamablehttp_client` → `streamable_http_client`,
   `CallToolResult.isError` → `is_error` — and drops `mcp.server.fastmcp` entirely. The bump

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -301,8 +301,15 @@ class CodegenError(RuntimeError):
         syntax_errors: list[str] | None = None,
         parse_detail: str = "",
         empty_summary: str = "",
+        applied_paths: list[str] | None = None,
     ) -> None:
         super().__init__(message)
+        # Files this attempt already wrote before it failed. `apply_files` is per-file
+        # atomic, not per-batch, so a later file's failure leaves earlier ones on disk —
+        # and the repair used to say "re-emit the full JSON object" without saying which.
+        # The model resent edits whose `find` text its own previous attempt had replaced,
+        # so a partially-successful attempt could never be repaired.
+        self.applied_paths = list(applied_paths or [])
         self.failed_edit_paths = list(failed_edit_paths or [])
         self.missing_edit_paths = list(missing_edit_paths or [])
         # The ``find`` snippets that did not match, per path. Wrong text, but a correct
@@ -1570,6 +1577,17 @@ class LLMCodegenAdapter:
           exact current content so the model re-anchors via ``edits``.
         """
         chunks: list[str] = [f"\n\nYOUR PREVIOUS ATTEMPT FAILED: {exc}\nRe-emit the full JSON object.\n"]
+        if exc.applied_paths:
+            # Without this the re-emission is guaranteed to fail: those files are already
+            # patched, so the `find` snippets from the previous attempt no longer occur in
+            # them. The model cannot know that from the failure message alone.
+            names = ", ".join(exc.applied_paths)
+            chunks.append(
+                f"These file(s) were ALREADY WRITTEN successfully by that attempt: {names}. "
+                "Do NOT include them again — their content has changed, so your previous "
+                "`find` snippets no longer match and re-sending them will fail. Emit only "
+                "the file(s) that did not land.\n"
+            )
         if exc.missing_edit_paths:
             names = ", ".join(exc.missing_edit_paths)
             chunks.append(
@@ -1833,6 +1851,7 @@ def apply_files(
             missing_edit_paths=missing_targets,
             failed_anchors=attempted_anchors,
             syntax_errors=syntax_messages,
+            applied_paths=[str(Path(w).relative_to(root)) for w in written],
         )
     if not written:
         detail = f" ({'; '.join(edit_failures)})" if edit_failures else ""

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1627,3 +1627,68 @@ def test_every_failure_kind_has_advice_that_matches_it(tmp_path: Path) -> None:
         suffix = gen._corrective_suffix(exc, tmp_path)
         assert suffix is not None, f"{expected_kind} has no advice"
         assert marker.lower() in suffix.lower(), f"{expected_kind} advice does not address it"
+
+
+# --- a partially-applied attempt can be repaired (SSPN-40) --------------------------
+#
+# `apply_files` is per-file atomic, not per-batch: a successful file is written before the
+# rest are attempted. When a later file fails, the earlier ones are already on disk — so a
+# repair that says "re-emit the full JSON object" without saying which landed guarantees the
+# model resends `find` snippets its own previous attempt replaced. A live run (SSPN-39)
+# produced a complete, correct change and failed anyway on `edit 0 'find' text not found`.
+
+
+def _one_file(rel: str, find: str, replace: str) -> dict[str, Any]:
+    return {"path": rel, "edits": [{"find": find, "replace": replace}]}
+
+
+def test_a_failure_reports_which_files_already_landed(tmp_path: Path) -> None:
+    from orchestrator.sdlc.codegen import CodegenError, apply_files
+
+    (tmp_path / "good.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (tmp_path / "bad.py").write_text("OTHER = 2\n", encoding="utf-8")
+
+    with pytest.raises(CodegenError) as exc:
+        apply_files(
+            [
+                _one_file("good.py", "VALUE = 1", "VALUE = 99"),
+                _one_file("bad.py", "TEXT THAT IS NOT THERE", "x"),
+            ],
+            tmp_path,
+            written_tracker={},
+            grounded=False,
+        )
+
+    assert exc.value.applied_paths == ["good.py"]
+    assert exc.value.failed_edit_paths == ["bad.py"]
+    # And it really is on disk — which is exactly why the retry must not resend it.
+    assert (tmp_path / "good.py").read_text() == "VALUE = 99\n"
+
+
+def test_the_repair_tells_the_model_not_to_resend_what_landed(tmp_path: Path) -> None:
+    from orchestrator.sdlc.codegen import CodegenError
+
+    (tmp_path / "bad.py").write_text("OTHER = 2\n", encoding="utf-8")
+    exc = CodegenError(
+        "changes need a repair pass",
+        failed_edit_paths=["bad.py"],
+        applied_paths=["good.py"],
+    )
+
+    block = LLMCodegenAdapter(_ScriptedLLM([]))._repair_block(exc, tmp_path)
+
+    assert "ALREADY WRITTEN" in block
+    assert "good.py" in block
+    assert "Do NOT include them again" in block
+
+
+def test_no_already_written_note_when_nothing_landed(tmp_path: Path) -> None:
+    """The common case is unchanged — no confusing note about an empty set."""
+    from orchestrator.sdlc.codegen import CodegenError
+
+    (tmp_path / "bad.py").write_text("OTHER = 2\n", encoding="utf-8")
+    exc = CodegenError("changes need a repair pass", failed_edit_paths=["bad.py"])
+
+    block = LLMCodegenAdapter(_ScriptedLLM([]))._repair_block(exc, tmp_path)
+
+    assert "ALREADY WRITTEN" not in block


### PR DESCRIPTION
Closes SSPN-40. Found when a live run produced a **complete, correct change** and failed anyway.

## The bug

`apply_files` is **per-file atomic, not per-batch**. A file whose edits all anchor is written to disk immediately, before the remaining files are attempted. So a later failure leaves the earlier ones applied.

`_repair_block` then said *"Re-emit the full JSON object"* and showed current content only for `exc.failed_edit_paths` — the files that **failed**. Nothing said which had succeeded, and their new content was never shown.

So the model resent its original edits for the already-written files, and those `find` snippets no longer existed — its own previous attempt had replaced them. **The retry was guaranteed to fail**, and it consumed the failure kind's one corrective attempt doing so.

## Observed

Run `099b43cf82a54589` (SSPN-39, live):

```
sdlc.codegen.edit_failed
sdlc.codegen.repair_retry
sdlc.codegen.edit_failed
CodegenError: ... src/orchestrator/sdlc/validity.py: edit 0 'find' text not found
```

Both files were **already fully and correctly written** in the worktree when that was reported. The change shipped by hand as [#147](https://github.com/synaptixs/spine/pull/147).

## The change

`CodegenError` carries `applied_paths`; the repair block names them and says not to resend:

> These file(s) were ALREADY WRITTEN successfully by that attempt: … Do NOT include them again — their content has changed, so your previous `find` snippets no longer match.

## Why it matters more over time

This only triggers when an attempt succeeds *partway*. Every improvement that gets codegen closer to a correct change makes it more likely to hit — which is why it surfaced now rather than earlier.

## Verification

3 tests. `test_a_failure_reports_which_files_already_landed` fails without the fix, and asserts the file really is on disk — which is precisely why resending it cannot work.

Full gate green, **2467 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)