### PR TITLE
fix(sdlc): a design honours the paths its spec names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@
 
 ### Fixed
 
+- **A design honours the paths its spec names.** The heuristic design read only the ticket's
+  title and summary, matching those words against the graph — so a ticket about "the
+  registry API" whose acceptance criteria named `src/orchestrator/cli.py` twice came back
+  proposing the registry *server* modules, and omitted the one file the spec named. Codegen
+  is handed that design as an instruction, and on a live run it submitted nothing at all
+  rather than choose between a spec and a design that disagreed. Paths stated in the
+  criteria and technical notes now come first; the graph reading and the overview remain as
+  fallbacks. A stated path that does not exist is dropped — naming a file to *create*
+  belongs in the approach, not in a list of files to open.
+
 - **The repair path no longer crashes on a symlinked worktree.** `applied_paths` names the
   files an attempt already wrote so the repair retry knows not to resend them — computed
   with a bare `Path.relative_to`, which raised on macOS, where `/tmp` is a symlink to

--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -541,7 +541,7 @@ async def _stage_design(
     # No LLM here yet: the deterministic design is the honest skeleton default, and it keeps
     # this stage runnable with no provider configured. Wiring the model in is phase 2 work,
     # not skeleton work.
-    design = await produce_design(spec, overview=overview, store=store, llm=None)
+    design = await produce_design(spec, overview=overview, store=store, llm=None, root=ctx.root)
     rendered = render_design_md(spec, design)
     path = ctx.write_artifact("design.md", rendered)
     touched = len(design.get("files_to_touch") or [])

--- a/src/orchestrator/sdlc/design.py
+++ b/src/orchestrator/sdlc/design.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import contextlib
 import json
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from orchestrator.runtime import ArtifactStore
@@ -64,6 +65,44 @@ def _structure_lines(overview: dict[str, Any] | None) -> list[str]:
             "Most-connected symbols: " + ", ".join(f"{s['name']} in {s.get('module', '?')}" for s in syms[:8])
         )
     return lines
+
+
+# Repo-relative source paths, matching `codegen._PATH_RE`. Duplicated rather than shared:
+# a six-character regex is cheaper to repeat than a new coupling between two modules that
+# otherwise do not know about each other.
+_PATH_RE = re.compile(r"\b((?:src/|tests/)[\w./-]+\.py)\b")
+
+
+def _stated_paths(spec: dict[str, Any], root: Path | None = None) -> list[str]:
+    """Paths the spec *states*, which outrank paths inferred from its words.
+
+    ``_landing_files`` reads only the title and summary, matching the ticket's language
+    against the graph. A ticket about "the registry API" whose criteria name
+    ``src/orchestrator/cli.py`` therefore came back proposing the registry *server* modules
+    — the wrong side of the wire — while the file the spec named twice was absent. Codegen
+    is then handed a design that contradicts its own spec, and on SSPN-49 it submitted
+    nothing at all rather than choose between them.
+
+    The criteria and technical notes are where a spec says which file it means, so they are
+    read here for the same reason ``codegen._paths_from`` reads them. A stated path that
+    does not exist is dropped: naming a file to create is a job for the approach, not for a
+    list of files to open.
+    """
+    blob = " ".join(
+        [
+            str(spec.get("summary") or ""),
+            str(spec.get("technical_notes") or ""),
+            *[str(a) for a in (spec.get("acceptance_criteria") or [])],
+        ]
+    )
+    out: list[str] = []
+    for rel in _PATH_RE.findall(blob):
+        if rel in out:
+            continue
+        if root is not None and not (root / rel).is_file():
+            continue
+        out.append(rel)
+    return out
 
 
 def _landing_files(spec: dict[str, Any], store: FactStore | None) -> list[str]:
@@ -129,14 +168,25 @@ def _overview_files(spec: dict[str, Any], overview: dict[str, Any] | None) -> li
 
 
 def _fallback_design(
-    spec: dict[str, Any], overview: dict[str, Any] | None, store: FactStore | None = None
+    spec: dict[str, Any],
+    overview: dict[str, Any] | None,
+    store: FactStore | None = None,
+    root: Path | None = None,
 ) -> dict[str, Any]:
