### PR TITLE
ci: episteme regenerates on develop only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,8 @@ jobs:
       # a merge, and the two-dot diff against a main that is behind shows all of them at
       # once. The guard asks "did a contributor carry the artifact?" — on a promotion the
       # answer is structurally no, and there is no way to make it pass without reverting
-      # the bank main is owed. Regeneration runs on main too, so main rebuilds from its own
-      # tree after this lands regardless.
+      # the bank main is owed. Since 3.20.0 regeneration runs on develop only, so a
+      # promotion is the *sole* way main's bank moves — see .github/workflows/episteme.yml.
       - name: PR does not modify episteme/
         if: github.event_name == 'pull_request' && github.base_ref != 'main'
         run: |

--- a/.github/workflows/episteme.yml
+++ b/.github/workflows/episteme.yml
@@ -9,11 +9,34 @@
 # Moving regeneration here keeps everything that made committing the bank worthwhile — it
 # stays readable in the repo, diffable per commit, and ingested as Doc nodes — while
 # removing the conflict entirely. PRs are forbidden from touching it (see ci.yml).
+#
+# ## Why `develop` only
+#
+# This ran on `main` too, until 3.20.0. `main` cannot be pushed to, so the bank arrived by a
+# PR the workflow opened itself — except "Allow GitHub Actions to create and approve pull
+# requests" is off, so the branch landed and no PR ever opened. Four releases, four orphan
+# branches nobody saw, because the step warned and exited 0.
+#
+# Enabling that setting would not have fixed it, which is the part worth recording. `main`
+# receives only what `develop` already regenerated, so the two banks are content-identical;
+# the *only* thing a main-side run produces is a new commit SHA in the stamp:
+#
+#     -Generated from commit `1eb9a0fa…` … by Spine 3.20.0.
+#     +Generated from commit `ad6e8de8…` … by Spine 3.20.0.
+#
+# And merging that PR creates a new commit, so the stamp is stale again the moment it lands.
+# It is a loop that cannot converge, and it was costing a release-day approval dance: every
+# push to `develop` re-queues gated checks and dismisses the promotion's approval.
+#
+# So `main` inherits `develop`'s bank verbatim. Its stamp names the commit the facts were
+# computed from — a `develop` commit — which is more accurate than naming the merge commit
+# that changed nothing. CI checks that the bank *builds* on every PR (ci.yml); it does not
+# run `understand --check`, so nothing depends on the stamp matching HEAD.
 name: Episteme
 
 on:
   push:
-    branches: [main, develop]
+    branches: [develop]
 
 # One regeneration at a time per branch. Superseding an in-flight run is safe and correct:
 # the output is a pure function of the tree, so the newest run computes the newest answer.
@@ -22,8 +45,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write # main cannot be pushed to; the bank arrives there by PR
+  contents: write # push the regenerated bank to develop; nothing else
 
 jobs:
   regenerate:
@@ -70,59 +92,13 @@ jobs:
           the tree, not authored, and is regenerated after merge so branches never carry
           it and never conflict over it."
 
-      # `develop` takes a direct push. `main` does not, and finding that out at push time
-      # is how the 3.17.0 promotion left main's bank stale: the run regenerated correctly,
-      # then died on `GH013: Changes must be made through a pull request` — a rule this
-      # workflow cannot and should not bypass.
-      - name: Push it (develop)
-        if: steps.commit.outputs.moved == 'true' && github.ref_name != 'main'
+      # `develop` takes a direct push. `main` does not — `GH013: Changes must be made through
+      # a pull request` — which is why this workflow no longer runs there at all; see the
+      # header.
+      - name: Push it
+        if: steps.commit.outputs.moved == 'true'
         run: |
           # Another merge may have landed while this ran. Rebase rather than force: the
           # regeneration is reproducible, and clobbering someone else's merge is not.
           git pull --rebase --autostash origin "${{ github.ref_name }}"
           git push origin HEAD:"${{ github.ref_name }}"
