### PR TITLE
feat(cli): understand says what it learned (restoring a commit #215 did not merge)

### DIFF
--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -207,6 +207,7 @@ orchestrator understand [PATH] [OPTIONS]
 | `--check` | Verify the committed episteme still matches the code; write nothing, exit non-zero if not. |
 | `--dialect` | SQL dialect (postgres\|mysql\|tsql\|oracle\|…); default: auto-detect. |
 | `--intents` | Also record which ticket each symbol was last changed for (`Intent`/`SERVES`). Opt-in — see the caveat below. |
+| `--json` | Emit the result — including every file written — as JSON. Without it the command prints what the bank says and names the three files to read first. |
 
 `--check` writes nothing: it re-renders and diffs against the committed bank, exiting non-zero
 when they disagree. That makes `episteme/` *provably* current in CI rather than hopefully

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -2052,6 +2052,9 @@ def understand(
             "Adds ~8s: one `git blame` per file. Opt-in — nothing renders these facts yet.",
         ),
     ] = False,
+    as_json: Annotated[
+        bool, typer.Option("--json", help="Emit the result — including every file written — as JSON.")
+    ] = False,
 ) -> None:
     """Build a committed `episteme/` — a code-true project knowledge base.
 
@@ -2092,14 +2095,53 @@ def understand(
         result = build_memory_bank(
             repo, out_dir=out_dir, refresh=refresh, sql_dialect=dialect, intents=intents, log=typer.echo
         )
-    _print(
-        {
-            "dir": result["dir"],
-            "greenfield": result["greenfield"],
-            "files": result["files"],
-            "grounded_nodes": result["summary"].get("grounded_nodes", 0),
-        }
-    )
+    if as_json:
+        _print(
+            {
+                "dir": result["dir"],
+                "greenfield": result["greenfield"],
+                "files": result["files"],
+                "grounded_nodes": result["summary"].get("grounded_nodes", 0),
+            }
+        )
+        return
+    for line in _understand_summary(result):
+        typer.echo(line)
+
+
+def _understand_summary(result: dict[str, Any]) -> list[str]:
+    """What the bank says, and which file to open first.
+
+    This used to print the raw result — a JSON array of all 62 filenames — so the first thing
+    anyone saw on their first run was a directory listing. The facts were in the files; the
+    terminal showed plumbing. The listing is still available under ``--json``, where a caller
+    that wants to parse it can ask for it.
+    """
+    summary = result.get("summary") or {}
+    profile = result.get("profile") or {}
+    nodes, grounded = summary.get("nodes", 0), summary.get("grounded_nodes", 0)
+    calls, imports = summary.get("edges_calls", 0), summary.get("edges_imports", 0)
+    docs = summary.get("edges_mentions", 0)
+
+    # `profile["languages"]` is a list, and interpolating it printed `['python']` at a stranger
+    # on their first run. The build's own `[understand]` lines already reported the node count
+    # and the directory, so this says what those did not rather than repeating them.
+    raw = profile.get("languages") or profile.get("language") or []
+    languages = ", ".join(str(x) for x in raw) if isinstance(raw, list | tuple) else str(raw)
+
+    out: list[str] = []
+    head = f"{grounded:,} grounded of {nodes:,} nodes"
+    out.append(f"{languages} · {head}" if languages else head)
+    out.append(f"{calls:,} call edges · {imports:,} imports · {docs:,} doc mentions")
+    # Three named files rather than "62 written": a reader needs one place to start, not an index.
+    out.append("")
+    out.append("Start here:")
+    out.append("  README.md          what this codebase is")
+    out.append("  architecture.md    how it fits together")
+    out.append("  symbol-index.md    every symbol, with file:line")
+    out.append("")
+    out.append(f"{len(result.get('files') or [])} files in total — `--json` lists them all.")
+    return out
 
 
 @app.command("state")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -328,3 +328,39 @@ def test_repo_arg_classifies_local_vs_git(tmp_path: Path) -> None:
     with _repo_arg(str(tmp_path)) as (path, is_remote):
         assert path == tmp_path.resolve()
         assert is_remote is False
+
+
+def test_understand_leads_with_what_it_learned_not_a_file_listing(tmp_path: Path) -> None:
+    """The first run used to print the raw result — a JSON array of every file written — so a
+    stranger's first impression was a directory listing rather than an answer. The listing is
+    still there under `--json`; the default is what the bank says.
+
+    Asserts on the rendered lines rather than by running the CLI: the summary is the thing under
+    test, and driving `understand` needs a real repo and several seconds.
+    """
+    from orchestrator.cli import _understand_summary
+
+    lines = _understand_summary(
+        {
+            "dir": str(tmp_path / "episteme"),
+            "greenfield": False,
+            "files": [f"f{i}.md" for i in range(62)],
+            "profile": {"languages": ["python"]},
+            "summary": {
+                "nodes": 2914,
+                "grounded_nodes": 2640,
+                "edges_calls": 2007,
+                "edges_imports": 665,
+                "edges_mentions": 383,
+            },
+        }
+    )
+    rendered = "\n".join(lines)
+    assert "python · 2,640 grounded of 2,914 nodes" in rendered
+    assert "2,007 call edges" in rendered
+    assert "README.md" in rendered and "symbol-index.md" in rendered
+    assert "62 files in total" in rendered
+    # The list repr is the bug this guards: `profile["languages"]` is a list, and interpolating
+    # it printed `['python']` at a stranger on their first run.
+    assert "['python']" not in rendered
+    assert "f0.md" not in rendered, "the file listing belongs behind --json"


### PR DESCRIPTION
**This is a re-land, not new work.** The change was reviewed and approved as part of [#215](https://github.com/synaptixs/spine/pull/215) but did not make it into the merge.

## What happened

#215 carried two commits:

| | |
|---|---|
| `bc4305b` — docs, finding 1 | merged ✅ |
| `d64a54c` — CLI, finding 2 | **not merged** ❌ |

When I pushed `d64a54c`, GitHub's PR API was lagging — it still reported the head as `bc4305b` with `mergeStateStatus: UNKNOWN`, while `git` showed local and remote both at `d64a54c`. The merge took the head GitHub knew about. I then deleted the branch, so the commit survived only as a dangling object in my local clone.

Recovered with `git cherry-pick d64a54c` — same content, verified below.

**My part in it:** I saw the head mismatch, said the push had landed, and moved on without re-checking that CI had queued on the new SHA. I'd flagged the lag and then didn't follow it through.

## What the change does (unchanged from #215)

`understand`'s last output was a JSON array of all 62 filenames. Now:

```
python · 2,640 grounded of 2,914 nodes
2,007 call edges · 665 imports · 383 doc mentions

Start here:
  README.md          what this codebase is
  architecture.md    how it fits together
  symbol-index.md    every symbol, with file:line

62 files in total — `--json` lists them all.
```

Three named files rather than sixty-two — a reader needs one place to start, not an index. `--json` keeps the old output for anything that parses it, and is documented in `CLI_REFERENCE.md`.

The test asserts `['python']` never appears: `profile["languages"]` is a list, and my first version interpolated it raw at a stranger on their first run. That's the failure a reader notices and a type checker doesn't.

## Verified after recovery

Re-ran against `pallets/click` — output above is from that run, not from memory.

`ruff check` · `mypy src tests` 633 files · `tests/test_cli.py` 29 passed.