### PR TITLE
docs(env): restructure .env.example so the blocks read in the order you need them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,90 +1,161 @@
-# Agent Orchestrator — environment template.
+# Spine — environment template.
 #
-#   cp .env.example .env      # then fill in the values you need
-#   orchestrator doctor       # verify readiness
+#   cp .env.example .env       # then fill in the blocks you need
+#   orchestrator doctor        # verify what is configured and what is missing
+#   orchestrator models        # what each stage currently resolves to
 #
-# `.env` is gitignored; pydantic-settings + the CLI auto-load it. A real
-# exported shell variable always wins over a value in this file.
+# `.env` is gitignored; pydantic-settings + the CLI auto-load it. A real exported
+# shell variable always wins over a value in this file.
 #
-# You do NOT need every variable — fill in the block(s) for what you're doing:
-#   • Mode A (local CLI: `ingest`, `sdlc feature`) needs only an LLM provider
-#     plus the source you read from (Confluence / Jira / Notion / file).
-#   • Mode B (autonomous `sdlc run` + web console) additionally needs the
-#     Orchestrator API + database + Temporal blocks.
-# Sections below are tagged [REQUIRED] / [MODE B] / [OPTIONAL] accordingly.
+# You do NOT need every variable. Fill in the block(s) for what you are doing:
+#   • Mode A (local CLI: `ingest`, `sdlc plan`, `sdlc feature`) needs an LLM
+#     provider plus the source you read from — Confluence / Jira / Notion / file.
+#   • Mode B (autonomous `sdlc run` + web console) additionally needs section 6.
+# Sections are tagged [REQUIRED] / [MODE B] / [OPTIONAL].
 
 
 # ============================================================================
-# 1. LLM provider                                                  [REQUIRED]
+# 1. LLM provider and model selection                              [REQUIRED]
 # ============================================================================
-# At least ONE of these. Set the key for the model family you use.
+# At least ONE key. Keys are per model family, not per run: keep the key for
+# every family that any stage still points at.
 ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
-# Ollama (local or cloud) needs no API key — set the endpoint and use an
-# ollama/* model below. Local: http://localhost:11434
-# OLLAMA_API_BASE=http://localhost:11434
 
-# Model selection — every stage resolves independently: its own variable, then
-# ORCHESTRATOR_MODEL, then the built-in default. `orchestrator models` lists the
-# ids with context windows and prices, and marks the ones that CANNOT do the
-# forced tool call that codegen and the acceptance judge both require — on those,
-# both silently fall back to parsing prose out of a text reply.
-# ORCHESTRATOR_MODEL=claude-opus-5     # one knob for every stage (the default)
-# SDLC_CODEGEN_MODEL=                  # codegen only; falls back to INTAKE_MODEL
+# Every stage resolves independently:
+#   explicit CLI flag  >  that stage's variable  >  ORCHESTRATOR_MODEL  >  default
+# The default is `claude-opus-5` for every stage. `orchestrator models` lists the
+# ids with context windows and prices, marks what each stage resolves to now, and
+# flags the ones that CANNOT do the forced tool call codegen and the acceptance
+# judge both require — on those, both silently fall back to parsing prose out of a
+# text reply. Take ids from that command: routing is LiteLLM-backed, and an id it
+# does not know fails at request time rather than at config time.
+#
+# One knob for everything:
+# ORCHESTRATOR_MODEL=claude-opus-5
+#
+# Or per stage — anything unset falls back to ORCHESTRATOR_MODEL, then the default:
+# SDLC_CODEGEN_MODEL=                  # codegen only
 # SDLC_JUDGE_MODEL=                    # the acceptance judge only
 # ORCHESTRATOR_INTAKE_MODEL=           # intent extraction + spec writing
-# SDLC_REVIEW_MODEL=                   # PR review; inherits INTAKE_MODEL if unset
+# SDLC_REVIEW_MODEL=                   # PR review
+#
+# Two things that catch people out:
+#   * SDLC_CODEGEN_MODEL falls back to ORCHESTRATOR_INTAKE_MODEL *before*
+#     ORCHESTRATOR_MODEL — deliberate, so a single-variable setup drives the whole
+#     pipeline instead of letting codegen jump provider quietly. It also means
+#     setting ORCHESTRATOR_INTAKE_MODEL moves codegen with it.
+#   * `sdlc plan --spec` makes no model call at all, so the build document is
+#     byte-identical whichever model is configured. The choice shows up only in
+#     section 10's system prompt line and section 11's cost table.
+
+# --- Ollama (local or cloud — no API key) -----------------------------------
+# OLLAMA_API_BASE makes `doctor` recognise it; LiteLLM reads it too (point at a
+# hosted URL for cloud).
+# OLLAMA_API_BASE=http://localhost:11434
+# Fully local — drives intake AND codegen:
+# ORCHESTRATOR_INTAKE_MODEL=ollama/qwen2.5-coder
+# Hybrid — local intake/review, a strong model for codegen:
+# ORCHESTRATOR_INTAKE_MODEL=ollama/llama3.3
+# SDLC_CODEGEN_MODEL=claude-opus-5
+# Codegen needs a *coder* model (qwen2.5-coder / deepseek-coder-v2); small
+# general models handle intake and review but struggle at codegen.
 
 
 # ============================================================================
