### PR TITLE
feat(pkg): summary counts edges by kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`pkg extract` counts edges by kind.** One total cannot show a kind that stopped being
+  emitted: `edges: 31073` reads identically whether the call graph resolved or collapsed to
+  zero while imports doubled. `FactStore.summary()` now carries an `edges_<kind>` count for
+  every kind, printed under the scan line and included in `--json`. Kinds with no edges
+  report `0` rather than being omitted — `REFERENCES 0` on a repo with entities is the line
+  worth reading, and a missing key looks like a question nobody asked. Existing keys are
+  unchanged, so the ten callers of `summary()` are unaffected.
+
 ## 3.15.0 — Everything that reports success has to be able to report failure
 
 ### Added

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -2387,6 +2387,12 @@ def pkg_extract(
         f"Scanned {path} — {summary['grounded_nodes']} grounded nodes, "
         f"{summary['external_nodes']} external, {summary['edges']} edges."
     )
+    # Per kind, because one total cannot show a kind that stopped being emitted. Zeros are
+    # printed rather than skipped: `REFERENCES 0` on a repo with entities is the line worth
+    # reading, and omitting it looks like a question nobody asked.
+    per_kind = {k[len("edges_") :]: v for k, v in summary.items() if k.startswith("edges_")}
+    if per_kind:
+        typer.echo("  " + "  ".join(f"{k.upper()} {v}" for k, v in per_kind.items()))
     if extractor.skipped:
         typer.echo(f"  (skipped {len(extractor.skipped)} unparseable file(s))")
 

--- a/src/orchestrator/pkg/store.py
+++ b/src/orchestrator/pkg/store.py
@@ -8,6 +8,7 @@ backs a Postgres/graph store without changing callers.
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 
 from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node
@@ -233,13 +234,28 @@ class FactStore:
         return [self._nodes[i] for i in ids if i in self._nodes]
 
     def summary(self) -> dict[str, int]:
+        """Counts of what was extracted, including edges **per kind**.
+
+        One total is not enough to notice a front-end that stopped emitting something.
+        ``edges: 31073`` reads identically whether the call graph resolved or collapsed to
+        zero while imports doubled — and a kind that silently goes missing is exactly the
+        completeness failure ``pkg verify`` exists for, arriving from the other direction:
+        the edge is not dangling, it was simply never emitted. A per-kind line makes
+        ``REFERENCES: 0`` on a repo with entities something you can see.
+
+        Kinds with no edges are included rather than omitted. "Zero" is the answer worth
+        reading; a missing key looks like a field that was never asked about.
+        """
         grounded = sum(1 for n in self._nodes.values() if n.grounded)
