### PR TITLE
chore(episteme): regenerate for 92d2947

### DIFF
--- a/episteme/README.md
+++ b/episteme/README.md
@@ -4,7 +4,7 @@
 Code-true knowledge base for **synaptixs-spine** (brownfield), built by `orchestrator understand` from the Product Knowledge Graph + project profile.
 
 <!-- spine-stamp -->
-Generated from commit `c4be7229fcadb7f9c99909125604f326c298d6fb` **plus uncommitted changes** by **Spine 3.18.0**.
+Generated from commit `92d2947254a8c078049cea4e77245189ae5de955` **plus uncommitted changes** by **Spine 3.18.0**.
 Verify it still matches the code with `orchestrator understand --check`.
 <!-- /spine-stamp -->
 


### PR DESCRIPTION
`episteme/` regenerated from `main`'s own tree by
[`.github/workflows/episteme.yml`](.github/workflows/episteme.yml).

Nothing here is authored: the knowledge base is a pure function of the tracked tree, so this
diff is whatever `orchestrator understand .` computes at this commit.

## Why a human opened it

The workflow pushed this branch correctly, then could not open the PR:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

That is the repository/org setting **"Allow GitHub Actions to create and approve pull
requests"**, which is disabled. `permissions: pull-requests: write` does not override it.

This is the second wall on the same path — #185 fixed the direct push being rejected by the
ruleset (`GH013`), and this is the next one behind it. The branch is pushed either way, so no
work is lost; the run just fails at the last step.

CI's *"PR does not modify episteme/"* guard exempts `base_ref == main`, so this PR is legal by
the same rule that lets a release promotion carry the artifact.

## Follow-up

Either enable that setting, or the workflow should treat a blocked PR creation as a soft
outcome — print the compare URL and exit 0, since the branch is already pushed. A separate
change covers the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)