-    # The graph reading first; the overview's names second; nothing at all rather than a guess.
-    files = _landing_files(spec, store) or _overview_files(spec, overview)
+    # What the spec *says* first; then the graph reading; then the overview's names; nothing
+    # at all rather than a guess. A path the ticket names is not a heuristic — inferring
+    # around it is how a design ends up contradicting the spec it was built from.
+    stated = _stated_paths(spec, root)
+    files = stated or _landing_files(spec, store) or _overview_files(spec, overview)
     ac = [str(a) for a in (spec.get("acceptance_criteria") or [])]
     # Say which it is. A consumer — a human reading design.md, or the codegen prompt now
     # carrying it — has to be able to tell a grounded reading from a shrug.
     risks = ["Heuristic design (no LLM) — confirm the affected files before building."]
+    if stated:
+        # Worth saying which reading produced the list: a reader who knows these paths came
+        # from the ticket itself does not need to second-guess them the way a keyword match
+        # deserves to be second-guessed.
+        risks = ["Files taken from the paths this ticket names, not inferred from its words."]
     if not files:
         risks = [
             "Heuristic design (no LLM) and nothing in the graph matched this ticket's words, "
@@ -239,8 +289,13 @@ async def produce_design(
     memory_bank: dict[str, str] | None = None,
     store: FactStore | None = None,
     llm: Any = None,
+    root: Path | None = None,
 ) -> dict[str, Any]:
     """Produce a grounded design dict for one spec — the pure core, no I/O.
+
+    ``root`` is the repo the design is for. It is used only to drop a path the spec names
+    that does not exist — naming a file to *create* belongs in the approach, not in a list
+    of files to open. Without it, stated paths are taken as written.
 
     An LLM writes it when configured, else a deterministic heuristic from the
     graph overview + acceptance criteria. When a ``FactStore`` is supplied, the
@@ -251,10 +306,12 @@ async def produce_design(
     ctx = {"overview": overview, "memory_bank": memory_bank or {}}
     try:
         design = (
-            await _llm_design(spec, ctx, llm) if llm is not None else _fallback_design(spec, overview, store)
+            await _llm_design(spec, ctx, llm)
+            if llm is not None
+            else _fallback_design(spec, overview, store, root)
         )
     except Exception:  # noqa: BLE001 — LLM/parse failure → deterministic design, never blocks
-        design = _fallback_design(spec, overview, store)
+        design = _fallback_design(spec, overview, store, root)
     if store is not None:
         with contextlib.suppress(Exception):  # impact is an annotation; never fail the design
             from orchestrator.sdlc.impact import blast_radius, to_dict

--- a/tests/sdlc/test_design.py
+++ b/tests/sdlc/test_design.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -284,3 +285,94 @@ async def test_the_design_agrees_with_the_investigation() -> None:
     landed = [land.where.split(":", 1)[0] for land in investigation.landing]
     assert design["files_to_touch"]
     assert all(f in landed for f in design["files_to_touch"])
+
+
+# --- a path the spec names outranks a path inferred from its words (SSPN-49) --------
+#
+# `_landing_files` reads only the title and summary, matching the ticket's language against
+# the graph. SSPN-49's ticket is about "the registry API" and its criteria name
+# src/orchestrator/cli.py twice — so the design proposed the registry *server* modules and
+# omitted the one file the spec named. Codegen was handed a design contradicting its own
+# spec and submitted nothing at all rather than choose between them.
+
+
+def _spec_naming(*paths: str, **extra: Any) -> dict[str, Any]:
+    return {
+        "title": "CLI commands crash when the registry API is down",
+        "summary": "Every CLI command that talks to the registry API crashes.",
+        "acceptance_criteria": [f"The fix lives in {p}." for p in paths],
+        **extra,
+    }
+
+
+def test_a_path_the_spec_names_is_used(tmp_path: Path) -> None:
+    from orchestrator.sdlc.design import _fallback_design
+
+    (tmp_path / "src" / "orchestrator").mkdir(parents=True)
+    (tmp_path / "src" / "orchestrator" / "cli.py").write_text("X = 1\n", encoding="utf-8")
+
+    design = _fallback_design(_spec_naming("src/orchestrator/cli.py"), None, None, tmp_path)
+
+    assert design["files_to_touch"] == ["src/orchestrator/cli.py"]
+
+
+def test_technical_notes_are_read_too(tmp_path: Path) -> None:
+    """Where a spec most often says which file it means."""
+    from orchestrator.sdlc.design import _stated_paths
+
+    spec = {"technical_notes": "`_client()` is at src/orchestrator/cli.py:61."}
+
+    assert _stated_paths(spec) == ["src/orchestrator/cli.py"]
+
+
+def test_a_stated_path_that_does_not_exist_is_dropped(tmp_path: Path) -> None:
+    """Naming a file to create belongs in the approach, not a list of files to open."""
+    from orchestrator.sdlc.design import _stated_paths
+
+    spec = _spec_naming("src/orchestrator/nope.py")
+
+    assert _stated_paths(spec, tmp_path) == []
+
+
+def test_stated_paths_are_taken_as_written_without_a_root() -> None:
+    """Callers with no repo on disk still get the spec's own paths."""
+    from orchestrator.sdlc.design import _stated_paths
+
+    assert _stated_paths(_spec_naming("src/a.py", "tests/test_a.py")) == ["src/a.py", "tests/test_a.py"]
+
+
+def test_duplicate_mentions_are_listed_once() -> None:
+    from orchestrator.sdlc.design import _stated_paths
+
+    spec = {
+        "summary": "Fix src/orchestrator/cli.py",
+        "technical_notes": "src/orchestrator/cli.py again",
+        "acceptance_criteria": ["and src/orchestrator/cli.py once more"],
+    }
+
+    assert _stated_paths(spec) == ["src/orchestrator/cli.py"]
+
+
+def test_the_risks_say_which_reading_produced_the_files(tmp_path: Path) -> None:
+    """A reader should not second-guess a path the ticket itself named."""
+    from orchestrator.sdlc.design import _fallback_design
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "a.py").write_text("X = 1\n", encoding="utf-8")
+
+    design = _fallback_design(_spec_naming("src/a.py"), None, None, tmp_path)
+
+    assert any("names" in r for r in design["risks"])
+    assert not any("confirm the affected files" in r for r in design["risks"])
+
+
+def test_a_spec_naming_nothing_still_falls_back_to_the_overview() -> None:
+    """The existing behaviour must survive: this adds a preference, not a replacement."""
+    from orchestrator.sdlc.design import _fallback_design
+
+    spec = {"title": "add csv export", "summary": "users need data out", "acceptance_criteria": []}
+    overview = {"modules": [{"name": "exporter", "path": "src/exporter.py"}]}
+
+    design = _fallback_design(spec, overview, None, None)
+
+    assert "Heuristic design (no LLM)" in design["risks"][0]