-        return {
+        out = {
             "nodes": len(self._nodes),
             "grounded_nodes": grounded,
             "external_nodes": len(self._nodes) - grounded,
             "edges": len(self._edges),
         }
+        counts = Counter(e.kind.value for e in self._edges)
+        out.update({f"edges_{kind.value.lower()}": counts.get(kind.value, 0) for kind in EdgeKind})
+        return out
 
 
 __all__ = ["CallSite", "FactStore"]

--- a/tests/pkg/test_facts_and_store.py
+++ b/tests/pkg/test_facts_and_store.py
@@ -171,8 +171,15 @@ def test_summary_reports_a_kind_with_no_edges_as_zero() -> None:
     """`REFERENCES: 0` is the line worth reading; a missing key looks unasked."""
     summary = FactStore(FactBatch()).summary()
 
-    for kind in EdgeKind:
-        assert summary[f"edges_{kind.value.lower()}"] == 0, f"{kind.value} should report zero"
+    # Asserted over the summary's own keys rather than by looping the enum: `EdgeKind` is
+    # `(str, Enum)`, and CodeQL reads the `str` base without seeing that the Enum metaclass
+    # supplies `__iter__` — a false positive, but an error-severity one. Checking the keys
+    # the method actually produced is the better assertion anyway: it catches a kind that
+    # was dropped from the output, which looping the enum and indexing would too, and also
+    # catches a stray extra key, which it would not.
+    per_kind = {k: v for k, v in summary.items() if k.startswith("edges_")}
+    assert len(per_kind) == len(EdgeKind.__members__), "one count per kind, no more, no less"
+    assert set(per_kind.values()) == {0}, f"an empty graph has no edges of any kind: {per_kind}"
 
 
 def test_summary_keeps_its_existing_keys() -> None:

--- a/tests/pkg/test_facts_and_store.py
+++ b/tests/pkg/test_facts_and_store.py
@@ -137,3 +137,46 @@ def test_impact_across_includes_exposes_by_default() -> None:
     explicit = {n.name for n, _ in store.impact_across("py:api.list_runs", kinds=(EdgeKind.CALLS,))}
     assert "GET /v1/runs" in default
     assert explicit == set()  # a caller that asks for CALLS only still gets the old reading
+
+
+def test_summary_counts_edges_by_kind() -> None:
+    """One total cannot show a kind that stopped being emitted.
+
+    `edges: 31073` reads identically whether the call graph resolved or collapsed to zero
+    while imports doubled. A kind silently going missing is the completeness failure
+    `pkg verify` exists for, arriving from the other side: the edge is not dangling, it was
+    never emitted at all.
+    """
+    batch = FactBatch()
+    a = Node("py:mod:a", NodeKind.MODULE, "a", "python", Provenance("a.py", 1))
+    b = Node("py:mod:b", NodeKind.MODULE, "b", "python", Provenance("b.py", 1))
+    batch.add_node(a)
+    batch.add_node(b)
+    c = Node("py:mod:c", NodeKind.MODULE, "c", "python", Provenance("c.py", 1))
+    batch.add_node(c)
+    batch.add_edge(Edge(a.id, b.id, EdgeKind.IMPORTS))
+    batch.add_edge(Edge(a.id, b.id, EdgeKind.CALLS))
+    # A distinct pair, since `FactBatch.add_edge` de-duplicates on (src, dst, kind).
+    batch.add_edge(Edge(a.id, c.id, EdgeKind.CALLS))
+
+    summary = FactStore(batch).summary()
+
+    assert summary["edges"] == 3
+    assert summary["edges_calls"] == 2
+    assert summary["edges_imports"] == 1
+    assert summary["edges_reads"] == 0
+
+
+def test_summary_reports_a_kind_with_no_edges_as_zero() -> None:
+    """`REFERENCES: 0` is the line worth reading; a missing key looks unasked."""
+    summary = FactStore(FactBatch()).summary()
+
+    for kind in EdgeKind:
+        assert summary[f"edges_{kind.value.lower()}"] == 0, f"{kind.value} should report zero"
+
+
+def test_summary_keeps_its_existing_keys() -> None:
+    """Ten callers read this dict; adding keys must not move the ones already there."""
+    summary = FactStore(FactBatch()).summary()
+
+    assert set(summary) >= {"nodes", "grounded_nodes", "external_nodes", "edges"}


### PR DESCRIPTION
A small enhancement found by interrogating the graph rather than reading the code.

## The gap

`pkg extract` reports one number:

```
Scanned . — 10118 grounded nodes, 698 external, 31073 edges.
```

That reads identically whether the call graph resolved or collapsed to zero while imports doubled. A front-end that stops emitting a kind is invisible.

It's the completeness failure `pkg verify` exists for, arriving from the other side: `verify` catches a **dangling** edge; nothing catches an edge that was **never emitted**.

## What it shows on this repo

```
IMPORTS 6462  CONTAINS 9418  CALLS 14816  IMPLEMENTS 273
READS 29      WRITES 1       EXPOSES 77   REFERENCES 0   MENTIONS 0
```

The graph here is **100% resolved** — `pkg verify` is happy — and still reports `REFERENCES 0` and `WRITES 1` on a codebase with a database layer. Until now that was visible only by writing a script against the store.

(`MENTIONS 0` is expected: doc linking is a post-pass run by `understand`/`state`, not by `pkg extract`.)

## Design notes

- **Zeros are printed, not omitted.** `REFERENCES 0` is the line worth reading; a missing key looks like a question nobody asked.
- **Additive.** The four existing keys keep their names and meanings, so the ten callers of `summary()` are unaffected, and `--json` carries the breakdown for free.

## Blast radius (PKG)

`summary()` is read from `cli`, `understand`, `impact`, `coverage` and `rca` — 10 call sites, all of which do `.get(...)` on specific keys. Adding keys cannot break them, and a test asserts the existing keys survive.

## Verification

3 tests. Full gate green, **2504 passed**.

One of those tests initially failed because I assumed `FactBatch.add_edge` appends — it de-duplicates on `(src, dst, kind)`. The test was wrong, not the code; corrected to use a distinct pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)