### PR TITLE
docs: 3.19.0 — documentation refresh and version bump

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,14 @@ ANTHROPIC_API_KEY=sk-ant-...
 # ORCHESTRATOR_INTAKE_MODEL=           # intent extraction + spec writing
 # SDLC_REVIEW_MODEL=                   # PR review
 #
+# Reasoning level sent to reasoning-capable models when a tool call is in play.
+# Default `high`. This is NOT optional plumbing on some providers: OpenAI rejects
+# function tools alongside a reasoning model's *implicit* default, so a level must be
+# named or every codegen call fails. `low`/`medium`/`high` all work and all keep the
+# reasoning — the error text suggests `none`, which would switch off the reasoning these
+# models are chosen for. Lower it to trade quality for latency and cost, not to fix an error.
+# ORCHESTRATOR_REASONING_EFFORT=high
+#
 # Two things that catch people out:
 #   * SDLC_CODEGEN_MODEL falls back to ORCHESTRATOR_INTAKE_MODEL *before*
 #     ORCHESTRATOR_MODEL — deliberate, so a single-variable setup drives the whole

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,9 +97,8 @@ PR** — deployment is out of scope by design.
 - **Comprehension is deterministic and no-LLM.** `understand` and the PKG produce
   byte-identical output for the same commit. The LLM lives in the *execution loop* (codegen) and
   *intake* extraction — never in comprehension.
-  *Known exception:* `state` is not currently byte-stable — components tying on their symbol
-  counts can swap order between runs, because the area list is sorted from a `set` with a
-  non-total key. Pin `PYTHONHASHSEED=0` when diffing until it is fixed.
+  `state` holds the same guarantee: its layout sorts on a total key, so a tie between two
+  components resolves identically every run regardless of Python's per-process hash seed.
 - **Everything is grounded and audited.** Every fact carries `file:line` provenance; every tool
   call, approval and decision is recorded in an append-only audit trail.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,83 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## 3.19.0 — What the graph is worth, measured; and four ways it was wrong
