### PR TITLE
release: 3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.15.0 — Everything that reports success has to be able to report failure
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.14.0"
+version = "3.15.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -3726,7 +3726,7 @@ wheels = [
 
 [[package]]
 name = "synaptixs-spine"
-version = "3.14.0"
+version = "3.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Cuts 3.15.0. **A minor, not a patch** — `mcp>=2` is a breaking requirement for anyone using that extra.

## The theme

One failure shape, found five ways: something reported an outcome it had not established.

- `getattr(result, "isError", False)` returned `False` under v2 — **every tool error reported as a success**
- `getattr(raw, "inputSchema", None)` returned `None` after the same rename — every tool silently lost its argument types, taking the `mcp contracts` labels *and* the argument coercion with them
- `author_tests` treated "nothing to test" as a skipped job, retried, and invented a test module for a paragraph — **discarding a change that was already correct**
- a partially-applied codegen attempt could not be repaired: the retry resent edits whose anchors it had itself consumed
- the validity gate returned `PROCEED` on a spec whose files could not fit in front of the model

**Two of those were regressions introduced by the v2 migration in this same release**, caught before it shipped. Both were defaulted reads that turn a rename into wrong data rather than an error. There is now a test built on the SDK's own `Tool` rather than our dataclass, so the next rename fails a test instead of a run.

## Also in

- MCP SDK v2 migration
- Generated fixtures are shown the types they construct
- Codegen's context budget: 40 KB → 200 KB (it was ~1% of the model's window)
- A stub submission no longer counts as progress
- `SDLC_PR_BASE` documented — unset silently means `main`
- README names `orchestrator models`, the default model, and `--spec`

## Changelog tidy

Each PR prepends its own `### Added/Changed/Fixed`, so `## Unreleased` had two `### Fixed` blocks. Regrouped into one of each — 9 entries. This recurs every release; worth fixing at some point.

## Verification

- `ruff format --check .`, `ruff check src tests`, `mypy src tests` — clean
- `pytest -q` — **2501 passed**, 30 skipped
- `uv build` — `synaptixs_spine-3.15.0` sdist + wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)