### PR TITLE
fix(codegen): "nothing to test" is an answer when there is nothing to test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@
 
 ### Fixed
 
+- **`author_tests` may answer "nothing to test" — but only when that is true.** The stage is
+  unconditional and no spec can turn it off, and an empty submission was always treated as a
+  skipped job and retried. On a documentation-only change it answered correctly first
+  ("no tests submitted: this is a prose edit"), was retried anyway, and the retry invented a
+  test module for a paragraph and corrupted it with markup — discarding a change that was
+  already complete and correct. Empty is now valid when the change touched no testable
+  source, and still refused when it did, so a source change that skips its tests is caught
+  exactly as before.
+
 - **v2 renamed `Tool.inputSchema` and `readOnlyHint` too, and the defaulted reads hid it.**
   `_to_tool` fetched both with `getattr(..., None)`, so the rename did not raise —
   `input_schema` silently became `None` and every tool lost its argument types. That took

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -1422,6 +1422,11 @@ class LLMCodegenAdapter:
             f"{self._definitions_for_tests(root)}"
             f"{_coverage_gap_block(gaps or [])}",
             root,
+            # "No tests" is a real answer when the change touched no testable source, and a
+            # skipped job when it did. Treating it as always-invalid made a documentation-only
+            # change retry until it invented a test module for a paragraph — and a live run
+            # died on the markup in that module, discarding a change that was already correct.
+            allow_empty=not _has_testable_source(self._written.get(root.resolve(), [])),
         )
 
     async def refine(self, *, spec: dict[str, Any], path: str, issue_key: str, failures: str) -> CodeChange:
@@ -1750,6 +1755,39 @@ def _is_placeholder(rel: str, content: str) -> bool:
     if name in _LEGITIMATELY_EMPTY:
         return False
     return len(content.strip()) < 3
+
+
+# The source half of `review._REVIEWABLE_SUFFIXES`. Documentation and config are reviewable
+# — a criterion can require them — but nothing writes a unit test against a paragraph.
+_TESTABLE_SUFFIXES = frozenset(
+    {
+        ".py",
+        ".java",
+        ".go",
+        ".c",
+        ".h",
+        ".cc",
+        ".cpp",
+        ".hpp",
+        ".cs",
+        ".ts",
+        ".tsx",
+        ".js",
+        ".jsx",
+        ".sql",
+        ".sh",
+    }
+)
+
+
+def _has_testable_source(written: list[Path]) -> bool:
+    """Whether this change touched anything a generated test could exercise.
+
+    The question `author_tests` needs answered before it decides that submitting nothing is
+    a failure. A change that only edits README.md has nothing to test; a change that edits a
+    module and submits no tests has skipped its job.
+    """
+    return any(p.suffix.lower() in _TESTABLE_SUFFIXES and not _is_test_file(p) for p in written)
 
 
 def _is_test_file(path: Path) -> bool:

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1824,3 +1824,66 @@ def test_test_files_are_not_mined_for_their_own_imports(tmp_path: Path) -> None:
     assert _is_test_file(Path("tests/sdlc/test_codegen.py"))
     assert _is_test_file(Path("src/pkg/thing_test.py"))
     assert not _is_test_file(Path("src/orchestrator/intake/specs.py"))
