### PR TITLE
chore(episteme): regenerate for a26484a

### DIFF
--- a/episteme/README.md
+++ b/episteme/README.md
@@ -4,7 +4,7 @@
 Code-true knowledge base for **synaptixs-spine** (brownfield), built by `orchestrator understand` from the Product Knowledge Graph + project profile.
 
 <!-- spine-stamp -->
-Generated from commit `7b5c224b8b44a8655622d13e6c872b6522c2ad76` **plus uncommitted changes** by **Spine 3.18.0**.
+Generated from commit `a26484a5da175aa3a963c47c32a14fb5bcec4774` **plus uncommitted changes** by **Spine 3.18.0**.
 Verify it still matches the code with `orchestrator understand --check`.
 <!-- /spine-stamp -->
 


### PR DESCRIPTION
Regenerated `episteme/` for `main` at a26484a, which now carries the CodeQL and CI fixes from #195.

The workflow generated and pushed this branch itself but could not open the PR: the repository has "Allow GitHub Actions to create and approve pull requests" disabled, so `gh pr create` is refused. The job now degrades gracefully — it prints the URL and exits 0 rather than failing the run — which is why the Episteme run on `main` is green.

Supersedes #193, whose base predates the CodeQL fix and is now 6 commits behind.

**Diff is one line:** the `spine-stamp` commit sha in `episteme/README.md`. No knowledge content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)