### PR TITLE
ci: install every language extra, so the accuracy gate measures what it claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,22 @@ jobs:
       # bump did exactly that, and the breakage — three renamed APIs — was only visible to
       # someone who had installed the extra locally. An optional extra the repo ships code
       # for is not optional to test.
+      #
+      # The six language extras, for the same reason and one sharper one. Without them only
+      # `python` and `sql` front-ends register, so:
+      #   * 89 tree-sitter tests skip — a tree-sitter API change lands green;
+      #   * and `pkg accuracy` cannot score any corpus case for those languages. The
+      #     TypeScript figures in the committed baseline were measured on a developer's
+      #     machine and skipped by every CI run since, which means a TypeScript regression
+      #     could not fail a build. A number nothing re-checks is not a gate.
+      # Measured before adding: all 8 front-ends registered takes the suite from 2,747
+      # passing / 25 skipped to 2,836 passing / 4 skipped, with no new failures, and this
+      # repo's own graph is unchanged (it is pure Python outside the corpus fixtures).
       - name: Install project
-        run: uv sync --extra dev --extra mcp
+        run: >-
+          uv sync --extra dev --extra mcp
+          --extra typescript --extra java --extra csharp
+          --extra c --extra cpp --extra go
 
       - name: Lint (ruff)
         run: uv run ruff check .


### PR DESCRIPTION
**The accuracy gate that landed in #179 protects one language.** Not by design — CI runs
`uv sync --extra dev --extra mcp`, so only the `python` and `sql` front-ends register.

| front-end | corpus cases | registered in CI | protected by the gate |
|---|---|---|---|
| python | 4 | ✅ stdlib | ✅ yes |
| typescript | 3 | ❌ | ❌ **no — skipped every run** |
| sql | 0 | ✅ via `dev` | — nothing to measure |
| java, csharp, c, cpp, go | 0 | ❌ | ❌ no |

So the TypeScript figures in the committed baseline — precision 1.00, recall 0.50 — were
measured on a developer's machine and have been skipped by every CI run since. **A TypeScript
regression could not have failed a build.** A number nothing re-checks is not a gate.

The skip behaviour itself is correct (it is the fix from #179 that stopped an absent extra
reading as a total collapse). It was just revealing that the gate had one language behind it.

## What changes

`uv sync` gains the six language extras. The comment above the install step already makes this
exact argument for `mcp`, which was added after a bump renamed three APIs and every MCP test
skipped past it — *"an optional extra the repo ships code for is not optional to test."*

## Measured before changing anything

| | before | after |
|---|---|---|
| tests | 2,747 passing / 25 skipped | **2,836 passing / 4 skipped** |
| new failures | — | **none** |
| this repo's graph | 10,647 python nodes | unchanged — pure Python outside the corpus fixtures |
| `pkg accuracy --check` | exit 0 | exit 0, no baseline regeneration needed |

The 4 remaining skips are unrelated: `tui` extra, an E2B key, `pytesseract`, and Postgres.

## Why now

This is the prerequisite for extending the corpus to the other six front-ends. Labelling cases
for languages CI cannot score would reproduce the TypeScript situation six more times — a
figure measured once and never protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)