-# 2. Requirements source — fill in the one(s) you read from
+# 2. Requirements sources — fill in the one(s) you read from
 # ============================================================================
 # `file://` sources (e.g. file://./spec.md) need NO credentials.
+#
+# For Atlassian, reads prefer an onboarded MCP server (section 3) when one
+# exposes the tool. The REST credentials below are the fallback for reads — and
+# the ONLY path for writes: creating issues, transitions and worklogs never go
+# through MCP.
 
-# --- Confluence (read) -----------------------------------------------------
+# --- Confluence (read) ------------------------------------------------------
 CONFLUENCE_BASE_URL=https://yourorg.atlassian.net/wiki
 CONFLUENCE_EMAIL=you@yourorg.com
 CONFLUENCE_API_TOKEN=replace-with-atlassian-api-token
 
-# --- Jira (only needed to CREATE issues; dry-run/preview needs none) -------
+# --- Jira (read, and the only path for writes) ------------------------------
 JIRA_BASE_URL=https://yourorg.atlassian.net
 JIRA_EMAIL=you@yourorg.com
 JIRA_API_TOKEN=replace-with-atlassian-api-token
 JIRA_PROJECT_KEY=ENG
+JIRA_ISSUE_TYPE=Story                  # issue type new tickets are filed as
+JIRA_EPIC_ISSUE_TYPE=Epic
 JIRA_DRY_RUN=true                      # false to write real issues
 
-# --- Notion (optional source) ----------------------------------------------
+# --- The same values under the names mcp-atlassian expects ------------------
+# The Docker image reads JIRA_URL / JIRA_USERNAME rather than the *_BASE_URL and
+# *_EMAIL pair above. Duplicate them when you run that server.
+# JIRA_URL=https://yourorg.atlassian.net
+# JIRA_USERNAME=you@yourorg.com
+# CONFLUENCE_URL=https://yourorg.atlassian.net/wiki
+# CONFLUENCE_USERNAME=you@yourorg.com
+
+# --- Notion (optional source) -----------------------------------------------
 # NOTION_API_TOKEN=secret_...
 
-# --- OpenSpec (optional, spec-driven source; https://openspec.dev) ----------
+# --- OpenSpec (optional, spec-driven; https://openspec.dev) -----------------
 # Read change proposals from openspec/changes/ as deterministic, intent-shaped
 # specs (no creds, no LLM extraction). Default root is ./openspec — override:
 # ORCHESTRATOR_OPENSPEC_ROOT=./openspec
-# Use with: orchestrator ingest --source openspec://<change-id>   (or openspec:// for all)
+# Use with: orchestrator ingest --source openspec://<change-id>
 
 
 # ============================================================================
-# 3. Target repo + GitHub auth — for `sdlc feature`/`run` that push & open PRs
+# 3. MCP — read sources through a governed server                  [OPTIONAL]
+# ============================================================================
+# Preferred over REST wherever a capable server is onboarded: credentials live
+# with the operator's server rather than in this file. `orchestrator mcp list`
+# shows what is onboarded and which tools resolve.
+#
+# Point at an mcpServers JSON file; transport is inferred (command=stdio, url=http).
+# ORCHESTRATOR_MCP_CONFIG=./mcp.json
+# Pin a server when more than one could serve the tool:
+# MCP_JIRA_SERVER=atlassian
+# MCP_CONFLUENCE_SERVER=atlassian
+# Override tool names if your server differs from the presets:
+# MCP_CONFLUENCE_PAGE_TOOL=confluence_get_page
+# MCP_CONFLUENCE_CHILDREN_TOOL=confluence_get_page_children
+#
+# Running mcp-atlassian: set TOOLSETS=all on the server itself. From v0.22.0 its
+# default narrows to six core toolsets, and a tool that quietly disappears shows
+# up here as an intake failure with no obvious cause.
+
+
+# ============================================================================
+# 4. Target repo and GitHub auth — for runs that push and open PRs
 # ============================================================================
 # SDLC_REPO_URL=https://github.com/yourorg/yourrepo.git
-# Branch an SDLC run builds on AND opens its PR into. Unset means the remote's default
-# branch — so on a repo that merges to develop, leaving this out builds the work on main.
-# `--base` overrides it per run.
+# The branch a run builds on AND opens its PR into. Unset means the remote's
+# default branch — so on a repo that merges to develop, leaving this out builds
+# the work on main. `--base` overrides it per run.
 # SDLC_PR_BASE=develop
+#
 # Simplest auth — a PAT or pre-minted token (either name works):
 # GITHUB_TOKEN=ghp_...
 # GH_TOKEN=ghp_...
+#
 # Or a GitHub App (also powers the PR reviewer webhook):
 # GITHUB_APP_ENABLED=true
 # GITHUB_APP_ID=123456
