### PR TITLE
docs(readme): name the models command, the default, and --spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ everyday workflow in about ten minutes.
 It extracts a backlog of intents, writes a spec, generates the implementation and
 tests, gets them green, and opens a PR — with **two human gates** (before building,
 before merging). A safe mode builds entirely locally (branch + diff, no external
-writes) so you can inspect everything first.
+writes) so you can inspect everything first. Already written the spec yourself? Hand
+it straight to `orchestrator sdlc autorun --spec <file>` instead of deriving one from
+a source.
 
 **Code-grounded understanding.** Before generating, it builds a **Product Knowledge
 Graph** of your repo — modules, types, functions, call sites, blast radius — and
@@ -134,7 +136,10 @@ directions — consume external MCP tools, or expose the whole pipeline *as* an 
 server to Claude Code, Codex, or your IDE.
 
 **Bring your own model.** Multi-provider via LiteLLM (Anthropic, OpenAI, Bedrock),
-or run fully offline on a local model (Ollama). Mix models per stage.
+or run fully offline on a local model (Ollama). Mix models per stage. Run
+`orchestrator models` to see which models are available — each id with its context
+window, price, and whether it supports the tool calling codegen and the judge need.
+The default is `claude-opus-5`.
 
 **Durable.** Long-running pipelines are checkpointed (Temporal + Postgres) — they
 survive restarts and resume across human approval pauses.


### PR DESCRIPTION
Closes SSPN-46. **The README edit is the model's, unmodified** (`sdlc autorun --spec`, run `ec54cc9413094658`, live).

## What changed

Two paragraphs in *Features & capabilities*:

- **Bring your own model** now names `orchestrator models` and states the `claude-opus-5` default. It previously said "Mix models per stage" and stopped, leaving a reader with nowhere to go.
- **Requirements → reviewed PR** gains one sentence on handing `sdlc autorun --spec` a spec you wrote — user-facing since 3.14.0 and mentioned nowhere in the README.

## Every acceptance criterion, checked

```
orchestrator models    1        --spec           1
claude-opus-5          1        files changed    README.md
all links absolute (CI's "README links absolute" rule)
```

No other section touched, nothing removed, no new headings or tables.

## Why this is a hand-opened PR

The run produced this change correctly and then **failed on a stage that should not have run**. `author_tests` wrote `tests/docs/test_readme_model_and_spec_docs.py` — a test module the spec explicitly told it not to write — and corrupted it with `</content>` markup at line 138.

`author_tests` is a mandatory stage. A spec cannot turn it off, so on a documentation-only change it invents something to test. Filed separately; it is a pipeline defect, not a defect in this change.

One thing that did work: the run logged `syntax_retry`, not `repair_retry` — [#140](https://github.com/synaptixs/spine/pull/140)'s fix correctly matched the advice to the failure. One corrective attempt just wasn't enough.

## Verification

Full suite green (**2492 passed**), diagrams render, no relative links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)