### PR TITLE
feat(plugin): the build document as an MCP tool, for a host that owns the model

### DIFF
--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -189,6 +189,9 @@ At a glance:
 | [`read_memory_bank`](#read_memory_bank) | Read a repo's committed `episteme/` (code‑true project knowledge). | no |
 | [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
 | [`ingest_preview`](#ingest_preview) | Preview the backlog (derived intents + gaps) for a requirements source — dry‑run. | no |
+| **Plan it, then decide — before anything is built** | | |
+| [`sdlc_plan`](#sdlc_plan) | **The build document.** Twelve grounded sections for one ticket: requirement, intent, root cause, what the graph knows, blast radius, design, files, acceptance criteria, the codegen prompt, cost and confidence — each labelled with where it came from. **No model, no credentials, nothing spent.** | `.spine/` |
+| [`sdlc_approve`](#sdlc_approve) | Record that a **human** read that document and decided. Binds to a digest of it, so a plan that changes afterwards reads as *stale* rather than still approved. | `.spine/` |
 | [`sdlc_feature`](#sdlc_feature) | **Ship it.** One intent end‑to‑end: spec → grounded codegen → tests → branch → *(optionally)* PR. | gated |
 | [`sdlc_start_run` + gate tools](#the-autonomous-run-sdlc_start_run--friends) | Drive the long, autonomous, gated run as a job (needs the Mode‑B backend). | gated |
 
@@ -297,10 +300,72 @@ Spine derives and any gaps, before running a feature.
 
 ---
 
+#### `sdlc_plan`
+
+**The build document for one ticket, before anything is built.** Twelve sections in fixed
+order, each labelled with where it came from — quoted from the ticket, computed from the
+graph, inferred by a model, or decided by a person. **No model call, no credentials,
+nothing spent.**
+
+```jsonc
+// tool: sdlc_plan
+{
+  "repo_path": ".",                  // local path or git URL
+  "spec": {
+    "intent_id": "PROJ-14",
+    "title": "CLI crashes when the registry API is down",
+    "summary": "Quote the actual error and name the real files — the root-cause section
+                reads an exception named anywhere here, and a path the graph knows becomes
+                the fault module.",
+    "acceptance_criteria": ["…one independently checkable statement per entry…"],
+    "met_criteria": {
+      "Any other non-success HTTP status surfaces the status code…":
+        "src/orchestrator/cli.py:134 — _check() already does this"
+    }
+  }
+}
+```
+
+**Returns** the rendered `document` **and** the `path` it was persisted to
+(`.spine/plans/<INTENT>-build.md`), plus `superseded` when it replaced an older version.
+
+**A spec it cannot validate is refused**, with the specific problem and the valid field
+names — so if you drafted the spec, read the error and fix it rather than working around it.
+
+> **`met_criteria` is the field worth your attention.** It maps a stated criterion to the
+> evidence that existing code *already satisfies it*. No deterministic pass can make that
+> call — but you can: read the ticket, then check with `explain_symbol` or `blast_radius`
+> before filling it in. On the ticket this was built from, two of six criteria described
+> behaviour that already existed, and a run would have reported them met having changed
+> nothing. That is the single most valuable thing you can add to a plan.
+
+**Where this matters most:** a machine with no model API key. You have the model and the
+tracker credentials; Spine has the graph. Read the ticket yourself, draft the spec, and call
+this — the document comes back grounded, and Spine never needed a key.
+
+#### `sdlc_approve`
+
+Records that a **human** read the document and decided. Binds to a digest of it, so a plan
+that changes afterwards reads as *stale* rather than still approved, and `sdlc autorun`
+refuses to build without a current one.
+
+```jsonc
+// tool: sdlc_approve
+{ "repo_path": ".", "intent_id": "PROJ-14", "decided_by": "alice", "note": "why" }
+// add "reject": true to record a rejection instead
+```
+
+**Do not call this on the user's behalf without being asked.** It records a human decision;
+`decided_by` defaults to the repo's git identity, and the tool refuses rather than inventing
+an approver when it cannot tell who decided.
+
+---
+
 #### `sdlc_feature`
 
 **The main tool** — builds one intent end to end. Safe by default (local branch + diff, no
-external writes). Parameters:
+external writes). **Prefer `sdlc_plan` first**: it costs nothing, and it is the only way the
+user sees what would be built before the money is spent. Parameters:
 
 | Param | Meaning |
 |---|---|
@@ -495,6 +560,22 @@ generates code that fits, runs the repo's tests, and commits locally — no push
 ---
 
 ## 9. Safe vs. live (the write gate)
+
+**Three tiers, separated by what a tool costs you if it is wrong** — work down them, never up.
+
+| Tier | Tools | Costs | Writes |
+|---|---|---|---|
+| **Comprehend** | `map_repo`, `blast_radius`, `investigate`, `localize`, `root_cause`, … | nothing | nothing |
+| **Plan and decide** | `sdlc_plan`, `sdlc_approve` | nothing | `.spine/` only |
+| **Build** — *gated* | `sdlc_feature`, `sdlc_start_run` + gate tools | **real money, every call** | local, or a PR with `live=true` |
+
+**"Gated" means two separate things.** It spends: every call drives a model through codegen,
+tests and review, and a failed run costs what a successful one costs. And with `live=true` it
+writes where you cannot take it back — a tracker issue, a pushed branch, an open PR.
+
+**Safe mode still costs tokens.** `live=false` keeps every write local; it does not make the
+run free. The tier above it — `sdlc_plan` — is the one that costs nothing at all, which is
+why it belongs before anything is built rather than after.
 
 Spine is **safe by default**. `sdlc_feature` with `live` unset only ever creates a *local*
 branch, commits, and shows a diff — **no external writes**, Jira runs dry.

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -174,6 +174,9 @@ At a glance:
 | [`read_memory_bank`](#read_memory_bank) | Read a repo's committed `episteme/` (code‑true project knowledge). | no |
 | [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
 | [`ingest_preview`](#ingest_preview) | Preview the backlog (derived intents + gaps) for a requirements source — dry‑run. | no |
+| **Plan it, then decide — before anything is built** | | |
+| [`sdlc_plan`](#sdlc_plan) | **The build document.** Twelve grounded sections for one ticket: requirement, intent, root cause, what the graph knows, blast radius, design, files, acceptance criteria, the codegen prompt, cost and confidence — each labelled with where it came from. **No model, no credentials, nothing spent.** | `.spine/` |
+| [`sdlc_approve`](#sdlc_approve) | Record that a **human** read that document and decided. Binds to a digest of it, so a plan that changes afterwards reads as *stale* rather than still approved. | `.spine/` |
 | [`sdlc_feature`](#sdlc_feature) | **Ship it.** One intent end‑to‑end: spec → grounded codegen → tests → branch → *(optionally)* PR. | gated |
 | [`sdlc_start_run` + gate tools](#the-autonomous-run-sdlc_start_run--friends) | Drive the long, autonomous, gated run as a job (needs the Mode‑B backend). | gated |
 
@@ -263,10 +266,70 @@ Spine derives and any gaps, before running a feature.
 
 ---
 
+#### `sdlc_plan`
+
+**The build document for one ticket, before anything is built.** Twelve sections in fixed
+order, each labelled with where it came from — quoted from the ticket, computed from the
+graph, inferred by a model, or decided by a person. **No model call, no credentials,
+nothing spent.**
+
+```jsonc
+// tool: sdlc_plan
+{
+  "repo_path": ".",                  // local path or git URL
+  "spec": {
+    "intent_id": "PROJ-14",
+    "title": "CLI crashes when the registry API is down",
+    "summary": "Quote the actual error and name the real files — the root-cause section
+                reads an exception named anywhere here, and a path the graph knows becomes
+                the fault module.",
+    "acceptance_criteria": ["…one independently checkable statement per entry…"],
+    "met_criteria": {
+      "Any other non-success HTTP status surfaces the status code…":
+        "src/orchestrator/cli.py:134 — _check() already does this"
+    }
+  }
+}
+```
+
+**Returns** the rendered `document` **and** the `path` it was persisted to
+(`.spine/plans/<INTENT>-build.md`). **A spec it cannot validate is refused**, with the
+specific problem and the valid field names.
+
+> **This is the tool for a machine with no model API key.** Codex has the model and — through
+> its own onboarded `mcp-atlassian` server — the tracker credentials, including enterprise
+> Jira behind a personal access token that Spine's own adapter cannot speak to. Read the
+> ticket yourself, draft the spec, call this. The document comes back grounded in the repo's
+> real graph, and Spine never needed a key of its own.
+
+> **`met_criteria` is the field worth your attention.** It maps a stated criterion to the
+> evidence that existing code *already satisfies it*. No deterministic pass can make that
+> call — but you can: read the ticket, then check with `explain_symbol` or `blast_radius`
+> before filling it in. On the ticket this was built from, two of six criteria described
+> behaviour that already existed, and a run would have reported them met having changed
+> nothing.
+
+#### `sdlc_approve`
+
+Records that a **human** read the document and decided. Binds to a digest of it, so a plan
+that changes afterwards reads as *stale* rather than still approved.
+
+```jsonc
+// tool: sdlc_approve
+{ "repo_path": ".", "intent_id": "PROJ-14", "decided_by": "alice", "note": "why" }
+// add "reject": true to record a rejection instead
+```
+
+**Do not call this on the user's behalf without being asked.** It records a human decision,
+and the tool refuses rather than inventing an approver when it cannot tell who decided.
+
+---
+
 #### `sdlc_feature`
 
 **The main tool** — builds one intent end to end. Safe by default (local branch + diff, no
-external writes). Parameters:
+external writes). **Prefer `sdlc_plan` first**: it costs nothing, and it is the only way the
+user sees what would be built before the money is spent. Parameters:
 
 | Param | Meaning |
 |---|---|
@@ -461,6 +524,22 @@ generates code that fits, runs the repo's tests, and commits locally — no push
 ---
 
 ## 9. Safe vs. live (the write gate)
+
+**Three tiers, separated by what a tool costs you if it is wrong** — work down them, never up.
+
+| Tier | Tools | Costs | Writes |
+|---|---|---|---|
+| **Comprehend** | `map_repo`, `blast_radius`, `investigate`, `localize`, `root_cause`, … | nothing | nothing |
+| **Plan and decide** | `sdlc_plan`, `sdlc_approve` | nothing | `.spine/` only |
+| **Build** — *gated* | `sdlc_feature`, `sdlc_start_run` + gate tools | **real money, every call** | local, or a PR with `live=true` |
+
+**"Gated" means two separate things.** It spends: every call drives a model through codegen,
+tests and review, and a failed run costs what a successful one costs. And with `live=true` it
+writes where you cannot take it back — a tracker issue, a pushed branch, an open PR.
+
+**Safe mode still costs tokens.** `live=false` keeps every write local; it does not make the
+run free. The tier above it — `sdlc_plan` — is the one that costs nothing at all, which is
+why it belongs before anything is built rather than after.
 
 Spine is **safe by default**. `sdlc_feature` with `live` unset only ever creates a *local*
 branch, commits, and shows a diff — **no external writes**, Jira runs dry.

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -468,6 +468,60 @@ async def sdlc_plan(repo_path: str, spec: dict[str, Any], persist_plan: bool = T
         return {"error": str(exc)}
 
 
+def sdlc_approve(
+    repo_path: str,
+    intent_id: str,
+    decided_by: str = "",
+    note: str = "",
+    reject: bool = False,
+) -> dict[str, Any]:
+    """Record that a **human** read a build document and decided. Binds the decision to a
+    digest of the document body, so a plan that changes afterwards reads as *stale* rather
+    than silently still approved — and `sdlc autorun` refuses to build without a current one.
+    Needs `sdlc_plan` to have produced the document first. ``decided_by`` defaults to the
+    repo's git identity; a decision nobody is named for is not recorded."""
+    import datetime as _dt
+
+    from orchestrator.sdlc.builddoc import (
+        PlanApproval,
+        decided_by_default,
+        derived_at,
+        plan_digest,
+        plan_dir,
+        save_approval,
+    )
+
+    def run(repo: Any) -> dict[str, Any]:
+        document = plan_dir(repo) / f"{intent_id}-build.md"
+        if not document.is_file():
+            return {
+                "error": f"no plan at {document} — run sdlc_plan for {intent_id} first",
+            }
+        # The tool cannot invent an approver. A host may know who its user is, but this
+        # process does not, and an approval attributed to nobody is a rumour.
+        who = decided_by or decided_by_default(repo)
+        if not who:
+            return {"error": "cannot tell who is approving — pass decided_by"}
+        approval = PlanApproval(
+            intent_id=intent_id,
+            decision="REJECTED" if reject else "APPROVED",
+            decided_by=who,
+            decided_at=_dt.date.today().isoformat(),
+            digest=plan_digest(document.read_text(encoding="utf-8")),
+            commit=derived_at(repo),
+            note=note,
+        )
+        return {
+            "intent_id": intent_id,
+            "decision": approval.decision,
+            "decided_by": who,
+            "decided_at": approval.decided_at,
+            "path": str(save_approval(approval, root=repo)),
+        }
+
+    return _in_repo(repo_path, run)
+
+
 def docs_for(repo_path: str, symbol: str = "") -> dict[str, Any]:
     """Which docs describe the code — the doc-ingestion surface. With a ``symbol``, the doc pages
     that **MENTION** it (grounded to the repo's docs). Without one, a doc-coverage summary: how many
@@ -619,6 +673,7 @@ _TOOLS = (
     regression_gaps,
     root_cause,
     sdlc_plan,
+    sdlc_approve,
     docs_for,
     # gated codegen / run control
     sdlc_feature,

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -5,16 +5,36 @@ here the orchestrator is the server, so Claude Code / Codex / Claude Desktop can
 call its capabilities as tools. The MCP server is a thin façade — each tool runs
 the real engine (intake, PKG grounding, readiness).
 
-Two tiers of tools. **Read-only comprehension** (no writes) — ``doctor``, ``pkg_grounding``,
-``read_memory_bank``, ``ingest_preview`` (dry-run), and the graph-query set ``map_repo`` /
-``blast_radius`` / ``explain_symbol`` / ``investigate`` / ``localize`` / ``regression_gaps`` /
-``root_cause`` — hands an assistant Spine's *engineering decisions* (what breaks, what's
-untested, where a change lands) with ``file:line`` provenance. All deterministic + no
-credentials, except ``root_cause``'s opt-in ``use_llm`` enrichment. The graph-query tools take
-a local path **or a git URL** (shallow-cloned behind the CLI's SSRF/host-allow-list guard). The
-heavy **gated ``sdlc``** run (real writes → PR) is the second tier. Tool *implementations* are
-module-level functions (unit-testable without the ``mcp`` extra); ``build_server`` lazy-imports
-``FastMCP`` and registers them.
+**Three tiers, separated by what a tool can cost you if it is wrong.**
+
+**1. Read-only comprehension** — ``doctor``, ``pkg_grounding``, ``read_memory_bank``,
+``ingest_preview`` (dry-run), and the graph-query set ``map_repo`` / ``blast_radius`` /
+``explain_symbol`` / ``investigate`` / ``localize`` / ``regression_gaps`` / ``root_cause``.
+Hands an assistant Spine's *engineering decisions* (what breaks, what's untested, where a
+change lands) with ``file:line`` provenance. Deterministic, no credentials — except
+``root_cause``'s opt-in ``use_llm`` enrichment. These take a local path **or a git URL**
+(shallow-cloned behind the CLI's SSRF/host-allow-list guard).
+
+**2. Plan and decide** — ``sdlc_plan`` and ``sdlc_approve``. These *write*, but only under
+``.spine/`` in the repo, and they still need no model and no credentials: ``build_plan``
+passes ``llm=None`` throughout, so the twelve-section document is rendered from the graph,
+git and the tree alone. That property is the point of this tier rather than an accident of
+it — it is what lets a host with its own model and its own tracker credentials drive Spine
+on a machine where Spine itself has neither.
+
+**3. The gated ``sdlc`` run** — ``sdlc_feature`` and the ``sdlc_start_run`` / ``_status`` /
+``_decide_gate`` / ``_result`` set. **Gated means two things, and both matter.** It spends
+real money: every call drives a model through codegen, tests and review. And with
+``live=true`` it writes where you cannot take it back — a tracker issue, a pushed branch, an
+open PR — which is why ``live`` additionally requires ``confirm=true``, an explicit human
+authorization on top of whatever confirmation the host already asks for. Safe mode
+(``live=false``) still costs tokens; it just keeps every write local.
+
+An assistant should work down the tiers, not up: comprehend, then plan and get the plan
+approved, then build. A run that starts at tier 3 is one nobody reviewed.
+
+Tool *implementations* are module-level functions (unit-testable without the ``mcp``
+extra); ``build_server`` lazy-imports ``FastMCP`` and registers them.
 """
 
 from __future__ import annotations

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -418,6 +418,56 @@ async def root_cause(repo_path: str, bug: str, use_llm: bool = False) -> dict[st
     }
 
 
+async def sdlc_plan(repo_path: str, spec: dict[str, Any], persist_plan: bool = True) -> dict[str, Any]:
+    """The twelve-section **build document** for one ticket: requirement, intent, root cause,
+    what the graph knows, blast radius, design, files, acceptance criteria, the codegen prompt,
+    cost and confidence. **Deterministic — no LLM, no credentials, nothing spent.** Every
+    section says where it came from. Hand it a ``spec`` object (title, summary,
+    acceptance_criteria, and optionally met_criteria mapping a criterion already satisfied by
+    existing code to the evidence). Stops at the document — it never changes code."""
+    from orchestrator.intake.specs import FeatureSpec
+    from orchestrator.sdlc.spec_file import SpecFileError, validate_spec
+
+    if not isinstance(spec, dict):
+        return {"error": f"spec must be an object, got {type(spec).__name__}"}
+    try:
+        # The same validator the CLI uses. A host's model drafts this spec, and
+        # ``FeatureSpec`` forbids extra keys — so an invented field is refused here, naming
+        # the valid ones, rather than rendering a document from a spec that is wrong.
+        resolved = validate_spec(spec, where="spec")
+    except SpecFileError as exc:
+        # Returned rather than raised: the caller is a model that can read this and fix the
+        # spec, which a stack trace on the host's side does not let it do.
+        return {"error": str(exc), "valid_fields": sorted(FeatureSpec.model_fields)}
+
+    from orchestrator.sdlc.builddoc import build_plan, load_approval, load_journey, persist
+
+    intent = str(resolved.get("intent_id") or "spec")
+
+    async def run(repo: Any) -> dict[str, Any]:
+        document = await build_plan(
+            resolved,
+            root=repo,
+            approval=load_approval(intent, root=repo),
+            journey=load_journey(intent, root=repo),
+        )
+        out: dict[str, Any] = {"intent_id": intent, "document": document}
+        if persist_plan:
+            written, superseded = persist(document, intent_id=intent, root=repo)
+            out["path"] = str(written)
+            if superseded is not None:
+                out["superseded"] = str(superseded)
+        return out
+
+    from orchestrator.registry.api.workspace import RepoPathError, RepoSourceError
+
+    try:
+        with _open_repo(repo_path) as repo:
+            return await run(repo)
+    except (RepoSourceError, RepoPathError) as exc:
+        return {"error": str(exc)}
+
+
 def docs_for(repo_path: str, symbol: str = "") -> dict[str, Any]:
     """Which docs describe the code — the doc-ingestion surface. With a ``symbol``, the doc pages
     that **MENTION** it (grounded to the repo's docs). Without one, a doc-coverage summary: how many
@@ -568,6 +618,7 @@ _TOOLS = (
     localize,
     regression_gaps,
     root_cause,
+    sdlc_plan,
     docs_for,
     # gated codegen / run control
     sdlc_feature,

--- a/src/orchestrator/sdlc/spec_file.py
+++ b/src/orchestrator/sdlc/spec_file.py
@@ -54,23 +54,36 @@ def load_spec_file(path: Path | str) -> dict[str, Any]:
         raise SpecFileError(f"{p} must contain a JSON object, got {type(payload).__name__}")
 
     payload.setdefault("intent_id", p.stem)
+    return validate_spec(payload, where=str(p))
+
+
+def validate_spec(payload: dict[str, Any], *, where: str = "spec") -> dict[str, Any]:
+    """Validate a spec **already parsed** and return the dict the pipeline expects.
+
+    Split out from :func:`load_spec_file` so every surface that accepts a spec validates
+    it the same way. The plugin takes one from a host's model rather than from disk, and a
+    second validator would eventually disagree with this one about what a spec is.
+
+    ``where`` names the thing being validated in the error, since the caller may have no
+    file to point at.
+    """
     try:
         spec = FeatureSpec.model_validate(payload)
     except Exception as exc:  # pydantic ValidationError — reported, not re-raised raw
-        raise SpecFileError(f"{p} is not a valid spec:\n{exc}") from exc
+        raise SpecFileError(f"{where} is not a valid spec:\n{exc}") from exc
 
     if not spec.title.strip():
-        raise SpecFileError(f"{p}: 'title' is required and cannot be empty")
+        raise SpecFileError(f"{where}: 'title' is required and cannot be empty")
     if not spec.acceptance_criteria:
         # Not fatal upstream, but a spec with nothing to satisfy gives the judge
         # nothing to judge — the run would report success having proved nothing.
         # 'proposed_criteria' deliberately doesn't count: unsourced criteria are
         # suggestions, not a contract to pass a run against.
         raise SpecFileError(
-            f"{p}: 'acceptance_criteria' is empty — there would be nothing for the "
+            f"{where}: 'acceptance_criteria' is empty — there would be nothing for the "
             "acceptance judge to verify, and the run would pass by default."
         )
     return spec.model_dump()
 
 
-__all__ = ["SpecFileError", "load_spec_file"]
+__all__ = ["SpecFileError", "load_spec_file", "validate_spec"]

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -531,3 +531,54 @@ def test_sdlc_plan_is_registered() -> None:
     from orchestrator.plugin.server import _TOOLS, sdlc_plan
 
     assert sdlc_plan in _TOOLS
+
+
+# ---- sdlc_approve: the gate, non-interactively -----------------------------
+
+
+async def test_approving_binds_the_decision_to_the_document(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import sdlc_approve, sdlc_plan
+
+    repo = _tiny_repo(tmp_path)
+    await sdlc_plan(str(repo), _plan_spec())
+
+    result = sdlc_approve(str(repo), "TCK-9", decided_by="falcon", note="read it")
+
+    assert result["decision"] == "APPROVED" and result["decided_by"] == "falcon"
+    after = await sdlc_plan(str(repo), _plan_spec())
+    assert "**approved** by falcon" in after["document"]
+
+
+async def test_a_rejection_says_who_and_why(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import sdlc_approve, sdlc_plan
+
+    repo = _tiny_repo(tmp_path)
+    await sdlc_plan(str(repo), _plan_spec())
+
+    sdlc_approve(str(repo), "TCK-9", decided_by="falcon", note="wrong files", reject=True)
+
+    after = await sdlc_plan(str(repo), _plan_spec())
+    assert "**rejected** by falcon" in after["document"] and "wrong files" in after["document"]
+
+
+def test_approving_a_plan_that_does_not_exist_is_refused(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import sdlc_approve
+
+    result = sdlc_approve(str(_tiny_repo(tmp_path)), "TCK-9", decided_by="falcon")
+
+    assert "no plan at" in result["error"]
+
+
+async def test_an_approval_nobody_is_named_for_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A host may know its user; this process does not, and must not invent one."""
+    from orchestrator.plugin import server as mod
+    from orchestrator.plugin.server import sdlc_approve, sdlc_plan
+
+    repo = _tiny_repo(tmp_path)
+    await sdlc_plan(str(repo), _plan_spec())
+    monkeypatch.setattr("orchestrator.sdlc.builddoc.decided_by_default", lambda _root="": "")
+
+    assert "cannot tell who is approving" in sdlc_approve(str(repo), "TCK-9")["error"]
+    assert mod.sdlc_approve in mod._TOOLS

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -429,3 +429,105 @@ async def test_plugin_serves_tools_over_stdio() -> None:
         } <= {t.name for t in tools.tools}
         result = await session.call_tool("doctor", {})
         assert result.is_error is False
+
+
+# ---- sdlc_plan: the build document, for a host that has the model ----------
+
+
+def _plan_spec(**over: Any) -> dict[str, Any]:
+    spec = {
+        "intent_id": "TCK-9",
+        "title": "A ticket",
+        "summary": "Something is broken in src/a.py.",
+        "acceptance_criteria": ["It stops crashing."],
+    }
+    spec.update(over)
+    return spec
+
+
+def _tiny_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "a.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    return repo
+
+
+async def test_sdlc_plan_returns_the_document_and_where_it_was_written(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import sdlc_plan
+
+    result = await sdlc_plan(str(_tiny_repo(tmp_path)), _plan_spec())
+
+    assert result["document"].startswith("# TCK-9 — build document")
+    assert result["document"].count("\n## ") >= 12
+    assert Path(result["path"]).is_file()
+
+
+async def test_sdlc_plan_needs_no_model_and_no_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point on a machine whose only model lives in the host app."""
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "ORCHESTRATOR_MODEL", "JIRA_API_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    from orchestrator.plugin.server import sdlc_plan
+
+    result = await sdlc_plan(str(_tiny_repo(tmp_path)), _plan_spec())
+
+    assert "error" not in result
+    assert "## 12. Confidence" in result["document"]
+
+
+async def test_an_invented_field_is_refused_with_the_valid_ones(tmp_path: Path) -> None:
+    """A host's model drafts this spec; a key it made up must not render a document."""
+    from orchestrator.plugin.server import sdlc_plan
+
+    result = await sdlc_plan(str(_tiny_repo(tmp_path)), _plan_spec(notes="invented"))
+
+    assert "document" not in result
+    assert "notes" in result["error"]
+    assert "acceptance_criteria" in result["valid_fields"]
+
+
+async def test_a_spec_with_nothing_to_satisfy_is_refused(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import sdlc_plan
+
+    result = await sdlc_plan(str(_tiny_repo(tmp_path)), _plan_spec(acceptance_criteria=[]))
+
+    assert "nothing for the acceptance judge" in result["error"]
+
+
+async def test_persist_can_be_turned_off(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import sdlc_plan
+    from orchestrator.sdlc.builddoc import plan_dir
+
+    repo = _tiny_repo(tmp_path)
+    result = await sdlc_plan(str(repo), _plan_spec(), persist_plan=False)
+
+    assert "path" not in result and result["document"]
+    assert not plan_dir(repo).exists()
+
+
+async def test_a_bad_repo_path_is_reported_not_raised(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import sdlc_plan
+
+    result = await sdlc_plan(str(tmp_path / "nope"), _plan_spec())
+
+    assert "error" in result and "document" not in result
+
+
+async def test_the_plugin_and_the_cli_render_the_same_document(tmp_path: Path) -> None:
+    """Two surfaces over one renderer must not be able to disagree."""
+    from orchestrator.plugin.server import sdlc_plan
+    from orchestrator.sdlc.builddoc import build_plan
+
+    repo = _tiny_repo(tmp_path)
+    spec = _plan_spec()
+    via_tool = await sdlc_plan(str(repo), spec, persist_plan=False)
+    via_cli = await build_plan(spec, root=repo)
+
+    assert via_tool["document"] == via_cli
+
+
+def test_sdlc_plan_is_registered() -> None:
+    from orchestrator.plugin.server import _TOOLS, sdlc_plan
+
+    assert sdlc_plan in _TOOLS

--- a/uv.lock
+++ b/uv.lock
@@ -3726,7 +3726,7 @@ wheels = [
 
 [[package]]
 name = "synaptixs-spine"
-version = "3.16.0"
+version = "3.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
On an enterprise machine there is no model API key — the only model lives in the Codex app — and enterprise Jira is reachable only through an onboarded `mcp-atlassian` server using a personal access token. That machine could not produce a build document: the `--source` path needs a model for intake, and Spine's Jira adapter speaks Cloud v3 rather than Server/DC personal-token auth.

**The answer is not to teach Spine to reach that Jira.** It is to invert the dependency.

```
Codex  ──mcp-atlassian (PAT)──▶  enterprise Jira      ← the host's credentials
Codex  ──its own model───────▶  drafts the spec       ← the host's model, no API key
Codex  ──synaptixs-spine─────▶  sdlc_plan(repo, spec) ← deterministic, no key at all
```

`build_plan` was already free of both — it passes `llm=None` to design and RCA — so exposing it costs a wrapper. The spec is the interface between the two halves.

Planned first: the build document for this change is [`SSPN-51`](docs/specs/build-documents), produced by the tool it describes. It found that **one of five criteria was already met** — the no-credentials property is inherited from `build_plan`, not established here — and flagged that its own investigation brief named none of the files being changed.

## Three commits

**`42ad19c` — `sdlc_plan`.** Returns both the document and the path it was persisted to. Validation reuses one validator: `validate_spec` is split out of `load_spec_file` rather than written twice, because two validators eventually disagree about what a spec is. **The refusal is returned, not raised** — the caller is a model that can read the error and fix the spec, and it carries the valid field names for that reason. A test asserts the tool and the CLI render byte-identical documents for the same spec and commit.

**`01cab25` — `sdlc_approve`.** Separate commit because the build document lists it as *proposed* rather than *stated*: inferred from the ticket, not asked for by it. Without it a host can produce plans it can never approve. It **refuses to invent an approver** — a host may know its user, this process does not, and an approval attributed to nobody is a rumour.

**`0472ce9` — docs.** The module docstring said "two tiers" and left *gated* to speak for itself, which reads as "needs confirmation" when it means two things: **every call spends real money**, and `live=true` writes where you cannot take it back. **Safe mode still costs tokens** — it keeps writes local, it does not make the run free. That makes three tiers, and both guides now carry the table plus the rule: work down them, never up.

Both guides also say what an assistant cannot infer from a docstring — that `met_criteria` is where this earns its place (the host has read the ticket *and* can call `explain_symbol`, so it can spot a criterion the code already satisfies), and that `sdlc_approve` must not be called unasked.

## Verification

- `2634 passed, 30 skipped` before the docs commit; 64 passing in `tests/plugin`
- `mypy src tests` clean (611 files), ruff clean
- Exercised directly: a valid spec returns 12 sections and a path; an invented key is refused with the field list; a spec with no criteria is refused; the tool and CLI outputs match

🤖 Generated with [Claude Code](https://claude.com/claude-code)