### PR TITLE
Four front-ends fabricated a CALLS edge for a shadowed name — measured, fixed, gated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## Unreleased
 
-### Added — the invention oracle now walks six front-ends, and found a defect in four
+### Fixed — four front-ends fabricated a `CALLS` edge for a shadowed name
 
 - **`pkg accuracy --oracle invention` and `pkg verify` were Python-only, and said `0`.** The
   detector re-parsed with the stdlib `ast`, so on a TypeScript, Go, C++ or C# repository a zero
@@ -34,10 +34,31 @@ All notable changes to this project are documented here. Format loosely follows
   (Java — variables and methods have separate namespaces, JLS §6.5.7; SQL — no lexical scope),
   or `unwalked`. The denominator reported is **bare calls**, not all `CALLS`: only a bare call
   can be reached by a shadow.
-- **The front-ends are unchanged.** No `*_extractor.py` was touched; this measures only. Porting
-  C's fix to the other four, a `shadowed_calls` corpus case each, and moving `invention` to a
-  `strict`-at-zero gate (recorded as `target_gate` in `scoreboard.json`) are the phases after
-  this one.
+- **Fixed by porting C's test to the other four** — a local `_bound_names` per front-end,
+  answering *did this function bind the name*, never *can we resolve it*. The difference is the
+  design: an unresolved callee in C++ is usually a header declaration linked from another
+  translation unit, and a Python-style "skip anything unresolved" fix would have silenced every
+  cross-translation-unit call in every C++ repository. The oracle keeps its own independent
+  implementation — a detector that imports the code it audits agrees with that code's bugs.
+- **Each helper carries the first line a name is in scope**, because two of the four languages
+  require it. Go's spec starts a `:=` scope at the end of the statement, so `cmd := cmd(path)`
+  calls the package-level `cmd`; C and C++ read the same way. Binding from the top of the
+  function would have dropped those edges — 5 in grpc-go alone. C# tracks the bare-call form
+  separately: `this.Handle()` is an explicit member access and cannot be shadowed.
+- **Re-measured on the same 11 repositories: 0 everywhere, and 47 edges removed for 47
+  fabrications found.** vue/core −1, leveldb −3, fmt −43, every other repo unchanged. No true
+  edge was lost across 38,602 bare calls; grpc-go kept all 6,285 of its `CALLS`. Precision
+  rises, recall is untouched — these edges were never in any expected set.
+- **Four corpus cases** — `corpus/{typescript,go,cpp,csharp}/shadowed_calls`, modelled on
+  `corpus/c/function_pointers`. Each was written and scored **before** the fix and each failed
+  at the predicted point: `CALLS` precision 0.50, recall 1.00. Each pairs the shadowed call
+  with an unshadowed sibling in the same file, so a front-end cannot pass by dropping both.
+- **`invention` is now gated `strict` at zero per language** — the only metric gated on an
+  absolute value rather than against the baseline, because it is the only one with a correct
+  value. Comparing to a stored number would let a non-zero baseline become the thing everyone
+  agrees to live with. A language whose status is not `measured` is skipped; its 0 means *not
+  examined*. The gate is proved by making it fail, and the original objection is preserved: the
+  *rate* still moves freely, only the count is held at zero.
 
 ### Changed — GraphIR Phase 4 closed without shipping either half
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## Unreleased
 
+### Added — the invention oracle now walks six front-ends, and found a defect in four
+
+- **`pkg accuracy --oracle invention` and `pkg verify` were Python-only, and said `0`.** The
+  detector re-parsed with the stdlib `ast`, so on a TypeScript, Go, C++ or C# repository a zero
+  meant *nothing ran*. New `pkg/scope.py` walks TypeScript, Go, C#, C++ and C with the same
+  tree-sitter parser each front-end uses, and the detector is restated language-neutrally: an
+  edge is invented when the call site is a **bare identifier** matching the target and that
+  name is **bound inside the calling function**.
+- **Four front-ends fabricate a `CALLS` edge for a shadowed name.** `outer(send)` calling its
+  own parameter `send` yields `ts:a.outer -CALLS-> ts:a.send` — the module-level function it
+  never reaches. Reproduces in Go, C++ and C#. This is the bug Python fixed in 3.18.0, in a
+  form the fix did not reach: these do not invent an id, they land on a **real node**, so
+  `pkg verify` sees no dangling edge and no corpus fixture carries the shape. C already refuses
+  it (`c_extractor._bound_names`) and has a corpus case; the other four have neither.
+- **Measured on 11 pinned public repositories:** 47 fabricated edges across 23,746 bare calls —
+  **46 in C++** (0.47%; leveldb and fmt), **1 in TypeScript** (vue/core), **0 in Go and C#** on
+  8,562 bare calls, and **0 in C** across 14,856, which is the control holding. Roughly an order
+  of magnitude rarer than Python's 3.16% was. Record, with SHAs and the reproducing command:
+  `docs/specs/invention-oracle-cross-language.md`.
+- **Two false positives in the oracle were found by hand and fixed before publishing.** A
+  TypeScript destructuring *default* was read as a binding (3 phantom findings on vue/core), and
+  Go's `:=` was treated as in scope on its own line, when the spec starts it after the statement
+  — so idiomatic `cmd := cmd(path)` read as fiction (5 on grpc-go). Both have regression tests
+  written against the language reference.
+- **Per front-end in the scoreboard and the CLI, with a `status`.** `measured`, `not-applicable`
+  (Java — variables and methods have separate namespaces, JLS §6.5.7; SQL — no lexical scope),
+  or `unwalked`. The denominator reported is **bare calls**, not all `CALLS`: only a bare call
+  can be reached by a shadow.
+- **The front-ends are unchanged.** No `*_extractor.py` was touched; this measures only. Porting
+  C's fix to the other four, a `shadowed_calls` corpus case each, and moving `invention` to a
+  `strict`-at-zero gate (recorded as `target_gate` in `scoreboard.json`) are the phases after
+  this one.
+
 ### Changed — GraphIR Phase 4 closed without shipping either half
 
 - **The parallel fan-out was measured and declined.** Timed on this repo's own graph, only

--- a/corpus/cpp/shadowed_calls/.repo/src/dispatch.cpp
+++ b/corpus/cpp/shadowed_calls/.repo/src/dispatch.cpp
@@ -1,0 +1,11 @@
+int handle() {
+    return 1;
+}
+
+int run(int (*handle)()) {
+    return handle();
+}
+
+int direct() {
+    return handle();
+}

--- a/corpus/cpp/shadowed_calls/expected.json
+++ b/corpus/cpp/shadowed_calls/expected.json
@@ -1,0 +1,64 @@
+{
+  "language": "cpp",
+  "case": "shadowed_calls",
+  "root": ".repo",
+  "why": "A local binding that shadows a resolvable name. The caller's own parameter is what runs; the file-level definition of the same name is never reached. Labelled from the source: the shadowed call site gets NO edge, and the unshadowed sibling in the same file gets one, so a front-end cannot pass by dropping both. C has carried this case since it was fixed there (corpus/c/function_pointers); this is the same shape in the four front-ends that had neither the fix nor a fixture.",
+  "nodes": [
+    {
+      "id": "cpp:src/dispatch.cpp",
+      "kind": "Module"
+    },
+    {
+      "id": "cpp:handle",
+      "kind": "Function"
+    },
+    {
+      "id": "cpp:run",
+      "kind": "Function"
+    },
+    {
+      "id": "cpp:direct",
+      "kind": "Function"
+    }
+  ],
+  "edges": [
+    {
+      "src": "cpp:src/dispatch.cpp",
+      "dst": "cpp:handle",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "cpp:src/dispatch.cpp",
+      "dst": "cpp:run",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "cpp:src/dispatch.cpp",
+      "dst": "cpp:direct",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "cpp:direct",
+      "dst": "cpp:handle",
+      "kind": "CALLS"
+    }
+  ],
+  "known_gaps": [],
+  "false_positives": [
+    {
+      "edge": {
+        "src": "cpp:run",
+        "dst": "cpp:handle",
+        "kind": "CALLS"
+      },
+      "why": "PREDICTED BEFORE SCORING. `cpp:run -CALLS-> cpp:handle`. `run`'s function-pointer parameter `handle` shadows the free function; the callee is decided at run time."
+    }
+  ],
+  "excluded": [
+    "`direct` (`Direct`) calling the same name without shadowing it is NOT excluded \u2014 it is the control. A fix that skipped every unresolved bare call would drop this edge too, and the case would catch that."
+  ],
+  "open_questions": [],
+  "resolved_by_measurement": [
+    "Written BEFORE the fix and scored: the front-end emitted an edge to the file-level definition, taking CALLS precision to 0.50 for this case. Unlike the Python and C inventions, the target is a REAL node, so nothing dangled and pkg verify stayed silent \u2014 which is why no existing check found it and why this fixture, not a verifier rule, is the guard."
+  ]
+}

--- a/corpus/csharp/shadowed_calls/.repo/App/Dispatch.cs
+++ b/corpus/csharp/shadowed_calls/.repo/App/Dispatch.cs
@@ -1,0 +1,15 @@
+namespace App;
+
+public class Dispatch {
+    public int Handle() {
+        return 1;
+    }
+
+    public int Run(System.Func<int> Handle) {
+        return Handle();
+    }
+
+    public int Direct() {
+        return Handle();
+    }
+}

--- a/corpus/csharp/shadowed_calls/expected.json
+++ b/corpus/csharp/shadowed_calls/expected.json
@@ -1,0 +1,73 @@
+{
+  "language": "csharp",
+  "case": "shadowed_calls",
+  "root": ".repo",
+  "why": "A local binding that shadows a resolvable name. The caller's own parameter is what runs; the file-level definition of the same name is never reached. Labelled from the source: the shadowed call site gets NO edge, and the unshadowed sibling in the same file gets one, so a front-end cannot pass by dropping both. C has carried this case since it was fixed there (corpus/c/function_pointers); this is the same shape in the four front-ends that had neither the fix nor a fixture.",
+  "nodes": [
+    {
+      "id": "csharp:App",
+      "kind": "Module"
+    },
+    {
+      "id": "csharp:App.Dispatch",
+      "kind": "Type"
+    },
+    {
+      "id": "csharp:App.Dispatch.Handle",
+      "kind": "Function"
+    },
+    {
+      "id": "csharp:App.Dispatch.Run",
+      "kind": "Function"
+    },
+    {
+      "id": "csharp:App.Dispatch.Direct",
+      "kind": "Function"
+    }
+  ],
+  "edges": [
+    {
+      "src": "csharp:App",
+      "dst": "csharp:App.Dispatch",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "csharp:App.Dispatch",
+      "dst": "csharp:App.Dispatch.Handle",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "csharp:App.Dispatch",
+      "dst": "csharp:App.Dispatch.Run",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "csharp:App.Dispatch",
+      "dst": "csharp:App.Dispatch.Direct",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "csharp:App.Dispatch.Direct",
+      "dst": "csharp:App.Dispatch.Handle",
+      "kind": "CALLS"
+    }
+  ],
+  "known_gaps": [],
+  "false_positives": [
+    {
+      "edge": {
+        "src": "csharp:App.Dispatch.Run",
+        "dst": "csharp:App.Dispatch.Handle",
+        "kind": "CALLS"
+      },
+      "why": "PREDICTED BEFORE SCORING. `csharp:App.Dispatch.Run -CALLS-> csharp:App.Dispatch.Handle`. C# resolves a simple name to the local/parameter before the member, so the delegate parameter `Handle` wins."
+    }
+  ],
+  "excluded": [
+    "`direct` (`Direct`) calling the same name without shadowing it is NOT excluded \u2014 it is the control. A fix that skipped every unresolved bare call would drop this edge too, and the case would catch that."
+  ],
+  "open_questions": [],
+  "resolved_by_measurement": [
+    "Written BEFORE the fix and scored: the front-end emitted an edge to the file-level definition, taking CALLS precision to 0.50 for this case. Unlike the Python and C inventions, the target is a REAL node, so nothing dangled and pkg verify stayed silent \u2014 which is why no existing check found it and why this fixture, not a verifier rule, is the guard."
+  ]
+}

--- a/corpus/go/shadowed_calls/.repo/shop/dispatch.go
+++ b/corpus/go/shadowed_calls/.repo/shop/dispatch.go
@@ -1,0 +1,13 @@
+package shop
+
+func Handle() int {
+	return 1
+}
+
+func Run(Handle func() int) int {
+	return Handle()
+}
+
+func Direct() int {
+	return Handle()
+}

--- a/corpus/go/shadowed_calls/expected.json
+++ b/corpus/go/shadowed_calls/expected.json
@@ -1,0 +1,64 @@
+{
+  "language": "go",
+  "case": "shadowed_calls",
+  "root": ".repo",
+  "why": "A local binding that shadows a resolvable name. The caller's own parameter is what runs; the file-level definition of the same name is never reached. Labelled from the source: the shadowed call site gets NO edge, and the unshadowed sibling in the same file gets one, so a front-end cannot pass by dropping both. C has carried this case since it was fixed there (corpus/c/function_pointers); this is the same shape in the four front-ends that had neither the fix nor a fixture.",
+  "nodes": [
+    {
+      "id": "go:shop",
+      "kind": "Module"
+    },
+    {
+      "id": "go:shop.Handle",
+      "kind": "Function"
+    },
+    {
+      "id": "go:shop.Run",
+      "kind": "Function"
+    },
+    {
+      "id": "go:shop.Direct",
+      "kind": "Function"
+    }
+  ],
+  "edges": [
+    {
+      "src": "go:shop",
+      "dst": "go:shop.Handle",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "go:shop",
+      "dst": "go:shop.Run",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "go:shop",
+      "dst": "go:shop.Direct",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "go:shop.Direct",
+      "dst": "go:shop.Handle",
+      "kind": "CALLS"
+    }
+  ],
+  "known_gaps": [],
+  "false_positives": [
+    {
+      "edge": {
+        "src": "go:shop.Run",
+        "dst": "go:shop.Handle",
+        "kind": "CALLS"
+      },
+      "why": "PREDICTED BEFORE SCORING. `go:shop.Run -CALLS-> go:shop.Handle`. `Run`'s parameter `Handle` shadows the package-level function for the whole body."
+    }
+  ],
+  "excluded": [
+    "`direct` (`Direct`) calling the same name without shadowing it is NOT excluded \u2014 it is the control. A fix that skipped every unresolved bare call would drop this edge too, and the case would catch that."
+  ],
+  "open_questions": [],
+  "resolved_by_measurement": [
+    "Written BEFORE the fix and scored: the front-end emitted an edge to the file-level definition, taking CALLS precision to 0.50 for this case. Unlike the Python and C inventions, the target is a REAL node, so nothing dangled and pkg verify stayed silent \u2014 which is why no existing check found it and why this fixture, not a verifier rule, is the guard."
+  ]
+}

--- a/corpus/typescript/shadowed_calls/.repo/app/dispatch.ts
+++ b/corpus/typescript/shadowed_calls/.repo/app/dispatch.ts
@@ -1,0 +1,11 @@
+export function handle(): number {
+  return 1;
+}
+
+export function run(handle: () => number): number {
+  return handle();
+}
+
+export function direct(): number {
+  return handle();
+}

--- a/corpus/typescript/shadowed_calls/expected.json
+++ b/corpus/typescript/shadowed_calls/expected.json
@@ -1,0 +1,64 @@
+{
+  "language": "typescript",
+  "case": "shadowed_calls",
+  "root": ".repo",
+  "why": "A local binding that shadows a resolvable name. The caller's own parameter is what runs; the file-level definition of the same name is never reached. Labelled from the source: the shadowed call site gets NO edge, and the unshadowed sibling in the same file gets one, so a front-end cannot pass by dropping both. C has carried this case since it was fixed there (corpus/c/function_pointers); this is the same shape in the four front-ends that had neither the fix nor a fixture.",
+  "nodes": [
+    {
+      "id": "ts:app/dispatch",
+      "kind": "Module"
+    },
+    {
+      "id": "ts:app/dispatch.handle",
+      "kind": "Function"
+    },
+    {
+      "id": "ts:app/dispatch.run",
+      "kind": "Function"
+    },
+    {
+      "id": "ts:app/dispatch.direct",
+      "kind": "Function"
+    }
+  ],
+  "edges": [
+    {
+      "src": "ts:app/dispatch",
+      "dst": "ts:app/dispatch.handle",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "ts:app/dispatch",
+      "dst": "ts:app/dispatch.run",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "ts:app/dispatch",
+      "dst": "ts:app/dispatch.direct",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "ts:app/dispatch.direct",
+      "dst": "ts:app/dispatch.handle",
+      "kind": "CALLS"
+    }
+  ],
+  "known_gaps": [],
+  "false_positives": [
+    {
+      "edge": {
+        "src": "ts:app/dispatch.run",
+        "dst": "ts:app/dispatch.handle",
+        "kind": "CALLS"
+      },
+      "why": "PREDICTED BEFORE SCORING. `ts:app/dispatch.run -CALLS-> ts:app/dispatch.handle`. `run`'s parameter `handle` shadows the module-level function; the call goes through the parameter, whose target is decided by the caller."
+    }
+  ],
+  "excluded": [
+    "`direct` (`Direct`) calling the same name without shadowing it is NOT excluded \u2014 it is the control. A fix that skipped every unresolved bare call would drop this edge too, and the case would catch that."
+  ],
+  "open_questions": [],
+  "resolved_by_measurement": [
+    "Written BEFORE the fix and scored: the front-end emitted an edge to the file-level definition, taking CALLS precision to 0.50 for this case. Unlike the Python and C inventions, the target is a REAL node, so nothing dangled and pkg verify stayed silent \u2014 which is why no existing check found it and why this fixture, not a verifier rule, is the guard."
+  ]
+}

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -123,6 +123,7 @@ Analysis, comparisons, test plans and assets. No completion state applies.
 | [cli-test-plan](cli-test-plan.md) | 50 commands, written against 3.16.0 |
 | [pkg-accuracy-test-plan](pkg-accuracy-test-plan.md) · [comprehension-test-plan](comprehension-test-plan.md) | Manual test plans |
 | [pkg-accuracy-gaps](pkg-accuracy-gaps.md) | Review of the accuracy programme |
+| [invention-oracle-cross-language](invention-oracle-cross-language.md) | The invention oracle across 8 front-ends — Phase 1 results, 11 pinned public repos (2026-08-24). **47 fabricated `CALLS` edges, not yet fixed** |
 | [models](models.md) · [spine-vignette-runbook](spine-vignette-runbook.md) | Reference / runbook |
 | [build-document](build-document.md) *(also above)* | The 12-section template |
 | [sdlc-tracking-blueprint](sdlc-tracking-blueprint.md) · [design-and-comprehension-milestones](design-and-comprehension-milestones.md) | Blueprints |

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -123,7 +123,7 @@ Analysis, comparisons, test plans and assets. No completion state applies.
 | [cli-test-plan](cli-test-plan.md) | 50 commands, written against 3.16.0 |
 | [pkg-accuracy-test-plan](pkg-accuracy-test-plan.md) · [comprehension-test-plan](comprehension-test-plan.md) | Manual test plans |
 | [pkg-accuracy-gaps](pkg-accuracy-gaps.md) | Review of the accuracy programme |
-| [invention-oracle-cross-language](invention-oracle-cross-language.md) | The invention oracle across 8 front-ends — Phase 1 results, 11 pinned public repos (2026-08-24). **47 fabricated `CALLS` edges, not yet fixed** |
+| [invention-oracle-cross-language](invention-oracle-cross-language.md) | The invention oracle across 8 front-ends (2026-08-24) — 47 fabricated `CALLS` edges found on 11 pinned public repos, four front-ends fixed, gated | **✔** |
 | [models](models.md) · [spine-vignette-runbook](spine-vignette-runbook.md) | Reference / runbook |
 | [build-document](build-document.md) *(also above)* | The 12-section template |
 | [sdlc-tracking-blueprint](sdlc-tracking-blueprint.md) · [design-and-comprehension-milestones](design-and-comprehension-milestones.md) | Blueprints |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -96,10 +96,21 @@ Measured against a hand-labelled corpus, all 8 languages
 
 | | Result |
 |---|---|
