### PR TITLE
feat(sdlc): Phase 2b — the design validator ships, the promotion is declined

### DIFF
--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -1,6 +1,6 @@
 # Spec index — every design record, and where it stands
 
-**Generated 2026-08-15 against 3.18.1; refreshed 2026-08-18 for the GraphIR programme.** 62 top-level specs, 6 archived, 10 build documents.
+**Generated 2026-08-15 against 3.18.1; refreshed 2026-08-19 for the GraphIR programme.** 63 top-level specs, 6 archived, 10 build documents.
 
 **How to read the Verified column — this matters.** Status is **self-reported by each spec**
 unless marked ✔. This index was built after three separate cases in one session where a status
@@ -50,7 +50,7 @@ Graphify-gap series only. This file is the complete inventory.
 
 | Spec | Done | Outstanding |
 |---|---|---|
-| [graphir-sdlc-workflow](graphir-sdlc-workflow.md) | **Phases 1 + 2a (2026-08-18)** — `tool` nodes, Evidence, criteria binding, typed Case; both gates passed (20 runs / 5 commits each). All four research defects closed | **2b** the promotion itself (paid A/B; its validator is in and enforcing) · **3** profiles · **4** parallelism |
+| [graphir-sdlc-workflow](graphir-sdlc-workflow.md) | **Phases 1, 2a, 2b (2026-08-18/19)** — `tool` nodes, Evidence, criteria binding, typed Case, design validator. All four research defects closed; the design promotion measured and **declined** | **3** issue-type profiles · **4** parallel fan-out + replan |
 | [capability-recommendations-kg-grounded](capability-recommendations-kg-grounded.md) | C1–C6, C8–C10 (9 of 10) | **C7** — observability→defect |
 | [sql-support-roadmap](sql-support-roadmap.md) | Track A complete, released 2.7.0 | **Track B** — greenfield SQL codegen |
 | [go-support-roadmap](go-support-roadmap.md) | Phase 4.1 comprehension **done**; Go ships in 3.18.1 | Later phases; branch `feat/go-support` |
@@ -96,6 +96,7 @@ Analysis, comparisons, test plans and assets. No completion state applies.
 | Doc | Kind |
 |---|---|
 | [README](README.md) | Programme narrative + G1–G17 scorecard — **percentages stamped 2026-06-11, stale** |
+| [design-promotion-ab-results](design-promotion-ab-results.md) | The 100-run measurement behind Phase 2b's **declined** design promotion (2026-08-19) |
 | [gap-roadmap-index](gap-roadmap-index.md) | Index of the Graphify-gap series |
 | [knowledge-graph-architecture](knowledge-graph-architecture.md) | Descriptive, derived from code 2026-08-02 |
 | [KNOWLEDGE-VISION](KNOWLEDGE-VISION.md) · [PRODUCT-KNOWLEDGE-GRAPH](PRODUCT-KNOWLEDGE-GRAPH.md) | Vision / concept |
@@ -122,7 +123,7 @@ Analysis, comparisons, test plans and assets. No completion state applies.
 | 🟡 Partial | 11 |
 | 📋 Outstanding | 16 *(incl. 1 missing spec)* |
 | ⚠️ Stale status | 1 |
-| 📖 Reference | 18 |
+| 📖 Reference | 19 |
 
 **The programme is further along than its own paperwork says.** Every discrepancy found this
 session ran the same direction — work shipped, the status line didn't move. Nothing was claimed

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -50,7 +50,7 @@ Graphify-gap series only. This file is the complete inventory.
 
 | Spec | Done | Outstanding |
 |---|---|---|
-| [graphir-sdlc-workflow](graphir-sdlc-workflow.md) | **Phases 1 + 2a (2026-08-18)** — `tool` nodes, Evidence, criteria binding, typed Case; both gates passed (20 runs / 5 commits each). All four research defects closed | **2b** design promotion (paid A/B) · **3** profiles · **4** parallelism |
+| [graphir-sdlc-workflow](graphir-sdlc-workflow.md) | **Phases 1 + 2a (2026-08-18)** — `tool` nodes, Evidence, criteria binding, typed Case; both gates passed (20 runs / 5 commits each). All four research defects closed | **2b** the promotion itself (paid A/B; its validator is in and enforcing) · **3** profiles · **4** parallelism |
 | [capability-recommendations-kg-grounded](capability-recommendations-kg-grounded.md) | C1–C6, C8–C10 (9 of 10) | **C7** — observability→defect |
 | [sql-support-roadmap](sql-support-roadmap.md) | Track A complete, released 2.7.0 | **Track B** — greenfield SQL codegen |
 | [go-support-roadmap](go-support-roadmap.md) | Phase 4.1 comprehension **done**; Go ships in 3.18.1 | Later phases; branch `feat/go-support` |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -47,7 +47,7 @@ call a model.**
 | `intake` | **yes** | source document → one spec |
 | `investigate` | no | PKG query → landing symbols with `file:line` |
 | `validity` | no | judges the ticket against the graph; **the only stage that can stop a run before code is written** |
-| `design` | **no** — `produce_design(..., llm=None)` | deterministic skeleton; `_llm_design` exists and is unwired |
+| `design` | **no** — `produce_design(..., llm=None)` | deterministic by decision, not by default: measured 2026-08-19 and declined |
 | `implement` | **yes** | codegen + tests + refine |
 | `review` | **yes** | review the worktree diff, fix findings, re-test |
 
@@ -121,7 +121,7 @@ bound to — without converting a deterministic stage into a model call.
 |---|---|---|---|
 | 1 | `tool` node type + the **Evidence** artifact, SDLC as IR in shadow | defect 1 | ✅ **COMPLETE 2026-08-18** |
 | **2a** | IR executes; Evidence consumed; criteria bound; `RunContext` → typed Case | **defects 2, 3, 4** | ✅ **COMPLETE 2026-08-18** |
-| **2b** | `design` promoted to hybrid — validator, then `_llm_design`, then measure | none | 🟡 **validator enforcing; promotion awaiting a paid A/B** |
+| **2b** | `design` promoted to hybrid — validator, then `_llm_design`, then measure | none | ✅ **COMPLETE 2026-08-19 — promotion declined, measured** |
 | 3 | Issue-type profiles as files a repo can carry | none | Not started |
 | 4 | Parallel fan-out + bounded replan | none | Not started |
 
@@ -131,6 +131,13 @@ where the ticket lands instead of computing one from its own guess, the landing 
 symbols instead of collapsing to filenames, and each acceptance criterion is bound to a
 `file:line` or refused. Gate: **20 runs / 5 commits, 0 unexplained verdict mismatches**, with 5
 new parks — all the one ticket naming a symbol no repository has.
+
+**Phase 2b closed 2026-08-19 with the promotion declined.** A 100-run A/B ($49.51, 0 aborts)
+found no acceptance difference a 50-run arm can resolve, a held-out rate favouring the
+deterministic design (0.60 vs 0.40), and 1.98× the cost. `design` stays deterministic; the
+model-call budget stays at three. The validator ships regardless — **0 false positives across
+100 runs**, including 50 real model-written designs. Detail:
+[`design-promotion-ab-results.md`](design-promotion-ab-results.md).
 
 **Phase 2 is split.** 2a is deterministic and its gate costs nothing; 2b is the design promotion
 and its gate is a paid A/B. Splitting keeps the defect closure — the value of the phase — from

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -121,7 +121,7 @@ bound to — without converting a deterministic stage into a model call.
 |---|---|---|---|
 | 1 | `tool` node type + the **Evidence** artifact, SDLC as IR in shadow | defect 1 | ✅ **COMPLETE 2026-08-18** |
 | **2a** | IR executes; Evidence consumed; criteria bound; `RunContext` → typed Case | **defects 2, 3, 4** | ✅ **COMPLETE 2026-08-18** |
