### PR TITLE
feat(mcp): migrate to the MCP Python SDK v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Changed
+
+- **Migrated to the MCP Python SDK v2** (`mcp>=2`). v1 spelled three things differently:
+  the client transport is now `streamable_http_client` (and takes a configured
+  `http_client` rather than `headers`, yielding two streams not three), the result flag is
+  `is_error`, and the server class is `mcp.server.MCPServer` — `mcp.server.fastmcp` is
+  gone. Transport settings moved off the server constructor onto the run call, so
+  `build_http_server` returns an `HttpServer` carrying both. Reading the error flag with
+  `getattr(result, "isError", False)` is also fixed: under v2 that silently reported every
+  tool error as a success, which is worse than the AttributeError the default was avoiding.
+
 ### Fixed
 
 - **A partially-applied codegen attempt can now be repaired.** `apply_files` is per-file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,12 +101,11 @@ office = [
 # Onboard external MCP servers (DBs, Atlassian, …) as orchestrator tools. The
 # MCP client lazy-imports this, so the base install stays MCP-free.
 mcp = [
-    # <2 until the v2 migration lands. v2 renames what this package actually uses:
-    # `streamablehttp_client` -> `streamable_http_client`, `CallToolResult.isError` ->
-    # `is_error`, and `mcp.server.fastmcp` is gone (FastMCP became MCPServer). The bump
-    # to 2.0.0 passed CI because CI installs `--extra dev` only, so every mcp test skips
-    # and the breakage is invisible until someone installs the extra.
-    "mcp>=1.28,<2",
+    # v2+: the client transport is `streamable_http_client`, the result flag is
+    # `is_error`, and the server class is `mcp.server.MCPServer`. v1 spelled all three
+    # differently, so there is no both-versions shim worth carrying — v1.x is on security
+    # fixes only.
+    "mcp>=2",
 ]
 # Media ingestion (G3) — local OCR for images. Tesseract via pytesseract + Pillow, lazy-imported by
 # pkg/media_extract.py, used ONLY by the opt-in `media extract` command. The deterministic reader

--- a/src/orchestrator/mcp/client.py
+++ b/src/orchestrator/mcp/client.py
@@ -45,7 +45,10 @@ class SessionMCPClient:
         async with self._session() as session:
             result = await session.call_tool(name, arguments)
             text = "".join(getattr(c, "text", "") or "" for c in (result.content or []))
-            return MCPToolResult(text=text, is_error=bool(getattr(result, "isError", False)))
+            # Read the flag, don't `getattr(..., False)` it. v1 spelled this `isError`; a
+            # defaulted lookup silently reported every tool error as a success when the name
+            # changed, which is worse than the AttributeError it was written to avoid.
+            return MCPToolResult(text=text, is_error=bool(result.is_error))
 
     @contextlib.asynccontextmanager
     async def _session(self) -> AsyncIterator[Any]:
@@ -74,10 +77,17 @@ class SessionMCPClient:
                     await session.initialize()
                     yield session
             else:
-                from mcp.client.streamable_http import streamablehttp_client
+                # v2 takes a configured http client rather than a `headers` kwarg, and
+                # yields two streams rather than three. `create_mcp_http_client` is the
+                # SDK's own factory, so MCP's recommended timeouts still apply.
+                from mcp.client.streamable_http import (  # type: ignore[attr-defined]
+                    create_mcp_http_client,  # re-exported here, but absent from __all__
+                    streamable_http_client,
+                )
 
+                http_client = create_mcp_http_client(headers=cfg.headers or None)
                 async with (
-                    streamablehttp_client(cfg.url or "", headers=cfg.headers or None) as (read, write, _),
+                    streamable_http_client(cfg.url or "", http_client=http_client) as (read, write),
                     ClientSession(read, write) as session,
                 ):
                     await session.initialize()

--- a/src/orchestrator/plugin/__main__.py
+++ b/src/orchestrator/plugin/__main__.py
@@ -66,14 +66,13 @@ def main(argv: list[str] | None = None) -> None:
     if args.http:
         from orchestrator.plugin.server import build_http_server
 
-        server = build_http_server(
+        build_http_server(
             host=args.host,
             port=args.port,
             path=args.path,
             stateless=args.stateless,
             allow_unauthenticated=args.allow_unauthenticated,
-        )
-        server.run("streamable-http")
+        ).run()
     else:
         from orchestrator.plugin.server import build_server
 

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import Any
 
 
@@ -577,14 +578,19 @@ _TOOLS = (
 )
 
 
-def _import_fastmcp() -> Any:
+def _import_server_class() -> Any:
+    """The SDK's server class — ``MCPServer`` since v2 (was ``mcp.server.fastmcp.FastMCP``).
+
+    It keeps the same surface this plugin uses: ``.tool()`` to register, ``.run()`` to
+    serve. What moved is transport configuration — see :class:`HttpServer`.
+    """
     try:
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server import MCPServer
     except ImportError as exc:  # pragma: no cover - only without the extra
         raise RuntimeError(
             "The orchestrator MCP plugin needs the 'mcp' extra: pip install 'synaptixs-spine[mcp]'"
         ) from exc
-    return FastMCP
+    return MCPServer
 
 
 def _register_tools(server: Any) -> Any:
@@ -599,7 +605,23 @@ def build_server() -> Any:
     Stdio transport (Phase A): the local plugin a desktop host launches as a
     subprocess. For the remote HTTP transport see ``build_http_server``.
     """
-    return _register_tools(_import_fastmcp()("synaptixs-spine"))
+    return _register_tools(_import_server_class()("synaptixs-spine"))
+
+
+@dataclass(frozen=True)
+class HttpServer:
+    """A built server plus the transport settings the SDK takes at run time.
+
+    v1 accepted ``host``/``port``/``streamable_http_path``/``stateless_http`` on the
+    constructor, so a built server was self-contained. v2 moved them to
+    ``run_streamable_http_async``, so they have to travel with it.
+    """
+
+    server: Any
+    transport: dict[str, Any]
+
+    def run(self) -> None:
+        self.server.run("streamable-http", **self.transport)
 
 
 def build_http_server(
@@ -609,7 +631,7 @@ def build_http_server(
     path: str = "/mcp",
     stateless: bool = False,
     allow_unauthenticated: bool = False,
-) -> Any:
+) -> HttpServer:
     """Build the FastMCP server for the remote ``streamable-http`` transport (Phase C).
 
     Auth is derived from env (``orchestrator.plugin.auth.build_auth_from_env``):
@@ -619,7 +641,7 @@ def build_http_server(
     """
     from orchestrator.plugin.auth import build_auth_from_env
 
-    fastmcp = _import_fastmcp()
+    server_cls = _import_server_class()
     auth_settings, verifier = build_auth_from_env()
 
     is_loopback = host in ("127.0.0.1", "localhost", "::1")
@@ -630,19 +652,23 @@ def build_http_server(
             "127.0.0.1, or pass --allow-unauthenticated for a trusted private network."
         )
 
-    server = fastmcp(
-        "synaptixs-spine",
-        host=host,
-        port=port,
-        streamable_http_path=path,
-        stateless_http=stateless,
-        auth=auth_settings,
-        token_verifier=verifier,
+    # SDK v2 takes transport settings at *run* time, not on the constructor — only auth
+    # stays on the server object. Carrying them together keeps the binding rule enforced
+    # here (where the refusal above lives) rather than at the call site.
+    server = server_cls("synaptixs-spine", auth=auth_settings, token_verifier=verifier)
+    return HttpServer(
+        server=_register_tools(server),
+        transport={
+            "host": host,
+            "port": port,
+            "streamable_http_path": path,
+            "stateless_http": stateless,
+        },
     )
-    return _register_tools(server)
 
 
 __all__ = [
+    "HttpServer",
     "blast_radius",
     "build_http_server",
     "build_server",

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -388,8 +388,8 @@ def test_http_server_loopback_unauthenticated_is_allowed(monkeypatch: pytest.Mon
 
     monkeypatch.delenv("ORCHESTRATOR_MCP_TOKEN", raising=False)
     monkeypatch.delenv("ORCHESTRATOR_MCP_INTROSPECTION_URL", raising=False)
-    server = build_http_server(host="127.0.0.1", port=8080)
-    assert server.settings.auth is None
+    built = build_http_server(host="127.0.0.1", port=8080)
+    assert built.server.settings.auth is None
 
 
 @pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="needs the 'mcp' extra")
@@ -399,10 +399,10 @@ def test_http_server_wires_static_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ORCHESTRATOR_MCP_TOKEN", "s3cret")
     monkeypatch.setenv("ORCHESTRATOR_MCP_RESOURCE_URL", "https://mcp.example.com")
     monkeypatch.delenv("ORCHESTRATOR_MCP_INTROSPECTION_URL", raising=False)
-    server = build_http_server(host="0.0.0.0", port=8080, path="/mcp")
+    built = build_http_server(host="0.0.0.0", port=8080, path="/mcp")
     # Auth is configured, so a public bind is permitted and the tools are registered.
-    assert server.settings.auth is not None
-    assert server.settings.port == 8080 and server.settings.host == "0.0.0.0"
+    assert built.server.settings.auth is not None
+    assert built.transport["port"] == 8080 and built.transport["host"] == "0.0.0.0"
 
 
 # ---- dogfood: drive the real stdio server (needs the `mcp` extra) -----------
@@ -428,4 +428,4 @@ async def test_plugin_serves_tools_over_stdio() -> None:
             "sdlc_run_result",
         } <= {t.name for t in tools.tools}
         result = await session.call_tool("doctor", {})
-        assert result.isError is False
+        assert result.is_error is False

--- a/uv.lock
+++ b/uv.lock
@@ -1129,6 +1129,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1173,12 +1186,19 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -1815,15 +1835,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1833,9 +1853,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -3810,7 +3843,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.2" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0" },
     { name = "litellm", specifier = ">=1.50" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28,<2" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "openai-whisper", marker = "extra == 'asr'", specifier = ">=20231117" },
     { name = "openpyxl", marker = "extra == 'dev'", specifier = ">=3.1" },
@@ -4200,6 +4233,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
     { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes SSPN-41, and removes the `<2` pin from [#148](https://github.com/synaptixs/spine/pull/148). v1.x is on security fixes only, so that pin had a shelf life.

## What changed in v2

Three renames, one restructure, and one latent bug:

| | v1 | v2 |
|---|---|---|
| server class | `mcp.server.fastmcp.FastMCP` | `mcp.server.MCPServer` (old module removed) |
| http transport | `streamablehttp_client(url, headers=…)` → 3 streams | `streamable_http_client(url, http_client=…)` → 2 streams |
| result flag | `CallToolResult.isError` | `is_error` |
| transport config | server constructor | the run call |

`MCPServer` keeps the surface this plugin uses — `.tool()` to register, `.run()` to serve — so the class swap is mechanical. What isn't: `host`/`port`/`streamable_http_path`/`stateless_http` moved **off the constructor**, so `build_http_server` now returns an `HttpServer` carrying the server and its transport together. That keeps the public-bind refusal where it already lives rather than pushing it to the call site.

## The latent bug

```python
is_error=bool(getattr(result, "isError", False))   # before
is_error=bool(result.is_error)                     # after
```

Under v2 that attribute doesn't exist, so the `getattr` returned `False` every time and reported **every tool error as a success** — silently. Worse than the `AttributeError` the default was written to avoid.

## On verification

My check before merging #146 said all four APIs survived under 2.0.0. It was wrong: `uv run --no-project --with "mcp==2.0.0"` silently resolved to **1.10.1**, so the probe never tested v2 at all.

Everything here was checked against a dedicated venv with a confirmed `mcp==2.0.0`:

```
streamablehttp_client : False      streamable_http_client: True
isError               : False      is_error              : True
mcp.server.fastmcp    : GONE
```

## Blast radius (PKG)

```
orchestrator.mcp.client      SessionMCPClient   callers=1  transitive=1
orchestrator.plugin.server   build_http_server  callers=4  transitive=4
```

Small, and unchanged by the migration.

## Verification

Full gate green with the extra installed: **2467 passed**, 88 of them MCP/plugin. Smoke-tested both entry points: `build_server()` returns an `MCPServer`, `build_http_server()` returns an `HttpServer` with the expected transport dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)