-| **Precision** | **1.00** on every node kind and every edge kind, all 8 languages |
+| **Precision** | **1.00** on every node kind and every edge kind, all 8 languages — *on the corpus*, and see the caveat below |
 | **Recall** | 1.00 on every kind **except `CALLS`** |
 | `CALLS` recall | 1.00 (c, sql) · 0.73 (python) · 0.67 (cpp, csharp, go, java) · **0.50 (typescript)** |
-| Invention on this repo | **0** invented targets across **15,855** `CALLS` edges (re-run 2026-08-21) |
+| Invention | **0** on this repo across **15,982** `CALLS`; **47** across 23,746 bare calls on 11 public repos in TypeScript/Go/C++/C# (2026-08-24) |
+
+**That precision row is a corpus score, and the corpus is missing a shape.** When a parameter
+or local **shadows** a resolvable name, TypeScript, Go, C++ and C# each emit a `CALLS` edge to
+the file-level definition the caller never reaches — the bug Python fixed in 3.18.0, in a form
+the fix did not reach. C already refuses it (`c_extractor._bound_names`) and has a corpus case;
+the other four have neither. Nothing caught it: the target is a real node so `pkg verify` sees
+no dangling edge, no fixture carries the shape so precision reads 1.00, and the invention
+oracle was Python-only until 2026-08-24. Measured rate on real code: **0.47% of bare calls in
+C++, 0.02% in TypeScript, 0 in Go and C# on this sample** — real, and roughly an order of
+magnitude rarer than Python's 3.16% was. Full record, with pinned SHAs and the reproducible
+command: [`invention-oracle-cross-language.md`](invention-oracle-cross-language.md).
 
 Structure — *this module contains this class which contains this method* — is either in the tree
 or it is not. **`CALLS` is different because it needs *resolution*:** the tree tells you a call
@@ -160,8 +171,10 @@ that. Nothing in the pipeline has to ration it.
 
 - **`CALLS` recall on TypeScript is 0.50** — half the call edges are missed. Structure is
   complete; the call graph is not.
-- **Two of four accuracy oracles are Python-only** (`runtime` via PEP 669, `invention` via
-  Python `ast`). On a non-Python repo `invention` reporting `0` means *not measured*, not clean.
+- **`runtime` is still Python-only** (PEP 669). On a non-Python repo it reports nothing, and
+  that is *not measured*, not clean. `invention` was the same until 2026-08-24 and now walks
+  six front-ends, naming Java and SQL as not-applicable with reasons rather than scoring them
+  0 — but the shadowing defect it found in four of them is **not yet fixed**.
 - **8 languages**, against 21–40 for the graph-only tools. Additive against a fixed schema
   (`facts.py`) rather than a ceiling, but it is today's number.
 
@@ -341,6 +354,7 @@ its output edge, and inside the model-call budget.
 | Deployment image + reusable CI workflow for central adoption | not started. **Not a G4 phase** — it was recommended as though it were; it needs adding to that spec before it can be scheduled |
 | `SPEC-INDEX.md` links `watch-items-roadmap.md`, which does not exist | not started |
 | `docs/specs/current-state.md` has a mermaid block that falls back to `<pre>` in our own UI | not started |
+| Shadowed-name `CALLS` invention in TypeScript, Go, C++, C# | **measured 2026-08-24, not fixed.** The oracle now sees it across six front-ends (Phase 1); porting C's `_bound_names` to the other four, adding a `shadowed_calls` corpus case each, and moving `invention` to a `strict`-at-zero gate are Phases 2–4. C++ first — it holds 46 of the 47 findings. [Record](invention-oracle-cross-language.md) |
 | TypeScript resolution via the TS compiler API | **idea, not scheduled** (2026-08-21). `CALLS` recall is **0.50** for TypeScript against 1.00 for C and SQL — tree-sitter parses the syntax correctly but has no symbol table, so a call site resolves to the wrong target or none. The language's own toolchain would fix that. Costs: a Node runtime dependency, loss of tree-sitter's error tolerance, and a determinism risk if resolution depends on installed packages — the same commit could then give different graphs on different machines |
 | G4 adoption — friction audit | ✅ **Phase 1 done 2026-08-19** — ≈28s cold start, no key; channels/proof/measurement outstanding |
 | `episteme.yml` main-branch path produces orphan branches | ✅ **fixed 2026-08-19** — regeneration is `develop`-only; `main` inherits the bank verbatim |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -99,18 +99,19 @@ Measured against a hand-labelled corpus, all 8 languages
 | **Precision** | **1.00** on every node kind and every edge kind, all 8 languages — *on the corpus*, and see the caveat below |
 | **Recall** | 1.00 on every kind **except `CALLS`** |
 | `CALLS` recall | 1.00 (c, sql) · 0.73 (python) · 0.67 (cpp, csharp, go, java) · **0.50 (typescript)** |
-| Invention | **0** on this repo across **15,982** `CALLS`; **47** across 23,746 bare calls on 11 public repos in TypeScript/Go/C++/C# (2026-08-24) |
+| Invention | **0** on this repo and on 11 pinned public repos across 6 front-ends, gated `strict` at zero per language (2026-08-24) |
 
-**That precision row is a corpus score, and the corpus is missing a shape.** When a parameter
-or local **shadows** a resolvable name, TypeScript, Go, C++ and C# each emit a `CALLS` edge to
-the file-level definition the caller never reaches — the bug Python fixed in 3.18.0, in a form
-the fix did not reach. C already refuses it (`c_extractor._bound_names`) and has a corpus case;
-the other four have neither. Nothing caught it: the target is a real node so `pkg verify` sees
-no dangling edge, no fixture carries the shape so precision reads 1.00, and the invention
-oracle was Python-only until 2026-08-24. Measured rate on real code: **0.47% of bare calls in
-C++, 0.02% in TypeScript, 0 in Go and C# on this sample** — real, and roughly an order of
-magnitude rarer than Python's 3.16% was. Full record, with pinned SHAs and the reproducible
-command: [`invention-oracle-cross-language.md`](invention-oracle-cross-language.md).
+**That precision row was a corpus score over a corpus missing a shape, and both have been
+fixed.** When a parameter or local **shadowed** a resolvable name, TypeScript, Go, C++ and C#
+each emitted a `CALLS` edge to the file-level definition the caller never reaches — the bug
+Python fixed in 3.18.0, in a form the fix did not reach. Nothing caught it: the target is a
+real node so `pkg verify` saw no dangling edge, no fixture carried the shape so precision read
+1.00, and the invention oracle was Python-only. Found by widening the oracle to six
+front-ends, measured at **47 fabricated edges across 23,746 bare calls** on 11 public repos,
+then fixed by porting C's `_bound_names` to the other four. **47 edges removed, 47
+fabrications — no true edge lost.** Guarded by `corpus/*/shadowed_calls`, four cases written
+and failed at 0.50 precision *before* the fix. Full record:
+[`invention-oracle-cross-language.md`](invention-oracle-cross-language.md).
 
 Structure — *this module contains this class which contains this method* — is either in the tree
 or it is not. **`CALLS` is different because it needs *resolution*:** the tree tells you a call
@@ -171,10 +172,13 @@ that. Nothing in the pipeline has to ration it.
 
 - **`CALLS` recall on TypeScript is 0.50** — half the call edges are missed. Structure is
   complete; the call graph is not.
-- **`runtime` is still Python-only** (PEP 669). On a non-Python repo it reports nothing, and
-  that is *not measured*, not clean. `invention` was the same until 2026-08-24 and now walks
-  six front-ends, naming Java and SQL as not-applicable with reasons rather than scoring them
-  0 — but the shadowing defect it found in four of them is **not yet fixed**.
+- **`runtime` is still Python-only** (PEP 669) — the last of the four oracles with that
+  limit. On a non-Python repo it reports nothing, and that is *not measured*, not clean.
+  `invention` was the same until 2026-08-24 and now walks six front-ends, naming Java and SQL
+  as not-applicable with reasons rather than scoring them 0.
+- **The invention oracle only knows about shadowing.** Other classes — `CONSUMES` matched on
+  `(verb, path)`, `EXPOSES` composed from mount prefixes — have no detector at all, and rest
+  on `sample_edges` plus a human reading the source.
 - **8 languages**, against 21–40 for the graph-only tools. Additive against a fixed schema
   (`facts.py`) rather than a ceiling, but it is today's number.
 
@@ -354,7 +358,7 @@ its output edge, and inside the model-call budget.
 | Deployment image + reusable CI workflow for central adoption | not started. **Not a G4 phase** — it was recommended as though it were; it needs adding to that spec before it can be scheduled |
 | `SPEC-INDEX.md` links `watch-items-roadmap.md`, which does not exist | not started |
 | `docs/specs/current-state.md` has a mermaid block that falls back to `<pre>` in our own UI | not started |
-| Shadowed-name `CALLS` invention in TypeScript, Go, C++, C# | **measured 2026-08-24, not fixed.** The oracle now sees it across six front-ends (Phase 1); porting C's `_bound_names` to the other four, adding a `shadowed_calls` corpus case each, and moving `invention` to a `strict`-at-zero gate are Phases 2–4. C++ first — it holds 46 of the 47 findings. [Record](invention-oracle-cross-language.md) |
+| Shadowed-name `CALLS` invention in TypeScript, Go, C++, C# | ✅ **closed 2026-08-24** — oracle widened to 6 front-ends, all four fixed, 4 corpus cases added, `invention` gated `strict` at zero per language. 47 fabricated edges removed with no true edge lost. [Record](invention-oracle-cross-language.md) |
 | TypeScript resolution via the TS compiler API | **idea, not scheduled** (2026-08-21). `CALLS` recall is **0.50** for TypeScript against 1.00 for C and SQL — tree-sitter parses the syntax correctly but has no symbol table, so a call site resolves to the wrong target or none. The language's own toolchain would fix that. Costs: a Node runtime dependency, loss of tree-sitter's error tolerance, and a determinism risk if resolution depends on installed packages — the same commit could then give different graphs on different machines |
 | G4 adoption — friction audit | ✅ **Phase 1 done 2026-08-19** — ≈28s cold start, no key; channels/proof/measurement outstanding |
 | `episteme.yml` main-branch path produces orphan branches | ✅ **fixed 2026-08-19** — regeneration is `develop`-only; `main` inherits the bank verbatim |

--- a/docs/specs/invention-oracle-cross-language.md
+++ b/docs/specs/invention-oracle-cross-language.md
@@ -1,7 +1,7 @@
-# The invention oracle across eight front-ends — Phase 1 results
+# The invention oracle across eight front-ends — measured, fixed, gated
 
-**Status:** Phase 1 complete. Phases 2–4 rescoped by what Phase 1 measured — see the last
-section before acting on them.
+**Status:** complete. Oracle widened, four front-ends fixed, four corpus cases added,
+`invention` gated `strict` at zero per language.
 **Measured:** 2026-08-24, against `develop` at `3ac6a81`.
 **Reproduce:** `orchestrator pkg accuracy --oracle invention <repo>` — every number below.
 
@@ -77,7 +77,7 @@ The denominator is **bare-identifier calls**, not all `CALLS`. Only a bare call 
 reached by a shadow; `0 of 1,677 CALLS` claims a sweep three times wider than `0 of 946 bare
 calls`, and only the second is what was at risk.
 
-| Front-end | Repositories (pinned) | Bare calls | Invented | Rate |
+| Front-end | Repositories (pinned) | Bare calls | Invented (before the fix) | Rate |
 |---|---|---|---|---|
 | **cpp** | leveldb `7ee830d02b62`, fmt `e27cc20bd93a` | 9,808 | **46** | 0.47% |
 | **typescript** | zod `3a49696865f3`, nest `4f783326fc99`, vue/core `e2bede96134f` | 5,376 | **1** | 0.02% |
@@ -118,7 +118,70 @@ both were bugs in the **oracle**:
 Both have a regression test in [`tests/pkg/test_scope.py`](../../tests/pkg/test_scope.py),
 each written against the language reference rather than against what the walker did.
 
-## What this means for Phases 2–4
+## The fix, and what it cost
+
+C's test, four more times — a local `_bound_names` per front-end, deliberately not a shared
+module. **The oracle keeps its own independent implementation**: a detector that imports the
+code it audits agrees with that code's bugs.
+
+Each helper answers *did this function bind the name*, never *can we resolve it*. The
+difference is the whole design. An unresolved callee in C++ is usually a function declared in
+a header and linked from another translation unit — ordinary, and it must keep its `cpp:name`
+id. A Python-style "skip anything unresolved" fix would have silenced every
+cross-translation-unit call in every C++ repository.
+
+Each helper also carries the **first line a name is in scope**, because two of the four
+languages need it. Go's spec starts a short variable declaration's scope at the end of the
+statement, so `cmd := cmd(binaryPath, …)` calls the package-level `cmd`; C and C++ read the
+same way. Binding from the top of the function would have dropped those edges — 5 of them in
+grpc-go alone. C# tracks the bare-call form separately for the same reason: `this.Handle()`
+is an explicit member access and cannot be shadowed.
+
+**Re-measured on the same 11 repositories: 0 across every front-end.** The cost is the part
+worth checking:
+
+| | Before | After | Removed |
+|---|---|---|---|
+| vue/core (ts) | 3,501 | 3,500 | 1 |
+| leveldb (c++) | 4,867 | 4,864 | 3 |
+| fmt (c++) | 8,934 | 8,891 | 43 |
+| the other 8 repos | — | — | **0** |
+| **total** | | | **47** |
+
+**47 edges removed, 47 fabrications found.** Every dropped edge is one of the hand-verified
+fabrications and nothing else moved, across 38,602 bare calls. grpc-go kept all 6,285 of its
+`CALLS` — the five `cmd := cmd(path)` sites are exactly what the line rule protects.
+
+Precision rises; recall is untouched. These edges were never in any expected set.
+
+## The guards
+
+**Four corpus cases** — `corpus/{typescript,go,cpp,csharp}/shadowed_calls`, modelled on
+`corpus/c/function_pointers`. Each was written and scored **before** the fix and each failed
+at the predicted point: `CALLS` precision **0.50**, recall 1.00. That order matters. A fixture
+written after a fix only proves the fix is self-consistent; one that fails first proves the
+fixture is real.
+
+Each case pairs the shadowed call with an unshadowed sibling in the same file, so a front-end
+cannot pass by dropping both — which is the failure mode a careless fix would have.
+
+**The gate.** `invention` moves from ungated to **`strict`, zero per language** — the only
+metric here gated on an absolute value rather than against the baseline, because it is the
+only one with a *correct* value. Comparing to a stored number would let a non-zero baseline
+become the thing everyone agrees to live with, which is how a defect count turns into a
+metric. A language whose `status` is not `measured` is skipped: its 0 means *not examined*.
+
+The gate was proved by making it fail, not by watching it pass
+([`test_accuracy.py`](../../tests/pkg/test_accuracy.py)). The original objection to gating it
+is preserved and still honoured — the *rate* may move freely with ordinary commits; only the
+count is held at zero.
+
+**What none of this catches**, stated rather than implied: the oracle detects *shadowing*. A
+front-end that fabricates some other way passes this gate, and corpus precision catches that
+only if the corpus happens to carry the shape. A new invention class needs a fixture as well
+as a detector.
+
+## What the numbers mean, and what is left
 
 **The defect is real and the fix is still worth making — but it is roughly an order of
 magnitude rarer than Python's was, and the phases should be sized to that.** Python's
@@ -128,23 +191,27 @@ at **0.20%** — 47 findings across **23,746 bare calls** — and two of the fou
 bare-call population, which is the tighter and more honest one. The comparison is a size
 check, not a like-for-like.) This is a correctness defect, not a flood.
 
-Concretely:
+Two of the four scored **zero before the fix** — Go across 6,435 bare calls, C# across 2,127.
+Their fix is **unproven at zero, not proven clean**: the construction reproduces in both, and
+their corpus cases failed at 0.50 precision like the others, but no public repository in this
+sample contained the shape. The fixture is what holds them, not the measurement.
 
-- **C++ first, alone if only one gets done.** It holds 46 of 47, and at 0.47% it is 25× the
-  next front-end. `fmt` alone accounts for 43.
-- **TypeScript second.** One finding, but it is the *invisible* one — a real node, no dangling
-  edge, no corpus case. It is also the front-end whose `CALLS` recall is already 0.50, so it
-  has the least margin to spend on a wrong edge.
-- **Go and C# are unproven at zero, not proven clean.** The construction reproduces in both;
-  this sample simply does not contain it. Fix them with the others — the change is the same
-  four lines C already carries — but do not claim the fix moved a number.
-- **The corpus cases (Phase 2) are the durable half.** A `shadowed_calls` fixture per
-  front-end costs an hour and turns "we measured 11 repos in August 2026" into a check that
-  runs on every commit forever. The measurement above is a snapshot; the fixture is a gate.
-- **Decision on record:** once all four refuse a shadowed name, `invention` moves to
-  **`strict` at zero, per language** — recorded today as `target_gate` in
-  `scoreboard.json` and in the `GATES` comment. It is not flipped yet, because a gate that
-  fails on the day it lands teaches everyone to ignore it.
+**The 47 was a snapshot; the fixtures and the gate are what persist.** "We measured 11 repos
+in August 2026" decays the moment anyone touches a front-end. `corpus/*/shadowed_calls` plus a
+strict gate runs on every commit forever, which is the durable half of this work — and the
+reason the corpus cases were written before the fix rather than after it.
+
+**Still open, and deliberately not done here:**
+
+- **The `runtime` oracle is still Python-only** (PEP 669). On a non-Python repo it reports
+  nothing, and that remains *not measured* rather than clean. It is the last of the four
+  oracles with this limitation.
+- **The oracle only knows about shadowing.** Other invention classes — `CONSUMES` matched on
+  `(verb, path)`, `EXPOSES` composed from mount prefixes — still have no detector and are
+  covered only by `sample_edges` and a human reading the source.
+- **C++ dangles heavily for unrelated reasons.** leveldb carries 4,485 dangling `REFERENCES`
+  edges from header-only types. Not this defect, but it is why the 46 fabricated `CALLS` did
+  not stand out to `pkg verify` even though they technically appeared in its output.
 
 ## Reproducing any row
 