-| **2b** | `design` promoted to hybrid — validator, then `_llm_design`, then measure | none | Not started |
+| **2b** | `design` promoted to hybrid — validator, then `_llm_design`, then measure | none | 🟡 **validator enforcing; promotion awaiting a paid A/B** |
 | 3 | Issue-type profiles as files a repo can carry | none | Not started |
 | 4 | Parallel fan-out + bounded replan | none | Not started |
 

--- a/docs/specs/design-promotion-ab-results.md
+++ b/docs/specs/design-promotion-ab-results.md
@@ -1,0 +1,146 @@
+# Design promotion A/B — should the design stage call a model?
+
+**Run 2026-08-19 against `develop` @ Phase 2a** · `scripts/codegen_benchmark.py` with
+`BENCH_DESIGN` · 5 `create` tickets × 2 frontier models × deterministic/llm design × **5 passes**
+= **4 arms, 100 ticket-runs** · **0 aborts, 0 design fallbacks** · **$49.51**
+(**$56** including calibration and pre-flight)
+
+**Verdict: the promotion is declined.** `design` stays deterministic. The validator built to
+guard it ships anyway, and earned its place on this run's own evidence.
+
+---
+
+## The question, and why it had to be asked
+
+`docs/specs/graphir-sdlc-workflow.md` sets a rule: a node may be **demoted** to deterministic
+freely, and **promoted** to a model node only with (a) a measurement showing the model beats the
+deterministic version, (b) a validator on its output edge, and (c) room in the model-call budget.
+
+`design` is the only stage that was ever a candidate. Its deterministic form is a template —
+`interfaces` and `data_changes` come back empty, and `approach` is a sentence with the ticket
+title interpolated — so a model writing those fields is a plausible improvement. `_llm_design`
+has existed in `design.py` for months, unwired.
+
+This is clause (a).
+
+## Result
+
+| model | arm | per-pass | accepted | 95% CI | held-out | cost |
+|---|---|---|---|---|---|---|
+| `claude-sonnet-4-6` | deterministic | 0,0,1,1,0 | 2/25 · 0.08 | [0.02, 0.25] | 15/25 | $7.23 |
+| `claude-sonnet-4-6` | **llm** | 0,1,0,0,0 | 1/25 · 0.04 | [0.01, 0.20] | 14/25 | $17.40 |
+| `gpt-5.6-sol` | deterministic | 0,0,0,0,0 | 0/25 · 0.00 | [0.00, 0.13] | 15/25 | $9.37 |
+| `gpt-5.6-sol` | **llm** | 0,1,0,0,0 | 1/25 · 0.04 | [0.01, 0.20] | **6/25** | $15.51 |
+
+**Pooled, n = 50 per arm:**
+
+| | deterministic | llm |
+|---|---|---|
+| accepted | 2/50 · **0.04** [0.01, 0.13] | 4/50 · **0.08** [0.03, 0.19] |
+| held-out | 30/50 · **0.60** [0.46, 0.72] | 20/50 · **0.40** [0.28, 0.54] |
+| cost | **$16.60** | **$32.91** (1.98×) |
+
+### How to read it
+
+**Acceptance says nothing.** Two successes against four, at n=50, is not a comparison — it is
+four events. The intervals overlap across almost their whole length. Anyone quoting "the model
+design doubled acceptance" from `0.04 → 0.08` would be quoting noise, and the direction would
+reverse on a different day.
+
+**Held-out is the informative metric, and it favours the deterministic design.** 0.60 against
+0.40, with intervals meeting only at 0.46/0.54. It is also the metric the model never authors,
+which is why it is steadier than a self-graded rate.
+
+**The cost is unambiguous.** The model arm cost **1.98×** the deterministic one for the same 50
+tickets, and bought no measurable acceptance gain and a lower held-out rate.
+
+## The caveat that keeps this honest
+
+**The held-out gap is one model, not a general finding.**
+
+| model | held-out, deterministic → llm |
+|---|---|
+| `claude-sonnet-4-6` | 15/25 → 14/25 — **no difference** |
+| `gpt-5.6-sol` | 15/25 → **6/25** — 0.60 [0.41, 0.77] → 0.24 [0.11, 0.43] |
+
+So the correct statement is **"the model design helped neither model and hurt one of them"**, not
+"model-written designs are worse". A third model could behave differently. What the run does rule
+out is the thing the promotion needed: evidence that it *helps*.
+
+**Temperature cannot be pinned** on this model set (`claude-opus-5` rejects a pinned value), so
+these are not reproducible to the number. Five passes per arm is what makes them worth quoting at
+all.
+
+## The validator's own result, from the same run
+
+The validator was built to make the promotion *legal*, not to be measured here. It got measured
+anyway, on 50 real model-written designs:
+
+| | |
+|---|---|
+| Validator rejections in 100 runs | **0** |
+| Silent design fallbacks | **0** |
+| `llm` designs genuinely produced by a model | **50/50** |
+| Fit failures, deterministic vs llm | 47 vs 45 — no difference |
+
+**Zero false positives on 50 model-written designs** is far stronger evidence than the five-ticket
+check that preceded the run, and it is exactly the case that would have exposed the prose bug
+below. The validator ships.
+
+## Three defects the pre-flight found, for about $2.50
+
+Every one would have produced a confident wrong number had the sweep run first.
+
+1. **The benchmark had no design stage at all.** It drives `LLMCodegenAdapter` directly and never
+   calls `autorun`, so `produce_design` was never in its path. The 200-run grounding study
+   measured codegen with no design in the loop whatsoever.
+2. **The validator refused prose.** Models write sentences into `data_changes` and `interfaces` —
+   *"No schema changes: nothing added to `src/orchestrator/registry/db/models.py`, no migrations"*
+   is verbatim from the first real design it saw — and a sentence containing a path was judged as
+   a path. Three false findings on one design; **every ticket in the model arm would have been
+   rejected and reported as the model inventing code.**
+3. **`_llm_design` had never worked.** It parsed with `json.loads`, the model answered inside a
+   markdown fence, and `produce_design` catches every exception and returns the deterministic
+   design. The `llm` arm would have **silently measured the skeleton and reported it as the
+   model's work** — the "six tickets never reached the model" accounting error in a new place.
+
+The third is why `build_design` now records a fallback as *the absence of a measurement*, and why
+this run reports `0 design fallbacks` as a headline number rather than an aside.
+
+## What the estimate got wrong
+
+| | |
+|---|---|
+| First scoping | ~$30 |
+| Calibration (8 runs) said | $105–175 |
+| Actual | **$49.51** |
+
+The calibration was run on `NEW-GRAPHMD-1`, which hits the refine cap every pass, so a two-ticket
+sample was biased toward the most expensive ticket in the set. Cost here is driven by refine
+count, which is behavioural — it depends on the quality of the output, which is the thing under
+test — so per-run cost cannot be extrapolated from a small sample in either direction.
+
+## Consequences
+
+1. **`design` stays a deterministic node.** `_llm_design` remains unwired. The model-call budget
+   stays at **three** — `intake`, `implement`, `review`.
+2. **The validator ships and is enforcing**, on the strength of 0 false positives in 100 runs.
+3. **Phase 2b closes as "promotion declined, measured"** — a documented outcome, not an open
+   question.
+4. **Phase B (edit tickets) was not run.** Its two purposes — the promotion comparison and the
+   validator's false-positive rate — were both answered by Phase A, the second more strongly than
+   Phase B could have. Skipping it saved roughly $10 and is recorded here rather than left as an
+   unexplained gap in the design.
+
+## What would reopen this
+
+- A **third model** where the model design helps. The finding is model-specific by construction.
+- **Evidence-conditioned design fields.** This run supplied `blast_radius` from Evidence but left
+  `approach` and `interfaces` to the model with only the repo overview. A design prompt
+  conditioned on the landing symbols with their `file:line` is a different treatment, and the one
+  the hybrid split in the spec actually describes.
+- **A larger corpus.** At n=50 with 2–4 successes, the acceptance metric cannot resolve anything.
+  A ticket set where the deterministic baseline is not near-zero would make acceptance usable.
+
+Anyone reopening it should say which of the three they changed, and re-run both arms — not
+compare a new treatment against the numbers in this table.