-
-      # On main the bank arrives the same way everything else does. CI's "PR does not
-      # modify episteme/" guard already exempts `base_ref == main`, so this PR is legal by
-      # the same rule that lets a release promotion carry the artifact.
-      - name: Open a pull request (main)
-        if: steps.commit.outputs.moved == 'true' && github.ref_name == 'main'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          FOR_SHA: ${{ steps.commit.outputs.for }}
-        run: |
-          branch="chore/episteme-${FOR_SHA}"
-          git push --force-with-lease origin HEAD:"$branch"
-          open=$(gh pr list --head "$branch" --state open --json number --jq 'length')
-          if [ "$open" != "0" ]; then
-            echo "a PR for $branch is already open"
-            exit 0
-          fi
-          {
-            printf '`episteme/` regenerated from main'"'"'s own tree by\n'
-            printf '[`.github/workflows/episteme.yml`](.github/workflows/episteme.yml).\n\n'
-            printf 'It arrives as a pull request because main'"'"'s ruleset requires one — a direct\n'
-            printf 'push is rejected with `GH013`, which is what left the bank stale after the\n'
-            printf '3.17.0 promotion. Nothing here is authored: the knowledge base is a pure\n'
-            printf 'function of the tracked tree, so this diff is whatever `orchestrator\n'
-            printf 'understand .` computes at this commit.\n\n'
-            printf 'CI'"'"'s "PR does not modify episteme/" guard exempts `base_ref == main`, the\n'
-            printf 'same rule that lets a release promotion carry the artifact.\n'
-          } > /tmp/episteme-pr-body.md
-          # `gh pr create` can be refused by a setting no workflow permission overrides:
-          # "Allow GitHub Actions to create and approve pull requests". When it is off the
-          # call fails with `GitHub Actions is not permitted to create or approve pull
-          # requests`, which is what happened on the 3.18.0 promotion.
-          #
-          # The branch is already pushed at that point, so nothing is lost and failing the run
-          # says otherwise. Print the one-click URL and exit 0: a human opens it in a moment,
-          # and if the setting is ever enabled this starts opening PRs by itself with no
-          # further change.
-          if ! gh pr create --base main --head "$branch" \
-              --title "chore(episteme): regenerate for ${FOR_SHA}" \
-              --body-file /tmp/episteme-pr-body.md; then
-            echo "::warning::Could not open the PR automatically — the branch is pushed and waiting."
-            echo "Open it here: ${{ github.server_url }}/${{ github.repository }}/pull/new/$branch"
-            echo "If this is the 'Actions is not permitted to create pull requests' refusal, the"
-            echo "fix is Settings -> Actions -> General -> Workflow permissions."
-          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,8 @@ them on a release cadence — so opening an issue first avoids duplicated effort
    The one exemption is a **release promotion** — a `develop` → `main` PR. Its `episteme/`
    diff is every bot commit made on `develop` since `main` last moved, which is the design
    working rather than a contributor carrying the artifact, so the check skips when the base
-   is `main`. `main` regenerates from its own tree after the merge either way.
+   is `main`. Since 3.20.0 that promotion is the **only** way `main`'s bank moves:
+   regeneration runs on `develop` alone, and `main` inherits it verbatim.
 4. Open the PR with a clear description of **what** and **why**, linking any issue.
 5. A maintainer reviews; the `security scan` check must pass.
 

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -171,7 +171,7 @@ its output edge, and inside the model-call budget.
 | Rust front-end | not started |
 | Express endpoint extraction (TypeScript) | unscheduled |
 | Deployment image + reusable CI workflow for central adoption | not started, needed before rollout |
-| `episteme.yml` main-branch path produces orphan branches | see §8 |
+| `episteme.yml` main-branch path produces orphan branches | ✅ **fixed 2026-08-19** — regeneration is `develop`-only; `main` inherits the bank verbatim |
 
 ## 8. The failure mode this project keeps having
 


### PR DESCRIPTION
Removes the `main`-side knowledge-base regeneration. Four releases produced four orphan branches; the fifth would have too.

## What was happening

`main` can't be pushed to, so the bank arrived by a PR the workflow opened itself. **"Allow GitHub Actions to create and approve pull requests" is off**, so the branch landed and no PR ever opened — and the step warned and `exit 0`, so nothing went red. `chore/episteme-044cdfd`, `chore/episteme-df650bd`, `chore/episteme-2a67977`, `chore/episteme-ad6e8de`.

## Enabling that setting would not have fixed it

`main` receives only what `develop` already regenerated, so the two banks are **content-identical**. The entire diff a main-side run produces:

```diff
-Generated from commit `1eb9a0fa…` … by Spine 3.20.0.
+Generated from commit `ad6e8de8…` … by Spine 3.20.0.
```

One line — a commit SHA in a stamp. And merging that PR creates a new commit, so the stamp is stale the moment it lands. **A loop that cannot converge**, generating one branch per release forever.

## It also cost a release-day approval dance

Every push to `develop` re-queues the promotion PR's gated workflow runs *and* dismisses its approval (`dismiss_stale_reviews_on_push: true`). This workflow guaranteed a push after every merge. 3.20.0 took **three head-SHA changes, two dismissed approvals, and eight workflow runs approved by hand** before it could merge — more wall-clock than any engineering task that day.

## The change

`main` inherits `develop`'s bank verbatim. Its stamp names the commit the facts were computed from — a `develop` commit — which is **more** accurate than naming a merge commit that changed nothing.

**Nothing depended on the stamp matching HEAD:** CI runs `orchestrator understand .` to check the bank *builds*, and has never run `understand --check`. Verified before making the change.

Also narrows `permissions:` — `pull-requests: write` went with the step that needed it — and corrects the `ci.yml` and `CONTRIBUTING.md` comments that told readers "main regenerates from its own tree after the merge", which will no longer be true.

The last orphan is deleted (`chore/episteme-ad6e8de`, was `98aaf9f`).

## Gate

`ruff check` · workflows parse as YAML · architecture diagram current. No source changed, so `mypy` and the suite are unaffected.