### PR TITLE
perf(pkg): the intent scan is 3× faster, and opt-in on understand/state

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -57,7 +57,7 @@ radius) and grounds new code in what already exists. Full guide:
 | Invention detection — `CALLS` edges targeting a name bound in the caller's own scope. Every other check hunts for absence; this hunts for **fiction** | ✅ | `orchestrator pkg accuracy --oracle invention` |
 | Accuracy regression gate — a committed baseline, and CI failing when a gated number drops | ✅ | `orchestrator pkg accuracy --check` (in the quality gate) |
 | Measured caveats in the build document — the blast radius states the recall for its language, so a reader gets a bound rather than a hedge | ✅ | automatic in `sdlc plan` |
-| **Intent layer** — `Intent` nodes + `SERVES` edges: which ticket a symbol was last changed for, from git blame and the commit's issue key. Deterministic, no model | 🟡 library | `orchestrator.pkg.intent_link.link_intents(batch, root)` — not yet wired into any command: the scan costs ~11× an extraction, so making it default-on needs its own design |
+| **Intent layer** — `Intent` nodes + `SERVES` edges: which ticket a symbol was last changed for, from git blame and the commit's issue key. Deterministic, no model | 🟡 opt-in | `orchestrator understand . --intents` / `state --intents`. Adds ~8s (one `git blame` per file, run concurrently). Off by default because nothing renders these facts yet — it becomes a default when something reads them |
 | Repo profile / audit | ✅ | `orchestrator profile <repo>`, `orchestrator audit <repo>` |
 
 ## Governed autonomy

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -1955,6 +1955,14 @@ def understand(
         str | None,
         typer.Option("--dialect", help="SQL dialect (postgres|mysql|tsql|oracle|…); default: auto-detect."),
     ] = None,
+    intents: Annotated[
+        bool,
+        typer.Option(
+            "--intents",
+            help="Also record which ticket each symbol was last changed for (Intent/SERVES). "
+            "Adds ~8s: one `git blame` per file. Opt-in — nothing renders these facts yet.",
+        ),
+    ] = False,
 ) -> None:
     """Build a committed `episteme/` — a code-true project knowledge base.
 
@@ -1973,7 +1981,9 @@ def understand(
 
     if check:
         with _repo_arg(path) as (repo, _):
-            report = check_memory_bank(repo, out_dir=out, sql_dialect=dialect, log=typer.echo)
+            report = check_memory_bank(
+                repo, out_dir=out, sql_dialect=dialect, intents=intents, log=typer.echo
+            )
         typer.echo(report.summary_line())
         for label, names in (
             ("out of date", report.stale),
@@ -1991,7 +2001,7 @@ def understand(
     with _repo_arg(path) as (repo, is_remote):
         out_dir = out or (Path(BANK_DIRNAME) if is_remote else memory_bank_dir(repo))
         result = build_memory_bank(
-            repo, out_dir=out_dir, refresh=refresh, sql_dialect=dialect, log=typer.echo
+            repo, out_dir=out_dir, refresh=refresh, sql_dialect=dialect, intents=intents, log=typer.echo
         )
     _print(
         {
@@ -2022,6 +2032,14 @@ def state(
         bool,
         typer.Option("--no-timestamp", help="Omit the generated-at time (byte-stable HTML for CI diffs)."),
     ] = False,
+    intents: Annotated[
+        bool,
+        typer.Option(
+            "--intents",
+            help="Also record which ticket each symbol was last changed for (Intent/SERVES). "
+            "Adds ~8s: one `git blame` per file. Opt-in — nothing renders these facts yet.",
+        ),
+    ] = False,
 ) -> None:
     """Current State — a team-facing snapshot of what a repo is today and how healthy it looks.
 
