### PR TITLE
release: promote 3.15.0 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.15.0 — Everything that reports success has to be able to report failure
 
 ### Added
 

--- a/episteme/README.md
+++ b/episteme/README.md
@@ -4,7 +4,7 @@
 Code-true knowledge base for **synaptixs-spine** (brownfield), built by `orchestrator understand` from the Product Knowledge Graph + project profile.
 
 <!-- spine-stamp -->
-Generated from commit `a5dadb3aa4d0f979fe2453d80c266514c37a873a` by **Spine 3.14.0**.
+Generated from commit `c556696140f61df139a5b0f23bc1ef786c3baffb` by **Spine 3.15.0**.
 Verify it still matches the code with `orchestrator understand --check`.
 <!-- /spine-stamp -->
 

--- a/episteme/tech-context.md
+++ b/episteme/tech-context.md
@@ -9,7 +9,7 @@
 | Migrations | yes |
 | Test runner | pytest |
 | Task type (default) | feature |
-| Version | `3.14.0` |
+| Version | `3.15.0` |
 | Requires Python | `>=3.12` |
 
 ## Infrastructure & runtime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.14.0"
+version = "3.15.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -3726,7 +3726,7 @@ wheels = [
 
 [[package]]
 name = "synaptixs-spine"
-version = "3.14.0"
+version = "3.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Promotes 3.15.0 to `main` for publishing. Three commits since the last promotion: the version bump, the changelog release, and the episteme regeneration.

## 3.15.0 — everything that reports success has to be able to report failure

**A minor, not a patch:** `mcp>=2` is a breaking requirement for anyone using that extra.

One failure shape, found five ways — something reported an outcome it had not established:

- `getattr(result, "isError", False)` returned `False` under SDK v2, so **every tool error was reported as a success**
- `getattr(raw, "inputSchema", None)` returned `None` after the same rename, so every tool silently lost its argument types — taking the `mcp contracts` labels *and* the argument coercion with them
- `author_tests` treated "nothing to test" as a skipped job, retried, and invented a test module for a paragraph — **discarding a change that was already correct**
- a partially-applied codegen attempt could not be repaired: the retry resent edits whose anchors it had itself consumed
- the validity gate returned `PROCEED` on a spec whose files could not fit in front of the model

Two of those were regressions introduced by the v2 migration **in this same release**, found and fixed before it shipped. Both were defaulted reads that turn a rename into wrong data rather than an error. A test now builds on the SDK's own `Tool` rather than our dataclass, so the next rename fails a test instead of a run.

Also in: the v2 migration itself, generated fixtures being shown the types they construct, codegen's context budget going from 40 KB to 200 KB (it was ~1% of the model's window), stub submissions no longer counting as progress, `SDLC_PR_BASE` documented, and a README that finally names `orchestrator models`, the default model, and `--spec`.

## Verification

With the `mcp` extra installed: `ruff format --check .`, `ruff check src tests`, `mypy src tests` clean, **2501 passed**. `uv build` produces `synaptixs_spine-3.15.0`.

Publishing to PyPI follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)