+
+3.18.x claimed the code graph makes generated code better. This release **measures that claim**
+in a controlled A/B — and every extraction defect below was found by pointing the measurement at
+codebases that are not this one.
+
+### Added — the grounding claim is now a number
+
+- **200 runs, 2 frontier models, 5 passes each, grounded against an identical ungrounded
+  control.** Every new module that integrated correctly came from a grounded run — **29/50**
+  under `mypy --strict` plus correct placement; the same tickets ungrounded produced **none**.
+  On tickets that already name the target file the two arms tie (**98/100**), which rules out a
+  generic more-context effect and locates the payoff precisely where the model cannot see.
+  Method, Wilson bounds and the abort accounting are in
+  [`codegen-model-comparison-results.md`](docs/specs/codegen-model-comparison-results.md).
+- **Replicated on an unrelated external codebase**, so the result is not an artefact of Spine
+  grading itself — see
+  [`external-repo-grounding-results.md`](docs/specs/external-repo-grounding-results.md).
+  Combined across both: **47/68 grounded, 3/68 ungrounded**, with the `edit`-ticket control at
+  122/124 either arm.
+- **Held-out grading.** Each ticket's acceptance suite is authored separately from the ticket;
+  the model never writes the test that grades it. A pass that never reached the model is
+  recorded as **aborted and excluded**, not silently counted as a failure.
+- `scripts/bench_aggregate.py` — Wilson score intervals (they stay sensible at small *n* and
+  near 0 or 1, where the normal approximation does not), aborted passes excluded, and a warning
+  below five passes.
+
+### Added — preflight judges the change, not the repository
+
+`sdlc` preflight now captures a **baseline** of `ruff check`, `ruff format` and `mypy` findings
+before generation and diffs against it, so a repo that already has findings no longer fails
+every build on pre-existing debt. A check whose baseline could not be captured is reported as
+skipped rather than assumed clean. Design record:
+[`preflight-baseline-diff.md`](docs/specs/preflight-baseline-diff.md).
+
+### Fixed — extraction defects, each found on real code
+
+- **A SQL Server database project was 95% invisible.** SSMS scripts UTF-16 by default and
+  separates batches with `GO`, a client directive that is not valid T-SQL — so an entire file
+  failed to parse and was skipped in silence. Encoding is now sniffed from the BOM and files are
+  split on `GO` and parsed batch by batch. On one real project: **676 of 709 `.sql` files
+  skipped → 0**, `READS` 2 → 186, `WRITES` 0 → 26. Neither cause was a dialect problem, so
+  `--dialect tsql` never helped.
+- **931 dangling edges on a real C#/TypeScript/SQL codebase.** TypeScript emitted edges to
+  imported symbols with no node to land on (**854** of them); C# qualified an external base type
+  into the deriving type's own namespace, inventing a target that does not exist. Both now
+  resolve to explicit external nodes.
+- **`extractor.py` discarded `finalize()`'s return value** — a front-end's whole-repo post-pass
+  computed its corrections and threw them away. C# is the first front-end to need one, which is
+  how this surfaced.
+- **TypeScript resolved relative imports three different ways**, so the same module reached the
+  graph under up to three ids. One resolver now serves declaration, call and type resolution.
+- **`state` rendered a different report for identical input.** Areas tying on their symbol
+  counts sorted out of a `set` on score alone, and Python randomises string hashing per process
+  — five identical runs produced three distinct outputs. The sort key is now total. The
+  regression test renders under five `PYTHONHASHSEED` values **in subprocesses**, which is the
+  only way to see the bug: the seed is fixed for the life of a process. `state` is byte-stable
+  again, as [ARCHITECTURE.md](ARCHITECTURE.md) always claimed; the 3.18.1 caveat is withdrawn.
+- **LiteLLM client.** `reasoning_effort` is sent only to models that declare support (from
+  `litellm.model_cost`, configurable with `ORCHESTRATOR_REASONING_EFFORT`, default `high`);
+  `response_format=json_object` is no longer sent alongside function tools, which OpenAI
+  rejects; every completion is wrapped in `asyncio.wait_for`, so a hung request fails the pass
+  instead of hanging the run; and the served model name is recorded from the response rather
+  than assumed from the request.
+
+### Documented
+
+- [`capability-matrix.md`](docs/specs/capability-matrix.md) and
+  [`competitive-landscape.md`](docs/specs/competitive-landscape.md) — Spine's column verified
+  against source, every other column marked public-documentation-only. RBAC is scored **🟡**
+  after an audit found `has_role` called at exactly one site, while multi-tenancy holds at ✅.
+- [`parsing-and-the-pkg.md`](docs/specs/parsing-and-the-pkg.md) — why every front-end is a real
+  parser (AST or tree-sitter or `sqlglot`) and never a regex, written for an engineering
+  audience.
+- `ORCHESTRATOR_REASONING_EFFORT` documented in `.env.example`, `CLI_REFERENCE.md` and
+  `USER_GUIDE.md`; the SQL Server capability in `KNOWLEDGE_GRAPH.md` §4 and `FEATURES.md`.
+
 ## 3.18.1 — The documentation catches up, and corrects itself
 
 No code changes. 3.17.0 and 3.18.0 shipped two releases of PKG work without the user-facing

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -94,6 +94,14 @@ built-in default.
 Pointing a stage at another vendor needs that vendor's key in the environment
 (`OPENAI_API_KEY` for `gpt-*`, `ANTHROPIC_API_KEY` for `claude-*`).
 
+**Reasoning models need their level named.** `ORCHESTRATOR_REASONING_EFFORT` (default `high`)
+sets the reasoning level sent whenever a tool call is in play. It is not a tuning knob you can
+ignore: OpenAI **rejects function tools alongside a reasoning model's implicit default**, so
+without an explicit level every codegen call fails on models like `gpt-5.6-sol`. `low`,
+`medium` and `high` all work and all keep the reasoning. The provider's own error suggests
+`none` — that disables the reasoning these models are chosen for, and is the wrong fix. Lower
+it to trade quality for latency and cost, never to clear an error.
+
 ### `orchestrator doctor`
 
 Check environment readiness and print a diagnostic report.
@@ -243,11 +251,8 @@ orchestrator state [PATH] [OPTIONS]
 Output format follows `--out`'s extension: `--out report.html` emits a single self-contained,
 shareable HTML report; any other extension (or stdout) emits markdown.
 