--- a/docs/specs/invention-oracle-cross-language.md
+++ b/docs/specs/invention-oracle-cross-language.md
@@ -1,0 +1,157 @@
+# The invention oracle across eight front-ends — Phase 1 results
+
+**Status:** Phase 1 complete. Phases 2–4 rescoped by what Phase 1 measured — see the last
+section before acting on them.
+**Measured:** 2026-08-24, against `develop` at `3ac6a81`.
+**Reproduce:** `orchestrator pkg accuracy --oracle invention <repo>` — every number below.
+
+---
+
+## The defect
+
+Four front-ends emit a `CALLS` edge to the wrong function when a name is **shadowed** by a
+parameter or a local. Two lines of TypeScript are enough:
+
+```ts
+export function send(x: string): void {}
+export function outer(send: (v: string) => void): void { send("hi"); }
+```
+
+The graph asserts `ts:a.outer -CALLS-> ts:a.send`. `outer` calls its own parameter; the
+module-level `send` is never reached. The same construction reproduces in Go (parameter
+shadowing a package function), C++ (function-pointer parameter shadowing a free function)
+and C# (delegate parameter shadowing a sibling method).
+
+**This is the bug Python fixed in 3.18.0, in a form the fix did not reach.** Python's
+front-end invented an *id* — `py:echo` for a module that did not exist — and the fix was to
+return `None` instead of guessing. These four do not invent an id. They resolve the shadowed
+name against their own file-level table and land on a **node that really exists**.
+
+**C is the exception, and it is the reason this is a port rather than a design.**
+`c_extractor._calls` already computes `_bound_names(fdeclr, body, source)` and skips a callee
+the function bound itself, with a comment naming the Python `py:echo` invention as its
+motive. One front-end was fixed and given a corpus case (`corpus/c/function_pointers`); the
+other four were never revisited.
+
+### Why nothing caught it
+
+| Check | What it said | Why |
+|---|---|---|
+| `pkg verify` dangling-edge | 0 for TypeScript, Go, C# | the target is a real node — just the wrong one |
+| `pkg accuracy` corpus | precision **1.00**, all four | no fixture carries the shape. `invention.py` says so in its own docstring: the shadowing cases are *"the whole gap between Python's 0.80 corpus precision and TypeScript's 1.00"* |
+| `pkg accuracy --oracle invention` | 0 | the detector re-parsed with the stdlib `ast` and looked at Python only |
+
+Three green checks over a case none of them examined — §9 of
+[STATE-OF-SPINE](STATE-OF-SPINE.md), again.
+
+## What Phase 1 built
+
+The detector is now stated language-neutrally, over
+[`pkg/scope.py`](../../src/orchestrator/pkg/scope.py):
+
+> a `CALLS` edge is invented when the call site at `file:line` is a **bare-identifier** call
+> whose name matches the target, and that name is **bound inside the calling function**.
+
+Both halves are load-bearing. Without the bare-call test, `this.send()` on a line that also
+declares a local `send` is flagged. Without *inside the function*, every correct call to a
+file-level definition is flagged, since a file-level `function send()` binds `send` too — the
+difference between a declaration and a shadow is which scope holds it.
+
+**The oracle re-implements binding analysis rather than importing C's.** An oracle that
+shares its subject's code agrees with its subject's bugs. What it does *not* re-implement is
+the parser: each language is walked with the same factory the front-end used, so a
+disagreement is about scope, never about syntax.
+
+**Java and SQL are excluded with a reason, not reported as clean.** Java gives variables and
+methods separate namespaces (JLS §6.5.7), so `int send` cannot shadow `send()`; a shadowing
+test there would manufacture findings. SQL's `CALL`/`PERFORM` fallback matches two keywords
+and a parenthesis, with no lexical scope to shadow. Both carry `status: not-applicable`, and
+a language with no walker carries `status: unwalked` — because a `0` that means *nothing ran*
+is the thing this project keeps mistaking for health.
+
+**The graph is untouched.** No `*_extractor.py` was modified; the module measures only.
+
+## Results — 11 public repositories, pinned
+
+The denominator is **bare-identifier calls**, not all `CALLS`. Only a bare call can be
+reached by a shadow; `0 of 1,677 CALLS` claims a sweep three times wider than `0 of 946 bare
+calls`, and only the second is what was at risk.
+
+| Front-end | Repositories (pinned) | Bare calls | Invented | Rate |
+|---|---|---|---|---|
+| **cpp** | leveldb `7ee830d02b62`, fmt `e27cc20bd93a` | 9,808 | **46** | 0.47% |
+| **typescript** | zod `3a49696865f3`, nest `4f783326fc99`, vue/core `e2bede96134f` | 5,376 | **1** | 0.02% |
+| **go** | gin `dcaa4296d111`, cobra `adbc8813901b`, grpc-go `9d1988d75f21` | 6,435 | 0 | 0.00% |
+| **csharp** | Dapper `6d48ef664acc`, Newtonsoft.Json `09bb545d7296` | 2,127 | 0 | 0.00% |
+| **c** *(control)* | libuv `f87c8e4f70f2`, + the C files of leveldb and fmt | 14,856 | 0 | 0.00% |
+| **python** | this repository | 15,982 | 0 | 0.00% |
+
+Every one of the 47 was read against its source before being counted. Two examples:
+
+- `fmt/test/format-test.cc:262` — `check_forwarding` is a local lambda declared eight lines
+  above. The graph asserts a call to a free function `check_forwarding`, which fmt does not
+  have.
+- `vue/core packages/runtime-dom/src/components/Transition.ts:101` — `hook.forEach(h => h(...args))`.
+  `h` is the arrow-function's parameter; the graph asserts a call to Vue's `h()` render
+  function imported from `@vue/runtime-core`.
+
+**46 of the 47 dangle; 1 does not.** The C++ front-end emits a name-keyed target and no node,
+so `pkg verify` reports these as dangling edges — visible, in principle. In practice they do
+not stand out: leveldb alone carries 4,485 dangling edges from unrelated header-only
+`REFERENCES`. The single TypeScript finding lands on a real external node and is invisible to
+every check that exists. The fixtures show all four front-ends can produce the invisible kind;
+this sample happened to catch mostly the other.
+
+### Two false positives, found by hand and fixed before publication
+
+The first run reported 4 for TypeScript and 5 for Go. Reading each against its source showed
+both were bugs in the **oracle**:
+
+- **A destructuring default is not a binding.** `const { arg: slotName = createSimpleExpression(…) } = x`
+  binds `slotName`. Sweeping the pattern for identifiers also bound `createSimpleExpression`,
+  so every later call to that import read as shadowed — 3 of the 4 TypeScript findings.
+- **Go's `:=` is not in scope on its own line.** The spec starts a short variable
+  declaration's scope at the *end* of the statement, so `cmd := cmd(binaryPath, …)` calls the
+  package-level `cmd`. Idiomatic Go, reported as fiction — all 5 Go findings. C and C++ read
+  the same way; the rule is now applied to every language.
+
+Both have a regression test in [`tests/pkg/test_scope.py`](../../tests/pkg/test_scope.py),
+each written against the language reference rather than against what the walker did.
+
+## What this means for Phases 2–4
+
+**The defect is real and the fix is still worth making — but it is roughly an order of
+magnitude rarer than Python's was, and the phases should be sized to that.** Python's
+shadowing bug was 496 edges, **3.16% of its whole call graph**. The four front-ends here run
+at **0.20%** — 47 findings across **23,746 bare calls** — and two of the four scored zero on
+8,562 of those. (The denominators are not the same: 3.16% is of all `CALLS`, 0.20% is of the
+bare-call population, which is the tighter and more honest one. The comparison is a size
+check, not a like-for-like.) This is a correctness defect, not a flood.
+
+Concretely:
+
+- **C++ first, alone if only one gets done.** It holds 46 of 47, and at 0.47% it is 25× the
+  next front-end. `fmt` alone accounts for 43.
+- **TypeScript second.** One finding, but it is the *invisible* one — a real node, no dangling
+  edge, no corpus case. It is also the front-end whose `CALLS` recall is already 0.50, so it
+  has the least margin to spend on a wrong edge.
+- **Go and C# are unproven at zero, not proven clean.** The construction reproduces in both;
+  this sample simply does not contain it. Fix them with the others — the change is the same
+  four lines C already carries — but do not claim the fix moved a number.
+- **The corpus cases (Phase 2) are the durable half.** A `shadowed_calls` fixture per
+  front-end costs an hour and turns "we measured 11 repos in August 2026" into a check that
+  runs on every commit forever. The measurement above is a snapshot; the fixture is a gate.
+- **Decision on record:** once all four refuse a shadowed name, `invention` moves to
+  **`strict` at zero, per language** — recorded today as `target_gate` in
+  `scoreboard.json` and in the `GATES` comment. It is not flipped yet, because a gate that
+  fails on the day it lands teaches everyone to ignore it.
+
+## Reproducing any row
+
+```bash
+git clone --depth 1 https://github.com/fmtlib/fmt && git -C fmt checkout e27cc20bd93a
+orchestrator pkg accuracy --oracle invention fmt
+```
+
+The per-front-end block prints `status`, invented count, bare-call denominator and total
+`CALLS`. A `status` other than `measured` means the row is not evidence of anything.

--- a/docs/specs/parsing-and-the-pkg.md
+++ b/docs/specs/parsing-and-the-pkg.md
@@ -1,6 +1,6 @@
 # How Spine parses code, and what lands in the PKG
 
-**Audience:** engineering · **Written 2026-08-16 against 3.18.1**
+**Audience:** engineering · **Written 2026-08-16 against 3.18.1 · §3 and §6 updated 2026-08-24**
 **Read alongside:** [`knowledge-graph-architecture.md`](knowledge-graph-architecture.md) (the
 graph itself), [`../../KNOWLEDGE_GRAPH.md`](../../KNOWLEDGE_GRAPH.md) (user-facing).
 
@@ -80,6 +80,11 @@ Parsing is not where accuracy is lost. **Every node kind and every edge kind exc
 scores 1.00 precision and 1.00 recall on the corpus, in all eight languages.** Structure is
 either in the tree or it is not.
 
+> **Read that sentence as the conditional it is: 1.00 *on the corpus*.** It held at 1.00 for
+> four front-ends that were fabricating `CALLS` edges, for the whole time they were, because no
+> fixture carried the shape — see the shadowed-callee section below. A corpus score bounds what
+> the corpus contains and nothing else.
+
 `CALLS` is different because it needs *resolution*: the tree tells you a call happened and what
 it was spelled, not which definition it reaches. That is a judgement, and judgements can be
 wrong.
@@ -111,6 +116,46 @@ C could not take the same fix. An unresolved callee in C is usually a function d
 header and linked from another translation unit, so skipping those would silence every
 cross-TU call in every C repository. The C test is therefore *"did this function bind the
 name"* (a function-pointer parameter) rather than *"can we resolve it"*.
+
+### The same class in four more front-ends — found 2026-08-24
+
+**The story above was told as one Python bug, closed. It was one instance of a class, and the
+other four front-ends had it the whole time.** When a parameter or local **shadows** a
+resolvable name, TypeScript, Go, C++ and C# each resolved it anyway:
+
+```ts
+export function send(x: string): void {}
+export function outer(send: (v: string) => void): void { send("hi"); }
+// emitted: ts:a.outer -CALLS-> ts:a.send   — `outer` calls its own parameter
+```
+
+It hid better than the Python bug did, and for the opposite reason. Python's inventor
+manufactured an id *and a phantom node*; these four resolve against their own file-level tables
+and land on a **node that genuinely exists**. So there was no dangling edge for `pkg verify` to
+report, no phantom node to notice, and no corpus case to fail — three checks agreeing on a case
+none of them examined.
+
+Found by widening the invention oracle past Python (`pkg/scope.py` walks five tree-sitter
+front-ends), measured at **47 fabricated edges across 23,746 bare calls** on 11 pinned public
+repositories, then fixed by giving each front-end **C's test**, which is why it is worth having
+written down here: *did this function bind the name*, never *can we resolve it*. **47 edges
+removed for 47 fabrications, with no true edge lost.**
+
+Two things the port needed that the C version does not spell out:
+
+- **A binding is not in scope on its own line, in three of the five languages.** Go's spec
+  starts a short variable declaration's scope at the *end* of the statement, so
+  `cmd := cmd(binaryPath, …)` calls the package-level `cmd` — idiomatic, and it occurs 5 times
+  in grpc-go alone. C and C++ read the same way. Each helper therefore records the first line a
+  name is in scope, not just the name.
+- **Only a bare-identifier call can be shadowed.** `this.Handle()` in C# and `this.method()` in
+  TypeScript are explicit member accesses that name the member whatever else is in scope, so
+  the bare form is tracked separately. Skipping both would have dropped real edges.
+
+The guard is a corpus case per front-end (`corpus/*/shadowed_calls`), each **written and scored
+before the fix** and each failing at `CALLS` precision 0.50 — a fixture written afterwards only
+proves the fix is self-consistent. Full record:
+[`invention-oracle-cross-language.md`](invention-oracle-cross-language.md).
 
 ---
 
@@ -189,13 +234,15 @@ The parser choice is not an aesthetic preference. It is what makes the accuracy 
 
 | | Result |
 |---|---|
-| Precision | **1.00** on every node kind and every edge kind, all 8 languages |
+| Precision | **1.00** on every node kind and every edge kind, all 8 languages — on the corpus, which now includes the shadowed-callee shape (§3) |
 | Recall | 1.00 on every kind except `CALLS` |
 | `CALLS` recall | 1.00 (c, sql) · 0.73 (python) · 0.67 (cpp, csharp, go, java) · 0.50 (typescript) |
-| Invention | **0** invented targets across 15,212 call edges |
+| Invention | **0** on this repo, and **0** across 11 pinned public repos in 6 front-ends (2026-08-24). Java and SQL are recorded *not-applicable* with reasons rather than scored 0 |
+| Invention gate | **`strict`, zero per language** — the one metric gated on an absolute value rather than against the baseline, because it is the one with a correct value |
 
-**The failure mode is silence, not fiction.** Everything the graph asserts exists; what it
-misses, it misses quietly. For an agent reasoning over the graph those are not equally bad — a
+**The failure mode is silence, not fiction** — held, rather than assumed. It was untrue for
+four front-ends until 2026-08-24, and what made it true again was a detector plus a fixture,
+not a claim. Everything the graph asserts exists; what it misses, it misses quietly. For an agent reasoning over the graph those are not equally bad — a
 missing edge makes it search, a fabricated one makes it confidently follow a call into a
 function that was never written.
 

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -3004,6 +3004,19 @@ def _invention_oracle(repo: str, sample: int, kind: str, as_json: bool) -> None:
                 "external_calls": report.external_calls,
                 "candidates": report.candidates,
                 "unexamined": report.unexamined,
+                "languages": [
+                    {
+                        "language": entry.language,
+                        "status": entry.status,
+                        "reason": entry.reason,
+                        "invented": len(entry.invented),
+                        "total_calls": entry.total_calls,
+                        "examined": entry.examined,
+                        "shadowable": entry.shadowable,
+                        "unexamined": entry.unexamined,
+                    }
+                    for entry in report.by_language
+                ],
                 "examples": list(report.examples),
             }
         )
@@ -3013,12 +3026,30 @@ def _invention_oracle(repo: str, sample: int, kind: str, as_json: bool) -> None:
     typer.echo(f"\ninvented CALLS edges — {len(report.invented)} ({rate} of all calls)")
     typer.echo(f"  {report.total_calls} CALLS, {report.external_calls} to external targets")
     typer.echo(f"  {report.candidates} candidate(s) examined, {report.unexamined} unexaminable")
+
+    if report.by_language:
+        typer.echo("\n  per front-end — a count only means 'clean' where status is measured:")
+        for entry in report.by_language:
+            typer.echo(
+                f"    {entry.language:<12} {entry.status:<14} "
+                f"{len(entry.invented):>5} invented / {entry.shadowable:>6} bare calls"
+                f"  (of {entry.total_calls} CALLS)"
+            )
+            if entry.reason:
+                typer.echo(f"      {entry.reason}")
+
     for line in report.examples:
         typer.echo(f"    {line}")
     typer.echo(
-        "\n  Each of these asserts a module outside the tree that does not exist.\n"
-        "  Exactly detected, not sampled: a name bound in the caller's scope cannot be one."
+        "\n  Each of these asserts a call that the source does not make.\n"
+        "  Exactly detected, not sampled: a name bound inside the caller cannot be one."
     )
+    if report.unmeasured_languages:
+        typer.echo(
+            "  NOT MEASURED here: "
+            + ", ".join(report.unmeasured_languages)
+            + " — these carry CALLS edges no walker examined."
+        )
 
     if sample:
         try:

--- a/src/orchestrator/pkg/accuracy.py
+++ b/src/orchestrator/pkg/accuracy.py
@@ -363,16 +363,25 @@ BASELINE = Path(__file__).with_name("scoreboard.json")
 #   ratchet — an increase fails. For a metric that rises only when the graph falls behind.
 #   false   — recorded, never fails.
 #
-# Invention is deliberately ungated. It is measured against the repository itself, so it
-# moves whenever anyone writes ordinary code: adding `def handler(cb): return cb()` moved it
-# from 496 to 497 and shifted the rate. A metric measured against a moving population cannot
-# be gated on equality, and a tolerance band would be an arbitrary number that eventually
-# fires on something legitimate and gets widened until it means nothing.
+# Invention is ungated *today*, and that is a phase, not a verdict. It is measured against the
+# repository itself, so its RATE moves whenever anyone writes ordinary code: adding
+# `def handler(cb): return cb()` moved it from 496 to 497. A metric measured against a moving
+# population cannot be gated on equality, and a tolerance band would be an arbitrary number
+# that eventually fires on something legitimate and gets widened until it means nothing.
 #
-# The cost is stated rather than hidden: nothing here would catch a front-end change that
-# adds thousands of phantom edges. Corpus precision catches it only if the corpus happens to
-# contain that shape.
+# But the *count* has a correct value, and it is zero. Once every front-end refuses a shadowed
+# name — Python does, C does, and the other four are the subject of this programme — the gate
+# becomes `strict` at zero per language, which is not a ratchet and not a band: any invented
+# edge is a defect. It stays False until that is true, because a gate that fails on the day it
+# lands teaches everyone to ignore it.
+#
+# The cost of the interim is stated rather than hidden: nothing here would catch a front-end
+# change that adds thousands of phantom edges. Corpus precision catches it only if the corpus
+# happens to contain that shape — and for four front-ends it does not.
 GATES = {"corpus": "strict", "parity": "ratchet", "invention": False, "runtime": False}
+
+#: Where `invention` is going, recorded next to where it is. See the comment above.
+INVENTION_TARGET_GATE = "strict"
 
 
 @dataclass(frozen=True)
@@ -448,9 +457,24 @@ def build_scoreboard(
             },
             "invention": {
                 "gated": GATES["invention"],
+                "target_gate": INVENTION_TARGET_GATE,
                 "count": len(invention.invented),
                 "total_calls": invention.total_calls,
-                "note": "moves with ordinary commits — recorded as a trend, never gated",
+                # Per front-end, with each one's standing. A language absent from this map
+                # emitted no CALLS edges here; a language present with `status` other than
+                # `measured` was NOT examined, and its zero says nothing about its health.
+                "languages": {
+                    entry.language: {
+                        "status": entry.status,
+                        "invented": len(entry.invented),
+                        "total_calls": entry.total_calls,
+                        "examined": entry.examined,
+                        "shadowable": entry.shadowable,
+                        "unexamined": entry.unexamined,
+                    }
+                    for entry in invention.by_language
+                },
+                "note": "rate moves with ordinary commits; count is a defect count — see GATES",
             },
         },
     }

--- a/src/orchestrator/pkg/accuracy.py
+++ b/src/orchestrator/pkg/accuracy.py
@@ -363,25 +363,27 @@ BASELINE = Path(__file__).with_name("scoreboard.json")
 #   ratchet — an increase fails. For a metric that rises only when the graph falls behind.
 #   false   — recorded, never fails.
 #
-# Invention is ungated *today*, and that is a phase, not a verdict. It is measured against the
-# repository itself, so its RATE moves whenever anyone writes ordinary code: adding
-# `def handler(cb): return cb()` moved it from 496 to 497. A metric measured against a moving
-# population cannot be gated on equality, and a tolerance band would be an arbitrary number
-# that eventually fires on something legitimate and gets widened until it means nothing.
+# Invention is `strict` — the only metric here gated on an absolute value rather than on the
+# baseline, and the reason is that it is the only one with a *correct* value. A `CALLS` edge to
+# a name the calling function bound itself is a defect, not a score: there is no repository and
+# no commit where one is acceptable, so there is nothing for a ratchet to ratchet.
 #
-# But the *count* has a correct value, and it is zero. Once every front-end refuses a shadowed
-# name — Python does, C does, and the other four are the subject of this programme — the gate
-# becomes `strict` at zero per language, which is not a ratchet and not a band: any invented
-# edge is a defect. It stays False until that is true, because a gate that fails on the day it
-# lands teaches everyone to ignore it.
+# It was ungated until 2026-08-24, for a good reason that no longer holds. The *rate* does move
+# with ordinary code — adding `def handler(cb): return cb()` took it from 496 to 497 — and a
+# tolerance band would be an arbitrary number that eventually fires on something legitimate and
+# gets widened until it means nothing. But the rate was never what needed gating. The count was,
+# and every front-end that can express the defect now refuses it: Python (3.18.0), C, and
+# TypeScript/Go/C++/C# with the port that came with this gate.
 #
-# The cost of the interim is stated rather than hidden: nothing here would catch a front-end
-# change that adds thousands of phantom edges. Corpus precision catches it only if the corpus
-# happens to contain that shape — and for four front-ends it does not.
-GATES = {"corpus": "strict", "parity": "ratchet", "invention": False, "runtime": False}
-
-#: Where `invention` is going, recorded next to where it is. See the comment above.
-INVENTION_TARGET_GATE = "strict"
+# Strict here means **zero per language, not zero-versus-baseline**. Comparing to a stored
+# number would let a non-zero baseline become the thing everyone agrees to live with, which is
+# how a defect count turns into a metric.
+#
+# What it does NOT catch is stated rather than hidden: the oracle detects shadowing, so a
+# front-end that fabricates some other way passes this gate. Corpus precision catches that only
+# if the corpus happens to carry the shape — which is why `corpus/*/shadowed_calls` exists, and
+# why a new invention class needs a fixture as well as a detector.
+GATES = {"corpus": "strict", "parity": "ratchet", "invention": "strict", "runtime": False}
 
 
 @dataclass(frozen=True)
