### PR TITLE
docs: SDLC_PR_BASE decides which tree a run is built on

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,10 @@ JIRA_DRY_RUN=true                      # false to write real issues
 # 3. Target repo + GitHub auth — for `sdlc feature`/`run` that push & open PRs
 # ============================================================================
 # SDLC_REPO_URL=https://github.com/yourorg/yourrepo.git
+# Branch an SDLC run builds on AND opens its PR into. Unset means the remote's default
+# branch — so on a repo that merges to develop, leaving this out builds the work on main.
+# `--base` overrides it per run.
+# SDLC_PR_BASE=develop
 # Simplest auth — a PAT or pre-minted token (either name works):
 # GITHUB_TOKEN=ghp_...
 # GH_TOKEN=ghp_...

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -717,7 +717,7 @@ orchestrator sdlc autorun --source jira://PROJ-14 --issue PROJ-14 --path . --saf
 | `--live` / `--safe` | Write for real, or make no external write. (default: `--safe`) |
 | `--max-refine` | Correction attempts allowed **per check** — a red suite, a type error and a coverage gap each get their own allowance, so one cannot starve another. (default: `5`) |
 | `--review` / `--no-review` | Show the diff and ask before committing or pushing anything. (default: `--no-review`) |
-| `--base` | PR target branch. |
+| `--base` | Branch to build on **and** open the PR into (default `$SDLC_PR_BASE`, else the remote's default branch). The run's worktree is cut from this, so on a repo that merges to `develop`, leaving it unset builds the change on `main`. |
 | `--language` | Target language (auto detects). (default: `auto`) |
 | `--out` | Where run artifacts go (default: a run dir under the temp dir). |
 | `--resume` | Continue a run by id — adopts the issue it already created. |
@@ -806,7 +806,7 @@ orchestrator sdlc feature [OPTIONS]
 | `--max-refine` | Correction attempts allowed **per check** — a red suite, a type error and a coverage gap each get their own allowance, so one cannot starve another. (default: `5`) |
 | `--live` | Write for real: create the Jira issue, push the branch + open a PR, comment on Jira. Default --safe stays local (branch + commit + diff, dry-run Jira, no push). |
 | `--issue` | Adopt an existing tracker issue (e.g. SSPN-9) instead of creating one — the branch, PR, comment and transition all land on it. |
-| `--base` | PR target branch (default: $SDLC_PR_BASE, else the repo's default branch). |
+| `--base` | Branch to build on **and** open the PR into (default `$SDLC_PR_BASE`, else the repo's default branch). The worktree is cut from this — see `sdlc autorun` above. |
 | `--layout` | Target structure: auto (scaffold only empty repos), new (always scaffold a src/<pkg>/ skeleton), or existing (follow the repo's layout). (default: `auto`) |
 | `--package-name` | Override the scaffold package name (default: derived from repo). |
 | `--spec` | Implement a hand-written spec (JSON) instead of deriving one from the source — see `sdlc autorun` above for the format. |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -114,6 +114,7 @@ orchestrator doctor    # readiness report — tells you exactly what's set and w
 | `ORCHESTRATOR_MODEL` | One model for every stage (optional — defaults to `claude-opus-5`) | Step 3 |
 | `CONFLUENCE_*`, `JIRA_*` | Read requirements / file issues | Step 4 |
 | `SDLC_REPO_URL` | The repo it builds **into** | Step 4 |
+| `SDLC_PR_BASE` | The branch a run builds **on** and opens its PR into — set this to `develop` if that is where you merge, or runs are written against `main` | Step 4 |
 | `GITHUB_TOKEN` *(or `GITHUB_APP_*`)* | Auth for a private target repo | Step 4 |
 
 ### Choosing a model

--- a/src/orchestrator/init_scaffold.py
+++ b/src/orchestrator/init_scaffold.py
@@ -32,6 +32,14 @@ _OPTIONAL_HINTS: tuple[tuple[str, str], ...] = (
     ("SDLC_CODEGEN_MODEL", "Model for codegen only — implement / refine / revise / author_tests"),
     ("SDLC_JUDGE_MODEL", "Model for the acceptance judge only"),
     ("ORCHESTRATOR_INTAKE_MODEL", "Model for intake only — intent extraction and spec writing"),
+    # Not just the PR target: an SDLC run *branches from* this, so leaving it unset builds
+    # the work on the remote's default branch (usually main) while opening the PR into
+    # develop — a change written against a tree that predates everything merged since the
+    # last release. It was documented nowhere until that bit someone.
+    (
+        "SDLC_PR_BASE",
+        "Branch a run builds on AND opens its PR into (default: the remote's default branch)",
+    ),
     ("ORCHESTRATOR_DATABASE_URL", "Postgres URL (defaults to the docker-compose dev DB)"),
     ("SLACK_WEBHOOK_URL", "Slack incoming-webhook for approval-gate alerts (optional)"),
     ("SDLC_RUN_BUDGET_USD", "Per-run LLM spend cap; 0 disables enforcement (default 25)"),


### PR DESCRIPTION
Closes SSPN-44.

## The gap

`SDLC_PR_BASE` appeared in **no** documentation — not `.env.example`, not `USER_GUIDE.md`, not `CLI_REFERENCE.md`, not `doctor`'s checks, not `init`'s scaffold hints. It existed only in code.

That was survivable while it only chose a PR target. Since [#136](https://github.com/synaptixs/spine/pull/136) it decides **which branch the worktree is cut from**, and unset means the remote's default branch.

So anyone running Spine against a repo that merges to `develop` gets work built on `main` — a change written against a tree predating everything merged since the last release, able to revert work it never knew existed. They get the #136 fix and still hit the bug, because nothing tells them the knob exists.

## The change

- `init` scaffolds it commented (`_OPTIONAL_HINTS`), so a new project sees it
- `.env.example` documents it beside `SDLC_REPO_URL`, the variable it pairs with
- `USER_GUIDE.md`'s settings table names the *consequence*, not just the field
- `CLI_REFERENCE.md` stops describing `--base` as "PR target branch" on both commands — it is the build base too, which is the half that bites

## Blast radius (from the PKG, not grep)

```
orchestrator.init_scaffold   render_env_template  callers=6   transitive=11
                             scaffold_env         callers=6   transitive=6
```

Low, and `tests/test_env_example.py` enforces that every `_OPTIONAL_HINTS` entry is documented in `.env.example` — so the two cannot drift.

## Verification

Gate green, **2467 passed**. Diagrams still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)