### PR TITLE
fix(sdlc): a check that cannot apply is not a check the ticket failed

### DIFF
--- a/src/orchestrator/sdlc/builddoc.py
+++ b/src/orchestrator/sdlc/builddoc.py
@@ -415,47 +415,66 @@ def _confidence_block(
         "| what the plan established | reading | weight |",
         "|---|---|---|",
     ]
+    # A check that cannot apply to this ticket is not a check this ticket failed. Root
+    # cause is the case: a feature has none to establish, and scoring its absence capped
+    # every enhancement a point below every bug while telling the reader nothing.
+    # ``applies`` drops such a row out of the denominator instead.
     score = 0
-    for label, ok, good, bad in (
+    possible = 0
+    for label, applies, ok, good, bad, na in (
         (
             "Validity gate",
+            True,
             signals.get("verdict") == "PROCEED",
             "PROCEED — nothing contradicts the code",
             f"{signals.get('verdict') or 'unknown'} — the ticket disagrees with the code",
+            "",
         ),
         (
             "Where it lands",
+            True,
             bool(signals.get("brief_agrees")),
             "the brief and the design name the same files",
             "the brief names none of the files being changed",
+            "",
         ),
         (
             "Root cause",
+            bool(signals.get("root_cause")),
             bool(signals.get("fault_site")),
             "localized to a symbol",
             "a file at best — no line established",
+            "nothing to localize — not a bug, so nothing is owed",
         ),
         (
             "Named paths",
+            True,
             not signals.get("unverified"),
             "every path the design names is in the graph",
             "the design names paths the graph has never seen",
+            "",
         ),
         (
             "Context budget",
+            True,
             not signals.get("over_budget"),
             "the named files fit the window whole",
             "over budget — codegen will excerpt",
+            "",
         ),
     ):
+        if not applies:
+            rows.append(f"| {label} | {na} | n/a |")
+            continue
+        possible += 1
         score += 1 if ok else 0
         rows.append(f"| {label} | {good if ok else bad} | {'+' if ok else '−'} |")
 
-    band = "high" if score >= 5 else "medium" if score >= 3 else "low"
+    band = "high" if score == possible else "medium" if score * 2 >= possible else "low"
     out = [
-        f"**Is the analysis right? — {band}** ({score} of 5 checks positive). "
-        "A band, not a percentage: nothing here measures correctness, only how much the "
-        "plan managed to establish.\n",
+        f"**Is the analysis right? — {band}** ({score} of {possible} applicable checks "
+        "positive). A band, not a percentage: nothing here measures correctness, only how "
+        "much the plan managed to establish.\n",
         "\n".join(rows) + "\n",
     ]
 
@@ -1050,6 +1069,8 @@ def render_build_md(
             signals={
                 "verdict": getattr(raw_verdict, "value", raw_verdict),
                 "brief_agrees": bool(agreed),
+                # Whether section 3 rendered at all — not whether it localized well.
+                "root_cause": bool(root_cause),
                 "fault_site": bool(getattr(rca, "fault_site", "")),
                 "unverified": bool(blast.get("unverified_references")),
                 "over_budget": carried > context_budget,

--- a/tests/sdlc/test_builddoc.py
+++ b/tests/sdlc/test_builddoc.py
@@ -698,7 +698,7 @@ def test_a_plan_that_established_everything_scores_high(tmp_path: Path) -> None:
         validity=_Assessment(Verdict.PROCEED),
         rca=_RCA(fault_site="f at src/a.py:10"),
     )
-    assert "**Is the analysis right? — high** (5 of 5" in md
+    assert "**Is the analysis right? — high** (5 of 5 applicable checks" in md
 
 
 def test_a_plan_that_established_little_scores_low(tmp_path: Path) -> None:
@@ -715,7 +715,19 @@ def test_a_plan_that_established_little_scores_low(tmp_path: Path) -> None:
             }
         ),
     )
-    assert re.search(r"\*\*Is the analysis right\? — low\*\* \([012] of 5", md)
+    assert re.search(r"\*\*Is the analysis right\? — low\*\* \([012] of \d applicable", md)
+
+
+def test_a_feature_is_not_docked_for_having_no_root_cause(tmp_path: Path) -> None:
+    """A check that cannot apply is not a check this ticket failed.
+
+    Scoring an omitted section 3 as a failure capped every enhancement a point below
+    every bug, and said "a file at best" about a ticket that named no file at all.
+    """
+    md = _render(tmp_path, rca=_RCA(exception="", fault_module="", hypotheses=[]))
+    assert "| Root cause | nothing to localize — not a bug, so nothing is owed | n/a |" in md
+    assert "of 4 applicable checks" in md
+    assert "a file at best" not in md
 
 
 def test_the_completion_number_is_a_base_rate_not_a_guess(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3726,7 +3726,7 @@ wheels = [
 
 [[package]]
 name = "synaptixs-spine"
-version = "3.15.0"
+version = "3.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
Section 12 scored **"Root cause: a file at best — no line established"** as a negative for every *feature* ticket. A feature has no root cause to establish, so this capped every enhancement one point below every bug while telling the reader nothing about either. The wording was also false where it mattered: section 3 said *"no exception and no file named"*, while the confidence table asserted a file had been named.

```
before   | Root cause | a file at best — no line established            | − |   3 of 5
after    | Root cause | nothing to localize — not a bug, nothing is owed | n/a |  3 of 4
```

Rows now carry whether they apply. One that does not renders `n/a` and drops out of the denominator instead of scoring zero, so an enhancement reads "3 of 4 applicable checks" against a bug's "3 of 5" and the two are comparable. The band compares against what was possible rather than a hardcoded five. A bug is unaffected — SSPN-49 still scores 3 of 5 with its real `−`.

**Found by running the command against a real enhancement rather than a fixture.** The feature path had only ever been exercised by tests, which is exactly where a wrong denominator hides: every fixture asserted the number it already produced.

Nothing about derivation changes — same graph queries, same sections, same digest inputs. The document body does change, so approvals made before this go stale. That is the gate working as designed rather than a side effect to route around.

Also picks up a stale `uv.lock` — the pre-commit hook rebuilt the editable install and refreshed `synaptixs-spine` from 3.15.0 to 3.16.0, which the release commit had not touched.

Tests: one new (`test_a_feature_is_not_docked_for_having_no_root_cause`, asserting the `n/a` row, the `of 4` denominator, and that the false phrase is gone), two updated for the new wording. Full suite 2617 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)