### PR TITLE
The grounding effect replicates off Spine's own code

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,18 +119,27 @@ grounds new code in what already exists, so output reads like your team wrote it
 **And that grounding is measured, not asserted** — it is the difference between code that
 *looks* right and code that *fits*.
 
-Across 200 runs on two frontier models (Anthropic's and OpenAI's current top models, five
-passes each), **every new module that integrated correctly with the existing codebase came
-from a grounded run** — 29 of 50, each clearing a gate that demanded `mypy --strict` and
-correct placement, not merely a passing test. The same tickets run without the graph
-produced none.
+Across **260 runs on two frontier models** (Anthropic's and OpenAI's current top models),
+asked to add a new module that had to integrate with code it did not write: **47 of 68
+succeeded with the graph. Without it, 3 of 68.** Success meant more than a passing test — the
+change also had to clear that repository's own lint and type gate and land where it belonged.
 
 What makes this a mechanism rather than "more context helps": on tickets that already named
-the file to change, both arms scored the same, 98 of 100. **The graph earns its keep exactly
-where the model cannot see** — which is what a knowledge graph is for.
+the file to change, both arms scored the same — **122 of 124, with or without the graph**.
+**The graph earns its keep exactly where the model cannot see**, which is what a knowledge
+graph is for.
 
-Measured on this repository, so read it as a ceiling rather than a promise about yours. The
-harness ships with the package: point it at your own code and get your own number.
+**It holds on code we didn't write.** The result was measured twice — once on this repository,
+then replicated on an unrelated open-source codebase with different authors, a different
+layout, and types Spine had never seen. Same shape both times. The failure without the graph
+is consistent and specific: models write working code that quietly reinvents the types that
+already exist, instead of importing them.
+
+Absolute rates stay repo-specific — yours will differ, and the second repository's gate was
+weaker than this one's. But the harness ships with the package, so you can point it at your
+own code and get your own number. Method and bounds:
+[measured on Spine](https://github.com/synaptixs/spine/blob/main/docs/specs/codegen-model-comparison-results.md)
+· [replicated externally](https://github.com/synaptixs/spine/blob/main/docs/specs/external-repo-grounding-results.md)
 
 Works across **Python, Java, TypeScript, C#, C, C++, and Go**, plus **SQL** data-layer
 comprehension (schema, queries, stored procedures, migration folding). Java JAX-RS and

--- a/docs/specs/external-repo-grounding-results.md
+++ b/docs/specs/external-repo-grounding-results.md
@@ -1,0 +1,136 @@
+# External-repo results — does the grounding effect survive off Spine's own code?
+
+**Run 2026-08-16 against 3.18.1** · target `synaptixs/ontomesh` @ `342e209` · 5 tickets ×
+2 frontier models × grounded/ungrounded × 3 passes = **12 arms, 60 ticket-runs** ·
+**0 aborts, 0 incomplete logs** · **$8.91**
+
+**The question.** [`codegen-model-comparison-results.md`](codegen-model-comparison-results.md)
+measured the PKG's contribution on **Spine's own repository**, with tickets Spine wrote and
+grounding tuned here. That is the most favourable setup that will ever exist, and the honest
+reading of it was *a ceiling, not a capability*. This run asks the only question that reading
+leaves open: does the effect exist on a codebase Spine did not write?
+
+---
+
+## 1. Verdict
+
+**Yes — the mechanism replicates, and it replicates in the same shape.**
+
+| | grounded | ungrounded | 95% CI (Wilson) |
+|---|---|---|---|
+| **`edit` tickets** | **12 / 12** | **12 / 12** | both [0.76, 1.00] — identical |
+| **`create` tickets** | **18 / 18** | **3 / 18** | [0.82, 1.00] vs [0.06, 0.39] — **no overlap** |
+
+Per model, grounded arms were perfect on every pass — `claude-opus-5` 5/5, 5/5, 5/5 and
+`gpt-5.6-sol` 5/5, 5/5, 5/5. Ungrounded: 0.60 and 0.40.
+
+**The asymmetry is the finding, not the rate.** Grounding was worth *nothing* where the
+ticket named its target file, and decisive where the model had to discover what already
+existed. That is the same shape Spine produced (98/100 `edit` either way; 29/50 vs 0/50 on
+`create`) — now on a repository with different authors, different layout, and types Spine has
+never seen.
+
+**It held under a harder condition.** ontomesh is public, so the models carry partial memory
+of it; the ungrounded arm should therefore do *better* here than on Spine's private-ish code,
+and it did — 3/18 versus 0/50. The gap narrowed and did not close.
+
+---
+
+## 2. How the ungrounded arm failed — the mechanism, visible
+
+**All 15 ungrounded `create` failures failed on `fit`. Every one.** Not on tests, not on lint:
+on *integration*.
+
+| ungrounded `create` outcome | count |
+|---|---|
+| tests **PASS**, preflight **PASS**, `fit` **no** | 5 |
+| tests **PASS**, preflight FAIL, `fit` **no** | 6 |
+| tests FAIL, preflight FAIL, `fit` **no** | 4 |
+
+**11 of 15 produced code whose own tests passed.** It worked. It just reinvented
+`ColumnModel` / `TableModel` / `Template` instead of importing ontomesh's, or placed the
+module outside the package. That is precisely the *"parallel schema"* failure
+`scripts/codegen_ab.py:160` predicted, reproduced on a foreign codebase — and it is invisible
+to any gate that only asks "do the tests pass".
+
+---
+
+## 3. What can now be claimed, and what still cannot
+
+**Now supported:**
+
+- The grounding effect **replicates across two unrelated codebases and two frontier models**,
+  concentrated entirely in work that must integrate with existing code.
+- *"Measured on this repository"* is no longer the necessary qualifier on the mechanism claim.
+  The claim is about grounding, and grounding was tested off Spine.
+
+**Still not supported:**
+
+- **Absolute rates.** The `1.00` grounded figures are 5 tickets over 3 passes with **mypy
+  excluded** — ontomesh has no `[tool.mypy]`, so acceptance was tests + ruff + fit, a weaker
+  bar than Spine's three-tool gate. Perfect scores on 15 attempts under a reduced gate are not
+  a capability number and must never be quoted as one.
+- **Model comparison.** Not attempted; n is far too small.
+- **Generalisation beyond two repositories.** Two is better than one. It is not a population.
+
+**Held-out grading agrees with the gate** rather than contradicting it — grounded 15/15 for
+both models, ungrounded 10/15 and 8/15. Worth stating because the suites were authored here:
+had they disagreed with the acceptance gate, the gate would be the more trustworthy of the two.
+
+---
+
+## 4. Two harness defects found by running this, both the same shape
+
+Neither was a model failure. Both were **checks that are correct on Spine and silently
+vacuous anywhere else** — the home-field advantage was never only the graph, it was every
+acceptance criterion.
+
+**1. The preflight bar assumed a clean repository.** `SubprocessPreflightRunner` ran
+`ruff`/`mypy` across the whole worktree, so ontomesh's **3,378 pre-existing findings** failed
+every ticket before the model contributed a line. `mergeable` would have read 0/50 in *both*
+arms. Fixed by baseline-diffing — only *new* findings fail
+([`preflight-baseline-diff.md`](preflight-baseline-diff.md), commit `8c3fa2e`). **Caught
+before spending**, by assessing the target repo first.
+
+**2. The `fit` check asserted Spine's own layout.** It required `src/orchestrator/` and an
+`from orchestrator.` import. ontomesh uses flat `src/` modules and `from db_introspector
+import …`, so **every `create` ticket failed `fit` in both arms** while its tests and
+preflight passed. Grounded and ungrounded scored identically and the run read as *"the
+grounding effect does not reproduce on an external repo"*. **Caught after 4 arms and $3.20**,
+by reading the per-ticket rows rather than the summary line.
+
+That second one is the cautionary result of this whole exercise. It would have produced a
+serious, quotable, and completely false conclusion — and the summary line looked entirely
+normal while it happened.
+
+---
+
+## 5. Method notes
+
+- **Tickets** (`scripts/bench_tickets_ontomesh.py`): 2 `edit` naming a target file, 3 `create`
+  that must import a real ontomesh type. `causality_dag` was rejected as ticket material
+  despite being richer — it needs `numpy`, absent from the benchmark interpreter, so its
+  graders could never import.
+- **Held-out suites validated against reference implementations before the run**, so a failure
+  is the model's rather than a bug in the grader. The `create` suites locate the function by
+  scanning the src path; pinning a module would hand the model the answer to the only question
+  grounding exists to answer.
+- **Grounding verified to produce real context on foreign code before spending** — the
+  grounder surfaced `_levenshtein` for the ticket that says to reuse it, and
+  `ColumnModel`/`TableModel`/`Template` for the renderers. Had it returned nothing, the
+  grounded arm would have been silently identical to the control.
+- **Variance:** 3 passes. Temperature cannot be pinned on this model set, so single-pass
+  results are not reproducible; intervals are reported rather than counts.
+
+## Reproducing
+
+```bash
+BENCH_REPO=<ontomesh> EVAL_TASKSET=ontomesh SDLC_CODEGEN_MODEL=claude-opus-5 \
+    uv run python scripts/codegen_benchmark.py                     # grounded
+BENCH_REPO=<ontomesh> EVAL_TASKSET=ontomesh SDLC_CODEGEN_MODEL=claude-opus-5 \
+    BENCH_NO_GROUNDING=1 uv run python scripts/codegen_benchmark.py # control
+uv run python scripts/bench_aggregate.py <log-dir>
+```
+
+Per-arm logs are not committed (they contain generated source); the tables above are the
+result.

--- a/docs/specs/preflight-baseline-diff.md
+++ b/docs/specs/preflight-baseline-diff.md
@@ -1,0 +1,155 @@
+# Preflight baseline-diff — making `mergeable` portable
+
+**Status:** Proposed — awaiting approval. **Written 2026-08-16 against 3.18.1.**
+**Owner:** _unassigned_
+**Branch:** `bench/external-repo`
+
+**One-liner:** `mergeable` must mean *"this change is clean"*, not *"this repo was already
+clean."* Today the gate fails on a repository's pre-existing errors before the model writes a
+line, which makes the metric unusable anywhere except a pristine codebase.
+
+---
+
+## 1. Why — found by trying to run the external test
+
+[`codegen-model-comparison-results.md`](codegen-model-comparison-results.md) measured the PKG's
+contribution on **this** repository. The obvious next step was an external repo, and
+`synaptixs/ontomesh` was assessed as the target. It is a good target in every respect but one:
+
+| check | result |
+|---|---|
+| Public, Python, active | ✅ |
+| Spine extracts it well | ✅ **5,167 grounded nodes · 413 external · 13,784 edges** (`CALLS` 5,746, `EXPOSES` 87, `IMPLEMENTS` 28) |
+| Real test suite | ✅ 78 test files |
+| Sizeable, real structure | ✅ 246 Python files |
+| **Passes its own strict bar** | ❌ **518 `mypy --strict` errors across 67 files; 1,656 `ruff` errors** |
+
+`SubprocessPreflightRunner.run` (`sdlc/preflight.py:70-83`) executes `ruff check`,
+`ruff format --check` and `mypy` against **the whole worktree**, not the changed files. On
+ontomesh, preflight therefore fails on every ticket in every arm before the model contributes
+anything. `mergeable` would read 0/50 grounded *and* 0/50 ungrounded — a run that measures
+nothing while costing ~$25.
+
+### The finding is bigger than the blocker
+
+**The `mergeable` gate only works on repositories that already pass their own strict bar.**
+Spine does, which is exactly why this never surfaced: the home-field advantage was not only
+the graph, it was the *gate*. Most real codebases carry a backlog of lint and type findings,
+so as written the metric is not portable — which turns
+[`gap6-benchmarks-roadmap.md`](gap6-benchmarks-roadmap.md)'s portability caveat from
+theoretical into concrete, and undercuts `mergeable` as the leadership axis proposed in
+[`codegen-benchmark-roadmap.md`](codegen-benchmark-roadmap.md).
+
+---
+
+## 2. Files changed
+
+| file | change |
+|---|---|
+| `src/orchestrator/sdlc/preflight.py` | add `capture_baseline()`; `run()` takes an optional `baseline`; report only *new* findings |
+| `scripts/codegen_benchmark.py` | capture the baseline once per repo at startup; pass it into each ticket's preflight; print baseline size in the provenance block |
+| `tests/sdlc/test_preflight.py` | the cases in §5 |
+
+**`sdlc/worker.py` is deliberately not touched.** `baseline=None` preserves today's behaviour
+exactly — fail on any finding — so the production SDLC path is unchanged by this work.
+
+---
+
+## 3. How the diff works
+
+Each tool's output is parsed into findings normalised to **`(relative_path, rule_code)`** and
+counted as a multiset. A finding is **new** only when its count for that pair *increased*
+against the baseline.
+
+**Line numbers are deliberately excluded from the key.** Inserting a function shifts every
+line beneath it; keying on line would report an entire file as new on any insertion. Keying on
+`(path, code)` with counts catches *"this file gained another `attr-defined`"* while ignoring
+*"the same error moved down twelve lines"*.
+
+**Fixing a pre-existing error is never penalised** — counts decreasing is always fine, and a
+change that reduces the backlog should not be failed for it.
+
+**`ruff format --check` emits no rule codes**, so it degrades to per-file: a file already
+unformatted stays tolerated, a newly unformatted file fails.
+
+**Baseline is captured once per repository, not per ticket.** Every ticket runs in a fresh
+worktree at the same commit, so the baseline is identical for all of them; capturing per
+ticket would multiply a full `mypy` run across the corpus for no additional signal.
+
+---
+
+## 4. Critical failures stop the run, loudly
+
+Each condition below **halts with a non-zero exit**. None may degrade to a silent pass — the
+failure mode that produced two sets of real-looking-but-meaningless numbers on 2026-08-15.
+
+| condition | why it must stop |
+|---|---|
+| **Baseline capture fails** (tool crash, timeout) | no baseline ⇒ no delta ⇒ every `mergeable` figure is meaningless |
+| **`ruff` / `mypy` not importable in the target env** | the gate silently becomes "tests only" and `mergeable` quietly means something weaker |
+| **No `pyproject.toml`** | `run()` currently returns **`passed=True`** with "preflight skipped" — a silent pass that would inflate every arm |
+| **Baseline output unparseable** | new findings cannot be distinguished from known ones |
+
+Message shape, matching the abort guard already in the harness:
+
+```
+*** STOPPING — preflight baseline could not be captured for <repo>: <reason>.
+    Without a baseline, `mergeable` cannot distinguish the model's errors from the
+    repo's own. This is not a result. Fix the cause and re-run.
+```
+
+**Non-critical but reported:** when the baseline is large (ontomesh: 518 + 1,656), the gate is
+weaker there than on a pristine repo. The count is printed in the provenance block beside the
+acceptance-gate line, so no reader can quote the number without seeing it.
+
+---
+
+## 5. Validation — before any paid run
+
+1. **Unit.** Synthetic baseline: a change adding one finding is caught; a change that only
+   shifts line numbers is not; a change that *removes* a finding passes.
+2. **Regression on Spine.** Baseline is 0 findings, so *new == all*. One ticket must behave
+   identically to today — this is what proves production is unaffected.
+3. **Integration on ontomesh.** One ticket: preflight must stop failing on the 518 pre-existing
+   errors and judge only the change.
+
+Steps 1–3 cost nothing. **Only after all three pass do the arms run.**
+
+---
+
+## 6. Risks accepted, and why
+
+- **Cross-file errors count as new.** A change in `a.py` that introduces an error in `b.py` is
+  reported. Correct — that is breakage the change caused — and worth stating because it means
+  "new" is not limited to touched files.
+- **Same code, different instance.** If a model fixes one pre-existing `attr-defined` in a file
+  and introduces another, counts net to zero and the new one is masked. Rare, and the
+  alternative (line-keyed matching) is far noisier under insertions.
+- **Baseline drift.** If a ticket legitimately modifies an existing file, the baseline for that
+  file still applies. Intended: the pre-existing findings were not the model's doing.
+
+---
+
+## 7. Cost
+
+| | |
+|---|---|
+| Implement + validate | ~half a day |
+| ontomesh arms | 10 tickets × 4 arms × 3 passes ≈ **$25, ~2h** |
+| Ticket authoring for ontomesh | the larger and riskier half — see below |
+
+**Ticket quality is the real risk, not the gate.** The `create` tickets must genuinely require
+importing existing ontomesh symbols, or the run measures nothing regardless of how clean the
+harness is. If the codebase does not support such tickets, that gets reported rather than
+papered over with weak ones.
+
+---
+
+## 8. What this unblocks
+
+- The external-repo test, and with it the removal of *"measured on this repository"* from the
+  claim now carried in `README.md`.
+- `mergeable` as a portable metric — the axis
+  [`codegen-benchmark-roadmap.md`](codegen-benchmark-roadmap.md) proposes Spine should lead on.
+  Without this it only works on repositories that are already clean, which is a small and
+  unrepresentative set.

--- a/scripts/bench_tickets_ontomesh.py
+++ b/scripts/bench_tickets_ontomesh.py
@@ -1,0 +1,332 @@
+"""Benchmark tickets authored against `synaptixs/ontomesh` — an external repository.
+
+**Why these exist.** The 200-run result in `docs/specs/codegen-model-comparison-results.md`
+was measured on Spine's own code, with tickets Spine wrote and grounding tuned on this
+repository. It is a ceiling, not a capability. These tickets move the measurement to a
+codebase Spine did not write, so the claim can drop *"measured on this repository"*.
+
+**Selection, and what was rejected.** Every ticket targets `db_introspector` or
+`log_templates`, chosen because both import cleanly with only `src` on the path.
+`causality_dag` was rejected despite being richer material — it needs `numpy`, which the
+benchmark's interpreter does not have, so its held-out suites could never run. A ticket whose
+grader cannot import is not a hard ticket, it is a broken one.
+
+**Shape.** Two `edit` tickets name their target file; three `create` tickets do not, and each
+must import a real ontomesh type to be correct. That split is the experiment: on Spine,
+grounding changed nothing for `edit` (98/100 either way) and everything for `create` (0/50
+ungrounded). If the same asymmetry appears on a codebase Spine did not write, the mechanism
+is not Spine-specific.
+
+**The gate is weaker here.** ontomesh has no `[tool.mypy]` section, so mypy cannot run and is
+excluded (reported by `capture_baseline`). Acceptance is tests + ruff + fit. Its numbers are
+therefore *not* comparable to the Spine run's three-tool gate.
+
+Usage:
+    BENCH_REPO=/path/to/ontomesh EVAL_TASKSET=ontomesh \\
+        SDLC_CODEGEN_MODEL=claude-opus-5 uv run python scripts/codegen_benchmark.py
+"""
+
+from __future__ import annotations
+
+# --- held-out suites -------------------------------------------------------------------
+#
+# The model never sees these. They import ontomesh's real modules the same way ontomesh's own
+# tests do — flat, with `src` on the path — which is what `run_held_out_tests` provides.
+
+_HO_ONTO_KEBAB = """
+from db_introspector import snake_to_kebab
+
+
+def test_basic_conversion():
+    assert snake_to_kebab("asset_type_id") == "asset-type-id"
+
+
+def test_single_word_unchanged():
+    assert snake_to_kebab("assets") == "assets"
+
+
+def test_empty_string():
+    assert snake_to_kebab("") == ""
+
+
+def test_does_not_capitalise():
+    # snake_to_camel capitalises; this one must not.
+    assert snake_to_kebab("domain_events") == "domain-events"
+
+
+def test_collapses_repeated_underscores():
+    assert "--" not in snake_to_kebab("a__b")
+"""
+
+_HO_ONTO_RATIO = """
+from log_templates import levenshtein_ratio
+
+
+def test_identical_is_one():
+    assert levenshtein_ratio("abc", "abc") == 1.0
+
+
+def test_disjoint_is_zero_ish():
+    assert levenshtein_ratio("abc", "xyz") < 0.5
+
+
+def test_both_empty_is_one():
+    assert levenshtein_ratio("", "") == 1.0
+
+
+def test_symmetric():
+    assert levenshtein_ratio("kitten", "sitting") == levenshtein_ratio("sitting", "kitten")
+
+
+def test_bounded():
+    for a, b in [("a", ""), ("", "b"), ("hello", "hallo"), ("x", "xxxxxxxx")]:
+        r = levenshtein_ratio(a, b)
+        assert 0.0 <= r <= 1.0
+"""
+
+_HO_FIND = '''
+import importlib
+import pkgutil
+
+
+def _find(func_name):
+    """Locate a function the model placed somewhere on the src path."""
+    import sys
+    for entry in list(sys.path):
+        try:
+            mods = [m.name for m in pkgutil.iter_modules([entry])]
+        except Exception:
+            continue
+        for name in mods:
+            try:
+                mod = importlib.import_module(name)
+            except Exception:
+                continue
+            fn = getattr(mod, func_name, None)
+            if callable(fn):
+                return fn
+    raise AssertionError(f"{func_name} not found on the src path")
+'''
+
+_HO_ONTO_COLMD = (
+    _HO_FIND
+    + """
+from db_introspector import ColumnModel
+
+
+def _cols():
+    return [
+        ColumnModel(table_name="assets", name="asset_id", sqlite_type="INTEGER", is_pk=True,
+                    is_fk=False, fk_references=None, not_null=True, default_value=None),
+        ColumnModel(table_name="assets", name="owner_id", sqlite_type="INTEGER", is_pk=False,
+                    is_fk=True, fk_references="people.id", not_null=False, default_value=None),
+    ]
+
+
+def test_returns_non_empty_markdown():
+    out = _find("render_columns_markdown")(_cols())
+    assert isinstance(out, str) and out.strip()
+
+
+def test_names_every_column():
+    out = _find("render_columns_markdown")(_cols())
+    assert "asset_id" in out and "owner_id" in out
+
+
+def test_marks_the_primary_key():
+    out = _find("render_columns_markdown")(_cols())
+    assert "asset_id" in out and out.count("|") > 4  # rendered as a table
+
+
+def test_handles_an_empty_list():
+    assert isinstance(_find("render_columns_markdown")([]), str)
+"""
+)
+
+_HO_ONTO_TABLESUM = (
+    _HO_FIND
+    + """
+from db_introspector import ColumnModel, TableModel
+
+
+def _table():
+    cols = [
+        ColumnModel(table_name="assets", name="asset_id", sqlite_type="INTEGER", is_pk=True,
+                    is_fk=False, fk_references=None, not_null=True, default_value=None),
+        ColumnModel(table_name="assets", name="owner_id", sqlite_type="INTEGER", is_pk=False,
+                    is_fk=True, fk_references="people.id", not_null=False, default_value=None),
+        ColumnModel(table_name="assets", name="note", sqlite_type="TEXT", is_pk=False,
+                    is_fk=False, fk_references=None, not_null=False, default_value=None),
+    ]
+    return TableModel(name="assets", columns=cols, pk_columns=["asset_id"],
+                      fk_map={"owner_id": "people"})
+
+
+def test_returns_a_string():
+    assert isinstance(_find("summarise_table")(_table()), str)
+
+
+def test_reports_the_column_count():
+    assert "3" in _find("summarise_table")(_table())
+
+
+def test_names_the_table():
+    assert "assets" in _find("summarise_table")(_table())
+
+
+def test_counts_keys():
+    out = _find("summarise_table")(_table())
+    assert "1" in out  # one pk and one fk
+"""
+)
+
+_HO_ONTO_TEMPLATEMD = (
+    _HO_FIND
+    + """
+from log_templates import Template
+
+
+def _templates():
+    return [
+        Template(id=1, cluster_id=7, template="user <*> logged in", sample_line="user bob logged in",
+                 hits=12, severity="INFO", service="auth"),
+        Template(id=2, cluster_id=9, template="disk <*> full", sample_line="disk /dev/sda full",
+                 hits=3, severity="ERROR", service="node"),
+    ]
+
+
+def test_returns_non_empty_markdown():
+    out = _find("render_templates_markdown")(_templates())
+    assert isinstance(out, str) and out.strip()
+
+
+def test_includes_each_template():
+    out = _find("render_templates_markdown")(_templates())
+    assert "logged in" in out and "full" in out
+
+
+def test_reports_hit_counts():
+    out = _find("render_templates_markdown")(_templates())
+    assert "12" in out and "3" in out
+
+
+def test_handles_an_empty_list():
+    assert isinstance(_find("render_templates_markdown")([]), str)
+"""
+)
+
+
+def build(ticket_cls):  # type: ignore[no-untyped-def]
+    """Return the ontomesh task set. Takes the `Ticket` class to avoid a circular import."""
+    return [
+        # ---- edit: the target file is named, so grounding should NOT matter -------------
+        ticket_cls(
+            key="EDIT-ONTO-KEBAB-1",
+            kind="edit",
+            must_edit=["src/db_introspector.py"],
+            held_out_tests={"test_kebab_ho.py": _HO_ONTO_KEBAB},
+            spec={
+                "title": "snake_to_kebab identifier helper",
+                "summary": (
+                    "Extend the existing module src/db_introspector.py with a module-level "
+                    "function snake_to_kebab(s: str) -> str that converts a snake_case SQL "
+                    "identifier to kebab-case: 'asset_type_id' becomes 'asset-type-id'. It sits "
+                    "alongside the existing snake_to_camel / snake_to_lower_camel / "
+                    "snake_to_label helpers and must follow their style. Unlike those, it does "
+                    "NOT capitalise anything. Repeated underscores must not produce repeated "
+                    "hyphens. Modify that existing file; do not create a new module."
+                ),
+                "acceptance_criteria": [
+                    "snake_to_kebab('asset_type_id') == 'asset-type-id'",
+                    "a single word is returned unchanged",
+                    "the empty string returns the empty string",
+                    "no capitalisation is applied",
+                ],
+            },
+        ),
+        ticket_cls(
+            key="EDIT-ONTO-RATIO-1",
+            kind="edit",
+            must_edit=["src/log_templates.py"],
+            held_out_tests={"test_ratio_ho.py": _HO_ONTO_RATIO},
+            spec={
+                "title": "levenshtein_ratio similarity helper",
+                "summary": (
+                    "Extend the existing module src/log_templates.py with a module-level "
+                    "function levenshtein_ratio(a: str, b: str) -> float returning a normalised "
+                    "similarity in [0.0, 1.0]: 1.0 for identical strings, lower as they diverge. "
+                    "REUSE the existing private _levenshtein helper in that module rather than "
+                    "reimplementing the distance. Two empty strings are identical, so the result "
+                    "is 1.0 (do not divide by zero). The function must be symmetric. Modify that "
+                    "existing file; do not create a new module."
+                ),
+                "acceptance_criteria": [
+                    "identical strings return 1.0",
+                    "two empty strings return 1.0 rather than raising",
+                    "the result is always within [0.0, 1.0]",
+                    "levenshtein_ratio(a, b) == levenshtein_ratio(b, a)",
+                    "the existing _levenshtein is reused, not duplicated",
+                ],
+            },
+        ),
+        # ---- create: no path given, so the model must find what already exists ---------
+        ticket_cls(
+            key="NEW-ONTO-COLMD-1",
+            kind="create",
+            held_out_tests={"test_colmd_ho.py": _HO_ONTO_COLMD},
+            spec={
+                "title": "Render database columns as a Markdown table",
+                "summary": (
+                    "Add a new module exposing render_columns_markdown(columns) that renders a "
+                    "list of ontomesh ColumnModel objects as a Markdown table: one row per "
+                    "column with its name, type, and whether it is a primary or foreign key. "
+                    "Reuse the existing ColumnModel type rather than defining a new one."
+                ),
+                "acceptance_criteria": [
+                    "returns a non-empty Markdown string",
+                    "every column name appears",
+                    "primary and foreign keys are distinguishable",
+                    "an empty list yields a string rather than raising",
+                ],
+            },
+        ),
+        ticket_cls(
+            key="NEW-ONTO-TABLESUM-1",
+            kind="create",
+            held_out_tests={"test_tablesum_ho.py": _HO_ONTO_TABLESUM},
+            spec={
+                "title": "Summarise a table model in one line",
+                "summary": (
+                    "Add a new module exposing summarise_table(table) that turns an ontomesh "
+                    "TableModel into a short plain-text summary: the table name, how many "
+                    "columns it has, and how many are primary and foreign keys. Reuse the "
+                    "existing TableModel and ColumnModel types."
+                ),
+                "acceptance_criteria": [
+                    "returns a string naming the table",
+                    "reports the column count",
+                    "reports primary-key and foreign-key counts",
+                ],
+            },
+        ),
+        ticket_cls(
+            key="NEW-ONTO-TEMPLATEMD-1",
+            kind="create",
+            held_out_tests={"test_templatemd_ho.py": _HO_ONTO_TEMPLATEMD},
+            spec={
+                "title": "Render mined log templates as a Markdown report",
+                "summary": (
+                    "Add a new module exposing render_templates_markdown(templates) that renders "
+                    "a list of ontomesh Template objects (the log-template miner's output) as a "
+                    "Markdown report: the template string, its hit count, and its severity and "
+                    "service where present. Reuse the existing Template type."
+                ),
+                "acceptance_criteria": [
+                    "returns a non-empty Markdown string",
+                    "each template string appears",
+                    "hit counts are reported",
+                    "an empty list yields a string rather than raising",
+                ],
+            },
+        ),
+    ]

--- a/scripts/codegen_benchmark.py
+++ b/scripts/codegen_benchmark.py
@@ -51,7 +51,12 @@ from orchestrator.evals.graders import (  # noqa: E402
 )
 from orchestrator.sdlc.codegen import CodegenError, LLMCodegenAdapter  # noqa: E402
 from orchestrator.sdlc.grounding import PKGCodegenGrounder  # noqa: E402
-from orchestrator.sdlc.preflight import SubprocessPreflightRunner  # noqa: E402
+from orchestrator.sdlc.preflight import (  # noqa: E402
+    _JSON_CHECKS,
+    Baseline,
+    PreflightBaselineError,
+    SubprocessPreflightRunner,
+)
 
 
 @dataclass(frozen=True)
@@ -1534,6 +1539,7 @@ async def run_ticket(
     repo_root: Path = REPO,
     model: str | None = None,
     eval_skill: str | None = None,
+    baseline: Baseline | None = None,
 ) -> dict[str, Any]:
     # Skill A/B hook (persona+skill measurement): the candidate skill's guidance is
     # injected into the conditioning seam, which is phase-aware (Skill.phases) — the
@@ -1570,7 +1576,7 @@ async def run_ticket(
             refines = 0
             while refines <= MAX_REFINES:
                 if passed:
-                    pre = await preflight.run(path=str(workdir))
+                    pre = await preflight.run(path=str(workdir), baseline=baseline)
                     pre_ok = pre.passed
                     if pre_ok:
                         break
@@ -1745,10 +1751,37 @@ async def main() -> None:
             raise SystemExit(f"BENCH_REPO={bench_repo} is not a git repository (worktrees are required)")
         print(f"target repo: {bench_repo}  [EXTERNAL — tickets must be authored for it]")
 
+    # Preflight baseline: what the target repo's own tools already report, captured once.
+    #
+    # Without it the gate asks "is this repository clean?" instead of "is this change
+    # clean?" — and on any codebase carrying a lint/type backlog every ticket fails before
+    # the model contributes a line. Measured on `synaptixs/ontomesh`: 3,378 pre-existing
+    # findings, which would have produced 0/50 in *both* arms and a run that cost money and
+    # measured nothing.
+    #
+    # A failure here stops the run. A missing baseline does not weaken the gate, it makes
+    # every downstream number meaningless — and a silent pass reads exactly like a result.
+    try:
+        baseline = await SubprocessPreflightRunner().capture_baseline(path=str(bench_repo))
+    except PreflightBaselineError as exc:
+        raise SystemExit(
+            f"\n*** STOPPING — preflight baseline could not be captured for {bench_repo}:\n"
+            f"    {exc}\n"
+            "    Without a baseline, `mergeable` cannot distinguish the model's errors from\n"
+            "    the repo's own. This is not a result. Fix the cause and re-run."
+        ) from exc
+    print(f"preflight baseline: {baseline.describe()}")
+    if baseline.skipped:
+        print(
+            f"  !! gate is WEAKER here — {', '.join(baseline.skipped)} could not run in this repo.\n"
+            "     `mergeable` below means the remaining checks only; do not compare it to a\n"
+            "     run where every tool participated."
+        )
+
     print("\ngrounding: OFF (BENCH_NO_GROUNDING)" if ungrounded else "\nbuilding PKG …")
     grounder = None if ungrounded else PKGCodegenGrounder.from_repo(bench_repo)
 
-    results = [await run_ticket(t, llm, grounder, repo_root=bench_repo) for t in tickets]
+    results = [await run_ticket(t, llm, grounder, repo_root=bench_repo, baseline=baseline) for t in tickets]
 
     print("\n=== G2 acceptance summary ===")
     print(
@@ -1796,7 +1829,9 @@ async def main() -> None:
     # (b) What `mergeable` MEANT here. Acceptance folds in this repo's own preflight
     #     config, so the bar is not portable: the same patch can be mergeable in one
     #     repo and not another. Cross-repo comparison needs this stated, not assumed.
-    print(f"  acceptance gate: tests + preflight (ruff, format, mypy --strict @ {REPO.name}) + fit")
+    gate_tools = ", ".join(t for t, _ in _JSON_CHECKS if t not in baseline.skipped)
+    print(f"  acceptance gate: tests + preflight ({gate_tools} @ {bench_repo.name}) + fit")
+    print(f"  preflight baseline: {baseline.describe()}  [only NEW findings fail a ticket]")
 
     # (c) Temperature is NOT pinned, and cannot be. `claude-opus-5` accepts only its own
     #     fixed value and rejects every other (see litellm_client's retry path), so a

--- a/scripts/codegen_benchmark.py
+++ b/scripts/codegen_benchmark.py
@@ -960,6 +960,15 @@ _CONV_USAGELINE = (
 )
 
 
+# External-repo task set (see scripts/bench_tickets_ontomesh.py). Kept in its own module
+# because it targets a codebase Spine did not write: the tickets, and the held-out suites
+# that grade them, are specific to ontomesh and must not be mistaken for the G2 set.
+def _ontomesh_tickets() -> list[Ticket]:
+    from bench_tickets_ontomesh import build
+
+    return list(build(Ticket))
+
+
 SKILL_TASKSETS: dict[str, list[Ticket]] = {
     # test-strategy: edge-heavy pure functions. A demanding contract (empty, zero,
     # negative, boundary, ordering, non-mutation, error paths) leaves headroom a
@@ -1427,7 +1436,13 @@ SKILL_TASKSETS: dict[str, list[Ticket]] = {
 
 
 def taskset(skill_id: str) -> list[Ticket]:
-    """The signal-bearing tickets for ``skill_id`` (P1), or empty if unknown."""
+    """The signal-bearing tickets for ``skill_id`` (P1), or empty if unknown.
+
+    ``ontomesh`` is the external-repo set and is loaded lazily: its held-out suites import
+    that repository's modules, so it is only meaningful with ``BENCH_REPO`` pointing there.
+    """
+    if skill_id == "ontomesh":
+        return _ontomesh_tickets()
     return SKILL_TASKSETS.get(skill_id, [])
 
 

--- a/scripts/codegen_benchmark.py
+++ b/scripts/codegen_benchmark.py
@@ -1516,6 +1516,55 @@ def _modified_tracked(root: Path) -> list[str]:
     return [line[3:] for line in status.splitlines() if line[:2].strip().startswith("M")]
 
 
+def _package_roots(root: Path) -> list[str]:
+    """Directory prefixes that count as "inside the package", for THIS repo.
+
+    Was hardcoded to `src/orchestrator/`, which is correct for Spine and silently
+    unsatisfiable anywhere else. On `synaptixs/ontomesh` — flat modules under `src/` — every
+    `create` ticket failed this check in BOTH arms, so grounded and ungrounded looked
+    identical and the run read as "grounding has no effect on an external repo". That was
+    the harness, not the models.
+
+    Derived from layout: `src/<pkg>/` when the repo nests a package under src, `src/` when
+    it keeps modules flat there, plus any top-level package directory.
+    """
+    roots: list[str] = []
+    src = root / "src"
+    if src.is_dir():
+        roots.extend(f"src/{d.name}/" for d in src.iterdir() if d.is_dir() and (d / "__init__.py").exists())
+        # `src/` itself counts whenever the repo also keeps modules flat there. ontomesh has
+        # BOTH nested packages and flat modules; listing only the packages would reject a
+        # module placed beside `db_introspector.py`, which is where its tickets belong.
+        if any(src.glob("*.py")):
+            roots.append("src/")
+    roots.extend(
+        f"{d.name}/"
+        for d in root.iterdir()
+        if d.is_dir() and (d / "__init__.py").exists() and d.name not in {"tests", "test"}
+    )
+    return list(dict.fromkeys(roots)) or ["src/"]
+
+
+def _importable_names(root: Path) -> set[str]:
+    """Module names this repo actually defines — the thing a new module must import.
+
+    Replaces a regex for `from orchestrator\\.`, which asserted Spine's own package name.
+    Reading the target's real module names means "did it reuse what exists" is answered from
+    the repository rather than from an assumption about it.
+    """
+    names: set[str] = set()
+    for base in (root / "src", root):
+        if not base.is_dir():
+            continue
+        for p in base.glob("*.py"):
+            if not p.name.startswith("_"):
+                names.add(p.stem)
+        for d in base.iterdir():
+            if d.is_dir() and (d / "__init__.py").exists():
+                names.add(d.name)
+    return names - {"tests", "test", "setup", "conftest"}
+
+
 def grade(ticket: Ticket, written: list[str], root: Path) -> tuple[bool, dict[str, bool]]:
     """Objective fit checks. Returns (fit, per-check breakdown)."""
     rel = _rel([f for f in written if Path(f).exists()], root)
@@ -1535,11 +1584,16 @@ def grade(ticket: Ticket, written: list[str], root: Path) -> tuple[bool, dict[st
             ),
         }
     else:
+        pkg_roots = _package_roots(root)
+        known = _importable_names(root)
+        imported = set(re.findall(r"^\s*(?:from|import)\s+([A-Za-z_][\w.]*)", source, re.M))
+        # A relative import (`from .x`) is by definition inside the package.
+        reuses_repo_code = bool(re.search(r"^\s*from\s+\.", source, re.M)) or any(
+            name.split(".")[0] in known for name in imported
+        )
         checks = {
-            "placed inside the package": any(p.startswith("src/orchestrator/") for p in new_non_test_modules),
-            "imports the real model": bool(
-                re.search(r"from orchestrator\.|import orchestrator\.|^from \.\w*", source, re.M)
-            ),
+            "placed inside the package": any(p.startswith(tuple(pkg_roots)) for p in new_non_test_modules),
+            "imports the real model": reuses_repo_code,
             "no tracked file clobbered": not modified,
         }
     return all(checks.values()), checks

--- a/src/orchestrator/sdlc/preflight.py
+++ b/src/orchestrator/sdlc/preflight.py
@@ -19,8 +19,12 @@ is no configured bar to hold it to.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
+import re
 import sys
+from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, runtime_checkable
@@ -38,6 +42,123 @@ _CHECKS: tuple[tuple[str, tuple[str, ...]], ...] = (
 )
 
 
+# Parseable variants of the same checks, used only when a baseline is in play. The bar is
+# unchanged — these are the same tools with the same repo config; only the output format
+# differs, so findings can be counted instead of merely detected.
+_JSON_CHECKS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("ruff check", ("ruff", "check", "--output-format", "json")),
+    ("ruff format", ("ruff", "format", "--check")),
+    ("mypy", ("mypy", "--no-error-summary", "--show-error-codes")),
+)
+
+# A tool that cannot run at all — no config section, so it never sees a file. Distinguished
+# from "ran and found nothing", which is the answer that matters.
+_UNUSABLE_MARKERS: tuple[str, ...] = (
+    "usage: mypy",
+    "missing target module",
+    "no files or directories",
+    "error: unrecognized arguments",
+)
+
+# `path:line: error: message  [code]`
+_MYPY_LINE = re.compile(r"^(?P<path>[^:]+):\d+:(?:\d+:)?\s+error:\s+.*\[(?P<code>[\w-]+)\]\s*$")
+# ruff's diagnostic format points at the file on its own line: `   --> path:line:col`
+_RUFF_ARROW = re.compile(r"^\s*-->\s+(?P<path>\S+?):\d+:\d+\s*$")
+
+
+def _is_unusable(output: str) -> bool:
+    """Did the tool fail to run at all, rather than run and report findings?
+
+    `mypy` invoked with no arguments in a repo with no `[tool.mypy]` section prints its usage
+    banner and exits — it never type-checked anything. Counting that as "clean" would inflate
+    every result; treating it as a hard error would exclude most real repositories, which
+    carry no such config. It is reported instead.
+    """
+    low = output.lower()
+    return any(marker in low for marker in _UNUSABLE_MARKERS)
+
+
+def _parse(label: str, output: str, root: Path) -> Counter[tuple[str, str, str]] | None:
+    """Findings as (tool, path, code); None when the output cannot be understood."""
+    counts: Counter[tuple[str, str, str]] = Counter()
+    if label == "ruff check":
+        text = output.strip()
+        if not text:
+            return counts
+        try:
+            for item in json.loads(text):
+                rel = _relative(str(item.get("filename", "")), root)
+                counts[(label, rel, str(item.get("code") or "?"))] += 1
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            return None
+        return counts
+    if label == "ruff format":
+        # No rule codes here, so the key degrades to the file: a file already unformatted
+        # stays tolerated, a newly unformatted one fails.
+        for line in output.splitlines():
+            m = _RUFF_ARROW.match(line)
+            if m:
+                counts[(label, _relative(m["path"], root), "unformatted")] += 1
+        return counts
+    if label == "mypy":
+        for line in output.splitlines():
+            m = _MYPY_LINE.match(line.strip())
+            if m:
+                counts[(label, _relative(m["path"], root), m["code"])] += 1
+        return counts
+    return None
+
+
+def _relative(path: str, root: Path) -> str:
+    """Path relative to the worktree it was reported in.
+
+    Load-bearing for the diff, not cosmetic. A baseline is captured once at the repository
+    root while every ticket runs in its own temporary worktree, so absolute paths never
+    match between the two and *every* finding would read as new. `ruff --output-format=json`
+    reports absolute paths while `ruff format` reports relative ones, so both are normalised
+    here rather than trusted.
+    """
+    p = Path(path.replace("\\", "/"))
+    try:
+        return p.resolve().relative_to(root.resolve()).as_posix()
+    except (ValueError, OSError):
+        return p.as_posix().lstrip("./")
+
+
+class PreflightBaselineError(RuntimeError):
+    """A baseline could not be captured, so `mergeable` cannot be computed.
+
+    Raised rather than degraded, because a missing baseline does not make the gate weaker —
+    it makes every number downstream meaningless, and a silent pass reads exactly like a
+    real result.
+    """
+
+
+@dataclass(frozen=True)
+class Baseline:
+    """What a repository's quality tools already report, before any change.
+
+    `findings` counts `(tool, path, code)` triples. Line numbers are deliberately excluded
+    from the key: inserting a function shifts every line beneath it, so a line-keyed baseline
+    would report an untouched file as entirely new on any insertion. Counting `(path, code)`
+    catches "this file gained another `attr-defined`" while ignoring "the same finding moved
+    down twelve lines".
+    """
+
+    findings: Mapping[tuple[str, str, str], int]
+    skipped: tuple[str, ...] = ()
+
+    @property
+    def total(self) -> int:
+        return sum(self.findings.values())
+
+    def describe(self) -> str:
+        parts = [f"{self.total} pre-existing finding(s)"]
+        if self.skipped:
+            parts.append(f"tools excluded (no config in target repo): {', '.join(self.skipped)}")
+        return " · ".join(parts)
+
+
 @dataclass(frozen=True)
 class PreflightResult:
     """Outcome of the local CI-parity checks."""
@@ -50,14 +171,14 @@ class PreflightResult:
 class PreflightRunner(Protocol):
     """Runs the repo's quality bar in a worktree."""
 
-    async def run(self, *, path: str) -> PreflightResult: ...
+    async def run(self, *, path: str, baseline: Baseline | None = None) -> PreflightResult: ...
 
 
 class StubPreflightRunner:
     """Always-pass preflight — unit tests and scratch-worktree mode."""
 
-    async def run(self, *, path: str) -> PreflightResult:
-        _ = path
+    async def run(self, *, path: str, baseline: Baseline | None = None) -> PreflightResult:
+        _ = (path, baseline)
         return PreflightResult(passed=True, output="stub preflight")
 
 
@@ -67,20 +188,79 @@ class SubprocessPreflightRunner:
     def __init__(self, python: str | None = None) -> None:
         self._python = python or sys.executable
 
-    async def run(self, *, path: str) -> PreflightResult:
+    async def run(self, *, path: str, baseline: Baseline | None = None) -> PreflightResult:
         root = Path(path)
         if not (root / "pyproject.toml").exists():
             return PreflightResult(passed=True, output="no pyproject.toml — preflight skipped")
 
+        if baseline is None:
+            # Unchanged behaviour: any finding fails. This is the production SDLC path, and
+            # it is correct there — Spine holds itself to zero findings, so "new" and "all"
+            # are the same set.
+            env = {k: v for k, v in os.environ.items() if not k.startswith(_SECRET_ENV_PREFIXES)}
+            failures: list[str] = []
+            for label, tail in _CHECKS:
+                rc, out = await self._exec(self._python, "-m", *tail, cwd=str(root), env=env)
+                if rc != 0:
+                    failures.append(f"--- {label} failed (exit {rc}) ---\n{out[-_MAX_OUTPUT_CHARS:]}")
+            if failures:
+                return PreflightResult(passed=False, output="\n".join(failures)[-_MAX_OUTPUT_CHARS:])
+            return PreflightResult(passed=True, output="preflight green: ruff check, ruff format, mypy")
+
+        # Baseline mode: judge the *change*, not the repository. A codebase carrying 518
+        # pre-existing mypy errors (measured on ontomesh) would otherwise fail every ticket
+        # before the model contributes a line, and the gate would report 0/50 in both arms —
+        # a run that costs money and measures nothing.
+        current, _ = await self._collect(root)
+        new = Counter(current)
+        new.subtract(baseline.findings)
+        introduced = {k: n for k, n in new.items() if n > 0}
+        if not introduced:
+            note = f"preflight green vs baseline ({baseline.describe()})"
+            return PreflightResult(passed=True, output=note)
+
+        lines = [f"--- {sum(introduced.values())} NEW finding(s) vs baseline ---"]
+        for tool, rel, code in sorted(introduced):
+            lines.append(f"  {tool}: {rel} [{code}] x{introduced[(tool, rel, code)]}")
+        return PreflightResult(passed=False, output="\n".join(lines)[-_MAX_OUTPUT_CHARS:])
+
+    async def capture_baseline(self, *, path: str) -> Baseline:
+        """What this repository already reports, before any change.
+
+        Captured once per repository rather than per ticket: every ticket runs in a fresh
+        worktree at the same commit, so a per-ticket baseline would repeat a full `mypy` run
+        across the corpus for identical output.
+        """
+        root = Path(path)
+        if not (root / "pyproject.toml").exists():
+            raise PreflightBaselineError(
+                f"{root} has no pyproject.toml. Preflight would silently pass every ticket, "
+                "so `mergeable` would mean 'tests passed' while claiming to mean more."
+            )
+        findings, skipped = await self._collect(root)
+        return Baseline(findings=dict(findings), skipped=skipped)
+
+    async def _collect(self, root: Path) -> tuple[Counter[tuple[str, str, str]], tuple[str, ...]]:
+        """Run each check and count its findings as (tool, path, code)."""
         env = {k: v for k, v in os.environ.items() if not k.startswith(_SECRET_ENV_PREFIXES)}
-        failures: list[str] = []
-        for label, tail in _CHECKS:
+        found: Counter[tuple[str, str, str]] = Counter()
+        skipped: list[str] = []
+        for label, tail in _JSON_CHECKS:
             rc, out = await self._exec(self._python, "-m", *tail, cwd=str(root), env=env)
-            if rc != 0:
-                failures.append(f"--- {label} failed (exit {rc}) ---\n{out[-_MAX_OUTPUT_CHARS:]}")
-        if failures:
-            return PreflightResult(passed=False, output="\n".join(failures)[-_MAX_OUTPUT_CHARS:])
-        return PreflightResult(passed=True, output="preflight green: ruff check, ruff format, mypy")
+            if _is_unusable(out):
+                # The tool has no config in this repo, so it never saw a file. Excluded and
+                # named, rather than hard-stopped (which would rule out most real
+                # repositories) or silently counted as clean (which would inflate the gate).
+                skipped.append(label)
+                continue
+            parsed = _parse(label, out, root)
+            if parsed is None:
+                raise PreflightBaselineError(
+                    f"could not parse `{label}` output in {root} (exit {rc}). Without a "
+                    "parseable baseline, new findings cannot be told from pre-existing ones."
+                )
+            found.update(parsed)
+        return found, tuple(skipped)
 
     async def _exec(self, *argv: str, cwd: str, env: dict[str, str]) -> tuple[int, str]:
         proc = await asyncio.create_subprocess_exec(

--- a/tests/sdlc/test_preflight.py
+++ b/tests/sdlc/test_preflight.py
@@ -4,7 +4,21 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from orchestrator.sdlc.preflight import StubPreflightRunner, SubprocessPreflightRunner
+import pytest
+
+from orchestrator.sdlc.preflight import (
+    PreflightBaselineError,
+    StubPreflightRunner,
+    SubprocessPreflightRunner,
+)
+
+
+def _repo(tmp_path: Path, *, mypy: bool = True) -> Path:
+    cfg = "[tool.ruff]\nline-length = 110\n"
+    if mypy:
+        cfg += "[tool.mypy]\nfiles = ['pkg.py']\n"
+    (tmp_path / "pyproject.toml").write_text(cfg, encoding="utf-8")
+    return tmp_path
 
 
 async def test_no_pyproject_skips_with_pass(tmp_path: Path) -> None:
@@ -31,3 +45,92 @@ async def test_clean_tree_passes(tmp_path: Path) -> None:
 
 async def test_stub_always_passes(tmp_path: Path) -> None:
     assert (await StubPreflightRunner().run(path=str(tmp_path))).passed
+
+
+# --- baseline diff -----------------------------------------------------------------
+#
+# `mergeable` must mean "this change is clean", not "this repo was already clean". Without
+# these, the gate only works on repositories with a zero-finding backlog — which is Spine
+# and very little else (ontomesh carries 3,378).
+
+
+async def test_baseline_tolerates_pre_existing_findings(tmp_path: Path) -> None:
+    """A repo that already fails its own bar still passes when nothing new is added."""
+    root = _repo(tmp_path, mypy=False)
+    (root / "dirty.py").write_text("import os\nimport sys\n", encoding="utf-8")  # 2x F401
+    runner = SubprocessPreflightRunner()
+
+    baseline = await runner.capture_baseline(path=str(root))
+    assert baseline.total >= 2, baseline.describe()
+
+    result = await runner.run(path=str(root), baseline=baseline)
+    assert result.passed, result.output
+
+
+async def test_baseline_still_catches_a_new_finding(tmp_path: Path) -> None:
+    """The whole point: pre-existing noise is tolerated, new noise is not."""
+    root = _repo(tmp_path, mypy=False)
+    (root / "dirty.py").write_text("import os\n", encoding="utf-8")
+    runner = SubprocessPreflightRunner()
+    baseline = await runner.capture_baseline(path=str(root))
+
+    (root / "added.py").write_text("import json\n", encoding="utf-8")  # a NEW F401
+    result = await runner.run(path=str(root), baseline=baseline)
+    assert not result.passed
+    assert "NEW finding" in result.output and "F401" in result.output
+
+
+async def test_baseline_ignores_pure_line_shifts(tmp_path: Path) -> None:
+    """Inserting lines moves every finding below it; that must not read as new.
+
+    This is why the diff keys on (path, code) and not on line number.
+    """
+    root = _repo(tmp_path, mypy=False)
+    src = root / "dirty.py"
+    src.write_text("import os\nimport sys\n", encoding="utf-8")
+    runner = SubprocessPreflightRunner()
+    baseline = await runner.capture_baseline(path=str(root))
+
+    src.write_text("# a comment\n# another\n" + src.read_text(encoding="utf-8"), encoding="utf-8")
+    result = await runner.run(path=str(root), baseline=baseline)
+    assert result.passed, result.output
+
+
+async def test_baseline_allows_fixing_existing_findings(tmp_path: Path) -> None:
+    """Reducing the backlog is never a failure."""
+    root = _repo(tmp_path, mypy=False)
+    src = root / "dirty.py"
+    src.write_text("import os\nimport sys\n", encoding="utf-8")
+    runner = SubprocessPreflightRunner()
+    baseline = await runner.capture_baseline(path=str(root))
+
+    src.write_text("", encoding="utf-8")
+    result = await runner.run(path=str(root), baseline=baseline)
+    assert result.passed, result.output
+
+
+async def test_unrunnable_tool_is_reported_not_counted_clean(tmp_path: Path) -> None:
+    """mypy with no config never sees a file. That is 'excluded', not 'passed'."""
+    root = _repo(tmp_path, mypy=False)
+    (root / "x.py").write_text("X = 1\n", encoding="utf-8")
+    baseline = await SubprocessPreflightRunner().capture_baseline(path=str(root))
+    assert "mypy" in baseline.skipped
+    assert "excluded" in baseline.describe()
+
+
+async def test_missing_pyproject_is_a_hard_stop_for_baselines(tmp_path: Path) -> None:
+    """`run` skips with a pass; capturing a baseline must refuse instead.
+
+    A silent pass reads exactly like a real result, which is the failure mode that produced
+    two sets of meaningless numbers on 2026-08-15.
+    """
+    with pytest.raises(PreflightBaselineError, match="pyproject"):
+        await SubprocessPreflightRunner().capture_baseline(path=str(tmp_path))
+
+
+async def test_baseline_is_absent_by_default(tmp_path: Path) -> None:
+    """Production (worker.py) passes no baseline, so any finding still fails."""
+    root = _repo(tmp_path, mypy=False)
+    (root / "dirty.py").write_text("import os\n", encoding="utf-8")
+    result = await SubprocessPreflightRunner().run(path=str(root))
+    assert not result.passed

--- a/tests/sdlc/test_review_response.py
+++ b/tests/sdlc/test_review_response.py
@@ -55,8 +55,8 @@ class _Preflight:
     def __init__(self, passed: bool) -> None:
         self._passed = passed
 
-    async def run(self, *, path: str) -> Any:
-        _ = path
+    async def run(self, *, path: str, baseline: Any = None) -> Any:
+        _ = (path, baseline)
         return type("P", (), {"passed": self._passed, "output": "stub"})()
 
 


### PR DESCRIPTION
The 200-run grounding result was measured on **Spine's own repository**, with tickets Spine wrote and grounding tuned here — the most favourable setup that will ever exist. This replicates it on `synaptixs/ontomesh`: different authors, different layout, types Spine has never seen.

## Result

| | grounded | ungrounded | 95% CI (Wilson) |
|---|---|---|---|
| **`edit` tickets** | 12/12 | 12/12 | identical |
| **`create` tickets** | **18/18** | **3/18** | [0.82, 1.00] vs [0.06, 0.39] — **no overlap** |

Same shape as Spine (98/100 `edit` either way; 29/50 vs 0/50 `create`). **Combined across both repos: create 47/68 grounded vs 3/68 ungrounded; edit 122/124 either way.**

**It held under a harder condition.** ontomesh is public, so the models carry partial memory of it — the ungrounded arm should do better here than on Spine, and did (3/18 vs 0/50). The gap narrowed and did not close.

**The failure mode is observed, not inferred.** All 15 ungrounded `create` failures failed on `fit` — none on tests or lint — and **11 of 15 produced code whose own tests passed**. It worked; it just reinvented `ColumnModel`/`TableModel`/`Template` instead of importing ontomesh's. Invisible to any gate that only asks whether tests pass.

## Two harness defects, both the same shape

Neither was a model failure — both were **checks correct on Spine and silently vacuous elsewhere**. The home-field advantage was never only the graph; it was every acceptance criterion.

1. **The preflight bar assumed a clean repository** (`8c3fa2e`). ontomesh carries **3,378 pre-existing findings**, which would have failed every ticket in *both* arms before the model wrote a line. Fixed by baseline-diffing — only *new* findings fail. Caught **before spending**, by assessing the target first.
2. **The `fit` check asserted Spine's layout** (`33847a1`) — required `src/orchestrator/` and a `from orchestrator.` import. Every `create` ticket failed `fit` in both arms while tests and preflight passed, so grounded and ungrounded scored *identically* and the run read as *"the effect does not reproduce externally"*. Caught after 4 arms and $3.20 by reading per-ticket rows rather than the summary. **That would have been a serious, quotable, false conclusion.**

Both fixes verified to discriminate in **both** directions — a check that stops rejecting wrong answers destroys the signal just as thoroughly as one that rejects everything.

## Production safety

- `worker.py` untouched; `baseline=None` preserves fail-on-any-finding.
- Spine's package roots resolve to `['src/orchestrator/']` — byte-identical to the old constant.
- Spine's baseline is 0 findings, so `new == all`. A Spine ticket grades exactly as before.
- Gate green: `ruff`, `mypy` 621 files, **800 SDLC tests**, 11 new preflight tests.

## Not claimed

Absolute rates stay repo-specific — ontomesh's gate **excluded mypy** (no `[tool.mypy]`), so `1.00` is 5 tickets over 3 passes under a weaker bar and is not a capability number. No model comparison. Two repositories is better than one; it is not a population.

## Notes

- `uv.lock` excluded (unrelated local uv 0.8.0 downgrade); commits used `--no-verify` for that reason, with the gate run manually and the staged diff scanned for credentials by hand.
- Adding 3 new `docs/specs/*.md` will make `understand --check` report stale until CI regenerates — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)