@@ -457,7 +459,6 @@ def build_scoreboard(
             },
             "invention": {
                 "gated": GATES["invention"],
-                "target_gate": INVENTION_TARGET_GATE,
                 "count": len(invention.invented),
                 "total_calls": invention.total_calls,
                 # Per front-end, with each one's standing. A language absent from this map
@@ -474,7 +475,7 @@ def build_scoreboard(
                     }
                     for entry in invention.by_language
                 },
-                "note": "rate moves with ordinary commits; count is a defect count — see GATES",
+                "note": "gated at zero per language, not against this baseline — see GATES",
             },
         },
     }
@@ -554,6 +555,19 @@ def compare_scoreboard(baseline: dict[str, Any], current: dict[str, Any]) -> lis
                                 f"{float(after):.4f}",
                             )
                         )
+
+    # Invention: zero per language, measured against nothing. `baseline` is unused on purpose
+    # — see GATES. A language whose status is not `measured` is skipped, because its 0 means
+    # "not examined" and gating on it would report health nobody checked.
+    if GATES["invention"] == "strict":
+        for lang, entry in sorted(
+            current.get("metrics", {}).get("invention", {}).get("languages", {}).items()
+        ):
+            if entry.get("status") != "measured":
+                continue
+            count = int(entry.get("invented", 0))
+            if count:
+                out.append(Regression("invention", f"{lang}: fabricated CALLS edge(s)", "0", str(count)))
 
     was_short = baseline.get("metrics", {}).get("parity", {}).get("shortfall")
     now_short = current.get("metrics", {}).get("parity", {}).get("shortfall")

--- a/src/orchestrator/pkg/cpp_extractor.py
+++ b/src/orchestrator/pkg/cpp_extractor.py
@@ -286,11 +286,25 @@ class CppExtractor:
 
     def _calls(self, caller: str, type_id: str | None, body: TSNode, ctx: _Ctx) -> None:
         siblings = ctx.type_methods.get(type_id or "", set())
+        bound = _bound_names(body, ctx.source)
         stack = list(body.named_children)
         while stack:
             n = stack.pop()
             if n.type == "call_expression":
                 fn = n.child_by_field_name("function")