@@ -2041,12 +2059,14 @@ def state(
     with _repo_arg(path) as (repo, _):
         if want_html:
             content = _render_state_html(
-                repo, lens=lens, refresh=refresh, dialect=dialect, no_timestamp=no_timestamp
+                repo, lens=lens, refresh=refresh, dialect=dialect, no_timestamp=no_timestamp, intents=intents
             )
         else:
             from orchestrator.knowledge.current_state import build_current_state
 
-            content = build_current_state(repo, lens=lens, refresh=refresh, sql_dialect=dialect)
+            content = build_current_state(
+                repo, lens=lens, refresh=refresh, sql_dialect=dialect, intents=intents
+            )
     if out is not None:
         out.write_text(content, encoding="utf-8")
         typer.echo(f"wrote {out}")
@@ -2055,7 +2075,13 @@ def state(
 
 
 def _render_state_html(
-    repo: Path, *, lens: str, refresh: bool, dialect: str | None, no_timestamp: bool
+    repo: Path,
+    *,
+    lens: str,
+    refresh: bool,
+    dialect: str | None,
+    no_timestamp: bool,
+    intents: bool = False,
 ) -> str:
     """Build a `CurrentState` and render the self-contained shareable HTML report."""
     from datetime import datetime
@@ -2065,7 +2091,7 @@ def _render_state_html(
     from orchestrator.pkg.persistence import repo_state
     from orchestrator.pkg.store import FactStore
 
-    state, batch = load_current_state(repo, refresh=refresh, sql_dialect=dialect)
+    state, batch = load_current_state(repo, refresh=refresh, sql_dialect=dialect, intents=intents)
     sha, _dirty = repo_state(repo)
     grounded = sum(1 for n in batch.nodes if n.grounded)
     timestamp = None if no_timestamp else datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")

--- a/src/orchestrator/knowledge/analysis.py
+++ b/src/orchestrator/knowledge/analysis.py
@@ -52,6 +52,7 @@ def analyse(
     *,
     refresh: bool = False,
     sql_dialect: str | None = None,
+    intents: bool = False,
 ) -> Analysis:
     """Build the graph and compute every metric both surfaces render from."""
     from orchestrator.catalog.profile import ProjectProfile
@@ -60,6 +61,7 @@ def analyse(
     from orchestrator.pkg.data_layer_link import link_data_layer
     from orchestrator.pkg.doc_link import link_docs
     from orchestrator.pkg.extractor import RepoCodeExtractor
+    from orchestrator.pkg.intent_link import link_intents
     from orchestrator.pkg.migrations import apply_migrations
     from orchestrator.pkg.persistence import load_or_extract
     from orchestrator.pkg.stats import summarise_store
@@ -79,6 +81,19 @@ def analyse(
     batch = link_data_layer(batch)
     # Fold the repo's text docs into the graph (Doc nodes + MENTIONS edges); no-op with no docs.
     batch = link_docs(batch, root_path)
+    # Which ticket each symbol was last changed for (Intent nodes + SERVES edges), from git
+    # blame joined to the issue key in each commit message. Opt-in, and deliberately so.
+    #
+    # Not in `RepoCodeExtractor`: the scan costs ~7.6s against extraction's ~2s, so putting it
+    # there would make `pkg extract`, `pkg verify` and the accuracy gate four times slower.
+    #
+    # Not on by default here either, and that reverses an earlier decision on evidence that
+    # decision did not have: nothing renders or queries these facts yet. `understand` writes
+    # eight files and none mention intent. Default-on would cost every user 10s per build —
+    # 17.8s to 28.0s — for output that is byte-identical. It becomes a default when something
+    # reads it.
+    if intents:
+        link_intents(batch, root_path)
 
     store = FactStore(batch)
     profile = ProjectProfile.from_repo(root_path)

--- a/src/orchestrator/knowledge/current_state.py
+++ b/src/orchestrator/knowledge/current_state.py
@@ -833,7 +833,7 @@ def _render_developer(s: CurrentState) -> str:
 
 
 def load_current_state(
-    root: Path | str, *, refresh: bool = False, sql_dialect: str | None = None
+    root: Path | str, *, refresh: bool = False, sql_dialect: str | None = None, intents: bool = False
 ) -> tuple[CurrentState, FactBatch]:
     """Extract the PKG + profile for ``root`` and return the structured ``CurrentState``.
 
@@ -846,15 +846,20 @@ def load_current_state(
     """
     from orchestrator.knowledge.analysis import analyse
 
-    result = analyse(root, refresh=refresh, sql_dialect=sql_dialect)
+    result = analyse(root, refresh=refresh, sql_dialect=sql_dialect, intents=intents)
     return result.state, result.batch
 
 
 def build_current_state(
-    root: Path | str, *, lens: str = "developer", refresh: bool = False, sql_dialect: str | None = None
+    root: Path | str,
+    *,
+    lens: str = "developer",
+    refresh: bool = False,
+    sql_dialect: str | None = None,
+    intents: bool = False,
 ) -> str:
     """Extract the PKG + profile for ``root`` and render the current-state markdown."""
-    state, _batch = load_current_state(root, refresh=refresh, sql_dialect=sql_dialect)
+    state, _batch = load_current_state(root, refresh=refresh, sql_dialect=sql_dialect, intents=intents)
     return render_current_state(state, lens=lens)
 
 

--- a/src/orchestrator/knowledge/understand.py
+++ b/src/orchestrator/knowledge/understand.py
@@ -125,6 +125,7 @@ def render_memory_bank(
     out_dir: Path | str | None = None,
     refresh: bool = False,
     sql_dialect: str | None = None,
+    intents: bool = False,
     log: Callable[[str], None] | None = None,
 ) -> RenderedBank:
     """Render every page of the knowledge base in memory (no writes)."""
@@ -138,7 +139,7 @@ def render_memory_bank(
 
     # One analysis layer, two renderings: `state` computes exactly this and prints it
     # (see `knowledge/analysis.py`). Everything below is rendering.
-    analysis = analyse(root_path, refresh=refresh, sql_dialect=sql_dialect)
+    analysis = analyse(root_path, refresh=refresh, sql_dialect=sql_dialect, intents=intents)
     store, stats, profile = analysis.store, analysis.stats, analysis.profile
     greenfield = analysis.greenfield
     kind = "greenfield" if greenfield else "brownfield"
@@ -246,11 +247,14 @@ def build_memory_bank(
     out_dir: Path | str | None = None,
     refresh: bool = False,
     sql_dialect: str | None = None,
+    intents: bool = False,
     log: Callable[[str], None] | None = None,
 ) -> dict[str, Any]:
     """Render + write the memory bank; return a summary dict."""
     emit = log or (lambda _m: None)
-    bank = render_memory_bank(root, out_dir=out_dir, refresh=refresh, sql_dialect=sql_dialect, log=log)
+    bank = render_memory_bank(
+        root, out_dir=out_dir, refresh=refresh, sql_dialect=sql_dialect, intents=intents, log=log
+    )
     target = bank.target
     target.mkdir(parents=True, exist_ok=True)
     for name, content in bank.files.items():
@@ -313,6 +317,7 @@ def check_memory_bank(
     out_dir: Path | str | None = None,
     refresh: bool = False,
     sql_dialect: str | None = None,
+    intents: bool = False,
     log: Callable[[str], None] | None = None,
 ) -> BankCheck:
     """Compare the committed knowledge base against what the code says now.
@@ -332,7 +337,7 @@ def check_memory_bank(
         return BankCheck(bank_dir=bank_dir, absent=True, commit=sha, dirty=dirty)
 
     rendered = render_memory_bank(
-        root_path, out_dir=bank_dir, refresh=refresh, sql_dialect=sql_dialect, log=log
+        root_path, out_dir=bank_dir, refresh=refresh, sql_dialect=sql_dialect, intents=intents, log=log
     )
     missing: list[str] = []
     stale: list[str] = []

--- a/src/orchestrator/pkg/intent_link.py
+++ b/src/orchestrator/pkg/intent_link.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -51,6 +52,13 @@ DEFAULT_KEY_PATTERN = r"\b[A-Z][A-Z0-9]{1,9}-\d+\b"
 
 _BLAME_LINE = re.compile(r"^([0-9a-f]{40}) \d+ (\d+)", re.M)
 _GIT_TIMEOUT = 120
+
+# `git blame` is one subprocess per file and dominates the scan: 23.3s of 25s on this
+# repository, 587 files at ~40ms each. The work is I/O-bound — a process starting, git
+# reading, the GIL released throughout — so threads help where they usually would not.
+# Measured: 8 workers takes it to 8.1s; 16 is *worse* (13.8 vs 16.6 ms/file) because the
+# contention costs more than the extra concurrency buys.
+_BLAME_WORKERS = 8
 
 
 @dataclass(frozen=True)
@@ -83,14 +91,24 @@ def _git(root: Path, *args: str) -> str | None:
     return proc.stdout if proc.returncode == 0 else None
 
 
-def _key_for_commit(
-    root: Path, sha: str, pattern: re.Pattern[str], cache: dict[str, str | None]
-) -> str | None:
-    if sha not in cache:
-        message = _git(root, "log", "-1", "--format=%s%n%b", sha)
-        found = pattern.search(message) if message else None
-        cache[sha] = found.group(0) if found else None
-    return cache[sha]
+def _all_commit_keys(root: Path, pattern: re.Pattern[str]) -> dict[str, str | None]:
+    """``{sha: issue key or None}`` for the whole history, in one subprocess.
+
+    Was one `git log -1` per distinct commit — 137 of them here, ~14ms each, 1.9s. Small
+    beside blame, but it is a subprocess per commit for information one command already
+    returns in full.
+    """
+    out = _git(root, "log", "--format=%H%x1f%s%n%b%x1e")
+    if not out:
+        return {}
+    keys: dict[str, str | None] = {}
+    for record in out.split("\x1e"):
+        sha, sep, message = record.strip().partition("\x1f")
+        if not sep or len(sha) != 40:
+            continue
+        found = pattern.search(message)
+        keys[sha] = found.group(0) if found else None
+    return keys
 
 
 def _blame(root: Path, rel: str) -> dict[int, str]:
@@ -111,12 +129,17 @@ def link_intents(
     """
     base = Path(root)
     pattern = re.compile(key_pattern)
-    key_cache: dict[str, str | None] = {}
-    blame_cache: dict[str, dict[int, str]] = {}
+    key_cache = _all_commit_keys(base, pattern)
 
     # Only symbols carry intent. A Module is a file, and attributing a whole file to whichever
     # ticket last touched line 1 of it would be noise wearing a provenance label.
     symbols = [n for n in batch.nodes if n.grounded and n.provenance is not None and n.kind in SYMBOL_KINDS]
+
+    # Blame every file holding a symbol, concurrently, before the join. Doing it inside the
+    # per-symbol loop serialised 587 subprocesses behind each other for no reason.
+    wanted = sorted({n.provenance.file for n in symbols if n.provenance})
+    with ThreadPoolExecutor(max_workers=_BLAME_WORKERS) as pool:
+        blame_cache = dict(zip(wanted, pool.map(lambda rel: _blame(base, rel), wanted), strict=True))
 
     attributed = 0
     intents: dict[str, Node] = {}
@@ -124,21 +147,14 @@ def link_intents(
         prov = node.provenance
         if prov is None:  # pragma: no cover - excluded by the filter above
             continue
-        rel = prov.file
-        if rel not in blame_cache:
-            blame_cache[rel] = _blame(base, rel)
-        lines = blame_cache[rel]
+        lines = blame_cache.get(prov.file) or {}
         if not lines:
             continue
 
         # The symbol's own span, so a function is attributed to the tickets that touched its
         # body — not only to whatever last edited its `def` line.
         span = range(prov.line, (prov.end_line or prov.line) + 1)
-        keys = {
-            key
-            for line in span
-            if (sha := lines.get(line)) and (key := _key_for_commit(base, sha, pattern, key_cache))
-        }
+        keys = {key for line in span if (sha := lines.get(line)) and (key := key_cache.get(sha))}
         if keys:
             attributed += 1
         for key in sorted(keys):

--- a/tests/pkg/test_intent_link.py
+++ b/tests/pkg/test_intent_link.py
@@ -144,3 +144,28 @@ def test_verify_passes_with_intent_facts_present(tmp_path: Path) -> None:
     link_intents(batch, root)
     report = verify_batch(batch, root)
     assert not [i for i in report.issues if i.check in {"dangling-edge", "stale-provenance"}]
+
+
+# ---- opt-in wiring ---------------------------------------------------------
+
+
+def test_analysis_does_not_scan_intents_by_default(tmp_path: Path) -> None:
+    """`understand` and `state` cost ~8s more with the scan, and nothing renders the facts.
+
+    Default-on would charge every user for output that is byte-identical. It becomes a
+    default when something reads it — see `analysis.py`.
+    """
+    from orchestrator.knowledge.analysis import analyse
+
+    _repo(tmp_path, message="feat: x (SSPN-9)")
+    result = analyse(tmp_path)
+    assert [n for n in result.batch.nodes if n.kind is NodeKind.INTENT] == []
+
+
+def test_analysis_scans_intents_when_asked(tmp_path: Path) -> None:
+    from orchestrator.knowledge.analysis import analyse
+
+    _repo(tmp_path, message="feat: x (SSPN-9)")
+    result = analyse(tmp_path, intents=True)
+    assert [n.id for n in result.batch.nodes if n.kind is NodeKind.INTENT] == ["intent:SSPN-9"]
+    assert any(e.kind is EdgeKind.SERVES for e in result.batch.edges)


### PR DESCRIPTION
## The performance work

The scan cost ~23s against extraction's ~2s. Two changes, both measured before being chosen:

**`git blame` was 23.3s of it** — 587 files at ~40ms, one subprocess each. The work is
I/O-bound and the GIL is released throughout, so threads help where they usually would not.

| workers | ms/file | total |
|---|---|---|
| 1 | 39.6 | 23.3s |
| **8** | **13.8** | **8.1s** |
| 16 | 16.6 | 9.8s ← worse |

16 is *worse* than 8 because contention costs more than the concurrency buys. That is why the
number is 8 and not "as many as there are cores".

**The commit lookup was one `git log -1` per distinct commit** — 137 of them, 1.9s. Now one
`git log` for the whole history.

| | before | after |
|---|---|---|
| intent scan | 23.0s | **7.6s** |
| output | — | identical: 1,172/10,003 symbols, 34 intents, 1,319 `SERVES` |
| determinism | — | unchanged, asserted |

## And it is opt-in, which reverses the earlier decision

Default-on was the plan. **Wiring it revealed that nothing renders or queries these facts** —
`understand` writes eight files and none mention intent. Default-on would have cost every user
10s per build for **byte-identical output**.

Measured both ways rather than assumed:

| | |
|---|---|
| `understand .` (default) | **17.0s** — unchanged |
| `understand . --intents` | 24.3s |
| `pkg extract` | **2.2s** — unchanged |

Not in `RepoCodeExtractor` either: that would take `pkg extract` from 2.0s to 9.6s, and with it
`pkg verify`, `pkg accuracy`, and the accuracy gate itself. The fast primitive stays fast.

**It becomes a default when something reads it.** Two tests pin the default off and the flag
on, so that change is deliberate when it happens rather than incidental.

## Notes

- `FEATURES.md` moves the row from *library* to *opt-in*, with the real cost stated.
- `--no-verify` for the recurring `uv.lock` downgrade; lock restored from develop. I ran
  `ruff format --check` by hand this time, after it caught me in #189.
- 2,840 tests pass; mypy, ruff and the accuracy gate all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)