+
+
+# --- "no tests" is an answer, or a skipped job, depending on the change (SSPN-47) ----
+#
+# author_tests is unconditional and no spec can turn it off. On a documentation-only change
+# it first answered correctly — "no tests submitted: this is a prose edit" — and that was
+# treated as an empty submission and retried, and the retry invented a test module for a
+# paragraph and corrupted it with markup. A finished, correct change was discarded.
+#
+# The rule has to hold both ways: empty is valid with no testable source, and a skipped job
+# with one.
+
+
+@pytest.mark.parametrize(
+    "written,expected",
+    [
+        ([Path("README.md")], False),
+        ([Path("docs/guide.rst"), Path("pyproject.toml")], False),
+        ([Path("src/pkg/thing.py")], True),
+        ([Path("README.md"), Path("src/pkg/thing.py")], True),
+        ([Path("tests/test_thing.py")], False),
+        ([], False),
+    ],
+)
+def test_testable_source_is_recognised(written: list[Path], expected: bool) -> None:
+    from orchestrator.sdlc.codegen import _has_testable_source
+
+    assert _has_testable_source(written) is expected
+
+
+def test_a_test_file_alone_is_not_testable_source() -> None:
+    """Otherwise author_tests would demand tests for the tests it just wrote."""
+    from orchestrator.sdlc.codegen import _has_testable_source
+
+    assert not _has_testable_source([Path("tests/sdlc/test_codegen.py")])
+
+
+async def test_a_docs_only_change_may_submit_no_tests(tmp_path: Path) -> None:
+    """The SSPN-46 case: a README edit that correctly has nothing to test."""
+    from orchestrator.sdlc.codegen import LLMCodegenAdapter
+
+    (tmp_path / "README.md").write_text("# Doc\n", encoding="utf-8")
+    llm = _ScriptedLLM([json.dumps({"summary": "documentation-only; nothing to test", "files": []})])
+    adapter = LLMCodegenAdapter(llm)
+    adapter._written[tmp_path.resolve()] = [tmp_path / "README.md"]
+
+    change = await adapter.author_tests(spec={"title": "t"}, path=str(tmp_path), issue_key="S-1")
+
+    assert change.files == []
+    assert "nothing to test" in change.summary
+
+
+async def test_a_source_change_that_submits_no_tests_is_still_refused(tmp_path: Path) -> None:
+    """The rule must not have loosened for real code."""
+    from orchestrator.sdlc.codegen import CodegenError, LLMCodegenAdapter
+
+    (tmp_path / "thing.py").write_text("X = 1\n", encoding="utf-8")
+    llm = _ScriptedLLM([json.dumps({"summary": "nothing to do", "files": []})] * 6)
+    adapter = LLMCodegenAdapter(llm)
+    adapter._written[tmp_path.resolve()] = [tmp_path / "thing.py"]
+
+    with pytest.raises(CodegenError):
+        await adapter.author_tests(spec={"title": "t"}, path=str(tmp_path), issue_key="S-1")


### PR DESCRIPTION
Closes SSPN-47. Found by the SSPN-46 live run.

## The bug

`author_tests` is unconditional — no spec can turn it off — and an empty submission was always read as a skipped job and retried.

On a documentation-only change the stage **answered correctly first**:

```
sdlc.codegen.empty_retry summary='No tests submitted: SSPN-46 is a
    documentation-only prose edit to README.md (already applied)...'
sdlc.codegen.syntax_retry
CodegenError: ... test_readme_model_and_spec_docs.py: line 138: invalid syntax — '</content>'
```

That correct answer was retried, and the retry invented a test module for a paragraph and corrupted it with markup. The run died, discarding a README change that was already complete and correct — every acceptance criterion met, only `README.md` touched. It shipped by hand as [#157](https://github.com/synaptixs/spine/pull/157).

## Conditional, not relaxed

The rule has to hold both ways, so this is not "skip the stage for docs":

- **no testable source touched** → empty is a valid answer
- **testable source touched** → empty is still refused, exactly as before

`_has_testable_source` uses the source half of `review._REVIEWABLE_SUFFIXES`. Documentation and config are *reviewable* — a criterion can require them — but nothing writes a unit test against a paragraph. Test files don't count either, or the stage would demand tests for the tests it just wrote.

## Verified against both wrong answers

| variant | fails |
|---|---|
| old always-retry | `docs_only_change_may_submit_no_tests` |
| blanket `allow_empty=True` | `source_change_that_submits_no_tests_is_still_refused` |

Only the conditional rule passes both. That second row is the point — the naive fix would have quietly let a real code change ship untested.

## Blast radius (PKG)

`LLMCodegenAdapter` is 97 direct / 163 transitive. This adds a helper and one keyword argument at an existing call site; no signature changes.

## Verification

9 new tests. Full gate green, **2501 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)