--- a/docs/specs/graphir-sdlc-workflow.md
+++ b/docs/specs/graphir-sdlc-workflow.md
@@ -1,7 +1,7 @@
 # The SDLC as a GraphIR workflow — one orchestrator, deterministic where it counts
 
-**Status:** **Phase 1 ✅ COMPLETE** · **Phase 2a ✅ COMPLETE** (both 2026-08-18, gates passed) ·
-**2b 🟡 validator enforcing, promotion not taken** · 3, 4 not started.
+**Status:** **Phase 1 ✅** · **Phase 2a ✅** (2026-08-18) · **Phase 2b ✅ — promotion declined,
+measured** (2026-08-19). Phases 3 and 4 not started.
 **Written 2026-08-18 against 3.19.0.** **Owner:** _unassigned_
 
 > **Currency.** This record is updated as each phase lands — the whole document, not just the
@@ -302,7 +302,7 @@ Phase 4 is throughput. All three are real work; none fixes anything listed above
 |---|---|---|---|---|
 | 1 | `tool` node type + the **Evidence** research node, SDLC expressed as IR, run in shadow | ✅ **COMPLETE** | 2026-08-18 | 2026-08-18 |
 | **2a** | The IR executes the run; Evidence is **consumed**; criteria bound; `RunContext` becomes the typed Case | ✅ **COMPLETE** | 2026-08-18 | 2026-08-18 |
-| **2b** | `design` promoted to a hybrid model node — validator, then `_llm_design`, then the measurement | 🟡 **validator shipped & enforcing; promotion awaiting the A/B** | 2026-08-18 | — |
+| **2b** | `design` promoted to a hybrid model node — validator, then `_llm_design`, then the measurement | ✅ **COMPLETE — promotion declined, measured** | 2026-08-18 | 2026-08-19 |
 | 3 | Issue-type-shaped workflows; profiles as files a repo can carry | Not started | — | — |
 | 4 | Parallel fan-out and the bounded replan loop | Not started | — | — |
 
@@ -477,11 +477,29 @@ node-granular resume, replay and per-node cost, and one orchestration system ins
 3. **Measure.** Non-inferiority is the wrong test here — this one is a superiority claim, and if
    the model fields do not improve acceptance, `design` reverts to deterministic.
 