### PR DESCRIPTION
Found by the SSPN-49 live run, which failed with `CodegenError: model output had no 'files' list`.

## The bug

`_landing_files` reads only `title` and `summary`, matching the ticket's language against the graph. SSPN-49's ticket is about *"the registry API"*, and its acceptance criteria name `src/orchestrator/cli.py` **twice**. The design proposed:

```
- src/orchestrator/registry/api/backlog.py
- src/orchestrator/registry/api/config.py
- src/orchestrator/registry/api/connections.py
- src/orchestrator/registry/api/runs.py
- src/orchestrator/mcp/onboard.py
```

Those are the registry **server**. The ticket is about the CLI **client**. The file the spec named is absent.

That design is carried into codegen as an instruction. Handed a spec saying "change `cli.py`" and a design saying "change these five", the run **submitted no files at all**, twice.

## The change

Paths stated in the criteria and technical notes rank ahead of paths inferred from the ticket's words — a path the spec names is not a heuristic. The graph reading and the overview stay as fallbacks, so a spec naming nothing behaves exactly as before.

Same fields and same regex `codegen._paths_from` already uses, duplicated rather than shared: a six-character regex is cheaper to repeat than a new coupling between two modules that otherwise don't know about each other.

A stated path that doesn't exist is dropped — naming a file to *create* belongs in the approach, not in a list of files to open. `root` is threaded through `produce_design` for that check and is optional, so callers without a repo on disk take stated paths as written.

## Replayed against the real spec

```
files_to_touch: ['src/orchestrator/cli.py', 'tests/test_cli.py']
risks         : Files taken from the paths this ticket names, not inferred from its words.
```

## Blast radius (PKG)

`produce_design` has 8 callers / 46 transitive; `_fallback_design` is internal with 2. The new parameter is optional and the new source is a *preference* ahead of existing fallbacks — the result's shape is unchanged.

## Verification

7 new tests; 2 fail against the old precedence. All 11 pre-existing design tests pass unchanged, including one asserting the overview fallback still works.

Full gate green, **2514 passed**. Three files changed, exactly as proposed: `design.py`, `autorun.py` (one line), `test_design.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)