### PR TITLE
fix(codegen): a new module is not a "parallel module"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@
 
 ### Fixed
 
+- **A new module is not a "parallel module".** The implement prompt said *"when the SPEC
+  names existing files, change THOSE files; do not create a parallel module instead"* — a
+  rule added after a run wrote a helper beside a file and never wired it in. As written it
+  also forbade the ordinary shape of an extract-a-wrapper refactor, so a spec asking for
+  "one place that wraps the request" left the model choosing between its instructions; three
+  runs submitted zero files. The prohibition is now on the outcome it was protecting
+  against: the named files must appear with `edits`, and a new module alongside them is
+  allowed.
+
 - **A design honours the paths its spec names.** The heuristic design read only the ticket's
   title and summary, matching those words against the graph — so a ticket about "the
   registry API" whose acceptance criteria named `src/orchestrator/cli.py` twice came back

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -432,9 +432,11 @@ _IMPLEMENT_SYSTEM = (
     "run`). Prefer the standard library; only add a dependency the SPEC names. "
     "Never name a new top-level module after a Python standard-library module "
     "(statistics, json, types, ...) — it shadows the real one. When the SPEC "
-    "names existing files, change THOSE files (with `edits`); do not create a "
-    "parallel module instead. Every new file must be complete and "
-    "syntactically valid."
+    "names existing files, those files MUST appear in your `files` with `edits` — "
+    "a helper written beside a file and never wired into it is not the change. You "
+    "MAY add a new module as well when the work genuinely belongs in one; what is "
+    "forbidden is leaving the named files untouched. Every new file must be "
+    "complete and syntactically valid."
 )
 
 _AGENTIC_MAX_STEPS = 16

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -1932,3 +1932,52 @@ def test_ordinary_paths_are_relative(tmp_path: Path) -> None:
     target.write_text("Y = 2\n", encoding="utf-8")
 
     assert _relative_paths([str(target)], tmp_path) == ["pkg/thing.py"]
+
+
+# --- a new module is not a "parallel module" (SSPN-49) -------------------------------
+#
+# The rule read "when the SPEC names existing files, change THOSE files; do not create a
+# parallel module instead." It was added after a run wrote a helper beside a file and never
+# wired it in — a real failure. But as written it forbids the ordinary shape of an
+# extract-a-wrapper refactor, and SSPN-49's spec asks for exactly that ("one place that
+# wraps the request"). Three runs on that ticket submitted zero files rather than choose
+# between the spec and the rule.
+#
+# These assert on prompt *content*, which is a weak test of a real change: a model's
+# behaviour cannot be unit-tested. What they do catch is the prohibition coming back, or the
+# obligation it was protecting being dropped.
+
+
+def test_the_prompt_still_requires_the_named_files_to_be_edited() -> None:
+    """The obligation the old rule was really protecting: do not leave them untouched."""
+    from orchestrator.sdlc.codegen import _IMPLEMENT_SYSTEM
+
+    assert "MUST appear in your `files` with `edits`" in _IMPLEMENT_SYSTEM
+    assert "leaving the named files untouched" in _IMPLEMENT_SYSTEM
+
+
+def test_the_prompt_no_longer_forbids_a_new_module_outright() -> None:
+    from orchestrator.sdlc.codegen import _IMPLEMENT_SYSTEM
+
+    assert "do not create a parallel module instead" not in _IMPLEMENT_SYSTEM
+    assert "MAY add a new module" in _IMPLEMENT_SYSTEM
+
+
+def test_the_stdlib_shadow_rule_is_untouched() -> None:
+    """Adjacent in the same string, and a genuine guard — it must survive the edit."""
+    from orchestrator.sdlc.codegen import _IMPLEMENT_SYSTEM
+
+    assert "Never name a new top-level module after a Python standard-library module" in _IMPLEMENT_SYSTEM
+    assert "Every new file must be complete and syntactically valid" in _IMPLEMENT_SYSTEM
+
+
+def test_only_the_python_prompt_carries_this_rule() -> None:
+    """No other language prompt has it, so none should grow it by copy-paste."""
+    from orchestrator.sdlc import codegen
+
+    others = [
+        v for k, v in vars(codegen).items() if k.startswith("_IMPLEMENT_SYSTEM_") and isinstance(v, str)
+    ]
+    assert others, "expected the per-language prompts to exist"
+    for prompt in others:
+        assert "parallel module" not in prompt


### PR DESCRIPTION
The blocker behind three failed SSPN-49 runs.

## The contradiction

**Prompt:** *"When the SPEC names existing files, change THOSE files (with `edits`); do not create a parallel module instead."*

**SSPN-49's spec:** *"Prefer one place that wraps the request over editing six call sites by hand — an httpx event hook, a small wrapper, or a context manager."*

A shared wrapper is a new module. The model was told to build one and told not to. It submitted zero files rather than violate either:

| run | wanted | outcome |
|---|---|---|
| `2a5463` | `cli_errors.py` | **wrote it**, then died on an unrelated crash (#163) |
| `5f899c` | — | zero files, `'(no summary given)'` |
| `bf7e5d` | `api_errors.py` | zero files, summary describing the module it decided it couldn't write |

## The change

One string. The prohibition moves from *"don't create a new module"* to *"don't leave the named files untouched"* — which is what the rule was protecting against. It was added after a run wrote a helper beside a file and never wired it in; that case is still covered.

```diff
-"names existing files, change THOSE files (with `edits`); do not create a "
-"parallel module instead. Every new file must be complete and "
+"names existing files, those files MUST appear in your `files` with `edits` — "
+"a helper written beside a file and never wired into it is not the change. You "
+"MAY add a new module as well when the work genuinely belongs in one; what is "
+"forbidden is leaving the named files untouched. Every new file must be "
```

## Scope

Two files. `_IMPLEMENT_SYSTEM` is one of nine language prompts — no other carries this rule, and a test now asserts none grows it by copy-paste. The adjacent stdlib-shadow guard is untouched, with its own test that passes either way.

## Verification

4 tests; **2 fail against the old rule**. Full gate green: **2518 passed**, against a **2514** baseline recorded before the edit — +4, no regressions.

## Two things stated plainly

**These tests are weak.** A model's behaviour cannot be unit-tested; they assert prompt *content*. What they catch is the prohibition returning or the obligation being dropped. The verification that matters is the next SSPN-49 run.

**This loosens a guard added after a real failure.** The replacement covers that case, but by prompt only. Enforcing it in code — `apply_files` refusing a submission that names none of the spec's stated paths — is a larger change and deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)