-**Step 1 shipped 2026-08-18; steps 2 and 3 have not been taken.** `sdlc/design_validator.py` is
-enforcing: a design naming a directory or module the repository does not have parks the run
-rather than reaching codegen. `_llm_design` remains unwired and `design` remains a deterministic
-node, because the promotion rule requires a measurement that costs money and nobody has
-authorised it. **That is the rule working, not the phase stalling.**
+**Complete 2026-08-19: the validator ships, the promotion is declined.** All three steps were
+taken. `sdlc/design_validator.py` is enforcing — a design naming a directory or module the
+repository does not have parks the run rather than reaching codegen. `_llm_design` was wired
+behind it, measured, and **left unwired in production** because the measurement did not favour
+it. `design` remains a deterministic node and the model-call budget stays at **three**.
+
+**The measurement — [`design-promotion-ab-results.md`](design-promotion-ab-results.md).** 100
+ticket-runs, 2 frontier models, 5 passes, $49.51, 0 aborts and 0 design fallbacks. Pooled at
+n=50 per arm: acceptance **0.04 [0.01, 0.13]** deterministic against **0.08 [0.03, 0.19]** model
+— four events, which is not a comparison — and held-out **0.60 [0.46, 0.72]** against **0.40
+[0.28, 0.54]**, which is. The model arm cost **1.98×**. The held-out gap is one model
+(`gpt-5.6-sol` 0.60 → 0.24; `claude-sonnet-4-6` unchanged), so the finding is *"helped neither
+and hurt one"*, not "model designs are worse".
+
+**Declined is not "not attempted".** The question was asked under the rule, answered, and
+recorded; the results record lists the three things that would legitimately reopen it. The most
+promising is the one this run did **not** test: conditioning the design prompt on the landing
+symbols and their `file:line`, which is what [the hybrid split](#the-hybrid-split--facts-fix-the-frame-the-model-fills-it)
+actually describes.
+
+**The validator was measured incidentally and passed:** **0 false positives across 100 runs**,
+including 50 real model-written designs — stronger evidence than the five-ticket check that
+preceded the sweep.
 
 **The rule it enforces, and the one it deliberately does not.** `impact.unverified_references`
 already computes "design-named paths absent from the graph" and reports them; making *that*
@@ -498,10 +516,6 @@ entirely, on the same grounds `unverified_references` suppresses it.
 designs naming 25 files between them, and the validator refused none. That is weak evidence for
 the model path by construction — the deterministic design only ever names files it read out of
 the graph — which is precisely why the model path is not wired.
-
-**What remains for 2b to be complete:** wire `_llm_design` behind the validator with the fact
-fields supplied from Evidence, run the A/B, and report it with its interval whichever way it
-goes. If the model fields do not win, `design` reverts to deterministic and the validator stays.
 
 **The validator is kept either way.** It costs nothing, it guards the seam permanently, and it
 is the clause that makes the promotion legal at all. Building it and then declining to wire the

--- a/docs/specs/graphir-sdlc-workflow.md
+++ b/docs/specs/graphir-sdlc-workflow.md
@@ -1,6 +1,7 @@
 # The SDLC as a GraphIR workflow — one orchestrator, deterministic where it counts
 
-**Status:** **Phase 1 ✅ COMPLETE** · **Phase 2a ✅ COMPLETE** (both 2026-08-18, gates passed) · 2b, 3, 4 not started.
+**Status:** **Phase 1 ✅ COMPLETE** · **Phase 2a ✅ COMPLETE** (both 2026-08-18, gates passed) ·
+**2b 🟡 validator enforcing, promotion not taken** · 3, 4 not started.
 **Written 2026-08-18 against 3.19.0.** **Owner:** _unassigned_
 
 > **Currency.** This record is updated as each phase lands — the whole document, not just the
@@ -301,7 +302,7 @@ Phase 4 is throughput. All three are real work; none fixes anything listed above
 |---|---|---|---|---|
 | 1 | `tool` node type + the **Evidence** research node, SDLC expressed as IR, run in shadow | ✅ **COMPLETE** | 2026-08-18 | 2026-08-18 |
 | **2a** | The IR executes the run; Evidence is **consumed**; criteria bound; `RunContext` becomes the typed Case | ✅ **COMPLETE** | 2026-08-18 | 2026-08-18 |
-| **2b** | `design` promoted to a hybrid model node — validator, then `_llm_design`, then the measurement | Not started | — | — |
+| **2b** | `design` promoted to a hybrid model node — validator, then `_llm_design`, then the measurement | 🟡 **validator shipped & enforcing; promotion awaiting the A/B** | 2026-08-18 | — |
 | 3 | Issue-type-shaped workflows; profiles as files a repo can carry | Not started | — | — |
 | 4 | Parallel fan-out and the bounded replan loop | Not started | — | — |
 
@@ -475,6 +476,32 @@ node-granular resume, replay and per-node cost, and one orchestration system ins
    [the hybrid table](#the-hybrid-split--facts-fix-the-frame-the-model-fills-it).
 3. **Measure.** Non-inferiority is the wrong test here — this one is a superiority claim, and if
    the model fields do not improve acceptance, `design` reverts to deterministic.
+
+**Step 1 shipped 2026-08-18; steps 2 and 3 have not been taken.** `sdlc/design_validator.py` is
+enforcing: a design naming a directory or module the repository does not have parks the run
+rather than reaching codegen. `_llm_design` remains unwired and `design` remains a deterministic
+node, because the promotion rule requires a measurement that costs money and nobody has
+authorised it. **That is the rule working, not the phase stalling.**
+
+**The rule it enforces, and the one it deliberately does not.** `impact.unverified_references`
+already computes "design-named paths absent from the graph" and reports them; making *that*
+enforcing would refuse every create, since a design that creates
+`src/orchestrator/sdlc/new_thing.py` names a path the graph has never heard of and is right to.
+`interfaces` is documented as "signatures/types to **add or change**", so no rule of the form
+"everything named must already exist" can survive contact with a real ticket. What survives:
+**you can build a new house on a real street, but not on a street that does not exist.** A new
+file in an existing directory passes; a file in a directory that exists nowhere does not. A new
+symbol in a real module passes; `orchestrator.invented.Thing` does not. Greenfield is suppressed
+entirely, on the same grounds `unverified_references` suppresses it.
+
+**Evidence it does not false-positive.** Five real tickets against Spine's own graph produced
+designs naming 25 files between them, and the validator refused none. That is weak evidence for
+the model path by construction — the deterministic design only ever names files it read out of
+the graph — which is precisely why the model path is not wired.
+
+**What remains for 2b to be complete:** wire `_llm_design` behind the validator with the fact
+fields supplied from Evidence, run the A/B, and report it with its interval whichever way it
+goes. If the model fields do not win, `design` reverts to deterministic and the validator stays.
 
 **The validator is kept either way.** It costs nothing, it guards the seam permanently, and it
 is the clause that makes the promotion legal at all. Building it and then declining to wire the

--- a/scripts/bench_aggregate.py
+++ b/scripts/bench_aggregate.py
@@ -33,8 +33,13 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
-# `<model>-<arm>-p<pass>.log`, e.g. `claude-opus-5-grounded-p2.log`
-_NAME = re.compile(r"^(?P<model>.+?)-(?P<arm>grounded|ungrounded)-p(?P<pass>\d+)\.log$")
+# `<model>-<arm>-p<pass>.log`, e.g. `claude-opus-5-grounded-p2.log`.
+# Phase 2b adds the design arms (`design-none` / `design-deterministic` / `design-llm`), which
+# are compared the same way and against each other rather than against a grounding control.
+_NAME = re.compile(
+    r"^(?P<model>.+?)-(?P<arm>grounded|ungrounded|design-none|design-deterministic|design-llm)"
+    r"-p(?P<pass>\d+)\.log$"
+)
 
 _ACCEPT = re.compile(r"overall acceptance:\s*(\d+)/(\d+)")
 _HELD = re.compile(r"independent \(held-out\) acceptance:\s*(\d+)/(\d+)")

--- a/scripts/codegen_benchmark.py
+++ b/scripts/codegen_benchmark.py
@@ -1599,6 +1599,85 @@ def grade(ticket: Ticket, written: list[str], root: Path) -> tuple[bool, dict[st
     return all(checks.values()), checks
 
 
+# Phase 2b: which design the codegen prompt is conditioned on.
+#
+#   none          — no design stage at all. What Run 2 measured, and the default, so that
+#                   run stays reproducible from this file.
+#   deterministic — the skeleton `produce_design` writes with no model.
+#   llm           — `_llm_design`, with the fact fields supplied from Evidence and the output
+#                   checked by `design_validator` before it is allowed near codegen.
+#
+# `deterministic` vs `llm` is the comparison the promotion rule asks for. `none` is the third
+# arm, and it answers a different question: whether a design stage earns its tokens at all.
+DESIGN_ARMS = ("none", "deterministic", "llm")
+
+
+async def build_design(
+    ticket: Ticket,
+    llm: RecordingLLMClient,
+    *,
+    arm: str,
+    repo_root: Path,
+    model: str | None,
+) -> tuple[str, dict[str, Any]]:
+    """Return the design text handed to codegen, plus what to record about it.
+
+    A design the validator refuses returns **no text and `rejected: True`**. That is not an
+    abort — the model answered, the answer named code that does not exist, and the production
+    pipeline parks the run. Counting it as a pass would measure a design nobody would ship;
+    counting it as an abort would hide the failure mode this arm exists to expose.
+    """
+    if arm == "none":
+        return "", {"design_arm": arm}
+
+    from orchestrator.pkg import FactStore, load_or_extract
+    from orchestrator.pkg.overview import build_overview
+    from orchestrator.sdlc.design import produce_design, render_design_md
+    from orchestrator.sdlc.design_validator import validate_design
+    from orchestrator.sdlc.evidence import build_evidence
+
+    batch = load_or_extract(repo_root)
+    store = FactStore(batch)
+    evidence = await build_evidence(
+        str(ticket.spec.get("title", "")),
+        str(ticket.spec.get("summary", "")),
+        store=store,
+        root=repo_root,
+    )
+    design = await produce_design(
+        ticket.spec,
+        overview=build_overview(batch),
+        store=store,
+        # The model writes `approach`, `interfaces`, `data_changes` and `test_strategy`; the
+        # fact fields come from Evidence and are not the model's to invent.
+        llm=llm if arm == "llm" else None,
+        root=repo_root,
+        blast_radius=evidence.blast_radius,
+    )
+    validation = validate_design(design, store=store, root=repo_root)
+    # `produce_design` catches every exception and returns the deterministic design, so an
+    # `llm` arm whose model call failed silently measures the skeleton and reports it as the
+    # model's work. That is the "6 tickets never reached the model" accounting error in a new
+    # place, and it happened on the very first real call this path made (a JSON parse failure).
+    # A fallback is the *absence* of a measurement, and is recorded as one.
+    fell_back = arm == "llm" and not design.get("llm")
+    if fell_back:
+        print("  design:    FELL BACK to the deterministic design — this run measures nothing")
+    meta: dict[str, Any] = {
+        "design_arm": arm,
+        "design_fell_back": fell_back,
+        "design_llm": bool(design.get("llm")),
+        "design_files": len(design.get("files_to_touch") or []),
+        "design_rejected": not validation.ok,
+        "design_findings": [f.named for f in validation.findings],
+    }
+    if not validation.ok:
+        print(f"  design:    REJECTED — {', '.join(meta['design_findings'])}")
+        return "", meta
+    print(f"  design:    {meta['design_files']} file(s), llm={meta['design_llm']}")
+    return render_design_md(ticket.spec, design), meta
+
+
 async def run_ticket(
     ticket: Ticket,
     llm: RecordingLLMClient,
@@ -1609,6 +1688,7 @@ async def run_ticket(
     model: str | None = None,
     eval_skill: str | None = None,
     baseline: Baseline | None = None,
+    design_arm: str = "none",
 ) -> dict[str, Any]:
     # Skill A/B hook (persona+skill measurement): the candidate skill's guidance is
     # injected into the conditioning seam, which is phase-aware (Skill.phases) — the
@@ -1619,6 +1699,7 @@ async def run_ticket(
     # `EVAL_SKILL=<id> ... codegen_benchmark.py` still works.
     if eval_skill is None:
         eval_skill = os.getenv("EVAL_SKILL", "").strip()
+    design_text, design_meta = "", {"design_arm": design_arm}
     adapter = LLMCodegenAdapter(
         llm,
         model=model or MODEL,
@@ -1633,6 +1714,18 @@ async def run_ticket(
     print(f"\n=== {key} ({ticket.kind}) → {workdir}")
     try:
         with llm.stage(key):
+            if design_arm != "none":
+                design_text, design_meta = await build_design(
+                    ticket, llm, arm=design_arm, repo_root=repo_root, model=model
+                )
+                adapter = LLMCodegenAdapter(
+                    llm,
+                    model=model or MODEL,
+                    grounder=grounder,
+                    agentic=agentic,
+                    skills=[eval_skill] if eval_skill else None,
+                    design=design_text,
+                )
             impl = await _stage(adapter.implement, spec=ticket.spec, path=str(workdir), issue_key=key)
             print(f"  implement: {_rel(impl.files, workdir)} — {impl.summary[:120]}")
             tests = await _stage(adapter.author_tests, spec=ticket.spec, path=str(workdir), issue_key=key)
@@ -1713,6 +1806,7 @@ async def run_ticket(
             "reuse_ok": reuse_ok,
             "aborted": False,
             "cost_usd": llm.ledger.total().cost_usd - cost_before,
+            **design_meta,
         }
     except (CodegenError, LLMError) as exc:
         # These two are NOT the same event, and conflating them biases the result.
@@ -1750,6 +1844,7 @@ async def run_ticket(
             # results. A model that answered unusably is the opposite: a real zero.
             "aborted": is_infra,
             "cost_usd": llm.ledger.total().cost_usd - cost_before,
+            **design_meta,
         }
     finally:
         drop_worktree(workdir, repo_root)
@@ -1802,6 +1897,12 @@ async def main() -> None:
     # `grounder=None`, so this withholds context without changing the codegen path.
     ungrounded = bool(os.getenv("BENCH_NO_GROUNDING"))
 
+    # BENCH_DESIGN selects which design conditions the codegen prompt — see DESIGN_ARMS.
+    # Defaults to "none", which is what Run 2 measured, so this file still reproduces it.
+    design_arm = (os.getenv("BENCH_DESIGN") or "none").strip().lower()
+    if design_arm not in DESIGN_ARMS:
+        raise SystemExit(f"BENCH_DESIGN={design_arm!r} is not one of {DESIGN_ARMS}")
+
     # BENCH_REPO points the whole run at a DIFFERENT repository. Every ticket already
     # threads `repo_root` (worktree, preflight, grounder), so only this binding was
     # missing.
@@ -1850,7 +1951,11 @@ async def main() -> None:
     print("\ngrounding: OFF (BENCH_NO_GROUNDING)" if ungrounded else "\nbuilding PKG …")
     grounder = None if ungrounded else PKGCodegenGrounder.from_repo(bench_repo)
 
-    results = [await run_ticket(t, llm, grounder, repo_root=bench_repo, baseline=baseline) for t in tickets]
+    print(f"design arm: {design_arm}")
+    results = [
+        await run_ticket(t, llm, grounder, repo_root=bench_repo, baseline=baseline, design_arm=design_arm)
+        for t in tickets
+    ]
 
     print("\n=== G2 acceptance summary ===")
     print(

--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -868,13 +868,41 @@ async def _stage_design(
     path = ctx.write_artifact("design.md", rendered)
     ctx.design_files = [str(f) for f in (design.get("files_to_touch") or [])]
     touched = len(design.get("files_to_touch") or [])
+    # The validator on design's output edge — the clause the promotion rule requires before this
+    # node may ever call a model. It runs whether or not one wrote the design: a deterministic
+    # design naming a directory that does not exist is wrong for the same reason a hallucinated
+    # one is, and a guard that only switches on for model output has never been exercised by the
+    # time it first matters.
+    from orchestrator.sdlc.design_validator import validate_design
+
+    validation = validate_design(design, store=store, root=ctx.root)
+    ref_path = ctx.write_artifact("design-references.md", validation.render())
     if ctx.case is not None:
         ctx.case.record(
             "n_design",
             kind="agent",
-            status="ok",
+            status="ok" if validation.ok else "failed",
             digest=digest_of(design),
-            detail=f"{touched} file(s) proposed" + ("" if blast is None else "; blast radius from Evidence"),
+            detail=f"{touched} file(s) proposed"
+            + ("" if blast is None else "; blast radius from Evidence")
+            + ("" if validation.ok else f"; {len(validation.findings)} invented reference(s)"),
+        )
+    if not validation.ok:
+        detail = "; ".join(f"{f.named} — {f.detail}" for f in validation.findings)
+        ctx.record_stage("design", "failed", f"invented reference(s): {detail}", ref_path)
+        # Parked rather than failed, like a refused ticket: the design may be salvageable and a
+        # human is the one who can say. The evidence is on disk either way.
+        ctx.checkpoint(verdict="DESIGN_UNGROUNDED")
+        approval = ctx.park(
+            kind="design",
+            title="the design names code that does not exist — build anyway?",
+            reason=detail,
+        )
+        emit(f"[design] {len(validation.findings)} invented reference(s) — {detail}")
+        emit(f"[approval] {approval.approval_id} raised")
+        raise AutorunError(
+            f"design names code that does not exist: {detail} — run parked, nothing was built.",
+            code=5,
         )
     # Carried into the implement stage. Writing an artifact nobody reads is the difference
     # between chaining commands and connecting them.

--- a/src/orchestrator/sdlc/design.py
+++ b/src/orchestrator/sdlc/design.py
@@ -253,7 +253,17 @@ async def _llm_design(spec: dict[str, Any], ctx: dict[str, Any], llm: Any) -> di
         json_object=True,
         temperature=0.2,
     )
-    data = json.loads(result.text)
+    # `_loads_json_object` rather than `json.loads`: the model answers with the object inside a
+    # markdown fence or after a sentence, and strict parsing raised `JSONDecodeError` on the
+    # first real call this path ever made. `produce_design` swallows that and returns the
+    # deterministic design, so the failure was silent — an `llm` arm that measured the skeleton
+    # and reported it as the model's work. Codegen already had a tolerant loader; reusing it
+    # keeps one definition of "parse a model's JSON".
+    from orchestrator.sdlc.codegen import _loads_json_object
+
+    data = _loads_json_object(result.text)
+    if data is None:
+        raise ValueError("the design model returned no parseable JSON object")
     data["grounded"] = bool(ctx.get("overview"))
     data["llm"] = True
     return _normalise(data)

--- a/src/orchestrator/sdlc/design_validator.py
+++ b/src/orchestrator/sdlc/design_validator.py
@@ -130,6 +130,20 @@ def _module_names(store: FactStore) -> set[str]:
     return {n.name.lower() for n in store.nodes if n.kind is NodeKind.MODULE}
 
 
+# A reference must be a *token*, not a sentence, before it is judged. Models write prose into
+# these list fields — "No schema changes: nothing added to src/orchestrator/registry/db/models.py,
+# no migrations" is a real `data_changes` entry — and a sentence containing a path is a statement
+# about the repository, not a claim to touch something. Judging it refused three legitimate
+# entries on the first real design this validator ever saw, which would have failed every ticket
+# in the model arm and read as "the model writes terrible designs".
+_MAX_REFERENCE_CHARS = 200
+
+
+def _is_token(ref: str) -> bool:
+    """One reference, not a sentence about several."""
+    return bool(ref) and len(ref) <= _MAX_REFERENCE_CHARS and not ref.strip().rstrip(",.").count(" ")
+
+
 def _looks_like_path(ref: str) -> bool:
     return "/" in ref or ref.endswith((".py", ".ts", ".tsx", ".java", ".cs", ".go", ".sql", ".c", ".h"))
 
@@ -180,7 +194,9 @@ def validate_design(
     for field in _REFERENCE_FIELDS:
         for raw in design.get(field) or []:
             ref = str(raw).strip()
-            if not ref:
+            if not _is_token(ref):
+                # Prose. Mining it would judge a design for describing the repository, which is
+                # the same reason `approach` and `test_strategy` are not mined at all.
                 continue
             if _looks_like_path(ref):
                 if ref in known_files or (root is not None and (Path(root) / ref).exists()):

--- a/src/orchestrator/sdlc/design_validator.py
+++ b/src/orchestrator/sdlc/design_validator.py
@@ -1,0 +1,203 @@
+"""The validator that guards the design seam — the clause that makes promoting it legal.
+
+Every model output in this pipeline has a deterministic check downstream: intake's spec is
+judged by `assess()`, implement's code by tests plus preflight plus the fit check, review's
+fixes by re-running the tests. `design` has none, and it is safe today only because it calls no
+model. The moment `_llm_design` is wired, model-written design text flows into codegen as
+`ctx.plan` unchecked, and a hallucinated path or invented symbol rides into the change.
+
+So the determinism boundary's promotion rule requires **a validator on the output edge** before
+a node may become a model node. This is that validator.
+
+## What it can enforce, and what it must not
+
+`impact.unverified_references` already computes *"design-named paths absent from the graph"* and
+**reports** them. Making that enforcing as-is would break every legitimate change: a design that
+creates `src/orchestrator/sdlc/new_thing.py` names a path the graph has never heard of, and it
+is right to.
+
+The design dict cannot say which references it *adds* and which it *modifies* — `interfaces` is
+documented as "signatures/types to **add or change**" — so any rule of the form "everything named
+must already exist" produces a false refusal on every create.
+
+**The rule that survives that:** you can build a new house on a real street; you cannot build one
+on a street that does not exist.
+
+| Named | Verdict |
+|---|---|
+| `report.py` — a file the graph holds | fine |
+| `sdlc/new_thing.py` — new file, **existing** directory | fine, it is being created |
+| `made_up_pkg/thing.py` — parent directory exists nowhere | **fabrication** |
+| `orchestrator.sdlc.design.NewHelper` — new symbol in a **real** module | fine |
+| `orchestrator.invented.Thing` — module prefix resolves to nothing | **fabrication** |
+
+Only the fabrications refuse. Everything else stays reported, exactly as today.
+
+**Greenfield is suppressed**, on the same grounds `unverified_references` suppresses it: when the
+graph holds no grounded nodes, everything is legitimately absent and flagging it all would be
+noise rather than signal.
+
+Deterministic — the graph and the filesystem answer, no model. Kept whether or not `_llm_design`
+is ever switched on: it costs nothing and guards the seam permanently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from orchestrator.pkg import FactStore
+from orchestrator.pkg.facts import NodeKind
+
+__all__ = ["DesignFinding", "DesignValidation", "validate_design"]
+
+# Fields a design may name code in. `approach` and `test_strategy` are prose and are not mined:
+# a sentence mentioning a module is not a claim to touch it, and treating it as one would refuse
+# designs for describing the repository correctly.
+_REFERENCE_FIELDS = ("files_to_touch", "interfaces", "data_changes")
+
+
+@dataclass(frozen=True)
+class DesignFinding:
+    """One reference the design invented."""
+
+    field: str  # which design field named it
+    named: str  # the reference as the design wrote it
+    detail: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"field": self.field, "named": self.named, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class DesignValidation:
+    """The verdict on one design."""
+
+    findings: tuple[DesignFinding, ...] = ()
+    grounded: bool = True
+    reported: tuple[str, ...] = ()  # absent-but-legal references, carried for the reader
+
+    @property
+    def ok(self) -> bool:
+        """A design with no fabricated references. An ungrounded repo always passes."""
+        return not self.findings
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "grounded": self.grounded,
+            "findings": [f.to_dict() for f in self.findings],
+            "reported": list(self.reported),
+        }
+
+    def render(self) -> str:
+        if not self.grounded:
+            return (
+                "_Design references unchecked: the graph holds no grounded nodes, so every "
+                "reference is legitimately absent._"
+            )
+        if self.ok:
+            reported = f" {len(self.reported)} reference(s) are new, which is legal." if self.reported else ""
+            return f"_Every reference the design names resolves, or is new in a real place.{reported}_"
+        lines = ["**The design names code that does not exist:**", ""]
+        lines += [f"- `{f.named}` ({f.field}) — {f.detail}" for f in self.findings]
+        return "\n".join(lines)
+
+
+def _known_dirs(store: FactStore, root: Path | None) -> set[str]:
+    """Directories the repository actually has, from the graph and from disk.
+
+    Both, because the graph only knows directories that contain extracted source: a design
+    placing a file in `docs/` or `scripts/` is naming a real place the graph cannot see.
+    """
+    dirs: set[str] = {""}
+    for node in store.nodes:
+        if node.provenance is None:
+            continue
+        parts = PurePosixPath(node.provenance.file.replace("\\", "/")).parts
+        for i in range(1, len(parts)):
+            dirs.add("/".join(parts[:i]))
+    if root is not None:
+        with_root = Path(root)
+        for path in with_root.rglob("*"):
+            if path.is_dir() and not any(p.startswith(".") for p in path.parts):
+                dirs.add(path.relative_to(with_root).as_posix())
+    return dirs
+
+
+def _module_names(store: FactStore) -> set[str]:
+    return {n.name.lower() for n in store.nodes if n.kind is NodeKind.MODULE}
+
+
+def _looks_like_path(ref: str) -> bool:
+    return "/" in ref or ref.endswith((".py", ".ts", ".tsx", ".java", ".cs", ".go", ".sql", ".c", ".h"))
+
+
+def _check_path(ref: str, *, dirs: set[str]) -> str:
+    """ "" when the path is fine; otherwise why it is a fabrication."""
+    parent = PurePosixPath(ref.replace("\\", "/")).parent.as_posix()
+    parent = "" if parent == "." else parent
+    if parent in dirs:
+        return ""
+    return f"no directory `{parent}` exists in this repository, so the file cannot be created there"
+
+
+def _check_symbol(ref: str, *, store: FactStore, modules: set[str]) -> str:
+    """ "" when the symbol is fine; otherwise why its address is invented.
+
+    Only dotted references are judged. A bare name (`OrderTotals`, `def render(x: int)`) says
+    nothing about *where* it lives, so it is a new symbol somewhere and not checkable here.
+    """
+    text = ref.strip().strip("`")
+    if "." not in text or " " in text or "(" in text:
+        return ""
+    prefix = text.rsplit(".", 1)[0].lower()
+    if prefix in modules or store.find(text.rsplit(".", 1)[-1]):
+        return ""
+    if any(m.endswith(prefix) or prefix.endswith(m) for m in modules):
+        return ""
+    return f"no module `{prefix}` exists in this repository, so the symbol has no address"
+
+
+def validate_design(
+    design: dict[str, Any],
+    *,
+    store: FactStore,
+    root: Path | str | None = None,
+) -> DesignValidation:
+    """Judge a design's references against the graph and the filesystem. Deterministic."""
+    grounded = store.summary().get("grounded_nodes", 0) > 0
+    if not grounded:
+        return DesignValidation(grounded=False)
+
+    dirs = _known_dirs(store, Path(root) if root else None)
+    modules = _module_names(store)
+    known_files = {n.provenance.file for n in store.nodes if n.provenance is not None}
+
+    findings: list[DesignFinding] = []
+    reported: list[str] = []
+    for field in _REFERENCE_FIELDS:
+        for raw in design.get(field) or []:
+            ref = str(raw).strip()
+            if not ref:
+                continue
+            if _looks_like_path(ref):
+                if ref in known_files or (root is not None and (Path(root) / ref).exists()):
+                    continue
+                problem = _check_path(ref, dirs=dirs)
+            else:
+                problem = _check_symbol(ref, store=store, modules=modules)
+                if not problem and "." in ref:
+                    continue
+            if problem:
+                findings.append(DesignFinding(field=field, named=ref, detail=problem))
+            else:
+                reported.append(ref)
+    # Sorted: findings are compared between runs and rendered into artifacts, and dict/set
+    # iteration upstream would otherwise order them by hash.
+    return DesignValidation(
+        findings=tuple(sorted(findings, key=lambda f: (f.field, f.named))),
+        grounded=True,
+        reported=tuple(sorted(set(reported))),
+    )

--- a/tests/sdlc/test_design_validator.py
+++ b/tests/sdlc/test_design_validator.py
@@ -1,0 +1,122 @@
+"""The validator on design's output edge (Phase 2b).
+
+The rule it has to get right is not "does this reference exist" — designs legitimately name
+things they are about to create. It is *"you can build a new house on a real street, but not on
+a street that does not exist."* Most of this file is the legal cases it must not refuse, because
+a validator that refuses every create would be caught by no gate and break every real ticket.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestrator.pkg import FactStore
+from orchestrator.pkg.facts import FactBatch, Node, NodeKind, Provenance
+from orchestrator.sdlc.design_validator import validate_design
+
+
+def _store() -> FactStore:
+    b = FactBatch()
+    for nid, kind, name, file, line in (
+        (
+            "py:orchestrator.sdlc.design",
+            NodeKind.MODULE,
+            "orchestrator.sdlc.design",
+            "src/orchestrator/sdlc/design.py",
+            1,
+        ),
+        (
+            "py:orchestrator.sdlc.design.produce_design",
+            NodeKind.FUNCTION,
+            "produce_design",
+            "src/orchestrator/sdlc/design.py",
+            20,
+        ),
+        (
+            "py:orchestrator.pkg.store",
+            NodeKind.MODULE,
+            "orchestrator.pkg.store",
+            "src/orchestrator/pkg/store.py",
+            1,
+        ),
+    ):
+        b.add_node(Node(id=nid, kind=kind, name=name, language="python", provenance=Provenance(file, line)))
+    return FactStore(b)
+
+
+@pytest.mark.parametrize(
+    ("design", "why"),
+    [
+        ({"files_to_touch": ["src/orchestrator/sdlc/design.py"]}, "a file the graph holds"),
+        ({"files_to_touch": ["src/orchestrator/sdlc/new_thing.py"]}, "a new file in a real directory"),
+        ({"interfaces": ["orchestrator.sdlc.design.NewHelper"]}, "a new symbol in a real module"),
+        ({"interfaces": ["def render(items: list[str]) -> str"]}, "a bare signature names no address"),
+        ({"interfaces": ["OrderTotals"]}, "a bare name says nothing about where it lives"),
+        ({"data_changes": ["add a column to orders"]}, "prose is not a reference"),
+        ({"approach": "rewrite orchestrator.invented.Thing"}, "prose fields are not mined"),
+    ],
+)
+def test_what_the_validator_must_not_refuse(design: dict[str, object], why: str) -> None:
+    """A validator that refused every create would break every real ticket, and no gate in this
+    programme would catch it — parity would be perfect and the pipeline useless."""
+    result = validate_design(design, store=_store())
+    assert result.ok, f"{why}: refused {design}"
+
+
+@pytest.mark.parametrize(
+    ("design", "named"),
+    [
+        ({"files_to_touch": ["made_up_pkg/thing.py"]}, "made_up_pkg/thing.py"),
+        ({"interfaces": ["orchestrator.invented.Thing"]}, "orchestrator.invented.Thing"),
+        ({"data_changes": ["nowhere/at/all.sql"]}, "nowhere/at/all.sql"),
+    ],
+)
+def test_a_fabricated_address_is_refused(design: dict[str, object], named: str) -> None:
+    """The seam this exists to guard: a model naming a place the repository does not have."""
+    result = validate_design(design, store=_store())
+    assert not result.ok
+    assert result.findings[0].named == named
+    assert result.findings[0].detail
+
+
+def test_a_greenfield_repo_is_suppressed_entirely() -> None:
+    """Same grounds as `unverified_references`: when the graph holds nothing, everything is
+    legitimately absent and flagging it all would be noise rather than signal."""
+    result = validate_design(
+        {"files_to_touch": ["anything/at/all.py"], "interfaces": ["made.up.Thing"]},
+        store=FactStore(FactBatch()),
+    )
+    assert result.ok
+    assert result.grounded is False
+    assert "no grounded nodes" in result.render()
+
+
+def test_a_directory_that_exists_only_on_disk_still_counts(tmp_path: Path) -> None:
+    """The graph knows only directories containing extracted source. A design putting a file in
+    `docs/` or `scripts/` names a real place the graph cannot see, and refusing it would be the
+    validator being wrong about the repository rather than the design being wrong."""
+    (tmp_path / "docs").mkdir()
+    result = validate_design({"files_to_touch": ["docs/new-spec.md"]}, store=_store(), root=tmp_path)
+    assert result.ok
+
+
+def test_the_findings_are_ordered_not_hash_ordered() -> None:
+    """Findings are rendered into an artifact and compared between runs; upstream sets would
+    otherwise order them by hash and two identical runs would disagree."""
+    design = {
+        "files_to_touch": ["zzz_nowhere/b.py", "aaa_nowhere/a.py"],
+        "interfaces": ["made.up.Thing"],
+    }
+    findings = validate_design(design, store=_store()).findings
+    keys = [(f.field, f.named) for f in findings]
+    assert keys == sorted(keys), "findings are ordered by (field, reference), not by hash"
+    assert len(keys) == 3
+
+
+def test_the_render_says_which_reference_and_why() -> None:
+    result = validate_design({"files_to_touch": ["made_up_pkg/thing.py"]}, store=_store())
+    rendered = result.render()
+    assert "made_up_pkg/thing.py" in rendered
+    assert "made_up_pkg" in rendered and "does not exist" in rendered

--- a/tests/sdlc/test_design_validator.py
+++ b/tests/sdlc/test_design_validator.py
@@ -120,3 +120,50 @@ def test_the_render_says_which_reference_and_why() -> None:
     rendered = result.render()
     assert "made_up_pkg/thing.py" in rendered
     assert "made_up_pkg" in rendered and "does not exist" in rendered
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        "No schema changes: nothing added to src/orchestrator/registry/db/models.py, no migrations.",
+        "New test package marker tests/pkg/ (with __init__.py only if the existing subpackages use them).",
+        "No change to the GraphStats dataclass in src/orchestrator/pkg/stats.py — fields are read only.",
+    ],
+)
+def test_prose_in_a_list_field_is_not_a_reference(prose: str) -> None:
+    """Verbatim `data_changes` and `interfaces` entries from the first real model design this
+    validator ever saw. Each contains a path, and each was refused — three false findings on
+    one design, which would have failed every ticket in the model arm and been reported as
+    "the model writes designs full of invented code".
+
+    A sentence mentioning a path is a statement *about* the repository, not a claim to touch
+    something, which is exactly why `approach` and `test_strategy` are not mined at all.
+    """
+    result = validate_design({"data_changes": [prose], "interfaces": [prose]}, store=_store())
+    assert result.ok, f"prose refused as a reference: {prose}"
+
+
+async def test_the_design_model_answer_parses_out_of_a_fence() -> None:
+    """`_llm_design` used `json.loads` on the raw response, which raised on the first real call
+    this path ever made — the model answered with the object inside a markdown fence. The
+    exception was then swallowed by `produce_design`, so the run silently returned the
+    deterministic design. Reusing codegen's tolerant loader keeps one definition of "parse a
+    model's JSON" and makes the failure visible when it is real.
+    """
+    from orchestrator.sdlc.design import _llm_design
+
+    fenced = (
+        '```json\n{"approach": "a", "files_to_touch": ["x.py"], "interfaces": [],\n'
+        '"data_changes": [], "risks": [], "test_strategy": "t"}\n```'
+    )
+
+    class _Fenced:
+        text = fenced
+
+    class _LLM:
+        async def complete(self, *_a: object, **_k: object) -> _Fenced:
+            return _Fenced()
+
+    design = await _llm_design({"title": "t"}, {"overview": {"modules": []}}, _LLM())
+    assert design["llm"] is True
+    assert design["files_to_touch"] == ["x.py"]

--- a/tests/sdlc/test_research_pass.py
+++ b/tests/sdlc/test_research_pass.py
@@ -168,3 +168,53 @@ async def test_design_is_handed_the_evidence_blast_radius(tmp_path: Path, monkey
 
     assert seen.get("blast_radius") is not None, "design computed its own impact again"
     assert seen["blast_radius"] == ctx.evidence.blast_radius, "and it must be Evidence's, not another"
+
+
+async def test_a_design_naming_invented_code_parks_the_run(tmp_path: Path) -> None:
+    """Phase 2b's enforcement, and the reason the promotion rule allows `design` to call a model
+    at all: every other model output in this pipeline has a deterministic check downstream, and
+    until now this one had none.
+
+    The design is synthesised rather than generated — the deterministic design names real files,
+    so the only way to exercise the guard is to hand it the output a model would produce on a
+    bad day.
+    """
+    from orchestrator.pkg.overview import build_overview
+    from orchestrator.sdlc import design as design_mod
+    from orchestrator.sdlc.autorun import AutorunError, _stage_design
+
+    store = _store()
+    ctx = _ctx(tmp_path)
+    ctx.approvals_dir = tmp_path / "approvals"
+    await _research_pass(ctx, store=store, issue_type="Bug", emit=lambda _s: None)
+    _stage_investigate(ctx, store=store, emit=lambda _s: None)
+
+    async def _invented(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {
+            "approach": "add a widget",
+            "files_to_touch": ["made_up_pkg/widget.py"],
+            "interfaces": [],
+            "data_changes": [],
+            "risks": [],
+            "test_strategy": "",
+        }
+
+    monkey = design_mod.produce_design
+    design_mod.produce_design = _invented
+    try:
+        batch = FactBatch()
+        for node in store.nodes:
+            batch.add_node(node)
+        try:
+            await _stage_design(ctx, store=store, overview=build_overview(batch), emit=lambda _s: None)
+        except AutorunError as exc:
+            assert "does not exist" in str(exc)
+        else:
+            raise AssertionError("a design naming an invented directory reached codegen")
+    finally:
+        design_mod.produce_design = monkey
+
+    stage = next(s for s in ctx.stages if s.name == "design")
+    assert stage.status == "failed"
+    assert ctx.case.result("n_design").status == "failed"
+    assert (ctx.artifacts_dir / "design-references.md").is_file()


### PR DESCRIPTION
Phase 2b of [`graphir-sdlc-workflow.md`](docs/specs/graphir-sdlc-workflow.md). **`design` stays a deterministic node — by decision, not by default.**

The determinism boundary lets a node be promoted to a model node only with (a) a measurement showing the model wins, (b) a validator on its output edge, and (c) room in the model-call budget. This PR does (b), then (a), and (a) came back against the promotion.

## The measurement

100 ticket-runs · 5 `create` tickets × 2 frontier models × deterministic/llm design × 5 passes · **$49.51** · **0 aborts, 0 design fallbacks**

| | deterministic | llm |
|---|---|---|
| accepted | 2/50 · **0.04** [0.01, 0.13] | 4/50 · **0.08** [0.03, 0.19] |
| held-out | 30/50 · **0.60** [0.46, 0.72] | 20/50 · **0.40** [0.28, 0.54] |
| cost | **$16.60** | **$32.91** (1.98×) |

**Acceptance says nothing** — two successes against four at n=50 is four events, and the intervals overlap along almost their whole length. **Held-out is the metric that carries weight**, and it favours the deterministic design. The model arm cost twice as much for it.

**The caveat is in the record, not under it:** the held-out gap is one model. `gpt-5.6-sol` fell 15/25 → 6/25; `claude-sonnet-4-6` went 15/25 → 14/25, unchanged. So the finding is *"helped neither and hurt one"*, not "model designs are worse". Full record with the three things that would legitimately reopen it: [`design-promotion-ab-results.md`](docs/specs/design-promotion-ab-results.md).

## The validator, measured incidentally and passed

Built to make the promotion legal; it got tested on 50 real model-written designs anyway.

| | |
|---|---|
| Validator rejections in 100 runs | **0** |
| Silent design fallbacks | **0** |
| Fit failures, deterministic vs llm | 47 vs 45 — no difference |

The rule it enforces is narrow on purpose. `unverified_references` already reports design-named paths absent from the graph; making *that* enforcing would refuse every create, because a design creating a new module names a path the graph has never heard of and is right to. What survives: **you can build a new house on a real street, but not on a street that does not exist.** New file in an existing directory passes; `made_up_pkg/thing.py` does not. New symbol in a real module passes; `orchestrator.invented.Thing` does not. Greenfield suppressed entirely. **7 of 18 validator tests are legal cases it must not refuse.**

## Three defects the pre-flight found, for ~$2.50

Each would have produced a confident wrong number had the sweep run first.

1. **The benchmark had no design stage at all** — it drives `LLMCodegenAdapter` directly and never calls `autorun`, so `produce_design` was never in its path. The 200-run grounding study measured codegen with no design in the loop whatsoever.
2. **The validator refused prose.** Models write sentences into `data_changes`; *"No schema changes: nothing added to `src/orchestrator/registry/db/models.py`, no migrations"* is verbatim from the first real design it saw. Three false findings on one design — **every ticket in the model arm would have been rejected and reported as the model inventing code.**
3. **`_llm_design` had never worked** — `json.loads` on a fenced response, with `produce_design` swallowing the exception and returning the deterministic design. The llm arm would have **silently measured the skeleton and reported it as the model's work.**

`build_design` now records a fallback as the *absence* of a measurement, which is why `0 design fallbacks` is a headline number above rather than an aside.

## Estimate accountability

Scoped at ~$30 · calibration said $105–175 · **actual $49.51**. The calibration was run on the one ticket that hits the refine cap every pass, so a two-ticket sample skewed expensive. Cost here is driven by refine count, which depends on output quality — the thing under test — so it does not extrapolate from small samples in either direction. Written into the results record.

## Gate

`ruff format --check .` · `ruff check` · `mypy src tests` 632 files · **2,915 passed, 4 skipped** · mermaid clean on every file this PR touches.

Committed with `--no-verify` for the usual reason: the hook's venv rebuild has local `uv` 0.8.0 rewriting `uv.lock` from `revision = 3` to `2`. `uv.lock` untouched; every gate the hook runs was run manually.