### PR TITLE
chore(release): 3.17.0 — Is the graph right?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
-## Unreleased — Is the graph right?
+## 3.17.0 — Is the graph right?
+
+**Scope, stated first so nothing below is read as more than it is.** This release makes the
+PKG *measurable* and measures **two of the eight front-ends** — `python` and `typescript`.
+The other six (`java`, `csharp`, `c`, `cpp`, `go`, `sql`) gain the machinery and no numbers:
+`pkg accuracy` will score them the moment a corpus exists for them, and reports them as
+**skipped** rather than zero until it does. The capability matrix still says what a front-end
+*can* emit; only Python and TypeScript now also say how well.
 
 ### Added
 
@@ -41,6 +48,17 @@ All notable changes to this project are documented here. Format loosely follows
   was last changed for*, joining `git blame` to the issue key in each commit's message.
   Deterministic, no model, and it reports its own coverage — which depends on the
   repository's history, not on the method.
+
+  **Library only in this release.** `orchestrator.pkg.intent_link.link_intents(batch, root)`
+  is not wired into any command, because the scan costs about 11× an extraction (2.0s → 23.0s
+  on this repository) and `git blame` runs once per file. Making it default-on needs a
+  commit-keyed cache or a single `git log --numstat` walk; that is its own change.
+
+- **CI measures every front-end it ships code for.** Previously CI installed neither the
+  `typescript` extra nor the five other tree-sitter ones, so only `python` and `sql`
+  front-ends registered — 89 tests skipped, and the TypeScript figures in the committed
+  baseline were measured once on a developer machine and skipped by every run since. A
+  TypeScript regression could not have failed a build. All six extras are now installed.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.16.2"
+version = "3.17.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Version bump and changelog for **3.17.0**. Two files: `pyproject.toml`, `CHANGELOG.md`.

## What ships

The PKG becomes *measurable*: four accuracy oracles, a committed baseline with a CI gate, the
measured recall carried into the build document a human reads, and an intent layer recording
which ticket a symbol was last changed for.

## Scope — stated first in the notes, and here

**This measures two of the eight front-ends.** `python` and `typescript` have numbers. `java`,
`csharp`, `c`, `cpp`, `go` and `sql` get the machinery and no corpus, and are reported as
**skipped** rather than zero until one exists.

That sentence leads the changelog deliberately. Without it the entry reads as "accuracy,
done", when it means "accuracy, for a quarter of the surface" — and the capability matrix
already invites readers to mistake capability for coverage.

The intent layer is likewise marked **library only**: `link_intents` is wired into no command,
because the scan costs ~11× an extraction (2.0s → 23.0s here) and `git blame` runs per file.

## Verified as a release, not as a branch

Built the wheel and installed it into a clean environment:

| check | result |
|---|---|
| version | `synaptixs_spine-3.17.0-py3-none-any.whl` |
| `orchestrator/pkg/scoreboard.json` in the wheel | ✅ present |
| `measured_recall('python')` from site-packages | `0.727` |
| `measured_recall('go')` | `None` — unmeasured, not zero |
| build document caveat on a clean install | quotes **0.73** with its "not this repository" clause |
| `--oracle invention` / `--oracle parity` on a repo with **no corpus** | both run |
| `pkg --help` | lists `verify` and `accuracy` |

The baseline shipping inside the wheel was phase 6's entire packaging argument, and this is
the first time it has been tested against an actual built artifact rather than an editable
install.

## After merge

`develop → main` triggers `release.yml` (tag + GitHub release). **The PyPI publish is a manual
`workflow_dispatch`** — `publish-pypi.yml` — so it stays your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)