-# GITHUB_APP_WEBHOOK_SECRET=replace-with-the-app-webhook-secret
 # GITHUB_APP_PRIVATE_KEY_PATH=./github-app.pem    # or inline GITHUB_APP_PRIVATE_KEY
+# GITHUB_APP_WEBHOOK_SECRET=replace-with-the-app-webhook-secret
 # GITHUB_APP_API_BASE_URL=https://api.github.com  # override for GitHub Enterprise
 # SDLC_GITHUB_INSTALLATION_ID=12345678            # pin a specific App installation
 
 
 # ============================================================================
-# 4. Mode B — autonomous pipeline (REST API + console)               [MODE B]
+# 5. Notifications and budget                                      [OPTIONAL]
+# ============================================================================
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...   # approval-gate alerts
+# SDLC_RUN_BUDGET_USD=25                # per-run LLM spend cap; 0 disables
+
+
+# ============================================================================
+# 6. Mode B — autonomous pipeline (REST API + console)               [MODE B]
 # ============================================================================
 # The CLI uses these to reach a running orchestrator server (e.g. approvals).
 # ORCHESTRATOR_API_URL=http://localhost:8000
@@ -100,32 +171,15 @@ JIRA_DRY_RUN=true                      # false to write real issues
 
 
 # ============================================================================
-# 5. Optional — notifications, budget                              [OPTIONAL]
+# 7. Serving Spine AS an MCP server over HTTP                      [OPTIONAL]
 # ============================================================================
-# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...   # approval-gate alerts
-# SDLC_RUN_BUDGET_USD=25                # per-run LLM spend cap; 0 disables
-
-
-# ============================================================================
-# 6. MCP — consume external servers (Atlassian, DBs, …)            [OPTIONAL]
-# ============================================================================
-# Point at an mcpServers JSON file; transport is inferred (command=stdio, url=http).
-# ORCHESTRATOR_MCP_CONFIG=./mcp.json
-# Override Confluence-via-MCP tool names if your server differs:
-# MCP_CONFLUENCE_SERVER=confluence
-# MCP_CONFLUENCE_PAGE_TOOL=confluence_get_page
-# MCP_CONFLUENCE_CHILDREN_TOOL=confluence_get_page_children
-
-
-# ============================================================================
-# 7. Remote MCP plugin server (Phase C: `orchestrator-mcp --http`) [OPTIONAL]
-# ============================================================================
-# Only when serving the orchestrator AS an MCP server over the network (hosted
-# Codex app / claude.ai). The local stdio plugin (`orchestrator-mcp`) needs none.
+# Only when exposing the orchestrator to a hosted Codex app or claude.ai
+# (`orchestrator-mcp --http`). The local stdio plugin needs none of this.
 # ORCHESTRATOR_MCP_HOST=0.0.0.0
 # ORCHESTRATOR_MCP_PORT=8080
 # ORCHESTRATOR_MCP_PATH=/mcp
 # ORCHESTRATOR_MCP_RESOURCE_URL=https://mcp.yourorg.com   # this server's public URL
+#
 # Auth — pick ONE:
 #  (a) static shared secret (single-tenant self-host behind TLS):
 # ORCHESTRATOR_MCP_TOKEN=replace-with-a-long-random-secret


### PR DESCRIPTION
Same seven sections, reordered so the file follows the order someone actually configures things in: provider and models → sources → MCP → target repo → notifications → Mode B → serving Spine as an MCP server. `.env` and `.env.example` now share a section skeleton, so the two diff cleanly against each other.

**Seven variables gain documentation they never had**, all already in use: `JIRA_ISSUE_TYPE`, `JIRA_EPIC_ISSUE_TYPE`, `MCP_JIRA_SERVER`, and the four aliases the `mcp-atlassian` image expects — it reads `JIRA_URL` / `JIRA_USERNAME` rather than the `*_BASE_URL` and `*_EMAIL` pair, which is a duplication nobody guesses.

**Three things the file was silent about**, each costing a debugging session rather than a re-read:

- **MCP is preferred for reads and is not a path for writes.** `JiraAdapter` is REST-only, so creating issues, transitions and worklogs bypass MCP entirely. An MCP-only setup reads tickets fine and silently cannot file one — discovered at the moment a `--live` run tries.
- **Set `TOOLSETS=all` on mcp-atlassian.** From v0.22.0 its default narrows to six core toolsets; a tool that disappears surfaces here as an intake failure with no visible cause.
- **Model resolution in full**, including that `SDLC_CODEGEN_MODEL` falls back to `ORCHESTRATOR_INTAKE_MODEL` *before* `ORCHESTRATOR_MODEL` — deliberate, but it means setting the intake variable moves codegen with it. And that `sdlc plan --spec` makes no model call at all, so the build document is byte-identical whichever model is configured.

**No documented variable was dropped** — verified by diffing the variable names against `HEAD:.env.example`.

Docs only; one file changed. No version bump — 3.16.0 is already published, and this ships with whatever release comes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)