### PR TITLE
fix(codegen): the repair path must not crash on a symlinked worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@
   worth reading, and a missing key looks like a question nobody asked. Existing keys are
   unchanged, so the ten callers of `summary()` are unaffected.
 
+## Unreleased
+
+### Fixed
+
+- **The repair path no longer crashes on a symlinked worktree.** `applied_paths` names the
+  files an attempt already wrote so the repair retry knows not to resend them — computed
+  with a bare `Path.relative_to`, which raised on macOS, where `/tmp` is a symlink to
+  `/private/tmp`: the written paths come back resolved and the worktree root does not, so
+  nothing is "in the subpath of" anything. The `ValueError` killed the whole run, and fired
+  only when an attempt partially succeeded, which is the exact case the information exists
+  to rescue. Both sides are resolved now, and a path genuinely outside the worktree is
+  reported rather than raised.
+
 ## 3.15.0 — Everything that reports success has to be able to report failure
 
 ### Added

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -1790,6 +1790,28 @@ def _has_testable_source(written: list[Path]) -> bool:
     return any(p.suffix.lower() in _TESTABLE_SUFFIXES and not _is_test_file(p) for p in written)
 
 
+def _relative_paths(written: list[str], root: Path) -> list[str]:
+    """Written paths relative to ``root``, tolerating symlinks and surprises.
+
+    This runs on the *error* path, naming what already landed so the repair retry knows not
+    to resend it. A bare ``Path.relative_to`` raised there and killed the whole run: on macOS
+    ``/tmp`` is a symlink to ``/private/tmp``, the written paths come back resolved and
+    ``root`` does not, so nothing is "in the subpath of" anything. The crash fired only when
+    an attempt partially succeeded — precisely the case this information exists to rescue.
+
+    Resolve both sides, and fall back to the raw string rather than raising: a path that is
+    genuinely outside the worktree is worth reporting, not worth losing the run over.
+    """
+    base = root.resolve()
+    out: list[str] = []
+    for w in written:
+        try:
+            out.append(str(Path(w).resolve().relative_to(base)))
+        except (ValueError, OSError):
+            out.append(str(w))
+    return out
+
+
 def _is_test_file(path: Path) -> bool:
     """Mirror of ``feature_runner._is_test_path``, kept here to avoid a circular import.
 
@@ -1987,7 +2009,7 @@ def apply_files(
             missing_edit_paths=missing_targets,
             failed_anchors=attempted_anchors,
             syntax_errors=syntax_messages,
-            applied_paths=[str(Path(w).relative_to(root)) for w in written],
+            applied_paths=_relative_paths(written, root),
         )
     if not written:
         if placeholders and not edit_failures:

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1887,3 +1887,48 @@ async def test_a_source_change_that_submits_no_tests_is_still_refused(tmp_path: 
 
     with pytest.raises(CodegenError):
         await adapter.author_tests(spec={"title": "t"}, path=str(tmp_path), issue_key="S-1")
+
+
+# --- the repair path must not crash (regression from #150) --------------------------
+#
+# `applied_paths` names what already landed so the repair retry knows not to resend it.
+# Computing it with a bare `Path.relative_to` raised on macOS, where /tmp is a symlink to
+# /private/tmp: the written paths come back resolved and the worktree root does not, so
+# nothing is "in the subpath of" anything. The ValueError killed the whole run — and it
+# fired only when an attempt partially succeeded, which is the exact case this information
+# exists to rescue.
+
+
+def test_written_paths_survive_a_symlinked_root(tmp_path: Path) -> None:
+    """The macOS /tmp -> /private/tmp shape, built explicitly rather than assumed."""
+    from orchestrator.sdlc.codegen import _relative_paths
+
+    real = tmp_path / "real"
+    (real / "src").mkdir(parents=True)
+    (real / "src" / "a.py").write_text("X = 1\n", encoding="utf-8")
+    link = tmp_path / "link"
+    link.symlink_to(real)
+
+    # root as the symlink, the written path as the resolved location — the failing shape.
+    assert _relative_paths([str(real / "src" / "a.py")], link) == ["src/a.py"]
+
+
+def test_a_path_outside_the_root_is_reported_not_raised(tmp_path: Path) -> None:
+    """Worth reporting; never worth losing the run over."""
+    from orchestrator.sdlc.codegen import _relative_paths
+
+    outside = tmp_path.parent / "elsewhere.py"
+
+    result = _relative_paths([str(outside)], tmp_path)
+
+    assert result == [str(outside)]
+
+
+def test_ordinary_paths_are_relative(tmp_path: Path) -> None:
+    from orchestrator.sdlc.codegen import _relative_paths
+
+    (tmp_path / "pkg").mkdir()
+    target = tmp_path / "pkg" / "thing.py"
+    target.write_text("Y = 2\n", encoding="utf-8")
+
+    assert _relative_paths([str(target)], tmp_path) == ["pkg/thing.py"]


### PR DESCRIPTION
A regression I introduced in [#150](https://github.com/synaptixs/spine/pull/150), found by the SSPN-49 live run.

## What happened

```
ValueError: '/private/tmp/sdlc-workspaces/.../cli_errors.py' is not in the
            subpath of '/tmp/sdlc-workspaces/.../SSPN-49'
```

#150 added `applied_paths` so a repair retry knows which files an attempt already wrote and must not resend. It computed them with a bare `Path.relative_to(root)`.

On macOS `/tmp` is a symlink to `/private/tmp`. The written paths come back **resolved** and `root` does not, so `relative_to` raises and the whole run dies.

## Why it's worse than it looks

It can only fire when an attempt **partially succeeded** — which is exactly the situation `applied_paths` exists to rescue. The fix for SSPN-40 crashed in the case it was written for, and it did so on the error path, where the one requirement is not failing.

## The change

Resolve both sides before comparing; report a path genuinely outside the worktree as-is rather than raising. Worth reporting, never worth losing a run over.

## Verification

3 tests, including one that builds the real symlink shape (`/tmp` → `/private/tmp`) rather than assuming it. It fails against the #150 implementation.

Full gate green, **2507 passed**.

## On SSPN-49

The run got as far as writing a 132-line `cli_errors.py` — a context manager wrapping the request block, which is the right design — before dying here. `cli.py` was never wired to it, and that wiring is most of the acceptance criteria, so I have not hand-finished it. SSPN-49 is worth re-running once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)