### PR TITLE
fix(ci): a blocked PR creation does not fail the episteme run

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,21 @@
 name: "Spine CodeQL config"
 
+# `corpus/` is ground truth for `pkg accuracy`, not application code. Its fixtures are tiny
+# hand-written programs in eight languages whose *shape* is the measurement — a call through a
+# parameter, a route with a computed path — and scanning them for vulnerabilities says nothing
+# about Spine.
+#
+# It also broke the build. CodeQL detects languages from repository contents, so adding C#,
+# Java, C, C++ and Go fixtures made it try to build a C# database, find nothing buildable, and
+# fail the run outright:
+#
+#     CodeQL could not process any code written in C#.
+#     Encountered a fatal error ... Exit code was 32
+#
+# The workflow matrix names only python and javascript-typescript; detection happens anyway.
+paths-ignore:
+  - corpus
+
 # Keeps the full security-and-quality suite and drops only the quality queries that
 # misread idiomatic typed Python. Every security query stays enabled.
 queries:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,15 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
-          language: ${{ matrix.language }}
+          # `languages`, PLURAL. The input was `language` until the corpus landed, and
+          # codeql-action silently ignores an unrecognised input — so the matrix value was
+          # never applied and CodeQL autodetected instead. That was invisible while the repo
+          # held only Python and JavaScript, because autodetection produced the same answer
+          # the matrix intended. Adding C#, Java, C, C++ and Go fixtures made it produce a
+          # different one: it set up tracing for all four compiled languages
+          # (CODEQL_TRACER_LANGUAGES: cpp:csharp:go:java), found no C# to build, and failed
+          # the run. The matrix was decorative for as long as it agreed with the guess.
+          languages: ${{ matrix.language }}
           # Query selection lives in the config file, not here — it also carries the
           # query-filters that drop two quality queries which can't read typed-Python
           # idiom. Setting `queries:` here as well would ADD to the config, not replace it.

--- a/.github/workflows/episteme.yml
+++ b/.github/workflows/episteme.yml
@@ -109,6 +109,20 @@ jobs:
             printf 'CI'"'"'s "PR does not modify episteme/" guard exempts `base_ref == main`, the\n'
             printf 'same rule that lets a release promotion carry the artifact.\n'
           } > /tmp/episteme-pr-body.md
-          gh pr create --base main --head "$branch" \
-            --title "chore(episteme): regenerate for ${FOR_SHA}" \
-            --body-file /tmp/episteme-pr-body.md
+          # `gh pr create` can be refused by a setting no workflow permission overrides:
+          # "Allow GitHub Actions to create and approve pull requests". When it is off the
+          # call fails with `GitHub Actions is not permitted to create or approve pull
+          # requests`, which is what happened on the 3.18.0 promotion.
+          #
+          # The branch is already pushed at that point, so nothing is lost and failing the run
+          # says otherwise. Print the one-click URL and exit 0: a human opens it in a moment,
+          # and if the setting is ever enabled this starts opening PRs by itself with no
+          # further change.
+          if ! gh pr create --base main --head "$branch" \
+              --title "chore(episteme): regenerate for ${FOR_SHA}" \
+              --body-file /tmp/episteme-pr-body.md; then
+            echo "::warning::Could not open the PR automatically — the branch is pushed and waiting."
+            echo "Open it here: ${{ github.server_url }}/${{ github.repository }}/pull/new/$branch"
+            echo "If this is the 'Actions is not permitted to create pull requests' refusal, the"
+            echo "fix is Settings -> Actions -> General -> Workflow permissions."
+          fi


### PR DESCRIPTION
Second wall on the same path.

[#185](https://github.com/synaptixs/spine/pull/185) fixed the direct push to `main` being
rejected by the ruleset (`GH013`). The 3.18.0 promotion got past that — **the branch pushed
correctly** — and then hit:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

That is the repository setting **"Allow GitHub Actions to create and approve pull requests"**,
which no workflow permission overrides. `pull-requests: write` does not help.

## The change

The branch is **already pushed** when this happens, so nothing is lost — and failing the run
says otherwise. A red X meaning *"the work is done and waiting"* is worse than no signal.

The step now warns, prints the one-click compare URL, and exits 0. **If the setting is ever
enabled it starts opening PRs by itself with no further change.**

## Why neither wall was findable earlier

The first needed a push to `main`. The second needed that push to *succeed*. Neither is
reachable from a branch, and the fix for the first is what exposed the second — which is why
both arrived as CI failures on a release rather than in review.

## The alternative, if you prefer it

Enabling that setting (Settings → Actions → General → Workflow permissions) makes the
automation work end to end and this fallback never fires. I have not changed it — repository
permissions are yours.

`main`'s stale bank from the failed run is in
[#193](https://github.com/synaptixs/spine/pull/193), opened by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)