### PR TITLE
fix(mcp): v2 renamed the Tool fields too, and the defaults hid it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@
 
 ### Fixed
 
+- **v2 renamed `Tool.inputSchema` and `readOnlyHint` too, and the defaulted reads hid it.**
+  `_to_tool` fetched both with `getattr(..., None)`, so the rename did not raise —
+  `input_schema` silently became `None` and every tool lost its argument types. That took
+  the `mcp contracts` type labels with it and stopped `MCPRegistry.call` coercing a
+  structured argument a server declares as a string, so a governed `jira_create_issue`
+  started failing validation again. Nothing went red, because every existing test builds an
+  `MCPTool` directly and never exercises the translation from the SDK's own type. A new test
+  module builds a real `mcp.types.Tool`, so the next rename fails a test instead of a run.
+
 - **Generated test fixtures are shown the types they construct.** `author_tests` was given
   the source under test but not the definitions of the types that source imports — so a
   fixture building a fake LLM client or a graph store wrote the constructor from inference.

--- a/src/orchestrator/mcp/client.py
+++ b/src/orchestrator/mcp/client.py
@@ -98,9 +98,15 @@ class SessionMCPClient:
             raise MCPError(f"MCP server {cfg.name!r} ({cfg.transport}) failed: {exc}") from exc
 
     def _to_tool(self, raw: Any) -> MCPTool:
+        # v2 renamed these to snake_case along with everything else. They were read with a
+        # defaulted `getattr`, so the rename did not raise — `input_schema` silently became
+        # None and every tool lost its argument types, which took the `mcp contracts` labels
+        # with it and stopped `MCPRegistry.call` coercing a structured argument the server
+        # declares as a string. A default that hides a rename is the same trap as
+        # `getattr(result, "isError", False)`; both are gone.
         annotations = getattr(raw, "annotations", None)
-        read_only = getattr(annotations, "readOnlyHint", None) if annotations is not None else None
-        schema = getattr(raw, "inputSchema", None)
+        read_only = getattr(annotations, "read_only_hint", None) if annotations is not None else None
+        schema = getattr(raw, "input_schema", None)
         return MCPTool(
             server=self._config.name,
             name=raw.name,

--- a/tests/mcp/test_sdk_field_names.py
+++ b/tests/mcp/test_sdk_field_names.py
@@ -1,0 +1,64 @@
+"""`_to_tool` reads the SDK's own field names — so a rename must fail a test, not a run.
+
+Every other test here builds an ``MCPTool`` (our dataclass) directly, which never exercises
+the translation from the SDK's ``Tool``. So when v2 renamed ``inputSchema`` to
+``input_schema`` and ``readOnlyHint`` to ``read_only_hint``, the defaulted ``getattr`` calls
+returned ``None`` instead of raising: every tool silently lost its argument types, which
+took the ``mcp contracts`` type labels with it and stopped ``MCPRegistry.call`` coercing a
+structured argument a server declares as a string. Nothing went red.
+
+These build a real ``mcp.types.Tool``, so the next rename is a failing test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.mcp.client import SessionMCPClient
+from orchestrator.mcp.config import MCPServerConfig
+
+mcp_types = pytest.importorskip("mcp.types", reason="needs the 'mcp' extra")
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "project_key": {"type": "string"},
+        "additional_fields": {"type": "string"},
+    },
+}
+
+
+def _client() -> SessionMCPClient:
+    return SessionMCPClient(MCPServerConfig(name="atlassian", command="x"))
+
+
+def _sdk_tool(**kw: object) -> object:
+    return mcp_types.Tool(name="jira_create_issue", inputSchema=_SCHEMA, **kw)
+
+
+def test_the_input_schema_survives_the_translation() -> None:
+    """The whole chain downstream — type labels and argument coercion — needs this."""
+    tool = _client()._to_tool(_sdk_tool())
+
+    assert tool.input_schema == _SCHEMA
+    assert tool.name == "jira_create_issue"
+
+
+def test_a_declared_string_argument_is_still_visible_as_one() -> None:
+    """What `mcp contracts` renders and what `MCPRegistry.call` coerces on."""
+    from orchestrator.mcp.schema_types import argument_type_label
+
+    tool = _client()._to_tool(_sdk_tool())
+
+    assert argument_type_label(tool.input_schema, "additional_fields") == "string"
+
+
+def test_the_read_only_hint_survives_the_translation() -> None:
+    annotated = _sdk_tool(annotations=mcp_types.ToolAnnotations(readOnlyHint=True))
+
+    assert _client()._to_tool(annotated).read_only is True
+
+
+def test_a_tool_without_annotations_reports_unknown_not_false() -> None:
+    """`None` means "the server did not say"; `False` would claim it declared a write."""
+    assert _client()._to_tool(_sdk_tool()).read_only is None


### PR DESCRIPTION
A regression I introduced in [#152](https://github.com/synaptixs/spine/pull/152), found while filing SSPN-46.

## What broke

#152 fixed `getattr(result, "isError", False)` and left a comment saying a defaulted read turns a rename into silently wrong data rather than an error. **Three lines above it, `_to_tool` did the same thing twice:**

```python
getattr(raw, "inputSchema", None)            # v2: input_schema
getattr(annotations, "readOnlyHint", None)   # v2: read_only_hint
```

Neither raised. `input_schema` became `None` for every tool, so:

- **`mcp contracts` lost the type labels** shipped for SSPN-14 — `jira_create_issue` degraded from its full argument list to a single `idempotency_key (any)`
- **`MCPRegistry.call` had no schema to read**, so [#131](https://github.com/synaptixs/spine/pull/131)'s coercion stopped encoding a structured argument the server declares as a string

The second one is the original SSPN-14 bug, reintroduced. It surfaced when filing a ticket failed with `additional_fields: Input should be a valid string`.

## Why nothing went red

Every existing test builds an `MCPTool` — our dataclass — directly. The translation from the SDK's own `Tool` was never exercised, so the field names it depends on were untested. The `mcp` extra now being in CI ([#148](https://github.com/synaptixs/spine/pull/148)) was necessary but not sufficient: there was no test to run.

## The fix

Correct field names, plus `tests/mcp/test_sdk_field_names.py` built on a real `mcp.types.Tool`. **Three of its four tests fail against what #152 shipped.**

## Verified against the live server

```
before: inputs: ['idempotency_key (any)']
after:  inputs: ['project_key (string)', 'summary (string)', 'issue_type (string)', ...]
        additional_fields -> string
```

And the coercion works again — SSPN-46 was filed through the governed path with a dict `additional_fields`.

Full gate green, **2492 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)