-> **Known issue — `state` output is not byte-stable across runs.** Components that tie on
-> their symbol counts can swap order between runs, because the area list is sorted from a
-> `set` with a non-total key and Python randomizes string hashing per process. Five identical
-> runs can produce two or three different outputs. If you diff `state` output, pin
-> `PYTHONHASHSEED=0` on both sides until this is fixed. `understand` is unaffected.
+Output is byte-stable: pair `--no-timestamp` with any extension and two runs of the same
+commit produce identical bytes, so a report can be diffed or checked into CI.
 
 ### `orchestrator profile`
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -36,6 +36,7 @@ radius) and grounds new code in what already exists. Full guide:
 |---|---|---|
 | Multi-language comprehension + codegen — Python, Java, TypeScript, C#, C, C++, Go | ✅ | automatic per repo |
 | SQL data-layer comprehension — schema, queries, stored procedures, migration folding | ✅ | `pip install 'synaptixs-spine[sql]'`; `.sql` per repo |
+| SQL Server database projects — **UTF-16** scripts (SSMS's default) and `GO` batch separators are handled, so a scripted `.Database` project reads instead of being skipped | ✅ | automatic; no flag. On one real project this was the difference between **676 of 709 `.sql` files skipped** and none |
 | SQL greenfield codegen — generate a migration, validate on an ephemeral DB | ✅ | `sdlc feature --language sql` (in-memory SQLite; `SDLC_SQL_ENGINE=postgres` for real Postgres) |
 | Framework-aware edges — JAX-RS endpoints (Java); ASP.NET Core endpoints and EF Core entities (C#) | ✅ | emitted into the PKG on `pkg extract` / `understand` |
 | C `#include` graph + header/source merge; codegen on **CMake or Meson** | ✅ | `.c`/`.h` per repo; `sdlc feature --language c` |

--- a/KNOWLEDGE_GRAPH.md
+++ b/KNOWLEDGE_GRAPH.md
@@ -321,8 +321,8 @@ orchestrator state . --out report.html     # one self-contained, shareable HTML 
 orchestrator state . --no-timestamp        # omit generated-at, for byte-stable CI diffs
 ```
 
-> **Known issue:** `state` is not byte-stable across runs — components tying on their symbol
-> counts can swap order, so identical runs can differ. Pin `PYTHONHASHSEED=0` when diffing.
+With `--no-timestamp`, two runs of the same commit produce identical bytes — the report is
+diffable and safe to check into CI.
 > `understand` is unaffected.
 
 It renders a plain-language **overview**, an **infrastructure & runtime** breakdown (the
@@ -392,6 +392,15 @@ T-SQL, Oracle, SQLite, …) from distinctive syntax — so T-SQL `[bracketed]` i
 back-ticks, and Oracle `VARCHAR2` parse under their own grammar instead of degrading as
 Postgres. Portable DDL with no tell-tale falls back to Postgres. Pin it with `--dialect`
 (on `pkg extract` / `understand` / `state`) when detection can't tell.
+
+**SQL Server database projects read as-scripted.** A `.Database` project scripted out of SSMS
+is not plain UTF-8 T-SQL: SSMS writes **UTF-16** by default, and it separates statements with
+**`GO`**, a client batch separator that is not valid T-SQL and makes a whole file unparseable if
+fed through as one statement. Both are handled — encoding is sniffed from the BOM, and files
+are split on `GO` and parsed batch by batch — so a scripted database project is extracted
+rather than skipped. Neither is a dialect problem, so `--dialect tsql` never fixed them. On one
+real SQL Server project this was the difference between **676 of 709 `.sql` files silently
+skipped** and none, taking `READS` from 2 to 186 and `WRITES` from 0 to 26.
 
 **Greenfield too.** SQL isn't only read — `sdlc feature --language sql` *generates* the data
 layer: it scaffolds a `migrations/` directory, writes a DDL migration for the intent, and
@@ -538,7 +547,8 @@ reviews honest.
   front-ends. Other languages aren't extracted yet (their files are simply not
   represented). For C, parsing is
   pre-preprocessor — heavy macro use yields partial facts (we never run `cpp`). For SQL, the
-  dialect is auto-detected (override with `--dialect`); stored-procedure bodies are re-parsed
+  dialect is auto-detected (override with `--dialect`); UTF-16 and `GO`-separated SQL Server
+  scripts are handled (see §4). Stored-procedure bodies are re-parsed
   best-effort — exotic procedural PL/pgSQL / T-SQL constructs degrade to partial facts;
   migration folding assumes linearly-ordered files.
 - **Heuristic edges.** Some edges (e.g. ORM-inferred foreign keys) are inferred and improve

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -136,6 +136,7 @@ Set one knob for everything, or a model per stage:
 | `SDLC_CODEGEN_MODEL` | codegen — implement, refine, revise, author_tests |
 | `SDLC_JUDGE_MODEL` | the acceptance judge |
 | `ORCHESTRATOR_INTAKE_MODEL` | intent extraction and spec writing |
+| `ORCHESTRATOR_REASONING_EFFORT` | reasoning level on tool-calling models (default `high`) |
 
 A stage's own variable wins over `ORCHESTRATOR_MODEL`, which wins over the default.
 Pointing a stage at another vendor needs that vendor's key in the environment.
@@ -231,10 +232,8 @@ orchestrator state . --no-timestamp        # omit generated-at, for byte-stable 
 `--out report.html` emits a **self-contained** page — CSS and diagrams inlined, nothing fetched
 — so a saved or emailed copy still renders. Any other extension emits markdown.
 
-> **Known issue:** `state` output is not byte-stable across runs. Components that tie on their
-> symbol counts can swap position, so five identical runs may produce two or three different
-> files. If you diff `state` output or check it into CI, set `PYTHONHASHSEED=0` on both sides
-> until this is fixed. `understand` is unaffected and is byte-identical run to run.
+With `--no-timestamp`, `state` is byte-stable: two runs of the same commit produce identical
+files, so you can diff a report or check it into CI. `understand` has the same guarantee.
 
 It renders a plain-language **overview**, an **infrastructure & runtime** breakdown (the
 datastores, queues, cloud, container services and external APIs the repo declares it needs —

--- a/docs/specs/capability-matrix.md
+++ b/docs/specs/capability-matrix.md
@@ -35,7 +35,7 @@ docs · **n/a** out of category
 | **Declared-vs-extracted parity check** | **✅** | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
 | **CI-checkable currency (`--check`)** | **✅** | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
 | **Accuracy regression gate in CI** | **✅** | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
-| Byte-stable report output | 🟡 ¹ | ➖ | ➖ | ➖ | ➖ | ✅ | ➖ | n/a | n/a |
+| Byte-stable report output | ✅ ¹ | ➖ | ➖ | ➖ | ➖ | ✅ | ➖ | n/a | n/a |
 | Blast-radius / impact analysis | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ | 🟡 | ➖ | ➖ |
 | Doc ingestion into the graph | ✅ | ➖ | ✅ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
 | Media (OCR / ASR) ingestion | ✅ ² | ➖ | ✅ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
@@ -73,11 +73,12 @@ docs · **n/a** out of category
 
 ## Footnotes
 
-**¹ Byte-stable output — partial, and the exception matters.** `understand` is byte-identical
-run to run. **`state` is not**: components that tie on their symbol counts sort out of a `set`
-with a non-total key, and Python randomises string hashing per process, so five identical runs
-produced three different outputs. `PYTHONHASHSEED=0` is the workaround
-([`current_state.py:647`](../../src/orchestrator/knowledge/current_state.py)).
+**¹ Byte-stable output — fixed in 3.19.0.** Both `understand` and `state` are byte-identical
+run to run. `state` was not, until 3.19.0: its area list sorted out of a `set` on score alone,
+and Python randomises string hashing per process, so five identical runs produced three
+different outputs. The sort key is now total, and a regression test renders under five
+`PYTHONHASHSEED` values in subprocesses — the only way to see the bug, since the seed is fixed
+for the life of a process.
 
 **² Media ingestion** shipped in **3.10.0** (G3) — images via OCR, audio/video via ASR, both
 through a committed `.spine-media/` artifact so no model runs in the deterministic build. Its

--- a/docs/specs/competitive-landscape.md
+++ b/docs/specs/competitive-landscape.md
@@ -148,9 +148,9 @@ refusal hide behind a missed one, and they cost very different things.
    PHP).
 4. **Two of four oracles are Python-only** (`runtime` via PEP 669, `invention` via Python `ast`).
    On a non-Python repo `invention` reports `0` meaning *not measured*, not clean.
-5. **Small self-inflicted credibility nicks:** `--intents` ships with no reader, and `state` is
-   not byte-stable (found 2026-08-14). Minor in themselves, but they sit directly under the
-   determinism claim that is a headline strength.
+5. **`--intents` ships with no reader** — it costs ~3× CPU and nothing renders its facts. Minor
+   in itself, but it sits under the determinism-and-measurement claim that is a headline
+   strength. (`state` was also not byte-stable when this was written; **fixed in 3.19.0**.)
 
 ---
 

--- a/docs/specs/comprehension-test-plan.md
+++ b/docs/specs/comprehension-test-plan.md
@@ -11,8 +11,9 @@ Companion to [`cli-test-plan.md`](cli-test-plan.md) (the broad CLI sweep) and
 [`pkg-accuracy-test-plan.md`](pkg-accuracy-test-plan.md) (the accuracy oracles). This one
 covers `understand` → `state` → `--intents` deeply.
 
-> **Two known failures are baked into this plan, at §5 and §9.** They are not hypotheticals —
-> both reproduced on every attempt. Do not treat a matching failure as your setup being broken.
+> **One known limitation is baked into this plan, at §9.** It is not a hypothetical — it
+> reproduced on every attempt. Do not treat a matching result as your setup being broken.
+> (§5's determinism failure was real when this was written and is **fixed in 3.19.0**.)
 
 ---
 
@@ -195,7 +196,7 @@ so it re-extracts rather than using the cache — it will be slower.
 
 ---
 
-## 5. `state` — the two lenses, and a **known determinism failure**
+## 5. `state` — the two lenses, and its determinism
 
 ```bash
 $SPINE state spine --lens developer --no-timestamp > st-dev.md
@@ -208,47 +209,29 @@ plain language with no symbol ids leaking through.
 
 Always pass `--no-timestamp` when diffing — otherwise the generated-at time guarantees a diff.
 
-### 5.1 ⚠️ KNOWN FAILING — `state` is not deterministic
+### 5.1 Determinism — `state` must render identically every run
 
 ```bash
-for i in 1 2 3 4 5; do $SPINE state spine --no-timestamp > run$i.md; done
+for i in 1 2 3 4 5; do $SPINE state . --no-timestamp > run$i.md; done
 md5 -q run*.md | sort | uniq -c
 ```
 
-**Expect 2–3 distinct hashes across 5 identical runs.** Observed: `3`, `1`, `1`.
+**Expect 1 distinct hash.** ✅ Fixed in 3.19.0.
 
-This violates invariant 2. Find the varying line:
+Until 3.19.0 this reported 2–3 distinct outputs. The layout sorted areas out of a `set` on
+score alone, and Python randomises string hashing per process, so equal-scoring components
+(`scripts.security_sweep` and `scripts.security_verify`, both `0 types, 12 fns`) swapped
+position between runs. The sort key is now total — `(-score, name)` — so ties resolve
+identically every time.
 
-```bash
-diff run1.md run2.md
-```
-
-Observed — the `scripts/` component list reorders entries that **tie** on their counts:
-
-```
-- **scripts/** — … `scripts.security_verify` (0 types, 12 fns), `scripts.security_sweep` (0 types, 12 fns), …
-- **scripts/** — … `scripts.security_sweep` (0 types, 12 fns), `scripts.security_verify` (0 types, 12 fns), …
-```
-
-**Root cause**, [`knowledge/current_state.py:647`](../../src/orchestrator/knowledge/current_state.py):
-
-```python
-areas = set(s.area_types) | set(s.area_funcs)      # set iteration order is per-process random
-for a in sorted(areas, key=lambda a: ...score..., reverse=True):   # stable sort keeps that order for ties
-```
-
-Python randomizes string hashing per process, so the set yields a different order each run;
-`sorted()` is stable, so equal-scoring areas inherit it. Confirm the diagnosis — pinning the
-seed must make it stable:
+The stronger form of the check, since a fresh process gets a fresh seed anyway:
 
 ```bash
-for i in 1 2 3 4 5; do PYTHONHASHSEED=0 $SPINE state spine --no-timestamp | sed -n '42p' | md5; done
+for s in 0 42 999; do PYTHONHASHSEED=$s $SPINE state . --no-timestamp | md5 -q; done
 ```
 
-Expect **5 identical hashes**. ✅ Verified.
-
-`PYTHONHASHSEED=0` is the workaround for any diffing you do today. The fix is a total sort
-key (append the area name as a tiebreaker).
+Also 1 distinct hash. `PYTHONHASHSEED` is no longer a workaround you need — it is just a way
+to prove the property holds.
 
 ### 5.2 The shareable report
 
@@ -319,8 +302,8 @@ nothing else. No page says which ticket a symbol serves — the facts are counte
 ## 7. `--intents` on `state`
 
 ```bash
-PYTHONHASHSEED=0 $SPINE state spine --no-timestamp > st-plain.md
-PYTHONHASHSEED=0 $SPINE state spine --intents --no-timestamp > st-intents.md
+$SPINE state . --no-timestamp > st-plain.md
+$SPINE state . --intents --no-timestamp > st-intents.md
 diff st-plain.md st-intents.md
 ```
 
@@ -331,9 +314,8 @@ Observed — **one line**, the size summary:
 > - Size: 643 namespaces (≈50 areas) · … · 1233 docs · 34 intents
 ```
 
-Pin `PYTHONHASHSEED=0` on both sides, or §5.1 will add unrelated noise to this diff and you
-will misread reordered `scripts/` entries as an intent effect. That is the trap this plan
-exists to spare you.
+Before 3.19.0 this diff also carried reordered `scripts/` entries from the non-determinism in
+§5.1, which was easy to misread as an intent effect. That noise is gone.
 
 ---
 
@@ -398,7 +380,7 @@ time and silent on CPU. On a shared CI runner the CPU figure is the one that bit
 |---|---|---|
 | 3 | `understand` deterministic | ✅ byte-identical |
 | 4 | `--check` currency gate | ✅ exit 0, writes nothing |
-| 5.1 | `state` deterministic | ❌ **3 distinct outputs / 5 runs** |
+| 5.1 | `state` deterministic | ✅ 1 distinct output (fixed 3.19.0) |
 | 5.2 | HTML report self-contained | ✅ no external fetches |
 | 6 | `--intents` renders content in episteme | ❌ counts only |
 | 7 | `--intents` renders content in state | ❌ one count |
@@ -421,7 +403,7 @@ docs/specs/comprehension-test-results/<version>-<YYYY-MM-DD>-<who>.md
 | 3 | re-run + `diff -rq` | identical | | |
 | 4 | `--check` | exit 0 | | |
 | 4 | `--check` after an edit | non-zero | | |
-| 5.1 | `state` ×5 | ❌ 2–3 hashes | | |
+| 5.1 | `state` ×5 | ✅ 1 hash | | |
 | 5.2 | `--out report.html` | 0 external refs | | |
 | 6 | `understand --intents` | 2 count lines only | | |
 | 7 | `state --intents` | 1 count line only | | |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synaptixs-spine"
-version = "3.18.1"
+version = "3.19.0"
 description = "Agent orchestration platform — planner, registry, runtime, verifier."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Prepares 3.19.0. Documentation only, plus the version bump — no source changes.

## Withdraws a caveat that is no longer true

3.18.1 documented `state` as not byte-stable. [#202](https://github.com/synaptixs/spine/pull/202) fixed it; the warning stayed behind in seven files, where it reads as a live defect in a guarantee the product does make. `ARCHITECTURE.md`'s determinism claim is restated without the exception, and `capability-matrix.md`'s cell goes 🟡 → ✅ with the footnote rewritten as history rather than a known issue.

## Documents two capabilities that shipped silently

- **`ORCHESTRATOR_REASONING_EFFORT`** appeared in no document. It is not optional plumbing: OpenAI rejects function tools alongside a reasoning model's implicit default, and the provider's suggested `none` is the wrong fix. Now in `.env.example`, `CLI_REFERENCE.md`, `USER_GUIDE.md`.
- **SQL Server database projects.** SSMS writes UTF-16 and separates batches with `GO`, which is not valid T-SQL — together they made a scripted project 95% invisible. Neither is a dialect problem, so no amount of reading the dialect docs would surface `--dialect tsql` as a non-fix. Now a paragraph in `KNOWLEDGE_GRAPH.md` §4 beside Multi-dialect, a pointer in the §9 limits, and a row in `FEATURES.md`.

## Version + changelog

`pyproject.toml` 3.18.1 → 3.19.0 (the only version string in the tree). The changelog entry is written from the commits in `v3.18.1..develop` — PRs #198–#204 — not from memory, and its figures were cross-checked against `codegen-model-comparison-results.md`, `external-repo-grounding-results.md` and `capability-matrix.md`.

## Gate

`ruff format --check .` 645 files · `ruff check` pass · `mypy src tests` 621 files, no issues · `check-mermaid.js` all blocks render as inline SVG. `episteme/` not staged.