### PR TITLE
docs+cli: the first run needs nothing, writes nothing, and says what it learned

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,28 @@ flowchart LR
     build --> pr
 ```
 
+**Try it on your own repo in under a minute.** No API key, no configuration, and it writes
+nothing — `state` reads your code and prints what it found:
+
 ```bash
 pip install synaptixs-spine
-orchestrator init && orchestrator doctor                  # scaffold .env, check readiness
+orchestrator state /path/to/your/repo
+```
+
+Measured cold on a clean machine: **25s to install, 0.8s to answer.** On
+[`pallets/click`](https://github.com/pallets/click) it opens with
+
+> This is a python library / service — **173 types** and **1722 functions** across **22
+> components** (78 files). Top priority: Refactor 3 god-classes (>40 members), e.g. `Context`
+> (60), `ProgressBar` (48).
+
+then the architecture, the areas, documentation coverage and drift. Deterministic — no model
+runs, so the same commit always gives the same report.
+
+**When you want it to write code**, that's when configuration starts to matter:
+
+```bash
+orchestrator init && orchestrator doctor                     # scaffold .env, check readiness
 orchestrator sdlc feature --source file://./spec.md --safe   # build locally — no pushes, no PRs
 ```
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -97,6 +97,28 @@ uv run orchestrator --help     # in this layout, prefix CLI calls with `uv run`
 
 ---
 
+## Step 1.5 — See what it knows about your repo (no configuration yet)
+
+Before any of the setup below, Spine can already read your code. `state` needs **no API key and
+no `.env`**, and **writes nothing** — it prints what it found:
+
+```bash
+orchestrator state /path/to/your/repo
+```
+
+On a clean machine that is 25 seconds to install and under a second to answer. Everything in
+this step is deterministic: no model runs, so the same commit always produces the same report.
+`orchestrator profile` and `orchestrator pkg extract --json` are the same — read-only, keyless.
+
+Configure when you want Spine to *write* code, which is Step 2 onward.
+
+> **`understand` is the one read command that does write.** It builds the committed knowledge
+> base — `episteme/` inside the repo — because that artifact is meant to be reviewed and
+> committed. Use `state` while you are evaluating; use `understand` once you have decided the
+> bank belongs in your repository.
+
+---
+
 ## Step 2 — Configure
 
 ```bash


### PR DESCRIPTION
G4 Phase 1 — the friction audit, and the two things it found.

## The audit passed its own bar

Measured cold against the published 3.20.0 wheel, fresh venv, `--no-cache-dir`:

| Step | Time |
|---|---|
| `python3 -m venv` | 1.4s |
| `pip install --no-cache-dir synaptixs-spine` | **25.4s** |
| `orchestrator state <repo>` | **0.8s** |
| **nothing → grounded answer** | **~28s** |

G4's exit criterion is *"< 60s, no API key, clean box"*. Met with half the budget spare.

## Finding 1 — the documented first command was the wrong one

`orchestrator init && orchestrator doctor` told a stranger configuration was required before anything worked. It isn't. Then `understand`, which **writes 62 files into their repo** — `?? episteme/` in their `git status` — before they'd decided to adopt anything.

The quick-start now opens with `orchestrator state /path/to/your/repo`: writes nothing, needs no key, answers in 0.8s. On `pallets/click`:

> This is a python library / service — **173 types** and **1722 functions** across **22 components** (78 files). Top priority: Refactor 3 god-classes (>40 members), e.g. `Context` (60), `ProgressBar` (48).

`init`/`doctor`/`sdlc feature` move under *"when you want it to write code"*, which is the only point at which they matter. `USER_GUIDE.md` gets the same as **Step 1.5** — fractional because the guide carries 40 cross-references to numbered steps and `Step 2.5` already sets the precedent.

**`understand` is unchanged in behaviour.** Writing a committed bank is the adopter's path working as designed; it's just the wrong thing to hand someone still deciding, and both docs now say which is which.

## Finding 2 — it printed a file listing instead of an answer

Before, the first run ended with a JSON array of all 62 filenames. After:

```
python · 2,640 grounded of 2,914 nodes
2,007 call edges · 665 imports · 383 doc mentions

Start here:
  README.md          what this codebase is
  architecture.md    how it fits together
  symbol-index.md    every symbol, with file:line

62 files in total — `--json` lists them all.
```

Three named files rather than sixty-two: a reader needs one place to start, not an index. `--json` still emits the full result for anything that parses it, and is documented in `CLI_REFERENCE.md`.

**Two bugs in my own first version**, both visible only by running it against a real repo: `profile["languages"]` is a list, so it printed `['python']` at a stranger; and the summary repeated the node count and directory the build's own progress lines had just reported. The test asserts the list repr is absent — that's the failure a reader notices and a type checker doesn't.

## Honesty of the numbers

Measured, not estimated. My first install run had warm pip caches and I re-ran with `--no-cache-dir` because that's what a stranger faces. The `click` quote is pasted from a real run, and I re-verified afterwards that `state` still adds **0** files.

## Gate

`ruff check` · `mypy src tests` 633 files · **2,917 passed, 4 skipped** · mermaid renders · architecture diagram current.