+                line = n.start_point[0] + 1
+                if (
+                    fn is not None
+                    and fn.type == "identifier"
+                    and line >= bound.get(_text(fn, ctx.source), 1 << 30)
+                ):
+                    # Called through a function pointer, a `std::function` or a lambda this
+                    # function bound. `_resolve_callee` name-keys an unresolved identifier to
+                    # `cpp:<name>` — correct for a function declared in a header, wrong here:
+                    # the callee is whatever the caller passed in. 46 of the 47 edges the
+                    # cross-language invention oracle found were this shape.
+                    stack.extend(n.named_children)
+                    continue
                 target = _resolve_callee(fn, ctx.source, siblings, type_id, ctx.free_funcs)
                 if target is not None:
                     ctx.batch.add_edge(
@@ -330,6 +344,102 @@ def _member(type_id: str, name: str, kind: NodeKind, line: int, ctx: _Ctx) -> No
     mid = f"{type_id}::{name}"
     ctx.batch.add_node(Node(mid, kind, name, "cpp", Provenance(ctx.rel, line)))
     ctx.batch.add_edge(Edge(type_id, mid, EdgeKind.CONTAINS, Provenance(ctx.rel, line)))
+
+
+# Declarator wrappers, in the order the grammar nests them: `int (*handle)()` is
+# function_declarator → parenthesized_declarator → pointer_declarator → identifier.
+_DECLARATOR_WRAPPERS = frozenset(
+    {
+        "init_declarator",
+        "pointer_declarator",
+        "reference_declarator",
+        "array_declarator",
+        "function_declarator",
+        "parenthesized_declarator",
+        "abstract_function_declarator",
+    }
+)
+
+
+def _declared_name(node: TSNode | None, source: bytes) -> str:
+    """The innermost declared name of a declarator, or ``""`` for an abstract one.
+
+    Followed through the ``declarator`` field only. Descending into ``parameters`` would bind
+    the parameter names of a function *pointer* — in `void f(void (*cb)(const char *x))`, `x`
+    names a parameter of the pointed-to function and is bound nowhere.
+    """
+    cur = node
+    for _ in range(32):  # a declarator cannot nest meaningfully deeper
+        if cur is None:
+            return ""
+        if cur.type in ("identifier", "field_identifier", "qualified_identifier"):
+            return _text(cur, source)
+        if cur.type not in _DECLARATOR_WRAPPERS:
+            return ""
+        nxt = cur.child_by_field_name("declarator")
+        if nxt is None and cur.type in (
+            "parenthesized_declarator",
+            "reference_declarator",
+            "pointer_declarator",
+        ):
+            nxt = cur.named_children[0] if cur.named_children else None
+        cur = nxt
+    return ""
+
+
+def _bound_names(body: TSNode, source: bytes) -> dict[str, int]:
+    """Names this function binds, each with the first line it is in scope.
+
+    A callee in this map is reached through a pointer, a ``std::function`` or a lambda, so the
+    target is decided at run time and no id names it. The same test C has carried since it was
+    fixed there, and deliberately the same shape: *did this function bind the name*, not *can
+    we resolve it*. An unresolved callee in C++ is usually declared in a header and defined in
+    another translation unit, which is ordinary and must keep its ``cpp:name`` id.
+
+    The line is kept because a declaration's scope starts at its declarator: `auto f = f();`
+    calls the outer ``f``. Parameters bind from the function header.
+    """
+    bound: dict[str, int] = {}
+
+    def bind(name: str, line: int) -> None:
+        if name and line < bound.get(name, 1 << 30):
+            bound[name] = line
+
+    header = body.parent
+    if header is not None:
+        cur = header.child_by_field_name("declarator")
+        for _ in range(32):
+            if cur is None:
+                break
+            plist = cur.child_by_field_name("parameters")
+            if plist is not None:
+                for param in plist.named_children:
+                    bind(
+                        _declared_name(param.child_by_field_name("declarator"), source),
+                        header.start_point[0] + 1,
+                    )
+                break
+            cur = cur.child_by_field_name("declarator")
+
+    stack = list(body.named_children)
+    while stack:
+        n = stack.pop()
+        if n.type == "declaration":
+            for i, child in enumerate(n.children):
+                if child.is_named and n.field_name_for_child(i) == "declarator":
+                    bind(_declared_name(child, source), n.end_point[0] + 2)
+        elif n.type == "for_range_loop":
+            bind(_declared_name(n.child_by_field_name("declarator"), source), n.start_point[0] + 1)
+        elif n.type == "lambda_expression":  # a lambda's own parameters
+            declarator = n.child_by_field_name("declarator")
+            plist = declarator.child_by_field_name("parameters") if declarator is not None else None
+            for param in plist.named_children if plist is not None else []:
+                bind(
+                    _declared_name(param.child_by_field_name("declarator"), source),
+                    n.start_point[0] + 1,
+                )
+        stack.extend(n.named_children)
+    return bound
 
 
 def _resolve_callee(

--- a/src/orchestrator/pkg/csharp_extractor.py
+++ b/src/orchestrator/pkg/csharp_extractor.py
@@ -467,7 +467,15 @@ def _call_edges(types: list[_TypeRec], source: bytes, rel: str, batch: FactBatch
     for rec in types:
         method_ids = {name: mid for name, mid, _ in rec.methods}
         for _name, mid, mnode in rec.methods:
-            for callee, line in _calls_in(mnode, source):
+            bound = _bound_names(mnode, source)
+            for callee, line, bare in _calls_in(mnode, source):
+                # A local, parameter or lambda argument shadows the sibling method: C# resolves
+                # a simple name to the innermost declaration, so `Handle()` under a parameter
+                # named `Handle` invokes the delegate, not the method. `this.Handle()` is an
+                # explicit member access and cannot be shadowed, which is why `bare` is carried
+                # rather than inferred — skipping it too would drop real edges.
+                if bare and line >= bound.get(callee, 1 << 30):
+                    continue
                 target = method_ids.get(callee)
                 if target is not None:
                     batch.add_edge(Edge(mid, target, EdgeKind.CALLS, Provenance(rel, line)))
@@ -591,18 +599,71 @@ def _member_name(fn: TSNode | None, source: bytes) -> str:
     return ""
 
 
-def _calls_in(mnode: TSNode, source: bytes) -> list[tuple[str, int]]:
-    """``(callee_name, line)`` for unqualified / ``this.`` calls inside a method."""
-    out: list[tuple[str, int]] = []
+def _calls_in(mnode: TSNode, source: bytes) -> list[tuple[str, int, bool]]:
+    """``(callee_name, line, bare)`` for unqualified / ``this.`` calls inside a method.
+
+    ``bare`` is True only for the ``Foo(...)`` form. ``this.Foo(...)`` resolves to the member
+    whatever else is in scope, so only the bare form can be shadowed by a local.
+    """
+    out: list[tuple[str, int, bool]] = []
     stack = list(mnode.named_children)
     while stack:
         node = stack.pop()
         if node.type == "invocation_expression":
-            name = _unqualified_call_name(node.child_by_field_name("function"), source)
+            fn = node.child_by_field_name("function")
+            name = _unqualified_call_name(fn, source)
             if name:
-                out.append((name, node.start_point[0] + 1))
+                out.append((name, node.start_point[0] + 1, fn is not None and fn.type == "identifier"))
         stack.extend(node.named_children)
     return out
+
+
+def _bound_names(mnode: TSNode, source: bytes) -> dict[str, int]:
+    """Names this method binds, each with the first line it is in scope.
+
+    C# forbids using a simple name as an outer meaning in a block where it later denotes a
+    local, so the line rarely changes an answer here — it is kept so the helper asserts what it
+    actually knows, and so the four front-ends read the same way.
+
+    Lambdas are descended into by the call walk, so their parameters bind too: a call inside
+    ``xs.Select(Handle => Handle())`` is attributed to the enclosing method.
+    """
+    bound: dict[str, int] = {}
+
+    def bind(node: TSNode | None, line: int) -> None:
+        if node is None:
+            return
+        name = _text(node, source)
+        if name and line < bound.get(name, 1 << 30):
+            bound[name] = line
+
+    def bind_params(plist: TSNode | None, line: int) -> None:
+        if plist is None:
+            return
+        if plist.type == "identifier":  # `x => …`, which carries no parameter_list
+            bind(plist, line)
+            return
+        for param in plist.named_children:
+            bind(param.child_by_field_name("name") or param, line)
+
+    bind_params(mnode.child_by_field_name("parameters"), mnode.start_point[0] + 1)
+
+    stack = list(mnode.named_children)
+    while stack:
+        n = stack.pop()
+        if n.type == "variable_declarator":
+            bind(n.child_by_field_name("name") or n, n.end_point[0] + 2)
+        elif n.type == "foreach_statement":
+            bind(n.child_by_field_name("left"), n.start_point[0] + 1)
+        elif n.type == "catch_declaration":
+            bind(n.child_by_field_name("name"), n.start_point[0] + 1)
+        elif n.type in ("lambda_expression", "anonymous_method_expression"):
+            bind_params(n.child_by_field_name("parameters"), n.start_point[0] + 1)
+        elif n.type == "local_function_statement":
+            bind(n.child_by_field_name("name"), n.start_point[0] + 1)
+            bind_params(n.child_by_field_name("parameters"), n.start_point[0] + 1)
+        stack.extend(n.named_children)
+    return bound
 
 
 def _unqualified_call_name(fn: TSNode | None, source: bytes) -> str:

--- a/src/orchestrator/pkg/go_extractor.py
+++ b/src/orchestrator/pkg/go_extractor.py
@@ -292,6 +292,7 @@ class GoExtractor:
         calls to a same-file package function, and `recv.M()` to a method of the receiver's
         own type. Everything else (cross-package, interface values, other objects) is left
         unresolved rather than guessed."""
+        bound = _bound_names(body.node, source)
         for call in _all_of_type(body.node, "call_expression"):
             fn = call.child_by_field_name("function")
             if fn is None:
@@ -299,6 +300,11 @@ class GoExtractor:
             target: str | None = None
             if fn.type == "identifier":
                 name = _text(fn, source)
+                # A name this function bound itself shadows the package-level function for the
+                # rest of the block. `local_funcs` still holds that package-level name, so
+                # resolving it would assert a call the source does not make.
+                if call.start_point[0] + 1 >= bound.get(name, 1 << 30):
+                    continue
                 if name in local_funcs:
                     target = f"{module_id}.{name}"
             elif fn.type == "selector_expression":
@@ -409,6 +415,64 @@ def _descendants(node: TSNode, type_name: str) -> list[TSNode]:
         else:
             stack.extend(n.named_children)
     return out
+
+
+def _bound_names(body: TSNode, source: bytes) -> dict[str, int]:
+    """Names this function binds, each with the first line it is in scope.
+
+    **The line is not decoration — Go's spec requires it.** The scope of a short variable
+    declaration begins at the *end* of the statement, so
+
+        cmd := cmd(binaryPath, logger, args)
+
+    calls the package-level ``cmd`` and binds a local of the same name for everything below.
+    Binding it from the top of the function would drop that edge — it occurs 5 times in
+    grpc-go alone. Parameters, which have no such rule, bind from the function header.
+
+    Deliberately narrow: only forms that *bind*. A plain ``=`` assigns to something already
+    declared and is not included, and neither is the right-hand side of anything.
+    """
+    bound: dict[str, int] = {}
+
+    def bind(name: str, line: int) -> None:
+        if name and name != "_" and line < bound.get(name, 1 << 30):
+            bound[name] = line
+
+    header = body.parent
+    if header is not None:
+        for fname in ("receiver", "parameters", "result", "type_parameters"):
+            plist = header.child_by_field_name(fname)
+            if plist is None:
+                continue
+            # Direct children only: `Send func(string)` nests a `parameter_list` under its
+            # `type`, and those inner names are bound nowhere.
+            for decl in plist.named_children:
+                for i, child in enumerate(decl.children):
+                    if child.is_named and decl.field_name_for_child(i) == "name":
+                        bind(_text(child, source), header.start_point[0] + 1)
+
+    stack = list(body.named_children)
+    while stack:
+        n = stack.pop()
+        after = n.end_point[0] + 2
+        if n.type == "short_var_declaration":
+            for ident in _all_of_type(n.child_by_field_name("left") or n, "identifier"):
+                bind(_text(ident, source), after)
+        elif n.type in ("var_spec", "const_spec"):
+            for i, child in enumerate(n.children):
+                if child.is_named and n.field_name_for_child(i) == "name":
+                    bind(_text(child, source), after)
+        elif n.type == "range_clause":
+            for ident in _all_of_type(n.child_by_field_name("left") or n, "identifier"):
+                bind(_text(ident, source), n.end_point[0] + 1)
+        elif n.type == "func_literal":  # a closure's own parameters, descended into below
+            plist = n.child_by_field_name("parameters")
+            for decl in plist.named_children if plist is not None else []:
+                for i, child in enumerate(decl.children):
+                    if child.is_named and decl.field_name_for_child(i) == "name":
+                        bind(_text(child, source), n.start_point[0] + 1)
+        stack.extend(n.named_children)
+    return bound
 
 
 def _all_of_type(node: TSNode, type_name: str) -> list[TSNode]:

--- a/src/orchestrator/pkg/invention.py
+++ b/src/orchestrator/pkg/invention.py
@@ -32,8 +32,33 @@ net increase. Both sub-classes are real and verified by hand.
 ``Name``/``Store`` node, so an imported callee is never flagged — which is correct, since an
 imported name genuinely does refer to something outside this file.
 
+**The same shape exists in four other front-ends, and this module could not see it.** The
+Python detector keys on an *external, single-segment* target, because that is what the
+Python front-end produced for an unresolved bare name. TypeScript, Go, C++ and C# do not
+produce that: they resolve the shadowed name against their file-level tables and emit an
+edge to a **real first-party node** — `ts:a.outer -CALLS-> ts:a.send` where `send` is the
+caller's own parameter. Nothing dangles, `pkg verify` reports zero, and the corpus scores
+1.00 because no fixture carried the shape. So the detector is stated language-neutrally
+here, over :mod:`orchestrator.pkg.scope`:
+
+    a ``CALLS`` edge is invented when the call site at ``file:line`` is a **bare-identifier**
+    call whose name matches the target, and that name is **bound inside the calling
+    function**.
+
+Both halves are load-bearing. Without the bare-call test, ``this.send()`` on a line that also
+declares a local ``send`` would be flagged. Without the *inside the function* test, every
+correct call to a file-level definition would be, since a file-level ``function send()`` binds
+``send`` too — the difference between a declaration and a shadow is which scope holds it.
+
+C is the control: it already refuses these (``c_extractor._bound_names``), and it is walked
+here rather than assumed, by an independent implementation — see the preamble of
+:mod:`orchestrator.pkg.scope` for why the oracle must not reuse the extractor's own answer.
+
+Java and SQL are **excluded with a reason** rather than reported as clean; ``status`` carries
+it, because "0" and "not measured" are the two readings this project keeps confusing.
+
 This module **measures only**. It changes no fact the extractor emits; the graph is
-byte-identical with and without it. Fixing the front-end is a separate ticket, which this
+byte-identical with and without it. Fixing the front-ends is a separate phase, which this
 number exists to prove.
 """
 
@@ -43,7 +68,7 @@ import ast
 from dataclasses import dataclass
 from pathlib import Path
 
-from orchestrator.pkg.facts import EdgeKind, FactBatch
+from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch
 
 _MAX_EXAMPLES = 15
 
@@ -57,9 +82,46 @@ class InventedCall:
     file: str
     line: int
     name: str
+    language: str = ""
 
     def __str__(self) -> str:
         return f"{self.file}:{self.line} {self.src} -CALLS-> {self.dst} ({self.name} is local)"
+
+
+#: A language was looked at and answered; was excluded for a stated reason; or has no walker
+#: and was **not measured**. Only ``MEASURED`` licenses reading a count of 0 as "clean".
+MEASURED = "measured"
+NOT_APPLICABLE = "not-applicable"
+UNWALKED = "unwalked"
+
+
+@dataclass(frozen=True)
+class LanguageInvention:
+    """One front-end's answer, with the standing of that answer attached.
+
+    ``status`` exists because this project's recurring failure is a zero that means "nothing
+    ran". A row is only evidence of a clean call graph when ``status == MEASURED``.
+    """
+
+    language: str
+    status: str
+    reason: str = ""
+    invented: tuple[InventedCall, ...] = ()
+    total_calls: int = 0
+    examined: int = 0
+    unexamined: int = 0
+    #: Edges whose call site is a bare identifier — the only ones a shadow can reach. The
+    #: honest denominator: `0 of 1677 CALLS` reads as a far wider clean sweep than `0 of 214
+    #: bare calls`, and only the second is what was actually at risk.
+    shadowable: int = 0
+
+    @property
+    def rate(self) -> float | None:
+        return len(self.invented) / self.total_calls if self.total_calls else None
+
+    @property
+    def shadowable_rate(self) -> float | None:
+        return len(self.invented) / self.shadowable if self.shadowable else None
 
 
 @dataclass(frozen=True)
@@ -71,6 +133,16 @@ class InventionReport:
     external_calls: int
     candidates: int
     unexamined: int
+    by_language: tuple[LanguageInvention, ...] = ()
+
+    @property
+    def measured_languages(self) -> tuple[str, ...]:
+        return tuple(e.language for e in self.by_language if e.status == MEASURED)
+
+    @property
+    def unmeasured_languages(self) -> tuple[str, ...]:
+        """Languages carrying ``CALLS`` edges that nothing here examined."""
+        return tuple(e.language for e in self.by_language if e.status == UNWALKED and e.total_calls)
 
     @property
     def rate(self) -> float | None:
@@ -139,12 +211,29 @@ def _visible_names(scopes: list[tuple[int, int, frozenset[str]]], line: int) -> 
 # ---- detection -------------------------------------------------------------
 
 
-def find_invented_calls(batch: FactBatch, root: Path | str) -> InventionReport:
-    """Every ``CALLS`` edge whose target is a name bound in the caller's own scope."""
-    base = Path(root)
-    external = {n.id for n in batch.nodes if n.external}
-    calls = [e for e in batch.edges if e.kind is EdgeKind.CALLS]
+def _terminal_name(node_id: str) -> str:
+    """The name as it is written at a bare call site, from a target id.
 
+    Ids are language-prefixed and then segmented differently per front-end
+    (``ts:a.send``, ``cpp:Ns::func``, ``go:<root>.Send``, ``ts:react:useState``), so the
+    name is whatever follows the last separator of either kind.
+    """
+    body = node_id.partition(":")[2] or node_id
+    for sep in (".", ":"):
+        body = body.rpartition(sep)[2] or body
+    return body
+
+
+def _python_invention(
+    calls: list[Edge], external: set[str], base: Path
+) -> tuple[LanguageInvention, int, int]:
+    """The original detector, unchanged: an external single-segment target bound in scope.
+
+    Kept as its own path rather than folded into the tree-sitter walk. Python's front-end
+    fails *differently* — it emitted `py:<name>`, an id for a module that does not exist —
+    and this is the number the committed scoreboard carries. A rewrite that moved it would
+    make the widening unreviewable.
+    """
     # Candidates only: a multi-segment id (`py:json.dumps`) names a real module path, and a
     # single-segment one may still be a builtin (`py:ValueError`). The binding test decides.
     candidates = [e for e in calls if e.dst in external and "." not in e.dst.partition(":")[2]]
@@ -172,15 +261,127 @@ def find_invented_calls(batch: FactBatch, root: Path | str) -> InventionReport:
         name = edge.dst.partition(":")[2]
         if name in _visible_names(scopes, edge.provenance.line):
             invented.append(
-                InventedCall(edge.src, edge.dst, edge.provenance.file, edge.provenance.line, name)
+                InventedCall(edge.src, edge.dst, edge.provenance.file, edge.provenance.line, name, "python")
             )
+    return (
+        LanguageInvention(
+            language="python",
+            status=MEASURED,
+            invented=tuple(invented),
+            total_calls=len(calls),
+            examined=len(candidates) - unexamined,
+            unexamined=unexamined,
+            shadowable=len(candidates) - unexamined,
+        ),
+        len(candidates),
+        unexamined,
+    )
+
+
+def _walked_invention(language: str, calls: list[Edge], base: Path) -> LanguageInvention:
+    """A tree-sitter front-end's answer: bare call, name matches target, name bound in-function."""
+    from orchestrator.pkg import scope as scope_mod
+
+    cache: dict[str, scope_mod.FileScopes | None] = {}
+
+    def scopes_for(rel: str) -> scope_mod.FileScopes | None:
+        if rel not in cache:
+            path = base / rel
+            try:
+                cache[rel] = scope_mod.scopes_for_source(path.read_bytes(), language, path.suffix)
+            except (OSError, KeyError, RuntimeError, ValueError):
+                cache[rel] = None
+        return cache[rel]
+
+    invented: list[InventedCall] = []
+    examined = unexamined = shadowable = 0
+    for edge in calls:
+        if edge.provenance is None:
+            unexamined += 1
+            continue
+        scopes = scopes_for(edge.provenance.file)
+        if scopes is None:
+            unexamined += 1
+            continue
+        line = edge.provenance.line
+        name = _terminal_name(edge.dst)
+        examined += 1
+        if name not in scopes.bare_call_names(line):
+            # A member call (`this.m()`, `ns.f()`) — a different resolution question, and one
+            # a scope test cannot answer. Looked at and cleared, but never at risk, so it is
+            # not part of the denominator this oracle can claim.
+            continue
+        shadowable += 1
+        if name in scopes.shadowed(line):
+            invented.append(InventedCall(edge.src, edge.dst, edge.provenance.file, line, name, language))
+    return LanguageInvention(
+        language=language,
+        status=MEASURED,
+        invented=tuple(invented),
+        total_calls=len(calls),
+        examined=examined,
+        unexamined=unexamined,
+        shadowable=shadowable,
+    )
+
+
+def find_invented_calls(batch: FactBatch, root: Path | str) -> InventionReport:
+    """Every ``CALLS`` edge whose target is a name bound inside the calling function.
+
+    Per language, because "0" is only meaningful next to which front-ends were looked at.
+    """
+    from orchestrator.pkg import scope as scope_mod
+
+    base = Path(root)
+    external = {n.id for n in batch.nodes if n.external}
+    calls = [e for e in batch.edges if e.kind is EdgeKind.CALLS]
+
+    # The caller's own node names the front-end that emitted the edge — exact, and independent
+    # of which optional extras happen to be installed on this machine.
+    node_language = {n.id: n.language for n in batch.nodes}
+    by_lang: dict[str, list[Edge]] = {}
+    for edge in calls:
+        by_lang.setdefault(node_language.get(edge.src, ""), []).append(edge)
+
+    roster: list[LanguageInvention] = []
+    invented: list[InventedCall] = []
+    candidates = unexamined = 0
+    for language in sorted(by_lang):
+        edges = by_lang[language]
+        if language == "python":
+            entry, cand, unex = _python_invention(edges, external, base)
+            candidates += cand
+            unexamined += unex
+        elif language in scope_mod.WALKERS:
+            entry = _walked_invention(language, edges, base)
+            candidates += entry.examined + entry.unexamined
+            unexamined += entry.unexamined
+        elif language in scope_mod.NOT_APPLICABLE:
+            entry = LanguageInvention(
+                language=language,
+                status=NOT_APPLICABLE,
+                reason=scope_mod.NOT_APPLICABLE[language],
+                total_calls=len(edges),
+            )
+        else:
+            entry = LanguageInvention(
+                language=language or "<unattributed>",
+                status=UNWALKED,
+                reason="no scope walker — these edges were not examined",
+                total_calls=len(edges),
+                unexamined=len(edges),
+            )
+            unexamined += len(edges)
+        roster.append(entry)
+        invented.extend(entry.invented)
 
     return InventionReport(
         invented=tuple(sorted(invented, key=lambda i: (i.file, i.line, i.dst))),
         total_calls=len(calls),
         external_calls=sum(1 for e in calls if e.dst in external),
-        candidates=len(candidates),
+        candidates=candidates,
         unexamined=unexamined,
+        by_language=tuple(roster),
     )
 
 
@@ -219,8 +420,12 @@ def score_invention(repo: Path | str, *, sql_dialect: str | None = None) -> Inve
 
 
 __all__ = [
+    "MEASURED",
+    "NOT_APPLICABLE",
+    "UNWALKED",
     "InventedCall",
     "InventionReport",
+    "LanguageInvention",
     "find_invented_calls",
     "sample_edges",
     "score_invention",

--- a/src/orchestrator/pkg/scope.py
+++ b/src/orchestrator/pkg/scope.py
@@ -1,0 +1,507 @@
+"""What a call site's enclosing scopes bind — per language, over the same parser.
+
+The invention oracle asks one question of a ``CALLS`` edge: *was the name at the call
+site bound by the calling function itself?* If it was, the call goes through a parameter,
+a local, or a nested closure, and any edge to a file-level definition of that name is
+fiction. :mod:`orchestrator.pkg.invention` answers that question for Python with the
+stdlib ``ast``. This module answers it for the tree-sitter front-ends.
+
+**This is a second implementation on purpose, and that is the whole point of an oracle.**
+``c_extractor._bound_names`` already computes bindings, and reusing it here would build a
+detector that agrees with the extractor by construction — including where the extractor is
+wrong. The measurement is only worth taking if it can disagree. What is deliberately *not*
+duplicated is the parser: each language is parsed with the same factory the front-end used,
+because a second grammar would be a second opinion about the syntax, and then a disagreement
+would not tell us which side was wrong.
+
+**Only bindings inside a function count.** A file-level ``function send() {}`` binds ``send``
+too, but that is the target the extractor resolved to, and calling it is correct. Invention is
+*shadowing* — a binding strictly inside the calling function, which the front-ends' name→id
+tables (file-level callables, sibling methods) cannot see. So :class:`Scope` carries ``local``,
+and the file scope is excluded from the test.
+
+Five languages are walked here. Two are excluded, with reasons rather than silence:
+
+- **Java** — the JLS gives variables and methods separate namespaces (§6.5.7), so ``int send``
+  does not shadow ``send()``. A shadowing test would report false positives, not findings.
+- **SQL** — the ``CALL``/``PERFORM`` fallback matches two keywords and a parenthesis; there is
+  no lexical scope for a name to be bound in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from tree_sitter import Node as TSNode
+
+
+@dataclass(frozen=True)
+class Binding:
+    """A name, and the first line at which it is in scope.
+
+    The line matters, and getting it wrong invents findings. Go's spec starts a short
+    variable declaration's scope *after* the statement, so ``cmd := cmd(binaryPath, …)``
+    calls the package-level ``cmd`` — legitimately — while binding a local of the same name
+    for everything below it. Treating the binding as covering its own declaration reported
+    that as fiction; it is idiomatic Go, and C and C++ read the same way.
+
+    Parameters are in scope from the head of the function; declarations from the line after
+    they end. TypeScript and C# are held to the same rule even though both forbid
+    use-before-declaration outright — where the language makes the earlier call impossible,
+    the conservative reading costs nothing, and this oracle is precision-first for the same
+    reason the graph is.
+    """
+
+    name: str
+    line: int
+
+
+@dataclass(frozen=True)
+class Scope:
+    """A line range and the names bound directly in it.
+
+    ``local`` is False only for the file scope. A name bound there is a declaration the
+    front-end can resolve, not a shadow of one.
+    """
+
+    start: int
+    end: int
+    bindings: tuple[Binding, ...]
+    local: bool
+
+    @property
+    def names(self) -> frozenset[str]:
+        return frozenset(b.name for b in self.bindings)
+
+
+@dataclass(frozen=True)
+class BareCall:
+    """A call site whose callee is a plain identifier — the only shape that can be shadowed.
+
+    ``obj.method()`` is excluded: the name that could be shadowed there is ``obj``, and
+    resolving it is a different question (the front-ends already refuse it without a type).
+    """
+
+    line: int
+    name: str
+
+
+@dataclass(frozen=True)
+class FileScopes:
+    """Every scope in one file, and every bare-identifier call site."""
+
+    scopes: tuple[Scope, ...]
+    calls: tuple[BareCall, ...]
+
+    def shadowed(self, line: int) -> frozenset[str]:
+        """Names bound by some function enclosing ``line``, and in scope *at* it.
+
+        The file scope is excluded: a name bound there is the declaration the front-end
+        resolved to, and calling it is correct.
+        """
+        return frozenset(
+            b.name
+            for s in self.scopes
+            if s.local and s.start <= line <= s.end
+            for b in s.bindings
+            if line >= b.line
+        )
+
+    def bare_call_names(self, line: int) -> frozenset[str]:
+        return frozenset(c.name for c in self.calls if c.line == line)
+
+
+# ---- the per-language contract ---------------------------------------------
+
+
+class _Lang(Protocol):
+    """One language's answer to: what opens a scope, what binds a name, what is a call."""
+
+    scope_nodes: frozenset[str]
+    call_nodes: frozenset[str]
+
+    def params(self, node: TSNode, src: bytes) -> Iterable[str]:
+        """Names a scope node binds in *its own* body — parameters, captures."""
+
+    def declares(self, node: TSNode, src: bytes) -> Iterable[str]:
+        """Names this node binds in the *enclosing* scope — locals, loop vars, catch targets."""
+
+
+def _text(node: TSNode | None, src: bytes) -> str:
+    return "" if node is None else src[node.start_byte : node.end_byte].decode("utf-8", "replace")
+
+
+@dataclass
+class _Open:
+    start: int
+    end: int
+    local: bool
+    bindings: list[Binding] = field(default_factory=list)
+
+
+def collect(root: TSNode, src: bytes, lang: _Lang) -> FileScopes:
+    """Walk once: attribute every binding to its innermost scope, record every bare call.
+
+    Scopes are recorded as line ranges and tested by containment afterwards rather than
+    resolved during the walk, so declaration order inside a scope does not change what a
+    later line sees — only :class:`Binding`'s own line does.
+    """
+    opened: list[_Open] = [_Open(1, 1 << 30, local=False)]
+
+    def visit(node: TSNode, current: _Open) -> None:
+        scope = current
+        if node.type in lang.scope_nodes:
+            start = node.start_point[0] + 1
+            scope = _Open(
+                start,
+                node.end_point[0] + 1,
+                local=True,
+                bindings=[Binding(n, start) for n in lang.params(node, src)],
+            )
+            opened.append(scope)
+        else:
+            # A declaration binds from the line after it ends — see `Binding`.
+            from_line = node.end_point[0] + 2
+            current.bindings.extend(Binding(n, from_line) for n in lang.declares(node, src))
+            if node.type in lang.call_nodes:
+                fn = node.child_by_field_name("function")
+                if fn is not None and fn.type == "identifier":
+                    calls.append(BareCall(node.start_point[0] + 1, _text(fn, src)))
+        for child in node.named_children:
+            visit(child, scope)
+
+    calls: list[BareCall] = []
+    visit(root, opened[0])
+    return FileScopes(
+        scopes=tuple(Scope(o.start, o.end, tuple(o.bindings), o.local) for o in opened),
+        calls=tuple(calls),
+    )
+
+
+# ---- helpers shared by more than one walker --------------------------------
+
+
+def _idents(node: TSNode | None, src: bytes, kinds: frozenset[str]) -> Iterator[str]:
+    """Every identifier of ``kinds`` in a subtree — for destructuring patterns and name lists.
+
+    Safe only on subtrees that hold no type annotation: a pattern's type is a *sibling* field
+    in every grammar walked here, never a child, so descending cannot pick up a type's own
+    parameter names.
+    """
+    if node is None:
+        return
+    if node.type in kinds:
+        yield _text(node, src)
+        return
+    for child in node.named_children:
+        yield from _idents(child, src, kinds)
+
+
+def _named_fields(node: TSNode, src: bytes, fname: str) -> Iterator[str]:
+    """Every child of ``node`` under field ``fname`` — Go's ``a, b int`` repeats ``name``."""
+    for i, child in enumerate(node.children):
+        if child.is_named and node.field_name_for_child(i) == fname:
+            yield _text(child, src)
+
+
+# ---- TypeScript -------------------------------------------------------------
+
+_TS_PATTERN_IDS = frozenset({"identifier", "shorthand_property_identifier_pattern"})
+
+# Field to follow instead of every named child, for the pattern nodes that carry an
+# expression alongside the name. `const { arg: slotName = createSimpleExpression(…) } = x`
+# binds `slotName`; a blind identifier sweep also binds `createSimpleExpression`, and then
+# every legitimate call to that import reads as a shadowed call. Measured on vue/core:
+# 3 of 4 findings were this, and all three were fiction.
+_TS_PATTERN_FIELD = {"pair_pattern": "value", "assignment_pattern": "left"}
+
+
+def _ts_pattern_names(node: TSNode | None, src: bytes) -> Iterator[str]:
+    """Names a TypeScript binding pattern binds — never a default value's contents."""
+    if node is None:
+        return
+    if node.type in _TS_PATTERN_IDS:
+        yield _text(node, src)
+        return
+    field_name = _TS_PATTERN_FIELD.get(node.type)
+    if field_name is not None:
+        yield from _ts_pattern_names(node.child_by_field_name(field_name), src)
+        return
+    if node.type in ("object_pattern", "array_pattern", "rest_pattern", "object_assignment_pattern"):
+        for child in node.named_children:
+            yield from _ts_pattern_names(child, src)
+
+
+class _TypeScript:
+    scope_nodes = frozenset(
+        {
+            "function_declaration",
+            "generator_function_declaration",
+            "function_expression",
+            "generator_function",
+            "function",
+            "arrow_function",
+            "method_definition",
+        }
+    )
+    call_nodes = frozenset({"call_expression"})
+
+    def params(self, node: TSNode, src: bytes) -> Iterable[str]:
+        # `x => x()` binds through the `parameter` field; everything else through
+        # `parameters`. Only the DIRECT children of `formal_parameters` are read: a
+        # parameter typed `(v: string) => void` carries its own `formal_parameters`
+        # under the `type` field, and `v` is bound nowhere.
+        single = node.child_by_field_name("parameter")
+        if single is not None:
+            return list(_ts_pattern_names(single, src))
+        params = node.child_by_field_name("parameters")
+        if params is None:
+            return []
+        out: list[str] = []
+        for child in params.named_children:
+            pattern = child.child_by_field_name("pattern") or (
+                child if child.type in _TS_PATTERN_IDS else None
+            )
+            out.extend(_ts_pattern_names(pattern, src))
+        return out
+
+    def declares(self, node: TSNode, src: bytes) -> Iterable[str]:
+        if node.type == "variable_declarator":  # let / const / var
+            return _ts_pattern_names(node.child_by_field_name("name"), src)
+        if node.type in ("for_in_statement", "for_statement"):
+            return _ts_pattern_names(node.child_by_field_name("left"), src)
+        if node.type == "catch_clause":
+            return _ts_pattern_names(node.child_by_field_name("parameter"), src)
+        if node.type in ("function_declaration", "generator_function_declaration"):
+            return [_text(node.child_by_field_name("name"), src)]
+        return []
+
+
+# ---- Go ---------------------------------------------------------------------
+
+
+class _Go:
+    scope_nodes = frozenset({"function_declaration", "method_declaration", "func_literal"})
+    call_nodes = frozenset({"call_expression"})
+
+    def params(self, node: TSNode, src: bytes) -> Iterable[str]:
+        out: list[str] = []
+        for fname in ("receiver", "parameters", "type_parameters", "result"):
+            plist = node.child_by_field_name(fname)
+            if plist is None:
+                continue
+            # Direct children only: `Send func(string)` nests a `parameter_list` under its
+            # `type`, and those inner names are bound nowhere.
+            for decl in plist.named_children:
+                out.extend(_named_fields(decl, src, "name"))
+        return out
+
+    def declares(self, node: TSNode, src: bytes) -> Iterable[str]:
+        if node.type == "short_var_declaration":  # `x := ...`
+            return _idents(node.child_by_field_name("left"), src, frozenset({"identifier"}))
+        if node.type in ("var_spec", "const_spec"):
+            return _named_fields(node, src, "name")
+        if node.type == "range_clause":
+            return _idents(node.child_by_field_name("left"), src, frozenset({"identifier"}))
+        if node.type == "type_switch_statement":
+            return _idents(node.child_by_field_name("alias"), src, frozenset({"identifier"}))
+        return []
+
+
+# ---- C# ---------------------------------------------------------------------
+
+
+class _CSharp:
+    scope_nodes = frozenset(
+        {
+            "method_declaration",
+            "constructor_declaration",
+            "destructor_declaration",
+            "operator_declaration",
+            "local_function_statement",
+            "lambda_expression",
+            "anonymous_method_expression",
+            "accessor_declaration",
+        }
+    )
+    call_nodes = frozenset({"invocation_expression"})
+
+    def params(self, node: TSNode, src: bytes) -> Iterable[str]:
+        out: list[str] = []
+        for fname in ("parameters", "parameter_list"):
+            plist = node.child_by_field_name(fname)
+            if plist is None:
+                continue
+            for p in plist.named_children:
+                name = p.child_by_field_name("name")
+                out.append(_text(name, src) if name is not None else _text(p, src))
+        return [n for n in out if n]
+
+    def declares(self, node: TSNode, src: bytes) -> Iterable[str]:
+        if node.type == "variable_declarator":
+            name = node.child_by_field_name("name")
+            return [_text(name if name is not None else node, src)]
+        if node.type in ("foreach_statement", "catch_declaration"):
+            target = node.child_by_field_name("left") or node.child_by_field_name("name")
+            return [_text(target, src)] if target is not None else []
+        if node.type == "local_function_statement":
+            return [_text(node.child_by_field_name("name"), src)]
+        return []
+
+
+# ---- C and C++ --------------------------------------------------------------
+
+# Declarator wrappers, in the order the grammar nests them: `void (*send)(char *)` is
+# function_declarator → parenthesized_declarator → pointer_declarator → identifier. Each is
+# followed through its `declarator` field only — descending into `parameters` would bind the
+# parameter names of a function *pointer*, which are bound nowhere.
+_DECL_WRAPPERS = frozenset(
+    {
+        "init_declarator",
+        "pointer_declarator",
+        "reference_declarator",
+        "array_declarator",
+        "function_declarator",
+        "parenthesized_declarator",
+        "attributed_declarator",
+        "abstract_function_declarator",
+    }
+)
+_DECL_NAMES = frozenset({"identifier", "field_identifier", "qualified_identifier"})
+_UNFIELDED_WRAPPERS = frozenset({"parenthesized_declarator", "reference_declarator", "pointer_declarator"})
+
+
+def _declarator_name(node: TSNode | None, src: bytes) -> str | None:
+    """The innermost declared name of a C/C++ declarator, or None for an abstract one."""
+    cur = node
+    seen = 0
+    while cur is not None and seen < 32:  # a declarator cannot nest meaningfully deeper
+        if cur.type in _DECL_NAMES:
+            return _text(cur, src)
+        if cur.type not in _DECL_WRAPPERS:
+            return None
+        nxt = cur.child_by_field_name("declarator")
+        if nxt is None and cur.type in _UNFIELDED_WRAPPERS:
+            # `for (auto &item : xs)` nests the identifier under `reference_declarator`
+            # with no field name at all; parentheses do the same.
+            nxt = cur.named_children[0] if cur.named_children else None
+        cur = nxt
+        seen += 1
+    return None
+
+
+def _c_parameters(node: TSNode) -> TSNode | None:
+    """The ``parameter_list`` of a definition, through any declarator wrappers around it."""
+    cur = node.child_by_field_name("declarator")
+    seen = 0
+    while cur is not None and seen < 32:
+        plist = cur.child_by_field_name("parameters")
+        if plist is not None:
+            return plist
+        cur = cur.child_by_field_name("declarator")
+        seen += 1
+    return None
+
+
+class _CFamily:
+    call_nodes = frozenset({"call_expression"})
+
+    def __init__(self, *, scope_nodes: frozenset[str]) -> None:
+        self.scope_nodes = scope_nodes
+
+    def params(self, node: TSNode, src: bytes) -> Iterable[str]:
+        plist = _c_parameters(node)
+        if plist is None:
+            return []
+        out: list[str] = []
+        for p in plist.named_children:
+            name = _declarator_name(p.child_by_field_name("declarator"), src)
+            if name:
+                out.append(name)
+        return out
+
+    def declares(self, node: TSNode, src: bytes) -> Iterable[str]:
+        if node.type == "declaration":
+            out: list[str] = []
+            for i, child in enumerate(node.children):
+                if child.is_named and node.field_name_for_child(i) == "declarator":
+                    name = _declarator_name(child, src)
+                    if name:
+                        out.append(name)
+            return out
+        if node.type in ("for_range_loop", "init_declarator"):
+            name = _declarator_name(node.child_by_field_name("declarator"), src)
+            return [name] if name else []
+        return []
+
+
+_C = _CFamily(scope_nodes=frozenset({"function_definition"}))
+_CPP = _CFamily(scope_nodes=frozenset({"function_definition", "lambda_expression"}))
+
+
+# ---- dispatch ---------------------------------------------------------------
+
+#: Languages this module can walk. A language absent here is *not measured*, and the oracle
+#: must say so rather than report zero — see `invention.LanguageInvention.status`.
+WALKERS: dict[str, _Lang] = {
+    "typescript": _TypeScript(),
+    "go": _Go(),
+    "csharp": _CSharp(),
+    "c": _C,
+    "cpp": _CPP,
+}
+
+#: Languages excluded on purpose, with the reason, so "no finding" is legible.
+NOT_APPLICABLE: dict[str, str] = {
+    "java": "variables and methods occupy separate namespaces (JLS 6.5.7) — a local cannot shadow a method",
+    "sql": "the CALL/PERFORM fallback matches two keywords; there is no lexical scope to shadow",
+    "python": "measured by the stdlib-ast detector in `invention`, not by a tree-sitter walk",
+}
+
+
+def _parser_for(language: str, suffix: str) -> Any:
+    """The front-end's own parser factory — never a second grammar (see the module docstring)."""
+    if language == "typescript":
+        from orchestrator.pkg.typescript_extractor import _ts_parser
+
+        return _ts_parser(suffix)
+    if language == "go":
+        from orchestrator.pkg.go_extractor import _go_parser
+
+        return _go_parser()
+    if language == "csharp":
+        from orchestrator.pkg.csharp_extractor import _csharp_parser
+
+        return _csharp_parser()
+    if language == "cpp":
+        from orchestrator.pkg.cpp_extractor import _cpp_parser
+
+        return _cpp_parser()
+    if language == "c":
+        from orchestrator.pkg.c_extractor import _c_parser
+
+        return _c_parser()
+    raise KeyError(language)
+
+
+def scopes_for_source(source: bytes, language: str, suffix: str) -> FileScopes:
+    """Parse ``source`` and collect its scopes and bare calls. Raises ``KeyError`` if unwalked."""
+    walker = WALKERS[language]
+    tree = _parser_for(language, suffix).parse(source)
+    return collect(tree.root_node, source, walker)
+
+
+__all__ = [
+    "NOT_APPLICABLE",
+    "WALKERS",
+    "BareCall",
+    "Binding",
+    "FileScopes",
+    "Scope",
+    "collect",
+    "scopes_for_source",
+]

--- a/src/orchestrator/pkg/scoreboard.json
+++ b/src/orchestrator/pkg/scoreboard.json
@@ -347,8 +347,19 @@
     "invention": {
       "count": 0,
       "gated": false,
-      "note": "moves with ordinary commits \u2014 recorded as a trend, never gated",
-      "total_calls": 15212
+      "languages": {
+        "python": {
+          "examined": 0,
+          "invented": 0,
+          "shadowable": 0,
+          "status": "measured",
+          "total_calls": 15982,
+          "unexamined": 0
+        }
+      },
+      "note": "rate moves with ordinary commits; count is a defect count \u2014 see GATES",
+      "target_gate": "strict",
+      "total_calls": 15982
     },
     "parity": {
       "declared": 75,

--- a/src/orchestrator/pkg/scoreboard.json
+++ b/src/orchestrator/pkg/scoreboard.json
@@ -37,14 +37,14 @@
         "cpp": {
           "edges": {
             "CALLS": {
-              "emitted": 2,
-              "expected": 3,
-              "matched": 2
+              "emitted": 3,
+              "expected": 4,
+              "matched": 3
             },
             "CONTAINS": {
-              "emitted": 8,
-              "expected": 8,
-              "matched": 8
+              "emitted": 11,
+              "expected": 11,
+              "matched": 11
             }
           },
           "nodes": {
@@ -54,14 +54,14 @@
               "matched": 1
             },
             "Function": {
-              "emitted": 5,
-              "expected": 5,
-              "matched": 5
+              "emitted": 8,
+              "expected": 8,
+              "matched": 8
             },
             "Module": {
-              "emitted": 2,
-              "expected": 2,
-              "matched": 2
+              "emitted": 3,
+              "expected": 3,
+              "matched": 3
             },
             "Type": {
               "emitted": 2,
@@ -73,14 +73,14 @@
         "csharp": {
           "edges": {
             "CALLS": {
-              "emitted": 2,
-              "expected": 3,
-              "matched": 2
+              "emitted": 3,
+              "expected": 4,
+              "matched": 3
             },
             "CONTAINS": {
-              "emitted": 11,
-              "expected": 11,
-              "matched": 11
+              "emitted": 15,
+              "expected": 15,
+              "matched": 15
             },
             "IMPLEMENTS": {
               "emitted": 1,
@@ -95,33 +95,33 @@
               "matched": 1
             },
             "Function": {
-              "emitted": 6,
-              "expected": 6,
-              "matched": 6
+              "emitted": 9,
+              "expected": 9,
+              "matched": 9
             },
             "Module": {
-              "emitted": 2,
-              "expected": 2,
-              "matched": 2
+              "emitted": 3,
+              "expected": 3,
+              "matched": 3
             },
             "Type": {
-              "emitted": 4,
-              "expected": 4,
-              "matched": 4
+              "emitted": 5,
+              "expected": 5,
+              "matched": 5
             }
           }
         },
         "go": {
           "edges": {
             "CALLS": {
-              "emitted": 2,
-              "expected": 3,
-              "matched": 2
+              "emitted": 3,
+              "expected": 4,
+              "matched": 3
             },
             "CONTAINS": {
-              "emitted": 12,
-              "expected": 12,
-              "matched": 12
+              "emitted": 15,
+              "expected": 15,
+              "matched": 15
             },
             "IMPLEMENTS": {
               "emitted": 1,
@@ -136,14 +136,14 @@
               "matched": 2
             },
             "Function": {
-              "emitted": 7,
-              "expected": 7,
-              "matched": 7
+              "emitted": 10,
+              "expected": 10,
+              "matched": 10
             },
             "Module": {
-              "emitted": 2,
-              "expected": 2,
-              "matched": 2
+              "emitted": 3,
+              "expected": 3,
+              "matched": 3
             },
             "Type": {
               "emitted": 3,
@@ -298,14 +298,14 @@
         "typescript": {
           "edges": {
             "CALLS": {
-              "emitted": 3,
-              "expected": 6,
-              "matched": 3
+              "emitted": 4,
+              "expected": 7,
+              "matched": 4
             },
             "CONTAINS": {
-              "emitted": 22,
-              "expected": 22,
-              "matched": 22
+              "emitted": 25,
+              "expected": 25,
+              "matched": 25
             },
             "IMPLEMENTS": {
               "emitted": 2,
@@ -325,14 +325,14 @@
               "matched": 4
             },
             "Function": {
-              "emitted": 12,
-              "expected": 12,
-              "matched": 12
+              "emitted": 15,
+              "expected": 15,
+              "matched": 15
             },
             "Module": {
-              "emitted": 5,
-              "expected": 5,
-              "matched": 5
+              "emitted": 6,
+              "expected": 6,
+              "matched": 6
             },
             "Type": {
               "emitted": 6,
@@ -346,20 +346,19 @@
     },
     "invention": {
       "count": 0,
-      "gated": false,
+      "gated": "strict",
       "languages": {
         "python": {
           "examined": 0,
           "invented": 0,
           "shadowable": 0,
           "status": "measured",
-          "total_calls": 15982,
+          "total_calls": 16039,
           "unexamined": 0
         }
       },
-      "note": "rate moves with ordinary commits; count is a defect count \u2014 see GATES",
-      "target_gate": "strict",
-      "total_calls": 15982
+      "note": "gated at zero per language, not against this baseline \u2014 see GATES",
+      "total_calls": 16039
     },
     "parity": {
       "declared": 75,

--- a/src/orchestrator/pkg/typescript_extractor.py
+++ b/src/orchestrator/pkg/typescript_extractor.py
@@ -323,6 +323,7 @@ def _calls(
 ) -> None:
     """Emit CALLS for precisely-resolvable ``call_expression`` sites in a body."""
     siblings = type_methods.get(type_id or "", set())
+    bound = _bound_names(body, source)
     stack = list(body.named_children)
     while stack:
         n = stack.pop()
@@ -330,11 +331,105 @@ def _calls(
             continue
         if n.type == "call_expression":
             fn = n.child_by_field_name("function")
+            line = n.start_point[0] + 1
+            if fn is not None and fn.type == "identifier" and line >= bound.get(_text(fn, source), 1 << 30):
+                # A call through a name this function bound itself — a parameter, a local, or a
+                # closure argument. `local_funcs` and `imports` still hold the FILE-level
+                # binding of that name, so resolving it would emit an edge to a definition the
+                # call never reaches. The callee here is decided by whoever supplied the value.
+                stack.extend(n.named_children)
+                continue
             target = _resolve_callee(fn, type_id, siblings, local_funcs, imports, namespaces, rel, source)
             if target is not None:
                 _ensure_external(batch, target)
                 batch.add_edge(Edge(caller, target, EdgeKind.CALLS, Provenance(rel, n.start_point[0] + 1)))
         stack.extend(n.named_children)
+
+
+def _pattern_names(node: TSNode | None, src: bytes) -> list[str]:
+    """Names a binding pattern binds — never the contents of a default value.
+
+    `const { arg: slotName = makeDefault() } = x` binds `slotName`. Sweeping the pattern for
+    identifiers also picks up `makeDefault`, and then every later call to it is skipped as
+    shadowed — a silently dropped edge, which is the failure this whole change exists to avoid
+    in the other direction.
+    """
+    if node is None:
+        return []
+    if node.type in ("identifier", "shorthand_property_identifier_pattern"):
+        return [_text(node, src)]
+    if node.type == "pair_pattern":
+        return _pattern_names(node.child_by_field_name("value"), src)
+    if node.type == "assignment_pattern":
+        return _pattern_names(node.child_by_field_name("left"), src)
+    if node.type in ("object_pattern", "array_pattern", "rest_pattern"):
+        return [n for c in node.named_children for n in _pattern_names(c, src)]
+    return []
+
+
+def _params_of(node: TSNode | None, src: bytes) -> list[str]:
+    """Parameter names of a callable. Direct children only, for one specific reason.
+
+    A parameter typed ``(v: string) => void`` carries its own ``formal_parameters`` under the
+    ``type`` field. ``v`` is bound nowhere, and treating it as a local would drop real calls.
+    """
+    if node is None:
+        return []
+    single = node.child_by_field_name("parameter")  # `x => …`
+    if single is not None:
+        return _pattern_names(single, src)
+    params = node.child_by_field_name("parameters")
+    if params is None:
+        return []
+    out: list[str] = []
+    for child in params.named_children:
+        pattern = child.child_by_field_name("pattern")
+        out.extend(_pattern_names(pattern if pattern is not None else child, src))
+    return out
+
+
+def _bound_names(body: TSNode, src: bytes) -> dict[str, int]:
+    """Names this function binds, each with the first line it is in scope.
+
+    A callee in this map is reached through a parameter, a local or a closure argument, so no
+    file-level id names it. The line matters: TypeScript's temporal dead zone makes a call
+    *above* a `const` an error rather than a call to an outer function, but keeping the line
+    costs nothing and keeps this helper honest about what it is asserting.
+
+    The walk mirrors `_calls_in_body` exactly — same `_CALL_SCOPE_STOP` boundaries — because a
+    binding set that covers more or less ground than the call walk would either drop real edges
+    or miss shadowed ones. Anonymous arrows are descended into by both: `hook.forEach(h => h())`
+    is where vue/core's one fabricated edge came from.
+    """
+    bound: dict[str, int] = {}
+
+    def bind(name: str, line: int) -> None:
+        if name and line < bound.get(name, 1 << 30):
+            bound[name] = line
+
+    for name in _params_of(body.parent, src):
+        bind(name, body.parent.start_point[0] + 1 if body.parent is not None else 1)
+
+    stack = list(body.named_children)
+    while stack:
+        n = stack.pop()
+        if n.type in _CALL_SCOPE_STOP:
+            continue
+        after = n.end_point[0] + 2  # a declaration is in scope from the line after it ends
+        if n.type == "variable_declarator":
+            for name in _pattern_names(n.child_by_field_name("name"), src):
+                bind(name, after)
+        elif n.type in ("for_in_statement", "for_statement"):
+            for name in _pattern_names(n.child_by_field_name("left"), src):
+                bind(name, n.start_point[0] + 1)
+        elif n.type == "catch_clause":
+            for name in _pattern_names(n.child_by_field_name("parameter"), src):
+                bind(name, n.start_point[0] + 1)
+        elif n.type in ("arrow_function", "function_expression", "generator_function"):
+            for name in _params_of(n, src):
+                bind(name, n.start_point[0] + 1)
+        stack.extend(n.named_children)
+    return bound
 
 
 def _resolve_callee(

--- a/tests/pkg/test_accuracy.py
+++ b/tests/pkg/test_accuracy.py
@@ -324,3 +324,52 @@ def test_parity_on_a_missing_repo_is_an_error() -> None:
 
     with pytest.raises(CorpusError, match="not a directory"):
         score_parity("/nope/does/not/exist")
+
+
+# ---- the invention gate: zero per language, not zero-versus-baseline -------
+
+
+def _board(languages: dict[str, Any]) -> dict[str, Any]:
+    return {"metrics": {"invention": {"gated": "strict", "languages": languages}}}
+
+
+def test_a_fabricated_edge_fails_the_gate() -> None:
+    """Proved by making it fail, not by watching it pass.
+
+    A gate nobody has seen fail is a gate nobody knows is wired up — this is the check that
+    the four front-end fixes are actually held in place by something.
+    """
+    from orchestrator.pkg.accuracy import compare_scoreboard
+
+    clean = _board({"cpp": {"status": "measured", "invented": 0}})
+    assert compare_scoreboard(clean, clean) == []
+
+    broken = _board({"cpp": {"status": "measured", "invented": 3}})
+    regressions = compare_scoreboard(clean, broken)
+    assert [r.metric for r in regressions] == ["invention"]
+    assert "cpp" in regressions[0].detail
+
+
+def test_the_gate_is_absolute_not_relative_to_the_baseline() -> None:
+    """A non-zero baseline must not license a non-zero current.
+
+    Gating against a stored number is how a defect count becomes a metric everyone agrees to
+    live with. There is no repository where a fabricated edge is acceptable.
+    """
+    from orchestrator.pkg.accuracy import compare_scoreboard
+
+    dirty_baseline = _board({"go": {"status": "measured", "invented": 5}})
+    assert compare_scoreboard(dirty_baseline, dirty_baseline) != []
+
+
+def test_an_unmeasured_language_is_not_gated() -> None:
+    """Its 0 means 'not examined'. Gating on it would report health nobody checked."""
+    from orchestrator.pkg.accuracy import compare_scoreboard
+
+    board = _board(
+        {
+            "java": {"status": "not-applicable", "invented": 0},
+            "rust": {"status": "unwalked", "invented": 0},
+        }
+    )
+    assert compare_scoreboard(board, board) == []

--- a/tests/pkg/test_cpp_extractor.py
+++ b/tests/pkg/test_cpp_extractor.py
@@ -131,3 +131,53 @@ def test_out_of_line_qualified_name_normalizes_whitespace(tmp_path: Path) -> Non
     assert "cpp:Conn::read" in by_id
     assert by_id["cpp:Conn::read"].name == "read"  # no embedded whitespace
     assert not any("\n" in n.id or "\n" in n.name for n in by_id.values())
+
+
+# ---- shadowed calls: a name the caller bound itself ------------------------
+#
+# `_resolve_callee` name-keys an unresolved identifier to `cpp:<name>`, which is right for a
+# function declared in a header and defined elsewhere — and wrong when the caller bound the
+# name itself, because then the callee is a pointer, a `std::function` or a lambda and is
+# decided at run time. 46 of the 47 edges found across 11 public repositories were this shape.
+# Guard: `corpus/cpp/shadowed_calls`.
+
+
+def _cpp_calls(tmp_path: Path, src: str) -> set[tuple[str, str]]:
+    _write(tmp_path, "src/dispatch.cpp", src)
+    batch = _extract(tmp_path, "src/dispatch.cpp")
+    return {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.CALLS}
+
+
+def test_a_function_pointer_parameter_shadowing_a_free_function_emits_no_call(
+    tmp_path: Path,
+) -> None:
+    src = (
+        "int handle() { return 1; }\n"
+        "int run(int (*handle)()) { return handle(); }\n"
+        "int direct() { return handle(); }\n"
+    )
+    calls = _cpp_calls(tmp_path, src)
+    assert ("cpp:run", "cpp:handle") not in calls
+    assert ("cpp:direct", "cpp:handle") in calls  # the control
+
+
+def test_a_local_lambda_shadows_a_free_function(tmp_path: Path) -> None:
+    """The fmt shape: `auto check = [](){...}; check();` — 43 edges in one file."""
+    src = "void check() {}\nvoid run() {\n  auto check = [](){ return 1; };\n  check();\n}\n"
+    assert ("cpp:run", "cpp:check") not in _cpp_calls(tmp_path, src)
+
+
+def test_a_callee_this_function_did_not_bind_keeps_its_name_keyed_id(tmp_path: Path) -> None:
+    """An unresolved call in C++ is usually a header declaration linked from another TU.
+
+    The test is 'did this function bind the name', not 'can we resolve it' — a Python-style
+    'skip anything unresolved' fix would silence every cross-translation-unit call.
+    """
+    src = "void run() {\n  external_helper();\n}\n"
+    assert ("cpp:run", "cpp:external_helper") in _cpp_calls(tmp_path, src)
+
+
+def test_a_function_pointer_parameters_own_names_bind_nothing(tmp_path: Path) -> None:
+    """In `void (*cb)(const char *x)`, `x` names a parameter of the pointed-to function."""
+    src = "void x() {}\nvoid run(void (*cb)(const char *x)) { x(); }\n"
+    assert ("cpp:run", "cpp:x") in _cpp_calls(tmp_path, src)

--- a/tests/pkg/test_csharp_extractor.py
+++ b/tests/pkg/test_csharp_extractor.py
@@ -371,3 +371,55 @@ def test_first_party_base_type_keeps_its_namespace(tmp_path: Path) -> None:
     batch = ex.finalize(ex.extract(path=src, module="Acme.Biz", rel="b.cs"))
     impl = [e for e in batch.edges if e.kind is EdgeKind.IMPLEMENTS]
     assert any(e.dst == "csharp:Acme.Biz.Base" for e in impl), "first-party base was repointed"
+
+
+# ---- shadowed calls: a name the caller bound itself ------------------------
+#
+# C# resolves a simple name to the innermost declaration, so a parameter or local named after
+# a sibling method wins. `this.Foo()` is an explicit member access and cannot be shadowed —
+# skipping it too would drop real edges, which is why the bare form is tracked separately.
+# Guard: `corpus/csharp/shadowed_calls`.
+
+
+def _cs_calls(tmp_path: Path, src: str) -> set[tuple[str, str]]:
+    batch, _ = _facts(tmp_path, src, "Dispatch.cs")
+    return {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.CALLS}
+
+
+DISPATCH = """\
+namespace App;
+
+public class Dispatch {
+    public int Handle() { return 1; }
+    public int Run(System.Func<int> Handle) { return Handle(); }
+    public int Direct() { return Handle(); }
+}
+"""
+
+
+def test_a_delegate_parameter_shadowing_a_sibling_method_emits_no_call(tmp_path: Path) -> None:
+    calls = _cs_calls(tmp_path, DISPATCH)
+    assert ("csharp:App.Dispatch.Run", "csharp:App.Dispatch.Handle") not in calls
+    assert ("csharp:App.Dispatch.Direct", "csharp:App.Dispatch.Handle") in calls  # the control
+
+
+def test_an_explicit_this_call_is_never_shadowed(tmp_path: Path) -> None:
+    """`this.Handle()` names the member whatever else is in scope."""
+    src = (
+        "namespace App;\n\npublic class Dispatch {\n"
+        "    public int Handle() { return 1; }\n"
+        "    public int Run(System.Func<int> Handle) { return this.Handle(); }\n}\n"
+    )
+    assert ("csharp:App.Dispatch.Run", "csharp:App.Dispatch.Handle") in _cs_calls(tmp_path, src)
+
+
+def test_a_local_shadows_a_sibling_method(tmp_path: Path) -> None:
+    src = (
+        "namespace App;\n\npublic class Dispatch {\n"
+        "    public int Handle() { return 1; }\n"
+        "    public int Run() {\n"
+        "        System.Func<int> Handle = () => 2;\n"
+        "        return Handle();\n"
+        "    }\n}\n"
+    )
+    assert ("csharp:App.Dispatch.Run", "csharp:App.Dispatch.Handle") not in _cs_calls(tmp_path, src)

--- a/tests/pkg/test_go_extractor.py
+++ b/tests/pkg/test_go_extractor.py
@@ -205,3 +205,57 @@ def test_repo_extractor_dispatches_go_by_suffix(tmp_path: Path) -> None:
     batch = RepoCodeExtractor().extract(tmp_path)
     langs = {n.language for n in batch.nodes}
     assert "go" in langs and "python" in langs
+
+
+# ---- shadowed calls: a name the caller bound itself ------------------------
+#
+# `local_funcs` holds the package-level names in this file. A parameter or `:=` local of the
+# same name shadows one for the rest of the block, so resolving through that set asserts a
+# call the source does not make. Guard: `corpus/go/shadowed_calls`.
+
+
+def _call_edges(root: Path, src: str) -> set[tuple[str, str]]:
+    _, edges, _ = _facts(root, "shop/dispatch.go", src)
+    return {(s, d) for s, d, k in edges if k is EdgeKind.CALLS}
+
+
+def test_a_parameter_shadowing_a_package_function_emits_no_call(tmp_path: Path) -> None:
+    src = (
+        "package shop\n\n"
+        "func Handle() int { return 1 }\n\n"
+        "func Run(Handle func() int) int { return Handle() }\n\n"
+        "func Direct() int { return Handle() }\n"
+    )
+    calls = _call_edges(tmp_path, src)
+    assert ("go:shop.Run", "go:shop.Handle") not in calls
+    assert ("go:shop.Direct", "go:shop.Handle") in calls  # the control
+
+
+def test_short_declaration_does_not_shadow_its_own_right_hand_side(tmp_path: Path) -> None:
+    """Go's spec: a `:=` identifier's scope begins at the END of the statement.
+
+    `cmd := cmd(path)` therefore calls the package-level `cmd`. Binding it from the top of the
+    function would drop that edge — it occurs 5 times in grpc-go alone.
+    """
+    src = (
+        "package shop\n\n"
+        "func cmd(p string) int { return 1 }\n\n"
+        'func New() int {\n\tcmd := cmd("x")\n\treturn cmd\n}\n'
+    )
+    assert ("go:shop.New", "go:shop.cmd") in _call_edges(tmp_path, src)
+
+
+def test_short_declaration_shadows_every_line_below_it(tmp_path: Path) -> None:
+    src = (
+        "package shop\n\nfunc run() int { return 1 }\n\n"
+        "func New() int {\n\trun := func() int { return 2 }\n\treturn run()\n}\n"
+    )
+    assert ("go:shop.New", "go:shop.run") not in _call_edges(tmp_path, src)
+
+
+def test_a_closure_parameter_shadows_a_package_function(tmp_path: Path) -> None:
+    src = (
+        "package shop\n\nfunc apply() int { return 1 }\n\n"
+        "func New(xs []func() int) {\n\tfor _, apply := range xs {\n\t\tapply()\n\t}\n}\n"
+    )
+    assert ("go:shop.New", "go:shop.apply") not in _call_edges(tmp_path, src)

--- a/tests/pkg/test_invention.py
+++ b/tests/pkg/test_invention.py
@@ -10,9 +10,20 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 from orchestrator.pkg import RepoCodeExtractor
-from orchestrator.pkg.facts import Edge, EdgeKind, Node, NodeKind, Provenance
-from orchestrator.pkg.invention import _scopes, _visible_names, find_invented_calls, sample_edges
+from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+from orchestrator.pkg.invention import (
+    MEASURED,
+    NOT_APPLICABLE,
+    UNWALKED,
+    LanguageInvention,
+    _scopes,
+    _visible_names,
+    find_invented_calls,
+    sample_edges,
+)
 
 
 def _visible(source: str, line: int) -> set[str]:
@@ -199,3 +210,160 @@ def test_an_empty_or_zero_sample_is_empty(tmp_path: Path) -> None:
     batch = RepoCodeExtractor().extract(tmp_path)
     assert sample_edges(batch, EdgeKind.CONSUMES, 5) == []
     assert sample_edges(batch, EdgeKind.CALLS, 0) == []
+
+
+# ---- the other four front-ends ---------------------------------------------
+#
+# The Python detector could not see these. A shadowed name in TypeScript, Go, C++ or C#
+# does not become an ungrounded `py:name`-style id — it resolves against the front-end's own
+# file-level table and lands on a *real node*. Nothing dangles, so `pkg verify` was silent;
+# no corpus case carried the shape, so precision read 1.00. Each case below is the minimal
+# reproduction, and each is paired with the honest call it must not touch.
+
+_SHADOW_CASES = {
+    "typescript": (
+        "a.ts",
+        "export function send(x: string): void {}\n"
+        "export function outer(send: (v: string) => void): void { send('hi'); }\n"
+        "export function honest(): void { send('real'); }\n",
+        "tree_sitter_typescript",
+    ),
+    "go": (
+        "a.go",
+        "package main\n\nfunc Send(x string) {}\n"
+        'func Outer(Send func(string)) { Send("hi") }\n'
+        'func Honest() { Send("real") }\n',
+        "tree_sitter_go",
+    ),
+    "csharp": (
+        "A.cs",
+        "using System;\nclass A {\n  void Send(string x) {}\n"
+        '  void Outer(Action<string> Send) { Send("hi"); }\n'
+        '  void Honest() { Send("real"); }\n}\n',
+        "tree_sitter_c_sharp",
+    ),
+    "cpp": (
+        "a.cpp",
+        "void send(const char *x) {}\n"
+        'void outer(void (*send)(const char *)) { send("hi"); }\n'
+        'void honest() { send("real"); }\n',
+        "tree_sitter_cpp",
+    ),
+}
+
+
+def _one_language(tmp_path: Path, language: str) -> LanguageInvention:
+    name, source, extra = _SHADOW_CASES[language]
+    pytest.importorskip(extra, reason=f"install the '{language}' extra")
+    (tmp_path / name).write_text(source, encoding="utf-8")
+    report = find_invented_calls(RepoCodeExtractor().extract(tmp_path), tmp_path)
+    return next(e for e in report.by_language if e.language == language)
+
+
+def test_typescript_shadowed_parameter_is_invention(tmp_path: Path) -> None:
+    entry = _one_language(tmp_path, "typescript")
+    assert len(entry.invented) == 1
+    assert entry.invented[0].dst == "ts:a.send"
+    assert entry.invented[0].line == 2
+
+
+def test_go_shadowed_parameter_is_invention(tmp_path: Path) -> None:
+    entry = _one_language(tmp_path, "go")
+    assert len(entry.invented) == 1
+    assert entry.invented[0].name == "Send"
+
+
+def test_csharp_shadowed_parameter_is_invention(tmp_path: Path) -> None:
+    entry = _one_language(tmp_path, "csharp")
+    assert len(entry.invented) == 1
+    assert entry.invented[0].dst == "csharp:A.Send"
+
+
+def test_cpp_shadowed_function_pointer_is_invention(tmp_path: Path) -> None:
+    entry = _one_language(tmp_path, "cpp")
+    assert len(entry.invented) == 1
+    assert entry.invented[0].dst == "cpp:send"
+
+
+def test_the_honest_call_in_the_same_file_is_never_flagged(tmp_path: Path) -> None:
+    """Each fixture's third function calls the same name without shadowing it.
+
+    If this ever fails the oracle is accusing correct code, which is worse than missing the
+    defect: the front-ends would then be 'fixed' into dropping real edges.
+    """
+    for language in _SHADOW_CASES:
+        case = tmp_path / language
+        case.mkdir()
+        entry = _one_language(case, language)
+        callers = {i.src for i in entry.invented}
+        assert len(callers) == 1, language
+        assert next(iter(callers)).lower().endswith("outer"), language
+
+
+def test_c_is_the_control_and_stays_clean(tmp_path: Path) -> None:
+    """`c_extractor._bound_names` already refuses these. Walked, not assumed."""
+    pytest.importorskip("tree_sitter_c", reason="install the 'c' extra")
+    (tmp_path / "a.c").write_text(
+        "void send(const char *x) {}\n"
+        'void outer(void (*send)(const char *)) { send("hi"); }\n'
+        'void honest(void) { send("real"); }\n',
+        encoding="utf-8",
+    )
+    report = find_invented_calls(RepoCodeExtractor().extract(tmp_path), tmp_path)
+    entry = next(e for e in report.by_language if e.language == "c")
+    assert entry.status == MEASURED
+    assert entry.invented == ()
+
+
+# ---- what a zero is allowed to mean ----------------------------------------
+
+
+def test_a_language_with_no_walker_is_unwalked_not_clean() -> None:
+    """The failure this project keeps having: a 0 that means 'nothing ran'."""
+    batch = FactBatch()
+    batch.add_node(Node("rust:a.f", NodeKind.FUNCTION, "f", "rust", Provenance("a.rs", 1)))
+    batch.add_node(Node("rust:a.g", NodeKind.FUNCTION, "g", "rust", Provenance("a.rs", 2)))
+    batch.add_edge(Edge("rust:a.f", "rust:a.g", EdgeKind.CALLS, Provenance("a.rs", 2)))
+
+    report = find_invented_calls(batch, Path("."))
+    entry = next(e for e in report.by_language if e.language == "rust")
+    assert entry.status == UNWALKED
+    assert entry.total_calls == 1
+    assert entry.unexamined == 1
+    assert report.unmeasured_languages == ("rust",)
+
+
+def test_java_and_sql_are_excluded_with_a_stated_reason() -> None:
+    batch = FactBatch()
+    batch.add_node(Node("java:a.A.f", NodeKind.FUNCTION, "f", "java", Provenance("A.java", 1)))
+    batch.add_node(Node("java:a.A.g", NodeKind.FUNCTION, "g", "java", Provenance("A.java", 2)))
+    batch.add_edge(Edge("java:a.A.f", "java:a.A.g", EdgeKind.CALLS, Provenance("A.java", 2)))
+
+    entry = next(e for e in find_invented_calls(batch, Path(".")).by_language if e.language == "java")
+    assert entry.status == NOT_APPLICABLE
+    assert "namespace" in entry.reason
+    assert entry.total_calls == 1
+    # Not counted as unmeasured: the language cannot express the defect, which is an answer.
+    assert "java" not in find_invented_calls(batch, Path(".")).unmeasured_languages
+
+
+def test_the_denominator_is_bare_calls_not_every_call(tmp_path: Path) -> None:
+    """`0 of 1677 CALLS` reads as a far wider sweep than `0 of 946 bare calls`.
+
+    Only a bare-identifier call can be reached by a shadow; a member call was never at risk,
+    and folding it into the denominator claims coverage the oracle does not have (§7).
+    """
+    pytest.importorskip("tree_sitter_typescript", reason="install the 'typescript' extra")
+    (tmp_path / "a.ts").write_text(
+        "export function target(): void {}\n"
+        "export class A {\n"
+        "  helper(): void {}\n"
+        "  run(): void { this.helper(); target(); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    report = find_invented_calls(RepoCodeExtractor().extract(tmp_path), tmp_path)
+    entry = next(e for e in report.by_language if e.language == "typescript")
+    assert entry.total_calls == 2  # this.helper() and target()
+    assert entry.shadowable == 1  # only target() is a bare identifier
+    assert entry.invented == ()

--- a/tests/pkg/test_invention.py
+++ b/tests/pkg/test_invention.py
@@ -260,44 +260,36 @@ def _one_language(tmp_path: Path, language: str) -> LanguageInvention:
     return next(e for e in report.by_language if e.language == language)
 
 
-def test_typescript_shadowed_parameter_is_invention(tmp_path: Path) -> None:
-    entry = _one_language(tmp_path, "typescript")
-    assert len(entry.invented) == 1
-    assert entry.invented[0].dst == "ts:a.send"
-    assert entry.invented[0].line == 2
+@pytest.mark.parametrize("language", sorted(_SHADOW_CASES))
+def test_the_shadowed_call_is_no_longer_emitted(tmp_path: Path, language: str) -> None:
+    """Each front-end now refuses the shadowed name, so the oracle has nothing to report.
 
-
-def test_go_shadowed_parameter_is_invention(tmp_path: Path) -> None:
-    entry = _one_language(tmp_path, "go")
-    assert len(entry.invented) == 1
-    assert entry.invented[0].name == "Send"
-
-
-def test_csharp_shadowed_parameter_is_invention(tmp_path: Path) -> None:
-    entry = _one_language(tmp_path, "csharp")
-    assert len(entry.invented) == 1
-    assert entry.invented[0].dst == "csharp:A.Send"
-
-
-def test_cpp_shadowed_function_pointer_is_invention(tmp_path: Path) -> None:
-    entry = _one_language(tmp_path, "cpp")
-    assert len(entry.invented) == 1
-    assert entry.invented[0].dst == "cpp:send"
-
-
-def test_the_honest_call_in_the_same_file_is_never_flagged(tmp_path: Path) -> None:
-    """Each fixture's third function calls the same name without shadowing it.
-
-    If this ever fails the oracle is accusing correct code, which is worse than missing the
-    defect: the front-ends would then be 'fixed' into dropping real edges.
+    Written while the defect was live, when each of these reported exactly 1. Inverted with
+    the fix rather than deleted: an oracle that only ever returns 0 is indistinguishable from
+    one that is not running, and this is the pair that tells them apart — the front-end drops
+    the edge, and the detector that found it agrees.
     """
-    for language in _SHADOW_CASES:
-        case = tmp_path / language
-        case.mkdir()
-        entry = _one_language(case, language)
-        callers = {i.src for i in entry.invented}
-        assert len(callers) == 1, language
-        assert next(iter(callers)).lower().endswith("outer"), language
+    entry = _one_language(tmp_path, language)
+    assert entry.status == MEASURED
+    assert entry.invented == ()
+    assert entry.shadowable > 0, "nothing was examined — the oracle is not running"
+
+
+@pytest.mark.parametrize("language", sorted(_SHADOW_CASES))
+def test_the_unshadowed_sibling_keeps_its_edge(tmp_path: Path, language: str) -> None:
+    """The fix must skip the shadowed call only.
+
+    Each fixture's third function calls the same name without shadowing it. A front-end that
+    passed the test above by dropping every bare call would fail this one — which is how the
+    47 removed edges were shown to be exactly the 47 fabrications and nothing else.
+    """
+    name, source, extra = _SHADOW_CASES[language]
+    pytest.importorskip(extra, reason=f"install the '{language}' extra")
+    (tmp_path / name).write_text(source, encoding="utf-8")
+    batch = RepoCodeExtractor().extract(tmp_path)
+    callers = {e.src for e in batch.edges if e.kind is EdgeKind.CALLS}
+    assert len(callers) == 1, f"{language}: expected exactly the honest caller, got {callers}"
+    assert next(iter(callers)).lower().endswith("honest"), language
 
 
 def test_c_is_the_control_and_stays_clean(tmp_path: Path) -> None:

--- a/tests/pkg/test_scope.py
+++ b/tests/pkg/test_scope.py
@@ -1,0 +1,230 @@
+"""Per-language scope walking — what binds a name, and every reason *not* to say it does.
+
+The risk is asymmetric in the same way as the Python detector's, and worse here: this module
+exists to accuse the front-ends of fabricating edges, so a walker that over-binds manufactures
+findings that are themselves fiction. Two such bugs were found by hand-checking the first
+measurement run — a TypeScript destructuring default read as a binding (3 false findings on
+vue/core) and Go's short-variable-declaration scope taken to cover its own right-hand side
+(5 on grpc-go). Both have a test below, and each was verified against the language spec, not
+against what the walker happened to do.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.pkg.scope import NOT_APPLICABLE, WALKERS, scopes_for_source
+
+_SUFFIX = {"typescript": ".ts", "go": ".go", "csharp": ".cs", "cpp": ".cpp", "c": ".c"}
+_EXTRA = {
+    "typescript": "tree_sitter_typescript",
+    "go": "tree_sitter_go",
+    "csharp": "tree_sitter_c_sharp",
+    "cpp": "tree_sitter_cpp",
+    "c": "tree_sitter_c",
+}
+
+
+def _shadowed(language: str, source: str, line: int) -> frozenset[str]:
+    pytest.importorskip(_EXTRA[language], reason=f"install the '{language}' extra")
+    fs = scopes_for_source(source.encode(), language, _SUFFIX[language])
+    return fs.shadowed(line)
+
+
+def _bare(language: str, source: str, line: int) -> frozenset[str]:
+    pytest.importorskip(_EXTRA[language], reason=f"install the '{language}' extra")
+    fs = scopes_for_source(source.encode(), language, _SUFFIX[language])
+    return fs.bare_call_names(line)
+
+
+# ---- the shape the whole programme is about --------------------------------
+
+
+def test_typescript_parameter_shadows_a_module_function() -> None:
+    src = "export function send(x: string): void {}\nexport function outer(send: F): void { send('hi'); }\n"
+    assert "send" in _shadowed("typescript", src, 2)
+
+
+def test_go_parameter_shadows_a_package_function() -> None:
+    src = 'package main\n\nfunc Send(x string) {}\nfunc Outer(Send func(string)) { Send("hi") }\n'
+    assert "Send" in _shadowed("go", src, 4)
+
+
+def test_csharp_parameter_shadows_a_sibling_method() -> None:
+    src = 'class A {\n  void Send(string x) {}\n  void Outer(Action<string> Send) { Send("hi"); }\n}\n'
+    assert "Send" in _shadowed("csharp", src, 3)
+
+
+def test_cpp_function_pointer_parameter_shadows_a_free_function() -> None:
+    src = 'void send(const char *x) {}\nvoid outer(void (*send)(const char *)) { send("hi"); }\n'
+    assert "send" in _shadowed("cpp", src, 2)
+
+
+# ---- the file scope is not a shadow (AC: honest calls stay honest) ---------
+
+
+@pytest.mark.parametrize(
+    ("language", "src", "line", "name"),
+    [
+        ("typescript", "export function send(): void {}\nfunction honest() { send(); }\n", 2, "send"),
+        ("go", "package main\nfunc Send() {}\nfunc Honest() { Send() }\n", 3, "Send"),
+        ("csharp", "class A {\n  void Send() {}\n  void Honest() { Send(); }\n}\n", 3, "Send"),
+        ("cpp", "void send() {}\nvoid honest() { send(); }\n", 2, "send"),
+        ("c", "void send(void) {}\nvoid honest(void) { send(); }\n", 2, "send"),
+    ],
+)
+def test_a_file_level_definition_never_shadows_itself(language: str, src: str, line: int, name: str) -> None:
+    """The declaration the front-end resolved to. Counting it would flag every correct call."""
+    assert name not in _shadowed(language, src, line)
+
+
+# ---- binding forms, per language ------------------------------------------
+
+
+def test_typescript_binding_forms() -> None:
+    src = (
+        "function f(xs: any, {a, b}: O, ...rest: string[]) {\n"
+        "  const local = () => {};\n"
+        "  let v = 1;\n"
+        "  for (const item of rest) {}\n"
+        "  try {} catch (err) {}\n"
+        "  target();\n"
+        "}\n"
+    )
+    assert {"xs", "a", "b", "rest", "local", "v", "item", "err"} <= _shadowed("typescript", src, 6)
+
+
+def test_go_binding_forms() -> None:
+    src = (
+        "package main\n"
+        "func f(p func(), a, b int) {\n"
+        "\tlocal := func() {}\n"
+        "\tvar v, w = 1, 2\n"
+        "\tconst k = 3\n"
+        "\tfor _, item := range xs {\n"
+        "\t}\n"
+        "\ttarget()\n"
+        "}\n"
+    )
+    assert {"p", "a", "b", "local", "v", "w", "k", "item"} <= _shadowed("go", src, 8)
+
+
+def test_csharp_binding_forms() -> None:
+    src = (
+        "class A {\n"
+        "  void f(Action p, int n) {\n"
+        "    Action local = () => {};\n"
+        "    var v = 1;\n"
+        "    foreach (var item in xs) {}\n"
+        "    try {} catch (Exception err) {}\n"
+        "    target();\n"
+        "  }\n"
+        "}\n"
+    )
+    assert {"p", "n", "local", "v", "item", "err"} <= _shadowed("csharp", src, 7)
+
+
+def test_cpp_binding_forms() -> None:
+    src = (
+        "void f(void (*p)(), int n) {\n"
+        "  auto lam = [](int q){ return q; };\n"
+        "  int a = 1, b = 2;\n"
+        "  for (auto &item : xs) {}\n"
+        "  target();\n"
+        "}\n"
+    )
+    assert {"p", "n", "lam", "a", "b", "item"} <= _shadowed("cpp", src, 5)
+
+
+def test_c_binding_forms() -> None:
+    src = "void f(void (*p)(void), int n) {\n  void (*local)(void) = 0;\n  target();\n}\n"
+    assert {"p", "n", "local"} <= _shadowed("c", src, 3)
+
+
+# ---- reasons NOT to flag ---------------------------------------------------
+
+
+def test_typescript_destructuring_default_is_not_a_binding() -> None:
+    """`{ arg: slotName = makeDefault() }` binds `slotName`. It does not bind `makeDefault`.
+
+    Reading the default expression as a pattern made every later call to that import look
+    shadowed — 3 of the 4 findings on vue/core, all fiction.
+    """
+    src = (
+        "function f(xs: any) {\n  const { arg: slotName = makeDefault('x') } = xs;\n  makeDefault('y');\n}\n"
+    )
+    shadowed = _shadowed("typescript", src, 3)
+    assert "slotName" in shadowed
+    assert "makeDefault" not in shadowed
+
+
+def test_typescript_array_destructuring_default_is_not_a_binding() -> None:
+    src = "function f(xs: any) {\n  const [a, b = fallback()] = xs;\n  fallback();\n}\n"
+    shadowed = _shadowed("typescript", src, 3)
+    assert {"a", "b"} <= shadowed
+    assert "fallback" not in shadowed
+
+
+def test_typescript_a_function_types_own_parameters_bind_nothing() -> None:
+    """`cb: (nested: string) => void` declares `nested` inside a *type*. Nothing binds it."""
+    src = "function f(cb: (nested: string) => void) {\n  nested('boom');\n}\n"
+    assert "nested" not in _shadowed("typescript", src, 2)
+
+
+def test_go_short_declaration_is_not_in_scope_on_its_own_line() -> None:
+    """Go §Declarations: the scope of a `:=` identifier begins at the end of the statement.
+
+    `cmd := cmd(path, logger, args)` therefore calls the package-level `cmd` — idiomatic, and
+    reported as invention until the rule was applied (5 false findings on grpc-go).
+    """
+    src = "package main\nfunc f() {\n\tcmd := cmd(path)\n\t_ = cmd\n}\n"
+    assert "cmd" not in _shadowed("go", src, 3)
+
+
+def test_go_short_declaration_shadows_every_line_below_it() -> None:
+    src = "package main\nfunc f() {\n\tcmd := cmd(path)\n\tcmd()\n}\n"
+    assert "cmd" in _shadowed("go", src, 4)
+
+
+def test_cpp_declaration_is_not_in_scope_on_its_own_line() -> None:
+    src = "void f() {\n  auto helper = helper();\n  helper();\n}\n"
+    assert "helper" not in _shadowed("cpp", src, 2)
+    assert "helper" in _shadowed("cpp", src, 3)
+
+
+def test_cpp_function_pointer_parameters_own_names_bind_nothing() -> None:
+    """In `void (*send)(const char *x)`, `x` names a parameter of the pointed-to function."""
+    src = "void f(void (*send)(const char *x)) {\n  x();\n}\n"
+    shadowed = _shadowed("cpp", src, 2)
+    assert "send" in shadowed
+    assert "x" not in shadowed
+
+
+# ---- bare calls: the only shape a shadow can reach -------------------------
+
+
+def test_a_member_call_is_not_a_bare_call() -> None:
+    src = "class A {\n  m() { this.send(); other.send(); send(); }\n}\n"
+    assert _bare("typescript", src, 2) == frozenset({"send"})
+
+
+def test_bare_calls_are_recorded_with_their_line() -> None:
+    src = "package main\nfunc f() {\n\talpha()\n\tbeta()\n}\n"
+    assert _bare("go", src, 3) == frozenset({"alpha"})
+    assert _bare("go", src, 4) == frozenset({"beta"})
+
+
+# ---- the roster itself -----------------------------------------------------
+
+
+def test_java_and_sql_are_excluded_with_a_reason_not_a_walker() -> None:
+    """Silence is the failure mode this project keeps having — so absence carries a why."""
+    for language in ("java", "sql"):
+        assert language not in WALKERS
+        assert NOT_APPLICABLE[language]
+
+
+def test_every_walker_declares_both_halves_of_the_contract() -> None:
+    for language, walker in WALKERS.items():
+        assert walker.scope_nodes, language
+        assert walker.call_nodes, language

--- a/tests/pkg/test_scoreboard.py
+++ b/tests/pkg/test_scoreboard.py
@@ -2,10 +2,12 @@
 
 The design decision under test is *which* metrics may be gated. Every number here is
 deterministic run-to-run; what differs is what each is measured **against**. Corpus scores
-come from committed fixtures and cannot move when someone writes code. Invention is measured
-against the repository itself and moves on ordinary commits — adding `def handler(cb):
-return cb()` took it from 496 to 497. Gating that fails blameless PRs, which is how a gate
-gets switched off.
+come from committed fixtures and cannot move when someone writes code. Parity is measured
+against the repository and ratchets. Invention is the odd one: its *rate* moves on ordinary
+commits — adding `def handler(cb): return cb()` took it from 496 to 497 — but its *count* has
+a correct value, zero, so it is gated absolutely rather than against a baseline. Gating the
+rate would fail blameless PRs, which is how a gate gets switched off; gating the count cannot,
+because there is no repository where a fabricated edge is acceptable.
 """
 
 from __future__ import annotations
@@ -26,8 +28,11 @@ REPO = Path(__file__).resolve().parents[2]
 
 
 def _board(
-    *, matched: int = 8, emitted: int = 10, expected: int = 10, shortfall: int = 5, invented: int = 496
+    *, matched: int = 8, emitted: int = 10, expected: int = 10, shortfall: int = 5, invented: int = 0
 ) -> dict[str, Any]:
+    """A healthy board. `invented` defaults to 0 because a fabricated edge now fails the gate,
+    so a fixture carrying one would make every unrelated test in this file fail for the wrong
+    reason."""
     return {
         "version": 1,
         "metrics": {
@@ -40,7 +45,12 @@ def _board(
                 },
             },
             "parity": {"gated": "ratchet", "shortfall": shortfall, "surplus": 7},
-            "invention": {"gated": False, "count": invented, "total_calls": 15000},
+            "invention": {
+                "gated": "strict",
+                "count": invented,
+                "total_calls": 15000,
+                "languages": {"python": {"status": "measured", "invented": invented, "total_calls": 15000}},
+            },
         },
     }
 
@@ -82,14 +92,30 @@ def test_parity_shortfall_ratchets_one_way() -> None:
     assert any("parity" in i for i in scoreboard_improvements(_board(shortfall=5), _board(shortfall=4)))
 
 
-def test_invention_never_fails_the_build() -> None:
-    """The decision this phase turns on: measured against a moving population, so ungated.
+def test_invention_is_gated_at_zero_per_language() -> None:
+    """The decision this phase turns on, and the one it reversed.
 
-    One ordinary new file with a callback parameter moved it 496 -> 497. Gating it fails a
-    PR that adds a perfectly normal function.
+    Ungated until 2026-08-24 on the grounds that the population moves. That was right about
+    the *rate* and wrong about the *count*: a `CALLS` edge to a name the caller bound itself
+    is a defect at any commit, so there is nothing for a ratchet to ratchet.
     """
-    assert compare_scoreboard(_board(invented=496), _board(invented=5000)) == []
-    assert GATES["invention"] is False
+    assert GATES["invention"] == "strict"
+    assert compare_scoreboard(_board(invented=0), _board(invented=0)) == []
+    assert [r.metric for r in compare_scoreboard(_board(invented=0), _board(invented=1))] == ["invention"]
+
+
+def test_the_invention_gate_ignores_the_baseline_entirely() -> None:
+    """Comparing to a stored number is how a defect count becomes a metric people live with."""
+    assert compare_scoreboard(_board(invented=496), _board(invented=496)) != []
+
+
+def test_the_invention_rate_may_still_move_freely() -> None:
+    """The original objection, preserved: only the count is gated, never the rate."""
+    quiet = _board(invented=0)
+    busy = _board(invented=0)
+    busy["metrics"]["invention"]["total_calls"] = 90000
+    busy["metrics"]["invention"]["languages"]["python"]["total_calls"] = 90000
+    assert compare_scoreboard(quiet, busy) == []
 
 
 def test_every_metric_records_whether_it_is_gated() -> None:

--- a/tests/pkg/test_typescript_extractor.py
+++ b/tests/pkg/test_typescript_extractor.py
@@ -244,3 +244,67 @@ def test_relative_import_joins_to_the_first_party_module(tmp_path: Path) -> None
     mods = {n.id for n in batch.nodes if n.kind is NodeKind.MODULE}
     assert "ts:app/model/thing" in mods, mods
     assert "ts:./model/thing" not in mods, "raw specifier survived as a module id"
+
+
+# ---- shadowed calls: a name the caller bound itself ------------------------
+#
+# `local_funcs` and `imports` hold the FILE-level binding of a name. When a parameter, local
+# or closure argument shadows one, resolving through those tables asserts a call to a
+# definition the source never reaches — and the target is a real node, so nothing dangled and
+# `pkg verify` stayed silent. Measured across 11 public repositories before the fix; the
+# guard is `corpus/typescript/shadowed_calls`.
+
+
+def _calls(tmp_path: Path, src: str) -> set[tuple[str, str]]:
+    batch, _ = _facts(tmp_path, src, "dispatch.ts")
+    return {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.CALLS}
+
+
+def test_a_parameter_shadowing_a_module_function_emits_no_call(tmp_path: Path) -> None:
+    src = (
+        "export function handle(): number { return 1; }\n"
+        "export function run(handle: () => number): number { return handle(); }\n"
+        "export function direct(): number { return handle(); }\n"
+    )
+    calls = _calls(tmp_path, src)
+    assert ("ts:dispatch.run", "ts:dispatch.handle") not in calls
+    assert ("ts:dispatch.direct", "ts:dispatch.handle") in calls  # the control
+
+
+def test_a_closure_parameter_shadows_an_import(tmp_path: Path) -> None:
+    """`hook.forEach(h => h(...args))` — the one fabricated edge found in vue/core."""
+    src = (
+        'import { h } from "@vue/runtime-core";\n'
+        "export function callHook(hook: Function[]): void {\n"
+        "  hook.forEach(h => h());\n"
+        "}\n"
+        "export function render(): void { h(); }\n"
+    )
+    calls = _calls(tmp_path, src)
+    assert ("ts:dispatch.callHook", "ts:@vue/runtime-core:h") not in calls
+    assert ("ts:dispatch.render", "ts:@vue/runtime-core:h") in calls
+
+
+def test_a_destructuring_default_is_not_a_binding(tmp_path: Path) -> None:
+    """`{ arg: slot = makeDefault() }` binds `slot`, not `makeDefault`.
+
+    Reading the default expression as a pattern would silently drop every later call to that
+    name — the same class of error as the invention, pointing the other way.
+    """
+    src = (
+        "export function makeDefault(): number { return 0; }\n"
+        "export function build(node: any): number {\n"
+        "  const { arg: slot = makeDefault() } = node;\n"
+        "  return slot + makeDefault();\n"
+        "}\n"
+    )
+    assert ("ts:dispatch.build", "ts:dispatch.makeDefault") in _calls(tmp_path, src)
+
+
+def test_a_function_types_own_parameter_names_bind_nothing(tmp_path: Path) -> None:
+    """`cb: (nested: string) => void` declares `nested` inside a type. Nothing binds it."""
+    src = (
+        "export function nested(): void {}\n"
+        "export function outer(cb: (nested: string) => void): void { nested(); }\n"
+    )
+    assert ("ts:dispatch.outer", "ts:dispatch.nested") in _calls(tmp_path, src)


### PR DESCRIPTION
## The defect

TypeScript, Go, C++ and C# each emitted a `CALLS` edge to the wrong function when a parameter or local **shadowed** a resolvable name:

```ts
export function send(x: string): void {}
export function outer(send: (v: string) => void): void { send("hi"); }
// graph asserts: ts:a.outer -CALLS-> ts:a.send
```

`outer` calls its own parameter. This is the bug Python fixed in 3.18.0, in a form the fix did not reach — these front-ends do not invent an *id*, they resolve against their file-level table and land on a **real node**. C already refuses it (`c_extractor._bound_names`) and has a corpus case; the other four had neither.

**Nothing caught it.** `pkg verify` saw no dangling edge (the target exists). Corpus precision read 1.00 (no fixture carried the shape). `pkg accuracy --oracle invention` reported 0 (it re-parsed with the stdlib `ast` and looked at Python only). Three green checks over a case none of them examined.

## What this PR does

**1 — Widen the oracle.** New `pkg/scope.py` walks TypeScript, Go, C#, C++ and C, each with the same tree-sitter parser its front-end uses. The detector is restated language-neutrally: an edge is invented when the call site is a **bare identifier** matching the target and that name is **bound inside the calling function**. Both halves are load-bearing — without the bare-call test, `this.send()` beside a local `send` is flagged; without *inside the function*, every correct call to a file-level definition is.

Java and SQL carry `status: not-applicable` with the reason (JLS §6.5.7; no lexical scope). A language with no walker carries `unwalked`. A `0` only means clean where status is `measured`.

**2 — Corpus cases, written first.** `corpus/{typescript,go,cpp,csharp}/shadowed_calls`, modelled on `corpus/c/function_pointers`. Each was scored **before** the fix and failed at the predicted point: `CALLS` precision **0.50**, recall 1.00. Each pairs the shadowed call with an unshadowed sibling in the same file, so a front-end cannot pass by dropping both.

**3 — The fix.** A local `_bound_names` per front-end, answering *did this function bind the name*, never *can we resolve it*. An unresolved callee in C++ is usually a header declaration linked from another translation unit; a Python-style "skip anything unresolved" fix would silence every cross-translation-unit call. The oracle keeps its own independent implementation — a detector that imports the code it audits agrees with that code's bugs.

Each helper carries the first line a name is in scope, because two languages require it: Go's spec starts a `:=` scope at the *end* of the statement, so `cmd := cmd(path)` calls the package-level `cmd`. C# tracks the bare-call form separately — `this.Handle()` cannot be shadowed.

**4 — The gate.** `invention` moves from ungated to **`strict`, zero per language** — gated on an absolute value rather than against the baseline, because it is the only metric here with a *correct* value. Comparing to a stored number would let a non-zero baseline become the thing everyone agrees to live with. Proved by making it fail. The original objection is preserved: the *rate* still moves freely with ordinary commits, only the count is held at zero.

## Results — 11 pinned public repositories

| Front-end | Repos | Bare calls | Invented (before) |
|---|---|---|---|
| cpp | leveldb, fmt | 9,808 | **46** (0.47%) |
| typescript | zod, nest, vue/core | 5,376 | **1** (0.02%) |
| go | gin, cobra, grpc-go | 6,435 | 0 |
| csharp | Dapper, Newtonsoft.Json | 2,127 | 0 |
| c *(control)* | libuv + leveldb/fmt C | 14,856 | 0 |

Every finding was read against its source. After the fix, **0 across all 11**:

| | Before | After | Removed |
|---|---|---|---|
| vue/core | 3,501 | 3,500 | 1 |
| leveldb | 4,867 | 4,864 | 3 |
| fmt | 8,934 | 8,891 | 43 |
| other 8 repos | | | **0** |
| **total** | | | **47** |

**47 edges removed, 47 fabrications found.** No true edge lost across 38,602 bare calls; grpc-go kept all 6,285 of its `CALLS`. Precision rises, recall untouched — these were never in any expected set.

## Two false positives in the oracle, found by hand before publishing

The first run reported 4 for TypeScript and 5 for Go. Both were bugs in the **oracle**: a destructuring *default* read as a binding (`{ arg: slot = makeDefault() }`), and Go's `:=` treated as in scope on its own line. Regression tests for both, written against the language references.

## Honest limits

- Go and C# scored zero **before** the fix. Their fix is unproven at zero, not proven clean — the fixture holds them, not the measurement.
- The oracle only detects **shadowing**. `CONSUMES`/`EXPOSES` invention has no detector; a new class needs a fixture as well.
- `runtime` remains **Python-only** — the last of the four oracles with that limit.

## Gate

`mypy src tests` clean · `ruff` clean · **3,012 passing / 3 skipped** · `pkg accuracy --check` OK

Record with SHAs and the reproducing command: `docs/specs/invention-oracle-cross-language.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)