### PR TITLE
fix(codegen): a stub submission is not progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@
 
 ### Fixed
 
+- **A stub submission no longer counts as progress.** A run wrote a file literally named
+  `PLACEHOLDER` containing `x`, and the refine loop treated it as a file change — its stop
+  condition is "no file changes", so a model with nothing to say kept the loop alive and
+  spent two of three attempts on it while the real failure went unfixed. Placeholder names
+  (`PLACEHOLDER`, `TODO`, `FIXME`, `TBD`, `XXX`, `stub`) and essentially-empty bodies are
+  dropped at the write, so the loop's existing stop condition works. `__init__.py`,
+  `py.typed` and `.gitkeep` are exempt — they are legitimately empty. A submission that is
+  *only* placeholders is recoverable and routes to the same corrective retry as submitting
+  nothing at all.
+
 - **A partially-applied codegen attempt can now be repaired.** `apply_files` is per-file
   atomic, not per-batch: a successful file is written before the rest are attempted, so a
   later failure leaves earlier ones on disk. The repair then said "re-emit the full JSON

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -1700,6 +1700,31 @@ class LLMCodegenAdapter:
         )
 
 
+# Names and bodies that mean "I had nothing to say", not "here is a file". A run wrote a
+# file literally called PLACEHOLDER containing the single character `x`, and the refine
+# loop counted it as a file change — its stop condition is "no file changes", so a model
+# with nothing useful to offer kept the loop alive and spent two of three attempts on it
+# while a real failure went unfixed.
+_PLACEHOLDER_STEMS = frozenset({"placeholder", "todo", "fixme", "tbd", "xxx", "stub"})
+# Legitimately (near-)empty files, which the size rule must not catch.
+_LEGITIMATELY_EMPTY = frozenset({"__init__.py", "py.typed", ".gitkeep", ".gitignore"})
+
+
+def _is_placeholder(rel: str, content: str) -> bool:
+    """Whether this submission is a stub standing in for work, rather than work.
+
+    Two signals, deliberately narrow. A name that *is* a placeholder token is one
+    regardless of content. Otherwise only a body with essentially nothing in it counts,
+    and never for the files that are legitimately empty.
+    """
+    name = Path(rel).name
+    if Path(rel).stem.lower() in _PLACEHOLDER_STEMS:
+        return True
+    if name in _LEGITIMATELY_EMPTY:
+        return False
+    return len(content.strip()) < 3
+
+
 def apply_files(
     files: list[Any],
     root: Path,
@@ -1726,6 +1751,7 @@ def apply_files(
     syntax_failures: list[str] = []
     syntax_messages: list[str] = []
     missing_targets: list[str] = []  # edits aimed at a file that doesn't exist yet
+    placeholders: list[str] = []  # stub submissions dropped before they counted as work
     tracked_now = written_tracker.get(root.resolve(), [])
     for entry in files:
         if not isinstance(entry, dict):
@@ -1773,6 +1799,13 @@ def apply_files(
             continue
 
         if not isinstance(content, str):
+            continue
+        # Not a file, a shrug. Dropped before it can count as progress: the refine loop
+        # stops on "no file changes", so letting a stub through keeps the loop alive
+        # while nothing is fixed.
+        if _is_placeholder(rel, content):
+            logger.warning("sdlc.codegen.placeholder_skipped", extra={"path": rel})
+            placeholders.append(rel)
             continue
         # Stdlib-shadow guard: a new top-level module named like a Python
         # standard-library module (statistics.py, json.py, ...) hijacks
@@ -1854,6 +1887,17 @@ def apply_files(
             applied_paths=[str(Path(w).relative_to(root)) for w in written],
         )
     if not written:
+        if placeholders and not edit_failures:
+            # Recoverable, and the same shape as submitting nothing: the model answered but
+            # said nothing. Carrying `empty_summary` routes it to the corrective retry that
+            # tells it an answer this stage can use needs at least one real file.
+            raise CodegenError(
+                f"model output was only placeholder file(s): {', '.join(placeholders)}",
+                empty_summary=(
+                    f"submitted {len(placeholders)} placeholder file(s) and no real ones: "
+                    f"{', '.join(placeholders)}"
+                ),
+            )
         detail = f" ({'; '.join(edit_failures)})" if edit_failures else ""
         raise CodegenError(f"model output produced no writable files{detail}")
     return CodeChange(files=written, summary=summary)

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1692,3 +1692,62 @@ def test_no_already_written_note_when_nothing_landed(tmp_path: Path) -> None:
     block = LLMCodegenAdapter(_ScriptedLLM([]))._repair_block(exc, tmp_path)
 
     assert "ALREADY WRITTEN" not in block
+
+
+# --- a stub is not progress (SSPN-45) -----------------------------------------------
+#
+# A run wrote a file literally named PLACEHOLDER containing `x`, and the refine loop
+# counted it as a file change. Its stop condition is "no file changes", so a model with
+# nothing to say kept the loop alive and spent two of three attempts on it while the real
+# failure went unfixed. Dropping the stub at the write is enough: the loop needs no change.
+
+
+def test_a_placeholder_file_is_not_written(tmp_path: Path) -> None:
+    from orchestrator.sdlc.codegen import apply_files
+
+    change = apply_files(
+        [
+            {"path": "PLACEHOLDER", "content": "x"},
+            {"path": "real.py", "content": "VALUE = 1\n"},
+        ],
+        tmp_path,
+        written_tracker={},
+        grounded=False,
+    )
+
+    assert not (tmp_path / "PLACEHOLDER").exists()
+    assert [Path(f).name for f in change.files] == ["real.py"]
+
+
+@pytest.mark.parametrize("rel", ["PLACEHOLDER", "placeholder.py", "TODO.md", "src/pkg/stub.py"])
+def test_placeholder_names_are_rejected_whatever_they_contain(tmp_path: Path, rel: str) -> None:
+    from orchestrator.sdlc.codegen import _is_placeholder
+
+    assert _is_placeholder(rel, "def real_looking_code() -> int:\n    return 1\n")
+
+
+@pytest.mark.parametrize("rel", ["__init__.py", "src/pkg/__init__.py", "py.typed", ".gitkeep"])
+def test_legitimately_empty_files_are_kept(tmp_path: Path, rel: str) -> None:
+    """An empty __init__.py is a real file — the size rule must never catch it."""
+    from orchestrator.sdlc.codegen import _is_placeholder
+
+    assert not _is_placeholder(rel, "")
+
+
+def test_a_trivially_short_body_is_a_placeholder() -> None:
+    from orchestrator.sdlc.codegen import _is_placeholder
+
+    assert _is_placeholder("thing.py", "x")
+    assert _is_placeholder("thing.py", "  \n ")
+    assert not _is_placeholder("thing.py", "X = 1\n")
+
+
+def test_placeholders_only_is_recoverable_not_a_dead_end(tmp_path: Path) -> None:
+    """It is the same shape as submitting nothing, so it gets the same corrective retry."""
+    from orchestrator.sdlc.codegen import CodegenError, apply_files
+
+    with pytest.raises(CodegenError) as exc:
+        apply_files([{"path": "PLACEHOLDER", "content": "x"}], tmp_path, written_tracker={}, grounded=False)
+
+    assert "placeholder" in str(exc.value).lower()
+    assert exc.value.empty_summary, "must route to the empty-submission retry"


### PR DESCRIPTION
Closes SSPN-45.

## The bug

A run wrote a file literally named `PLACEHOLDER` containing the single character `x`:

```
[refine] ['PLACEHOLDER'] -
[run_tests #3] passed=False rc=1
[refine] [] - placeholder
[refine] no file changes — not fixable by editing code; stopping early
```

The loop's stop condition is *"no file changes"*. A junk file **is** a file change, so a model with nothing useful to say kept the loop alive and spent two of three attempts on it while the real failure went unfixed.

## Fixed at the write, not at the loop

Blast radius drove this. Per the PKG:

```
run_feature   callers=49  transitive=88     <- the loop
apply_files   (internal, via CodeChange=24) <- the write
```

Dropping the stub before it is written means the loop's existing progress test works unchanged — one narrow change instead of two, on the smaller surface.

## Deliberately narrow

- A name that **is** a placeholder token (`placeholder`, `todo`, `fixme`, `tbd`, `xxx`, `stub`) is one whatever it contains.
- Otherwise only a body that strips to almost nothing counts.
- **`__init__.py`, `py.typed`, `.gitkeep` are exempt** — legitimately empty, and the obvious false positive for a size rule.

A submission that is *only* placeholders raises with `empty_summary` set, so it routes to the corrective retry that already exists for "you submitted no files" rather than dying unrecoverable.

## Verification

11 tests. Both behavioural ones fail with the filter removed. Replayed the exact submission from run `8d5dc4bf542f4406`:

```
refused: model output was only placeholder file(s): PLACEHOLDER
recoverable (gets a retry): True
file on disk: False
```

Full gate green, **2478 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)