### PR TITLE
Bring the Claude Code and Codex plugins current with 3.23.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,19 @@
     {
       "name": "spine",
       "source": "./plugins/spine",
-      "description": "Understand any codebase, then ship changes to it. Read-only comprehension tools hand you engineering decisions (what breaks if you change X, what's untested, where a ticket/bug lands) from a deterministic Product Knowledge Graph; then delegate a ticket and, on confirm, get a reviewed, tested PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, C++, and Go, exposed as MCP tools + an understand-codebase skill.",
-      "version": "2.5.0",
+      "description": "Understand any codebase, then ship changes to it. Read-only comprehension tools hand you engineering decisions (what breaks if you change X, what's untested, where a ticket lands) from a deterministic Product Knowledge Graph — across one repository or several. Then delegate a ticket and, on confirm, get a reviewed, tested PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, C++, Go, and SQL, exposed as MCP tools + an understand-codebase skill.",
+      "version": "3.23.0",
       "category": "Engineering",
-      "keywords": ["sdlc", "codegen", "mcp", "knowledge-graph", "greenfield", "brownfield", "pkg"]
+      "keywords": [
+        "sdlc",
+        "codegen",
+        "mcp",
+        "knowledge-graph",
+        "greenfield",
+        "brownfield",
+        "pkg",
+        "multi-repo"
+      ]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## Unreleased — The plugins catch up with the product
+
+### Added — multi-repo reaches the plugin surface
+
+- **`blast_radius` and `investigate` take `repos`.** Point either at a `.spine/repos.yaml`
+  instead of a `repo_path` and the answer crosses a repository boundary: a handler reporting
+  `0 caller(s)` at home now names the service that depends on it. 3.23.0 shipped this on the
+  CLI only, so the headline capability of that release was invisible to Claude Code and Codex.
+- **`pkg_joins`** — `mode="propose"` derives a `joins:` block from the evidence (each candidate
+  carrying the edges it would create); `mode="check"` reports the calls no declared join could
+  place. Read-only; it never writes a config, same as the CLI.
+- **Every multi-repo answer carries a `standing` block** — the repos it covers and whether it is
+  `reproducible`. The CLI prints that on stderr; a tool has to *return* it, or a caller quotes a
+  number nothing can reproduce and nothing in the payload says so.
+
+### Added — `[all]`, because the documented install under-delivered
+
+- **`pip install 'synaptixs-spine[all]'`** — every language front-end, the MCP server, doc and
+  office ingestion. Both plugin READMEs and both guides said `[mcp]`, which installs the server
+  and a **Python-only** graph: a Java or Go repo yields zero nodes rather than an error, so the
+  documented install failed by looking like an empty repository. `[languages]` is the front-ends
+  alone.
+
+### Fixed — the manifests had stood at 2.5.0 through fifteen releases
+
+- **Version, tool list and language list are current** across `marketplace.json`, the Claude
+  Code `plugin.json` and the Codex `plugin.json`. They advertised 7 tools and 7 languages
+  against a registry of 20 and a front-end set of 8, and omitted `sdlc_plan` / `sdlc_approve`
+  entirely — both shipped in August and neither appeared in a manifest.
+- **`understand-codebase`** gained the cross-repo tools, the `standing` block, the plan/approve
+  tier, and SQL.
+- **Three tests so this cannot recur quietly.** Manifest versions are asserted against
+  `pyproject.toml`; every name in `_TOOLS` must appear in a user-facing guide; the pitch must
+  name all eight languages. The old test grepped the manifests for the word "Go" — written for
+  3.7.0, and green for every release after it.
+
+### Changed — one helper, not two
+
+- `unresolved_by_repo` moved to `pkg/joins_propose.py`; `cli.py` and the plugin server now share
+  it instead of carrying identical copies.
+
 ## 3.23.0 — One graph across several repositories
 
 ### Added — multi-repo comprehension

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ casually; they're contracts. Get the dir from `understand.BANK_DIRNAME` /
 
 | Package | What it owns |
 |---|---|
-| `pkg/` | The **PKG** (Program Knowledge Graph) — the source of truth. `facts.py` = the universal vocabulary (`NodeKind`/`EdgeKind`/`Node`/`Edge`/`FactBatch` — includes the `Doc` node + `MENTIONS` edge from doc ingestion); `extractor.py` dispatches per-suffix to language front-ends; `store.py` = query layer (incl. `docs_for`/`mentions_of`); `docs.py` = the deterministic doc→symbol binder, `doc_source.py` reads docs (md/rst/txt/PDF, section-split), `doc_link.py` = the `link_docs` post-pass (Doc nodes + MENTIONS) + drift; `overview.py` = bounded view for UIs; `persistence.py` = commit-keyed cache; `export.py`/`rdf.py` = projections |
+| `pkg/` | The **PKG** (Product Knowledge Graph) — the source of truth. `facts.py` = the universal vocabulary (`NodeKind`/`EdgeKind`/`Node`/`Edge`/`FactBatch` — includes the `Doc` node + `MENTIONS` edge from doc ingestion); `extractor.py` dispatches per-suffix to language front-ends; `store.py` = query layer (incl. `docs_for`/`mentions_of`); `docs.py` = the deterministic doc→symbol binder, `doc_source.py` reads docs (md/rst/txt/PDF, section-split), `doc_link.py` = the `link_docs` post-pass (Doc nodes + MENTIONS) + drift; `overview.py` = bounded view for UIs; `persistence.py` = commit-keyed cache; `export.py`/`rdf.py` = projections |
 | `knowledge/` | Synthesis **on top of** the PKG — `understand.py` (→ `episteme/*.md`), `current_state.py` (`state`, two lenses, incl. the Documentation section; runs `link_docs` as a post-pass), `renderers.py` |
 | `registry/` | FastAPI service + the operator web UI (`registry/api/web/`) |
 | `sdlc/` | The feature/run pipeline (largest package) |

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -78,8 +78,14 @@ Then make the `orchestrator-mcp` server available on PATH (the plugin declares i
 provides it):
 
 ```bash
-pip install 'synaptixs-spine[mcp]'          # provides the `orchestrator-mcp` command
+pip install 'synaptixs-spine[all]'          # provides the `orchestrator-mcp` command
 ```
+
+> **`[all]`, not `[mcp]`.** `[mcp]` installs the server alone, so the graph is **Python-only** —
+> and silently so: a Java or Go repo yields zero nodes rather than an error, which reads as
+> "nothing here" instead of "nothing parsed". `[all]` adds every language front-end, doc
+> ingestion and the MCP server; `[languages]` is the front-ends on their own.
+
 
 Restart Claude Code (or run `/reload-plugins`). Confirm with `/plugin` (Spine shows as
 installed + enabled) and `/mcp` (the `spine` server shows as connected).
@@ -186,6 +192,7 @@ At a glance:
 | `regression_gaps` | The production symbols a change (by symbol or trace) reaches that **no test covers** — what could break silently. | no |
 | `root_cause` | A grounded root‑cause report for a bug: fault site, ranked hypotheses + evidence, regression surface, fix approach. Deterministic by default; `use_llm=true` enriches (needs a model). | no |
 | `docs_for` | **Which docs describe the code.** With a `symbol`, the doc pages that mention it; without one, a doc‑coverage summary (% of symbols documented + top drift). Ingests `.md`/`.rst`/`.txt`/**HTML**, plus **PDF** (`[docs]`) and **Word/Excel** (`[office]`). | no |
+| `pkg_joins` | **The cross‑repo topology, proposed or checked.** `mode="propose"` derives a `joins:` block from the evidence (each candidate carrying the number of edges it would create); `mode="check"` reports the calls no declared join could place. Read‑only — it never writes a config. | no |
 | [`read_memory_bank`](#read_memory_bank) | Read a repo's committed `episteme/` (code‑true project knowledge). | no |
 | [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
 | [`ingest_preview`](#ingest_preview) | Preview the backlog (derived intents + gaps) for a requirements source — dry‑run. | no |
@@ -203,6 +210,47 @@ At a glance:
 > allow‑list); each returns structured fields **plus** a `markdown` rendering, bounded (top‑N +
 > `file:line`). To serve them to a **remote** host over HTTP, run the streamable‑HTTP server
 > (`orchestrator-mcp --http`, bearer/OAuth auth from env) — it registers the same tools.
+
+### Asking across several repositories
+
+The comprehension tools take **one** repository by default, and for a service that is called
+over HTTP that is a trap rather than a limitation. `blast_radius` on a route handler reports
+**`0 caller(s)`** — which is *true*, nothing in its own source calls it — and reads as safe to
+change.
+
+Declare your services in a **`.spine/repos.yaml`** and pass it as `repos=` to `blast_radius`
+or `investigate` instead of `repo_path`:
+
+```yaml
+repos:
+  billing: ../billing
+  web: ../web
+joins:
+  - kind: http
+    consumer: web
+    provider: billing
+```
+
+The same question then crosses the boundary:
+
+```
+- **billing** · `create_order` (Function, 0 caller(s), **1 dependent(s) in other repos**) — billing:app/routes.py:7
+```
+
+Three things worth knowing:
+
+- **The topology is declared, not guessed.** A `joins:` entry *narrows* the search; it does not
+  create the edge — matching `POST /v1/orders/42` against `POST /v1/orders/{id}` is still
+  resolution, done segment by segment, and refused outright when two endpoints match.
+- **A forgotten join is quiet.** A repository nobody listed is loud (no nodes, a visibly
+  narrower graph); a missing `joins:` entry looks exactly like two services that are not
+  coupled — which reads as health. Run `pkg_joins` with `mode="check"` before trusting a clean
+  result, and `mode="propose"` to see what the evidence supports. Neither writes anything.
+- **Every multi‑repo answer carries a `standing` block** — the repos it covers, and whether the
+  result is `reproducible`. A merged graph built over a repo with uncommitted work looks
+  identical to one built over clean trees, so the answer says which it was.
+
+`map_repo` stays single‑repo: there is no merged profile behind it. Call it per repository.
 
 ### Using the `understand-codebase` skill
 
@@ -609,8 +657,9 @@ Comprehension covers **eight front-ends**. Spine only needs a language's toolcha
 | Go | the **`go`** toolchain (`go build` / `go test`); multi-module aware |
 | SQL | nothing extra — schema, queries, stored procedures, ordered-migration folding |
 
-Comprehension front-ends beyond Python install as extras, e.g.
-`pip install 'synaptixs-spine[go]'`.
+Comprehension front-ends beyond Python install as extras — one at a time
+(`pip install 'synaptixs-spine[go]'`) or all at once with `[languages]`, which `[all]`
+already includes.
 
 `language=auto` detects from the repo. For C#, Spine additionally lifts ASP.NET Core
 endpoints and EF Core entities into the graph; for C/C++ it builds the `#include` graph and
@@ -634,7 +683,7 @@ name. Run `orchestrator pkg accuracy` to see the current numbers yourself.
 |---|---|
 | Claude doesn't see Spine's tools | Restart Claude Code or run `/reload-plugins`. Check `/mcp` and `/plugin`. |
 | `doctor` says the LLM provider is missing | Your `.env` isn't being found — launch Claude Code from a project with a `.env`, or use the raw‑MCP form (§3b) and set `ORCHESTRATOR_DOTENV` to its **absolute** path. |
-| `orchestrator-mcp: command not found` | The server isn't on PATH. `pip install 'synaptixs-spine[mcp]'`, or point `command` at the absolute path of the console script. |
+| `orchestrator-mcp: command not found` | The server isn't on PATH. `pip install 'synaptixs-spine[all]'`, or point `command` at the absolute path of the console script. |
 | Codegen times out | Set a faster model: `ORCHESTRATOR_INTAKE_MODEL=...` (or `SDLC_CODEGEN_MODEL`). |
 | "live needs a repo to push to" | Pass `repo=...` or set `SDLC_REPO_URL`; ensure `GITHUB_TOKEN`/`GH_TOKEN` is set. |
 | A `live` call refuses to write | That's the gate — pass `confirm=true` together with `live=true`. |
@@ -650,7 +699,7 @@ from the folder with your `.env`.
 
 ```
 # update the engine (new languages, fixes)
-pip install -U 'synaptixs-spine[mcp]'
+pip install -U 'synaptixs-spine[all]'
 /plugin marketplace update spine            # refresh the marketplace snapshot
 
 # remove

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -72,11 +72,17 @@ Both expose the exact same tools.
 ### 3a. As a Codex plugin (recommended)
 
 ```bash
-pip install 'synaptixs-spine[mcp]'                 # provides the `orchestrator-mcp` command
+pip install 'synaptixs-spine[all]'                 # provides the `orchestrator-mcp` command
 codex plugin marketplace add synaptixs/spine       # add the Spine marketplace
 codex plugin add spine@spine                        # install the plugin
 codex plugin list | grep spine                      # → spine@spine  installed, enabled
 ```
+
+> **`[all]`, not `[mcp]`.** `[mcp]` installs the server alone, so the graph is **Python-only** —
+> and silently so: a Java or Go repo yields zero nodes rather than an error, which reads as
+> "nothing here" instead of "nothing parsed". `[all]` adds every language front-end, doc
+> ingestion and the MCP server; `[languages]` is the front-ends on their own.
+
 
 Restart the Codex app. **Spine** now appears in your plugin list.
 
@@ -171,6 +177,7 @@ At a glance:
 | `regression_gaps` | The production symbols a change (by symbol or trace) reaches that **no test covers** — what could break silently. | no |
 | `root_cause` | A grounded root‑cause report for a bug: fault site, ranked hypotheses + evidence, regression surface, fix approach. Deterministic by default; `use_llm=true` enriches (needs a model). | no |
 | `docs_for` | **Which docs describe the code.** With a `symbol`, the doc pages that mention it; without one, a doc‑coverage summary (% of symbols documented + top drift). Ingests `.md`/`.rst`/`.txt`/**HTML**, plus **PDF** (`[docs]`) and **Word/Excel** (`[office]`). | no |
+| `pkg_joins` | **The cross‑repo topology, proposed or checked.** `mode="propose"` derives a `joins:` block from the evidence (each candidate carrying the number of edges it would create); `mode="check"` reports the calls no declared join could place. Read‑only — it never writes a config. | no |
 | [`read_memory_bank`](#read_memory_bank) | Read a repo's committed `episteme/` (code‑true project knowledge). | no |
 | [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
 | [`ingest_preview`](#ingest_preview) | Preview the backlog (derived intents + gaps) for a requirements source — dry‑run. | no |
@@ -189,6 +196,47 @@ At a glance:
 > tell me what a change would touch."* To serve these to a **remote** Codex/host over HTTP, run the
 > streamable‑HTTP server (`orchestrator-mcp --http`, bearer/OAuth auth from env — see §3b); it
 > registers the exact same tools.
+
+### Asking across several repositories
+
+The comprehension tools take **one** repository by default, and for a service that is called
+over HTTP that is a trap rather than a limitation. `blast_radius` on a route handler reports
+**`0 caller(s)`** — which is *true*, nothing in its own source calls it — and reads as safe to
+change.
+
+Declare your services in a **`.spine/repos.yaml`** and pass it as `repos=` to `blast_radius`
+or `investigate` instead of `repo_path`:
+
+```yaml
+repos:
+  billing: ../billing
+  web: ../web
+joins:
+  - kind: http
+    consumer: web
+    provider: billing
+```
+
+The same question then crosses the boundary:
+
+```
+- **billing** · `create_order` (Function, 0 caller(s), **1 dependent(s) in other repos**) — billing:app/routes.py:7
+```
+
+Three things worth knowing:
+
+- **The topology is declared, not guessed.** A `joins:` entry *narrows* the search; it does not
+  create the edge — matching `POST /v1/orders/42` against `POST /v1/orders/{id}` is still
+  resolution, done segment by segment, and refused outright when two endpoints match.
+- **A forgotten join is quiet.** A repository nobody listed is loud (no nodes, a visibly
+  narrower graph); a missing `joins:` entry looks exactly like two services that are not
+  coupled — which reads as health. Run `pkg_joins` with `mode="check"` before trusting a clean
+  result, and `mode="propose"` to see what the evidence supports. Neither writes anything.
+- **Every multi‑repo answer carries a `standing` block** — the repos it covers, and whether the
+  result is `reproducible`. A merged graph built over a repo with uncommitted work looks
+  identical to one built over clean trees, so the answer says which it was.
+
+`map_repo` stays single‑repo: there is no merged profile behind it. Call it per repository.
 
 Each tool below shows the **Codex prompt** (what you type), the **tool call** it maps to
 (the literal arguments — handy if you call it programmatically or want to be precise), and
@@ -573,8 +621,9 @@ Comprehension covers **eight front-ends**. Spine only needs a language's toolcha
 | Go | the **`go` toolchain** (`go build` / `go test`); multi-module aware |
 | SQL | nothing extra — schema, queries, stored procedures, ordered-migration folding |
 
-Comprehension front-ends beyond Python install as extras, e.g.
-`pip install 'synaptixs-spine[go]'`.
+Comprehension front-ends beyond Python install as extras — one at a time
+(`pip install 'synaptixs-spine[go]'`) or all at once with `[languages]`, which `[all]`
+already includes.
 
 `language=auto` detects from the repo. For C#, Spine additionally lifts ASP.NET Core
 endpoints and EF Core entities into the graph; for C/C++ it builds the `#include` graph and
@@ -592,7 +641,7 @@ satisfaction** (`IMPLEMENTS`) by matching method sets.
 |---|---|
 | Codex doesn't see Spine's tools | Restart Codex after install. Check `codex mcp list` / `codex plugin list`. |
 | `doctor` says the LLM provider is missing | Your `.env` isn't being found — set `ORCHESTRATOR_DOTENV` to its **absolute** path in the server/plugin env. |
-| `orchestrator-mcp: command not found` | The server isn't on PATH. `pip install 'synaptixs-spine[mcp]'`, or point `command` at the absolute path of the console script. |
+| `orchestrator-mcp: command not found` | The server isn't on PATH. `pip install 'synaptixs-spine[all]'`, or point `command` at the absolute path of the console script. |
 | Codegen times out | Set a faster model: `ORCHESTRATOR_INTAKE_MODEL=...` (or `SDLC_CODEGEN_MODEL`). Raise `tool_timeout_sec` for the server. |
 | "live needs a repo to push to" | Pass `repo=...` or set `SDLC_REPO_URL`; ensure `GITHUB_TOKEN`/`GH_TOKEN` is set. |
 | A `live` call refuses to write | That's the gate — pass `confirm=true` together with `live=true`. |
@@ -608,7 +657,7 @@ from the folder with your `.env`.
 
 ```bash
 # update the engine (new languages, fixes)
-pip install -U 'synaptixs-spine[mcp]'
+pip install -U 'synaptixs-spine[all]'
 codex plugin marketplace upgrade            # refresh a Git marketplace snapshot
 
 # remove

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -64,6 +64,9 @@ orchestrator --help
 Optional extras, added when you need them:
 - `pip install 'synaptixs-spine[sdlc]'` — run the generated tests (the `sdlc feature`/`run` path)
 - `pip install 'synaptixs-spine[tui]'` — the `orchestrator tui` terminal UI (Step 7)
+- `pip install 'synaptixs-spine[all]'` — everything below at once: every language front-end,
+  the MCP server and doc ingestion. This is the right install for the Claude Code / Codex
+  plugin; `[languages]` is the front-ends on their own.
 - `[java]`, `[typescript]`, `[csharp]`, `[c]`, `[cpp]`, `[go]`, `[sql]` — language parsers for
   comprehension + grounding (Python needs no extra). C# codegen also needs the **.NET SDK**
   (`dotnet`) on PATH; C / C++ codegen needs a C / C++ compiler plus **CMake** (greenfield) or
@@ -1154,8 +1157,11 @@ The reverse of Step 9: Spine can **become** an MCP server, so any host
 "intent → reviewed PR" pipeline as tools, with the **same human gates**.
 
 ```bash
-pip install 'synaptixs-spine[mcp]'        # or from source: uv sync --extra mcp
+pip install 'synaptixs-spine[all]'        # or from source: uv sync --extra all
 ```
+> `[mcp]` alone serves the tools but a **Python-only** graph — a Java or Go repo yields zero
+> nodes rather than an error. `[all]` is `[languages]` + `[mcp]` + doc ingestion, which is what
+> the comprehension tools are worth installing for.
 
 **10.1 — Local (the host launches it over stdio):**
 ```bash
@@ -1191,7 +1197,7 @@ deliver into a fresh **or** an existing repo from the host.
 [`codex-marketplace/`](codex-marketplace/). The MCP-server config above and the plugin
 are two layers of the same thing — the plugin *bundles* that server plus branding.
 ```bash
-pip install 'synaptixs-spine[mcp]'            # puts `orchestrator-mcp` on PATH
+pip install 'synaptixs-spine[all]'            # puts `orchestrator-mcp` on PATH
 codex plugin marketplace add synaptixs/spine  # or a local path to codex-marketplace/
 codex plugin add spine@spine
 ```

--- a/assets/spine-banner.svg
+++ b/assets/spine-banner.svg
@@ -1,4 +1,4 @@
-<svg width="100%" viewBox="0 0 1280 640" role="img" xmlns="http://www.w3.org/2000/svg"><title>Spine</title><desc>Spine — one governed, provenance-grounded platform: understand a codebase, design and debug grounded in a Program Knowledge Graph, ingest requirements from many sources, and build human-gated, reviewed PRs.</desc>
+<svg width="100%" viewBox="0 0 1280 640" role="img" xmlns="http://www.w3.org/2000/svg"><title>Spine</title><desc>Spine — one governed, provenance-grounded platform: understand a codebase, design and debug grounded in a Product Knowledge Graph, ingest requirements from many sources, and build human-gated, reviewed PRs.</desc>
 <rect x="0" y="0" width="1280" height="640" fill="#0B1020"/>
 <rect x="0" y="0" width="1280" height="6" fill="#2DD4BF"/>
 
@@ -7,7 +7,7 @@
 <text x="86" y="292" font-family="Inter, Arial, sans-serif" font-size="120" font-weight="700" fill="#F5F7FA">Spine</text>
 <text x="90" y="346" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="500" fill="#C9D2E0">Governed, provenance-grounded</text>
 <text x="90" y="382" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="500" fill="#C9D2E0">software delivery — end to end</text>
-<text x="90" y="430" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="400" fill="#9AA4B2">One platform, grounded in a Program Knowledge Graph.</text>
+<text x="90" y="430" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="400" fill="#9AA4B2">One platform, grounded in a Product Knowledge Graph.</text>
 <text x="90" y="512" font-family="ui-monospace, Menlo, monospace" font-size="22" font-weight="400" fill="#5DCAA5">pip install synaptixs-spine</text>
 <text x="90" y="548" font-family="Inter, Arial, sans-serif" font-size="21" font-weight="400" fill="#8A94A6">github.com/synaptixs/spine</text>
 

--- a/codex-marketplace/README.md
+++ b/codex-marketplace/README.md
@@ -8,17 +8,42 @@ Codex's plugin list instead of hand-editing `~/.codex/config.toml`.
 
 ```bash
 # 1. make the server available on PATH
-pip install 'synaptixs-spine[mcp]'        # provides the `orchestrator-mcp` command
+pip install 'synaptixs-spine[all]'        # provides the `orchestrator-mcp` command
 
 # 2. add this marketplace + install the plugin
 codex plugin marketplace add synaptixs/spine        # or a local path to this folder
 codex plugin add spine@spine
 ```
 
-Restart Codex; **Spine** appears in the plugin list. It exposes the orchestrator's MCP
-tools — `doctor`, `ingest_preview`, `pkg_grounding`, `read_memory_bank`, `sdlc_feature`
-(greenfield via `layout=new`, brownfield via `layout=existing`), and the gated
-`sdlc_start_run` / `…_status` / `…_decide_gate` / `…_result`.
+Restart Codex; **Spine** appears in the plugin list.
+
+> **Use `[all]`, not `[mcp]`.** `[mcp]` installs the server and nothing else, so the graph
+> is **Python-only** — and silently: a Java or Go repo yields zero nodes rather than an
+> error, which reads as "nothing here" instead of "nothing parsed". `[all]` adds every
+> language front-end, doc ingestion and the MCP server. `[languages]` is the front-ends
+> alone.
+
+## What it exposes
+
+**Comprehension — read-only, deterministic, no credentials.** `map_repo`, `blast_radius`
+("what breaks if I change X"), `explain_symbol`, `investigate` (where a ticket lands),
+`localize` (stack trace → fault site), `regression_gaps` (blast radius with no covering
+test), `root_cause`, `docs_for`, plus `read_memory_bank` (a repo's committed `episteme/`),
+`pkg_grounding` and `doctor`. Each takes a local path **or a git URL**, and returns typed
+fields **plus** a `markdown` rendering.
+
+**Across several repositories.** Declare your services in a `.spine/repos.yaml` and pass it
+as `repos=` to `blast_radius` or `investigate`: a handler with zero callers in its own
+source then names the service that depends on it. `pkg_joins` proposes or checks that
+topology — read-only, it never writes a config.
+
+**Plan and decide.** `sdlc_plan` renders a twelve-section build document from the graph, git
+and the tree (no model, no credentials); `sdlc_approve` records the decision on it. Both
+write only under `.spine/`.
+
+**Gated codegen.** `sdlc_feature` (greenfield via `layout=new`, brownfield via
+`layout=existing`) and the run-control set `sdlc_start_run` / `…_status` / `…_decide_gate` /
+`…_result`. These spend real money, and `live=true` additionally requires `confirm=true`.
 
 ## Credentials
 

--- a/codex-marketplace/plugins/spine/.codex-plugin/plugin.json
+++ b/codex-marketplace/plugins/spine/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spine",
-  "version": "2.5.0",
-  "description": "Spine — understand any codebase, then ship changes to it. Read-only comprehension tools hand you engineering decisions (what breaks if you change X, what's untested, where a ticket lands) from a deterministic Product Knowledge Graph; then delegate a ticket and (on confirm) get a reviewed, tested PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, C++, and Go.",
+  "version": "3.23.0",
+  "description": "Spine — understand any codebase, then ship changes to it. Read-only comprehension tools hand you engineering decisions (what breaks if you change X, what's untested, where a ticket lands, which docs describe it) from a deterministic Product Knowledge Graph, across one repository or several. Then plan, and on confirm get a reviewed, tested PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, C++, Go, and SQL.",
   "author": {
     "name": "Synaptixs",
     "url": "https://github.com/synaptixs/spine"
@@ -16,13 +16,14 @@
     "knowledge-graph",
     "greenfield",
     "brownfield",
-    "pkg"
+    "pkg",
+    "multi-repo"
   ],
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Spine",
     "shortDescription": "Delegate a ticket; get a reviewed PR",
-    "longDescription": "Spine understands a codebase as engineering decisions, then engineers within it. Its read-only comprehension tools — map_repo, blast_radius, explain_symbol, investigate, localize, regression_gaps, docs_for — answer 'what breaks if I change X', 'what's untested', 'where does this ticket land', and 'which docs describe this' from a deterministic Product Knowledge Graph (no LLM, no credentials, every fact file:line-grounded). Then delegate a ticket: Spine grounds new code in what already exists, generates and tests it, and — when you confirm — opens a pull request. Works for greenfield and brownfield repos across Python, Java, TypeScript, C#, C, C++, and Go. Safe by default: a local branch + diff with no external writes; live writes (a real Jira issue + PR) are gated behind an explicit confirm.",
+    "longDescription": "Spine understands a codebase as engineering decisions, then engineers within it. Its read-only comprehension tools — map_repo, blast_radius, explain_symbol, investigate, localize, regression_gaps, root_cause, docs_for — answer 'what breaks if I change X', 'what's untested', 'where does this ticket land' and 'which docs describe this' from a deterministic Product Knowledge Graph (no LLM, no credentials, every fact file:line-grounded). Declare your services in .spine/repos.yaml and those same questions cross a repository boundary: an HTTP handler with zero callers in its own source will name the service that depends on it, and pkg_joins proposes or checks the topology that makes those edges possible. Then plan — sdlc_plan renders a twelve-section build document from the graph, git and the tree alone, and sdlc_approve records the decision — before delegating a ticket: Spine grounds new code in what already exists, generates and tests it, and when you confirm, opens a pull request. Greenfield and brownfield across Python, Java, TypeScript, C#, C, C++, Go, and SQL. Safe by default: a local branch + diff with no external writes; live writes (a real Jira issue + PR) are gated behind an explicit confirm.",
     "developerName": "Synaptixs",
     "category": "Engineering",
     "capabilities": [
@@ -31,8 +32,9 @@
     ],
     "websiteURL": "https://github.com/synaptixs/spine",
     "defaultPrompt": [
-      "Use spine to add a slugify() helper to a new Python project (layout=new)",
-      "Use spine's pkg_grounding to show what this repo would reuse for a new feature",
+      "Use spine to map this repo — what is it, and what's untested?",
+      "Use spine's blast_radius to show what breaks if I change this function",
+      "Use spine to investigate where this ticket lands, across .spine/repos.yaml",
       "Use spine to implement this ticket in the current repo (layout=existing)"
     ]
   }

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -44,7 +44,7 @@ run. The graph pays exactly where the model cannot see the target, and ties wher
 *For engineers. The narrative version is [`KNOWLEDGE_GRAPH.md`](../../KNOWLEDGE_GRAPH.md); the
 full front-end detail is [`parsing-and-the-pkg.md`](parsing-and-the-pkg.md).*
 
-Everything else on this page rests on one artifact. The **Program Knowledge Graph** is a typed
+Everything else on this page rests on one artifact. The **Product Knowledge Graph** is a typed
 fact graph of the target codebase — **8 node kinds** (`Module` `Type` `Function` `Field`
 `Endpoint` `Entity` `Doc` `Intent`) and **11 edge kinds** (`IMPORTS` `CONTAINS` `CALLS`
 `IMPLEMENTS` `READS` `WRITES` `EXPOSES` `CONSUMES` `REFERENCES` `MENTIONS` `SERVES`) — where

--- a/plugins/spine/.claude-plugin/plugin.json
+++ b/plugins/spine/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "spine",
   "displayName": "Spine",
-  "version": "2.5.0",
-  "description": "Understand any codebase, then ship changes to it. Read-only comprehension tools (map_repo, blast_radius, explain_symbol, investigate, localize, regression_gaps, docs_for) hand you engineering decisions — what breaks if you change X, what's untested, where a ticket or bug lands, which docs describe it — from a deterministic Product Knowledge Graph (no LLM, no credentials, every fact file:line-grounded). Then delegate a ticket and, on confirm, get a reviewed, tested PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, C++, and Go. Safe by default: local branch + diff, no external writes; live writes are gated behind an explicit confirm.",
+  "version": "3.23.0",
+  "description": "Understand any codebase, then ship changes to it. Read-only comprehension tools (map_repo, blast_radius, explain_symbol, investigate, localize, regression_gaps, root_cause, docs_for) hand you engineering decisions — what breaks if you change X, what's untested, where a ticket or bug lands, which docs describe it — from a deterministic Product Knowledge Graph (no LLM, no credentials, every fact file:line-grounded). Declare several repositories in .spine/repos.yaml and the same questions answer across them: an HTTP handler with zero callers in its own source reports the service that depends on it, and pkg_joins proposes or checks that topology. Then plan (sdlc_plan / sdlc_approve — a twelve-section build document, still no model and no credentials), and on confirm get a reviewed, tested PR. Greenfield + brownfield across Python, Java, TypeScript, C#, C, C++, Go, and SQL. Safe by default: local branch + diff, no external writes; live writes are gated behind an explicit confirm.",
   "author": {
     "name": "Synaptixs",
     "url": "https://github.com/synaptixs/spine"
@@ -10,6 +10,15 @@
   "homepage": "https://github.com/synaptixs/spine",
   "repository": "https://github.com/synaptixs/spine",
   "license": "MIT",
-  "keywords": ["sdlc", "codegen", "mcp", "knowledge-graph", "greenfield", "brownfield", "pkg"],
+  "keywords": [
+    "sdlc",
+    "codegen",
+    "mcp",
+    "knowledge-graph",
+    "greenfield",
+    "brownfield",
+    "pkg",
+    "multi-repo"
+  ],
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/spine/skills/understand-codebase/SKILL.md
+++ b/plugins/spine/skills/understand-codebase/SKILL.md
@@ -7,14 +7,16 @@ description: >-
   decisions (what a change breaks, what's untested, where a ticket or bug lands), each
   grounded to file:line. Triggers: "how does this repo work", "what breaks if I change X",
   "where do I fix this / where does this land", "what's untested here", "explain this symbol",
-  "map this codebase", "which docs cover this". Tools: map_repo, blast_radius, explain_symbol,
-  investigate, localize, regression_gaps, docs_for (all read-only, no credentials, from the Spine plugin).
+  "map this codebase", "which docs cover this", "what depends on this in our other services".
+  Tools: map_repo, blast_radius, explain_symbol, investigate, localize, regression_gaps,
+  root_cause, docs_for, pkg_joins (all read-only, no credentials, from the Spine plugin).
 ---
 
 # Understand a codebase with Spine
 
 Spine reads a repository's **Product Knowledge Graph** — a deterministic, no-LLM index of its
 modules, types, functions, call sites, and blast radius, with every fact grounded to `file:line`.
+It covers Python, Java, TypeScript, C#, C, C++, Go and SQL.
 These MCP tools turn that graph into *decisions*, not just lookups: what a change breaks, what's
 untested, where work lands. They're **read-only, need no credentials**, and take a local
 `repo_path` (default: the current repository).
@@ -34,12 +36,38 @@ and they cite their sources.
 | see what a change could break silently | **`regression_gaps(symbol=… or trace=…)`** — blast-radius symbols with **no covering test** |
 | root-cause a bug (hypotheses + fix approach) | **`root_cause(bug=…)`** — fault site, ranked hypotheses with evidence, regression surface, fix approach; deterministic (add `use_llm=true` for richer hypotheses) |
 | find which docs describe code (or how documented it is) | **`docs_for(symbol=…)`** — the doc pages that mention a symbol; call with no symbol for a doc-coverage summary + top drift. Ingests `.md`/`.rst`/`.txt`/PDF |
+| ask any of the above **across several repositories** | **`blast_radius(repos=…)`** / **`investigate(repos=…)`** — pass a `.spine/repos.yaml` instead of `repo_path` |
+| see or sanity-check the cross-repo topology | **`pkg_joins(config=…, mode="propose"\|"check")`** — read-only; it never writes a config |
 
 Read a repo's committed knowledge base with **`read_memory_bank`** when one exists (built by
 `orchestrator understand`).
 
 `repo_path` defaults to the current repository, and also accepts a **git URL** (e.g.
 `https://github.com/org/repo`) — Spine shallow-clones it, extracts, and cleans up.
+
+## More than one repository
+
+When a change's real blast radius leaves the repo, a single-repo answer is worse than no answer.
+An HTTP handler reports **`0 caller(s)`** — which is *true*, nothing in its own source calls it —
+and reads as safe to change.
+
+If the project declares its services in a **`.spine/repos.yaml`**, pass it as `repos=` to
+`blast_radius` or `investigate` instead of `repo_path`. Every match then also reports the
+dependents it has **in other repositories**:
+
+```
+- **billing** · `create_order` (Function, 0 caller(s), **1 dependent(s) in other repos**) — billing:app/routes.py:7
+```
+
+- The topology is **declared, not guessed** — a `joins:` entry narrows the search; it does not
+  invent the edge. `pkg_joins(mode="propose")` derives candidates from the evidence and prints
+  them for review; `pkg_joins(mode="check")` reports the calls no declared join could place.
+  Run `check` before trusting a quiet result: a *missing* join looks exactly like two services
+  that aren't coupled, which reads as health.
+- Every multi-repo answer carries a **`standing`** block. If `reproducible` is `false`, one of
+  the declared repos has uncommitted work — say so rather than quoting a number nothing can
+  reproduce.
+- `map_repo` is single-repo only; there's no merged profile behind it. Call it per repository.
 
 ## How to work
 
@@ -58,6 +86,9 @@ Read a repo's committed knowledge base with **`read_memory_bank`** when one exis
 - **Deterministic:** same commit in → same answer out (a commit-keyed cache makes re-runs cheap).
 - **Structured + readable:** each tool returns typed fields (symbols, counts, `file:line`, gaps)
   **and** a `markdown` rendering.
-- **Understanding vs. changing:** these tools only *read*. To actually change the code — spec →
-  grounded codegen → tests → branch/PR — use Spine's gated `sdlc_feature`, which requires an
-  explicit `confirm` for any external write. Keep the two separate.
+- **Understanding vs. changing:** these tools only *read*. Between them and codegen sits a middle
+  tier — `sdlc_plan` writes a twelve-section build document (still no model, no credentials: it's
+  rendered from the graph, git and the tree) and `sdlc_approve` records the decision on it. To
+  actually change the code — spec → grounded codegen → tests → branch/PR — use Spine's gated
+  `sdlc_feature`, which requires an explicit `confirm` for any external write. Work *down* the
+  tiers: comprehend, then plan and get the plan approved, then build.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,20 @@ dev = [
     "python-docx>=1.1",
     "openpyxl>=3.1",
 ]
+# Every PKG language front-end at once. Without these the graph is Python-only —
+# and silently so: a repo whose language has no front-end yields zero nodes rather
+# than an error, which reads as "nothing here" instead of "nothing parsed".
+languages = [
+    "synaptixs-spine[c,cpp,csharp,go,java,sql,typescript]",
+]
+# What the plugin install should be: every language, the MCP server, and doc
+# ingestion. Deliberately NOT everything — `security` (semgrep), `media`/`asr`
+# (tesseract/whisper need system binaries), `sql-postgres` (testcontainers wants
+# Docker), `tui`, `otel` and `dev` stay opt-in, because an install that pulls a
+# container runtime to answer "what breaks if I change X" is one nobody finishes.
+all = [
+    "synaptixs-spine[languages,mcp,docs,office,sdlc]",
+]
 
 [project.scripts]
 orchestrator = "orchestrator.cli:app"

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -2983,14 +2983,9 @@ def _joins_check(repo_set: Any, merged: Any, as_json: bool) -> None:
 
 def _unresolved_by_repo(repo_set: Any) -> dict[str, list[Any]]:
     """Re-extract to collect the side-channel. Cheap: every repo is cache-warm by now."""
-    from orchestrator.pkg import RepoCodeExtractor
+    from orchestrator.pkg.joins_propose import unresolved_by_repo
 
-    out: dict[str, list[Any]] = {}
-    for key, root in repo_set:
-        extractor = RepoCodeExtractor()
-        extractor.extract(root)
-        out[key] = list(extractor.unresolved_calls)
-    return out
+    return unresolved_by_repo(repo_set)
 
 
 @pkg_app.command("capabilities")

--- a/src/orchestrator/knowledge/report_html.py
+++ b/src/orchestrator/knowledge/report_html.py
@@ -372,7 +372,7 @@ def _footer(state: CurrentState) -> str:
         caveat += "Call graph not yet available for this language. "
     caveat += f"{state.generated} generated types flagged and excluded from hotspots."
     return (
-        "<footer><p>Deterministic snapshot rendered from the Program Knowledge Graph — no LLM, "
+        "<footer><p>Deterministic snapshot rendered from the Product Knowledge Graph — no LLM, "
         f"nothing fetched. {_e(caveat)}</p></footer>"
     )
 

--- a/src/orchestrator/pkg/joins_propose.py
+++ b/src/orchestrator/pkg/joins_propose.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
     from orchestrator.pkg.facts import FactBatch
     from orchestrator.pkg.python_client import PendingCall
+    from orchestrator.pkg.repos import RepoSet
 
 
 @dataclass(frozen=True)
@@ -233,4 +234,21 @@ def render(candidates: Sequence[Candidate]) -> str:
     return "joins:\n" + "\n\n".join(c.as_yaml() for c in candidates) + "\n"
 
 
-__all__ = ["Candidate", "propose", "render"]
+def unresolved_by_repo(repo_set: RepoSet) -> dict[str, list[PendingCall]]:
+    """The HTTP calls each declared repo makes to a path it does not itself serve.
+
+    Re-extracts per repo to collect them. They live on the extractor as a side-channel and are
+    never facts, so they do not survive into a merged batch and cannot be read back out of one.
+    Cheap in practice: every repo is cache-warm by the time a caller needs this.
+    """
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    out: dict[str, list[PendingCall]] = {}
+    for key, root in repo_set:
+        extractor = RepoCodeExtractor()
+        extractor.extract(root)
+        out[key] = list(extractor.unresolved_calls)
+    return out
+
+
+__all__ = ["Candidate", "propose", "render", "unresolved_by_repo"]

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -9,11 +9,19 @@ the real engine (intake, PKG grounding, readiness).
 
 **1. Read-only comprehension** — ``doctor``, ``pkg_grounding``, ``read_memory_bank``,
 ``ingest_preview`` (dry-run), and the graph-query set ``map_repo`` / ``blast_radius`` /
-``explain_symbol`` / ``investigate`` / ``localize`` / ``regression_gaps`` / ``root_cause``.
-Hands an assistant Spine's *engineering decisions* (what breaks, what's untested, where a
-change lands) with ``file:line`` provenance. Deterministic, no credentials — except
-``root_cause``'s opt-in ``use_llm`` enrichment. These take a local path **or a git URL**
-(shallow-cloned behind the CLI's SSRF/host-allow-list guard).
+``explain_symbol`` / ``investigate`` / ``localize`` / ``regression_gaps`` / ``root_cause`` /
+``docs_for``. Hands an assistant Spine's *engineering decisions* (what breaks, what's
+untested, where a change lands, which docs describe it) with ``file:line`` provenance.
+Deterministic, no credentials — except ``root_cause``'s opt-in ``use_llm`` enrichment. These
+take a local path **or a git URL** (shallow-cloned behind the CLI's SSRF/host-allow-list
+guard).
+
+``blast_radius`` and ``investigate`` additionally take ``repos`` — a ``.spine/repos.yaml`` —
+and answer across every declared repository, reporting the dependents a change reaches in
+*other* repos. ``pkg_joins`` proposes or checks the topology that makes those edges possible;
+it is read-only and never writes a config. Every multi-repo answer carries a ``standing``
+block, because a merged graph built over a dirty tree looks identical to one that is
+reproducible.
 
 **2. Plan and decide** — ``sdlc_plan`` and ``sdlc_approve``. These *write*, but only under
 ``.spine/`` in the repo, and they still need no model and no credentials: ``build_plan``
@@ -214,6 +222,73 @@ def _in_repo_store(repo_path: str, fn: Callable[[Any, Any], dict[str, Any]]) -> 
         return {"error": str(exc)}
 
 
+def _merged_store(repos: str) -> tuple[Any, Any, Any]:
+    """``(FactStore, MergedFacts, RepoSet)`` for a ``.spine/repos.yaml`` — every declared
+    repository extracted, scoped and merged into one graph with its declared joins applied."""
+    from orchestrator.pkg import FactStore
+    from orchestrator.pkg.persistence import load_or_extract_repos
+    from orchestrator.pkg.repos import load_repo_config
+
+    repo_set = load_repo_config(repos)
+    merged = load_or_extract_repos(repo_set)
+    return FactStore(merged.batch), merged, repo_set
+
+
+def _standing(merged: Any) -> dict[str, Any]:
+    """The merged graph's standing, attached to every multi-repo answer.
+
+    A merged graph assembled from a repository with uncommitted work cannot be reproduced at a
+    commit, and looks identical to a clean one. The CLI prints that on stderr; a tool has to
+    return it, or the caller quotes a number that nothing can reproduce.
+    """
+    return {
+        "repos": [r.key for r in merged.repos],
+        "reproducible": merged.trusted,
+        "untrusted": list(merged.untrusted_keys),
+    }
+
+
+def _in_repos_store(repos: str, fn: Callable[[Any, Any], dict[str, Any]]) -> dict[str, Any]:
+    """Run ``fn(store, merged)`` over a merged multi-repo graph; a bad config returns
+    ``{"error": …}``."""
+    from orchestrator.pkg.repos import RepoConfigError
+
+    try:
+        store, merged, _repo_set = _merged_store(repos)
+    except RepoConfigError as exc:
+        return {"error": str(exc)}
+    out = fn(store, merged)
+    out.setdefault("standing", _standing(merged))
+    return out
+
+
+def _cross_repo_reach(store: Any, node_id: str) -> list[dict[str, Any]]:
+    """The symbols in *other* repositories that a change to this one reaches.
+
+    This is the whole point of a merged graph. An HTTP handler with ``0 caller(s)`` is telling
+    the truth — nothing in its own source calls it — and on its own that is the most dangerous
+    answer the graph can give.
+    """
+    from orchestrator.pkg.scoping import unscope_id
+
+    owner, _ = unscope_id(node_id)
+    if not owner:
+        return []
+    out: list[dict[str, Any]] = []
+    for node, hops in store.impact_of(node_id):
+        repo, _unscoped = unscope_id(node.id)
+        if repo and repo != owner:
+            out.append(
+                {
+                    "id": node.id,
+                    "repo": repo,
+                    "hops": hops,
+                    "where": str(node.provenance) if node.provenance else None,
+                }
+            )
+    return out
+
+
 def map_repo(repo_path: str, lens: str = "developer") -> dict[str, Any]:
     """A skim-first map of a repo: languages, components, **call-hotspots**, **test-coverage
     gaps**, and prioritized **recommendations**. Deterministic (no LLM). ``lens`` is
@@ -245,11 +320,20 @@ def map_repo(repo_path: str, lens: str = "developer") -> dict[str, Any]:
     return _in_repo(repo_path, run)
 
 
-def blast_radius(repo_path: str, symbol: str) -> dict[str, Any]:
+def blast_radius(repo_path: str = "", symbol: str = "", repos: str | None = None) -> dict[str, Any]:
     """ "What breaks if I change X" — a symbol's direct callers plus the cross-layer set a
-    change ripples into (CALLS + IMPORTS + REFERENCES), each with ``file:line``. Deterministic."""
+    change ripples into (CALLS + IMPORTS + REFERENCES), each with ``file:line``. Deterministic.
 
-    def run(store: Any, _repo: Any) -> dict[str, Any]:
+    Pass ``repos`` (a ``.spine/repos.yaml``) instead of ``repo_path`` to answer across every
+    declared repository: each match then also reports the dependents a change reaches **in
+    other repositories**, which is what a single-repo graph cannot see. An HTTP handler with
+    zero callers in its own source is the case this exists for."""
+    if not symbol:
+        return {"error": "provide a symbol"}
+    if bool(repo_path) == bool(repos):
+        return {"error": "provide exactly one of repo_path or repos"}
+
+    def run(store: Any, _ctx: Any) -> dict[str, Any]:
         matches = store.find(symbol)
         if not matches:
             return {"symbol": symbol, "found": False, "matches": []}
@@ -257,22 +341,26 @@ def blast_radius(repo_path: str, symbol: str) -> dict[str, Any]:
         for node in matches[:5]:
             callers = store.callers_of(node.id)
             touched = store.touches(node.id)
-            out.append(
-                {
-                    "id": node.id,
-                    "kind": node.kind.value,
-                    "where": str(node.provenance) if node.provenance else None,
-                    "caller_count": len(callers),
-                    "callers": [{"id": cs.caller.id, "at": cs.at} for cs in callers[:25]],
-                    "touch_count": len(touched),
-                    "touches": [
-                        {"id": t.id, "where": str(t.provenance) if t.provenance else None}
-                        for t in touched[:25]
-                    ],
-                }
-            )
+            entry: dict[str, Any] = {
+                "id": node.id,
+                "kind": node.kind.value,
+                "where": str(node.provenance) if node.provenance else None,
+                "caller_count": len(callers),
+                "callers": [{"id": cs.caller.id, "at": cs.at} for cs in callers[:25]],
+                "touch_count": len(touched),
+                "touches": [
+                    {"id": t.id, "where": str(t.provenance) if t.provenance else None} for t in touched[:25]
+                ],
+            }
+            if repos:
+                reach = _cross_repo_reach(store, node.id)
+                entry["cross_repo_count"] = len(reach)
+                entry["cross_repo"] = reach[:25]
+            out.append(entry)
         return {"symbol": symbol, "found": True, "matches": out, "markdown": _blast_markdown(out)}
 
+    if repos:
+        return _in_repos_store(repos, run)
     return _in_repo_store(repo_path, run)
 
 
@@ -302,20 +390,37 @@ def explain_symbol(repo_path: str, symbol: str) -> dict[str, Any]:
     return _in_repo_store(repo_path, run)
 
 
-def investigate(repo_path: str, title: str, problem: str = "") -> dict[str, Any]:
+def investigate(
+    repo_path: str = "", title: str = "", problem: str = "", repos: str | None = None
+) -> dict[str, Any]:
     """Where a ticket lands in the code: the real symbols to start from (``file:line`` + caller
-    counts), the owning areas, and any committed ``episteme/`` knowledge. Deterministic (no LLM)."""
+    counts), the owning areas, and any committed ``episteme/`` knowledge. Deterministic (no LLM).
+
+    Pass ``repos`` (a ``.spine/repos.yaml``) instead of ``repo_path`` to research across every
+    declared repository: a landing site then carries its repository and reports the dependents
+    it has in others, so a ticket landing in two services says so. The ``episteme/`` section is
+    omitted on a merged graph — a knowledge base belongs to one repository, and filling it from
+    an arbitrary one would be the brief inventing an owner."""
     if not title and not problem:
         return {"error": "provide a ticket title (and optionally a problem description)"}
+    if bool(repo_path) == bool(repos):
+        return {"error": "provide exactly one of repo_path or repos"}
 
-    def run(store: Any, repo: Any) -> dict[str, Any]:
+    def build(store: Any, root: Any) -> dict[str, Any]:
         from orchestrator.sdlc.investigate import build_investigation, render_investigation_md
 
-        inv = build_investigation(title, problem, store=store, root=repo)
+        inv = build_investigation(title, problem, store=store, root=root)
         return {
             "title": inv.title,
             "landing": [
-                {"name": h.name, "kind": h.kind, "where": h.where, "callers": h.callers, "module": h.module}
+                {
+                    "name": h.name,
+                    "kind": h.kind,
+                    "where": h.where,
+                    "callers": h.callers,
+                    "cross_repo": h.cross_repo,
+                    "module": h.module,
+                }
                 for h in inv.landing
             ],
             "areas": inv.areas,
@@ -323,7 +428,79 @@ def investigate(repo_path: str, title: str, problem: str = "") -> dict[str, Any]
             "markdown": render_investigation_md(inv),
         }
 
-    return _in_repo_store(repo_path, run)
+    if repos:
+        # `root=None`: see the docstring — a merged brief has no single owner for `episteme/`.
+        return _in_repos_store(repos, lambda store, _merged: build(store, None))
+    return _in_repo_store(repo_path, build)
+
+
+def pkg_joins(config: str = ".spine/repos.yaml", mode: str = "check") -> dict[str, Any]:
+    """Propose or check cross-repository joins. Read-only — it never writes a config.
+
+    ``mode="propose"`` derives a ``joins:`` block from the evidence (calls a repo makes to paths
+    it does not serve, matched against its neighbours' endpoints; shared tables; imports another
+    repo defines), each candidate carrying the number of edges it would create — a join
+    producing zero is noise.
+
+    ``mode="check"`` reports what the declared joins could not place. This is the countermeasure
+    for a quiet failure: a repository nobody listed is loud (no nodes, a visibly narrower
+    graph), but a missing ``joins:`` entry looks exactly like two services that are not coupled,
+    which reads as health."""
+    if mode not in ("propose", "check"):
+        return {"error": "mode must be 'propose' or 'check'"}
+    from orchestrator.pkg.repos import RepoConfigError
+
+    try:
+        _store, merged, repo_set = _merged_store(config)
+    except RepoConfigError as exc:
+        return {"error": str(exc)}
+
+    if mode == "propose":
+        return {"mode": "propose", "standing": _standing(merged), **_joins_proposal(repo_set, merged)}
+    return {"mode": "check", "standing": _standing(merged), **_joins_report(merged)}
+
+
+def _joins_proposal(repo_set: Any, merged: Any) -> dict[str, Any]:
+    from orchestrator.pkg.joins_propose import propose as propose_joins
+    from orchestrator.pkg.joins_propose import unresolved_by_repo
+
+    unresolved = unresolved_by_repo(repo_set)
+    declared = {(j.kind, j.consumer, j.provider) for j in repo_set.joins}
+    candidates = [
+        {
+            "kind": c.kind,
+            "consumer": c.consumer,
+            "provider": c.provider,
+            "base": c.base,
+            "edges": c.edges,
+            "examples": list(c.examples),
+            "already_declared": (c.kind, c.consumer, c.provider) in declared,
+        }
+        for c in propose_joins(merged.batch, unresolved)
+    ]
+    return {"candidates": candidates}
+
+
+def _joins_report(merged: Any) -> dict[str, Any]:
+    report = merged.joins
+    if report is None:
+        # Not the same as "everything joined". A config with no `joins:` block has nothing to
+        # report against, and "0 unplaced" here would be the silence this tool exists to prevent.
+        return {
+            "declared": 0,
+            "note": "no joins declared — run with mode='propose' to see what the evidence supports",
+        }
+    return {
+        "declared": len(report.per_join),
+        "joined": report.joined,
+        "examined": report.examined,
+        "recall": report.recall,
+        "per_join": [{"join": k, "edges": v} for k, v in report.per_join],
+        "unjoined": [
+            {"repo": u.repo, "verb": u.verb, "path": u.path, "at": u.where, "reason": u.reason}
+            for u in report.unjoined
+        ],
+    }
 
 
 def localize(repo_path: str, trace: str) -> dict[str, Any]:
@@ -610,6 +787,11 @@ def _blast_markdown(matches: list[dict[str, Any]]) -> str:
             f"- **Called by ({m['caller_count']}):** " + ", ".join(c["id"] for c in m["callers"][:10])
         )
         lines.append(f"- **Touches ({m['touch_count']}):** " + ", ".join(t["id"] for t in m["touches"][:10]))
+        # Only on a merged graph. Rendered even at zero: "no dependents in other repos" is an
+        # answer, and its absence would read the same as never having looked.
+        if "cross_repo_count" in m:
+            reached = ", ".join(f"{c['repo']}·`{c['id']}`" for c in m["cross_repo"][:10]) or "none"
+            lines.append(f"- **Dependents in other repos ({m['cross_repo_count']}):** {reached}")
     return "\n".join(lines)
 
 
@@ -692,6 +874,8 @@ _TOOLS = (
     localize,
     regression_gaps,
     root_cause,
+    # multi-repo: one graph across several repositories (`.spine/repos.yaml`)
+    pkg_joins,
     sdlc_plan,
     sdlc_approve,
     docs_for,

--- a/tests/plugin/test_manifests.py
+++ b/tests/plugin/test_manifests.py
@@ -15,7 +15,20 @@ _MANIFESTS = [
     _ROOT / "codex-marketplace" / "plugins" / "spine" / ".codex-plugin" / "plugin.json",
 ]
 # The comprehension tools the plugin's pitch should surface.
-_COMP_TOOLS = ("map_repo", "blast_radius", "explain_symbol", "investigate", "localize", "regression_gaps")
+_COMP_TOOLS = (
+    "map_repo",
+    "blast_radius",
+    "explain_symbol",
+    "investigate",
+    "localize",
+    "regression_gaps",
+    "root_cause",
+    "docs_for",
+    "pkg_joins",
+)
+# Every language the PKG has a front-end for. The pitch is what a user reads before
+# installing, so a missing language here is a language they never learn Spine covers.
+_LANGUAGES = ("Python", "Java", "TypeScript", "C#", "C", "C++", "Go", "SQL")
 
 
 def test_understand_codebase_skill_has_frontmatter() -> None:
@@ -42,8 +55,76 @@ def test_manifest_is_valid_json(manifest: Path) -> None:
     json.loads(manifest.read_text(encoding="utf-8"))  # raises on invalid JSON
 
 
-def test_plugin_pitch_leads_with_comprehension_and_go() -> None:
+def test_plugin_pitch_leads_with_comprehension_and_every_language() -> None:
     for manifest in _MANIFESTS:
         blob = manifest.read_text(encoding="utf-8")
         assert "comprehension" in blob, f"{manifest} pitch should surface the comprehension tools"
-        assert "Go" in blob, f"{manifest} language list should include Go"
+        for language in _LANGUAGES:
+            assert language in blob, f"{manifest} language list should include {language}"
+
+
+def _pyproject_version() -> str:
+    import tomllib
+
+    with (_ROOT / "pyproject.toml").open("rb") as fh:
+        version: str = tomllib.load(fh)["project"]["version"]
+    return version
+
+
+@pytest.mark.parametrize("manifest", _MANIFESTS, ids=lambda p: p.parent.name)
+def test_manifest_version_tracks_the_package(manifest: Path) -> None:
+    """The version a user reads in the plugin list is the version they installed.
+
+    Nothing else ties these together: the manifests are hand-written JSON that no release step
+    touches, so without this they simply stop being true — quietly, and for as long as nobody
+    happens to look. They stood at 2.5.0 through fifteen releases exactly this way.
+    """
+    declared = json.loads(manifest.read_text(encoding="utf-8"))
+    version = declared["version"] if "version" in declared else declared["plugins"][0]["version"]
+
+    assert version == _pyproject_version(), (
+        f"{manifest} declares {version}; pyproject is at {_pyproject_version()}"
+    )
+
+
+def test_every_registered_tool_is_documented_for_a_user() -> None:
+    """A tool nobody wrote down is one nobody calls.
+
+    Registration is the source of truth — this reads `_TOOLS` rather than a second list, so a
+    new tool fails here until it is documented, instead of shipping invisibly.
+
+    The **guides** are the bar, not the manifests: a marketplace blurb naming twenty tools sells
+    nothing, and run-control plumbing (`sdlc_run_status` and friends) belongs in a reference, not
+    a pitch. What the manifests owe is the *headline* set, which
+    `test_plugin_pitch_leads_with_comprehension_and_every_language` covers.
+    """
+    from orchestrator.plugin.server import _TOOLS
+
+    documented = "\n".join(
+        (_ROOT / doc).read_text(encoding="utf-8") for doc in ("CLAUDE_GUIDE.md", "CODEX_GUIDE.md")
+    )
+    missing = [fn.__name__ for fn in _TOOLS if fn.__name__ not in documented]
+
+    assert not missing, f"registered but undocumented: {', '.join(missing)}"
+
+
+def test_the_manifests_pitch_the_comprehension_tools_by_name() -> None:
+    """The tools a user picks the plugin *for* — these belong in the blurb they read first."""
+    for manifest in _MANIFESTS:
+        blob = manifest.read_text(encoding="utf-8")
+        named = [tool for tool in _COMP_TOOLS if tool in blob]
+        # marketplace.json carries a shorter blurb than the plugin manifests; require the
+        # headline pair everywhere and the full set where there is room for it.
+        assert "map_repo" in blob or "comprehension" in blob, f"{manifest} names no comprehension tool"
+        if manifest.name == "plugin.json":
+            assert len(named) >= 6, f"{manifest} names only {named}"
+
+
+def test_the_skill_tells_an_assistant_how_to_cross_a_repo_boundary() -> None:
+    """A single-repo answer about an HTTP handler is confidently wrong, not merely partial."""
+    body = _SKILL.read_text(encoding="utf-8")
+
+    assert ".spine/repos.yaml" in body
+    assert "repos=" in body
+    # The standing block is what separates a reproducible answer from one that only looks it.
+    assert "standing" in body and "reproducible" in body

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -582,3 +582,142 @@ async def test_an_approval_nobody_is_named_for_is_refused(
 
     assert "cannot tell who is approving" in sdlc_approve(str(repo), "TCK-9")["error"]
     assert mod.sdlc_approve in mod._TOOLS
+
+
+# ---- multi-repo: one graph across several repositories ---------------------
+# The case these exist for: an HTTP handler with **zero callers in its own source**. That
+# answer is true and, on a single-repo graph, the most dangerous one the graph can give.
+
+_BILLING = """\
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.post("/v1/orders")
+def create_order(payload: dict) -> dict:
+    return {"id": 1}
+"""
+
+_WEB_CLIENT = """\
+import requests
+
+
+def place_order(payload: dict) -> dict:
+    return requests.post("http://billing/v1/orders", json=payload).json()
+"""
+
+
+def _repo_at(root: Path, name: str, body: str) -> Path:
+    """A real git repo with one commit — a merged graph is only reproducible over clean trees."""
+    import os
+    import subprocess
+
+    (root / "app").mkdir(parents=True, exist_ok=True)
+    (root / "app" / name).write_text(body, encoding="utf-8")
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@e",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e",
+    }
+    for args in (["init", "-q"], ["add", "-A"], ["commit", "-qm", "init"]):
+        subprocess.run(["git", *args], cwd=root, check=True, env=env)
+    return root
+
+
+def _repos_config(tmp_path: Path, *, joins: bool = True) -> str:
+    billing = _repo_at(tmp_path / "billing", "routes.py", _BILLING)
+    web = _repo_at(tmp_path / "web", "client.py", _WEB_CLIENT)
+    block = "joins:\n  - kind: http\n    consumer: web\n    provider: billing\n" if joins else ""
+    cfg = tmp_path / "repos.yaml"
+    cfg.write_text(f"repos:\n  billing: {billing}\n  web: {web}\n{block}", encoding="utf-8")
+    return str(cfg)
+
+
+def test_blast_radius_reports_dependents_in_another_repo(tmp_path: Path) -> None:
+    out = blast_radius(symbol="create_order", repos=_repos_config(tmp_path))
+
+    assert out["found"], out
+    match = out["matches"][0]
+    # Zero callers at home is the true answer, and on its own it is the misleading one.
+    assert match["caller_count"] == 0
+    assert match["cross_repo_count"] >= 1
+    assert any(c["repo"] == "web" for c in match["cross_repo"])
+    assert "Dependents in other repos" in out["markdown"]
+
+
+def test_multi_repo_answers_carry_their_standing(tmp_path: Path) -> None:
+    """A graph built over a dirty tree looks identical to one that is reproducible."""
+    cfg = _repos_config(tmp_path)
+    clean = blast_radius(symbol="create_order", repos=cfg)
+    assert clean["standing"] == {
+        "repos": ["billing", "web"],
+        "reproducible": True,
+        "untrusted": [],
+    }
+
+    (tmp_path / "web" / "app" / "client.py").write_text(_WEB_CLIENT + "# edit\n", encoding="utf-8")
+    dirty = blast_radius(symbol="create_order", repos=cfg)
+    assert dirty["standing"]["reproducible"] is False
+    assert dirty["standing"]["untrusted"] == ["web"]
+
+
+def test_investigate_across_repos_reports_cross_repo_landing(tmp_path: Path) -> None:
+    out = investigate(title="change order creation", repos=_repos_config(tmp_path))
+
+    landing = {h["name"]: h for h in out["landing"]}
+    assert landing["create_order"]["cross_repo"] >= 1
+    assert "dependent(s) in other repos" in out["markdown"]
+    # `episteme/` belongs to one repository; a merged brief must not fill it from an arbitrary one.
+    assert out["has_knowledge"] is False
+
+
+def test_a_tool_takes_one_repo_or_many_but_never_both(tmp_path: Path) -> None:
+    cfg = _repos_config(tmp_path)
+    assert "exactly one" in blast_radius(repo_path=str(tmp_path), symbol="x", repos=cfg)["error"]
+    assert "exactly one" in blast_radius(symbol="create_order")["error"]
+    assert "exactly one" in investigate(repo_path=str(tmp_path), title="t", repos=cfg)["error"]
+
+
+def test_pkg_joins_check_reports_what_the_declared_joins_placed(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import pkg_joins
+
+    out = pkg_joins(_repos_config(tmp_path), "check")
+
+    assert out["mode"] == "check"
+    assert out["declared"] == 1
+    assert out["joined"] >= 1
+    assert out["per_join"][0]["join"] == "web -http-> billing"
+
+
+def test_pkg_joins_check_says_nothing_is_declared_rather_than_zero_unplaced(tmp_path: Path) -> None:
+    """ "0 unplaced" against no declarations is exactly the silence this command exists to break."""
+    from orchestrator.plugin.server import pkg_joins
+
+    out = pkg_joins(_repos_config(tmp_path, joins=False), "check")
+
+    assert out["declared"] == 0
+    assert "no joins declared" in out["note"]
+
+
+def test_pkg_joins_propose_derives_the_topology_from_evidence(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import pkg_joins
+
+    out = pkg_joins(_repos_config(tmp_path, joins=False), "propose")
+
+    candidate = out["candidates"][0]
+    assert (candidate["kind"], candidate["consumer"], candidate["provider"]) == ("http", "web", "billing")
+    # A join producing zero edges is noise, so every candidate carries what it would create.
+    assert candidate["edges"] >= 1
+    assert candidate["already_declared"] is False
+
+
+def test_pkg_joins_rejects_an_unknown_mode_and_a_missing_config(tmp_path: Path) -> None:
+    from orchestrator.plugin import server as mod
+    from orchestrator.plugin.server import pkg_joins
+
+    assert "propose" in pkg_joins(_repos_config(tmp_path), "sideways")["error"]
+    assert "cannot be read" in pkg_joins(str(tmp_path / "nope.yaml"), "check")["error"]
+    assert mod.pkg_joins in mod._TOOLS


### PR DESCRIPTION
The plugin manifests last changed at v3.8.1 and still declared **2.5.0** — a version they
had held through fifteen releases. They advertised 7 tools against a registry of 20, and
7 languages against a front-end set of 8. Two things were wrong beyond the metadata.

## Multi-repo reaches the plugin surface

3.23.0 shipped cross-repository comprehension on the CLI only, so the headline capability
of the current release was invisible to both hosts.

- **`blast_radius(repos=…)` and `investigate(repos=…)`** take a `.spine/repos.yaml` instead
  of a `repo_path` and answer across every declared repository. A handler reporting
  `0 caller(s)` at home now names the service that depends on it — verified against
  `corpus/multirepo/http_join`:

  ```
  - **billing** · `create_order` (Function, 0 caller(s), **1 dependent(s) in other repos**) — billing:app/routes.py:7
  ```

- **`pkg_joins`** — `mode="propose"` derives a `joins:` block from the evidence, each
  candidate carrying the edges it would create; `mode="check"` reports the calls no declared
  join could place. Read-only, never writes a config. Reports recall `0.67` on the corpus
  HTTP case, matching the measured number in the 3.23.0 changelog.

- **Every multi-repo answer returns a `standing` block** (`repos`, `reproducible`,
  `untrusted`). The CLI prints reproducibility on stderr; a tool has to *return* it, or a
  caller quotes a number nothing can reproduce and the payload says nothing about it.

`map_repo` stays single-repo — there is no merged profile behind it — and says so in the
skill and both guides rather than leaving it implicit.

## The documented install under-delivered

Both plugin READMEs and both guides said `pip install 'synaptixs-spine[mcp]'`, which serves
the tools over a **Python-only** graph: a Java or Go repo yields zero nodes rather than an
error, so following the documentation failed by looking like an empty repository.

New **`[all]`** (every language front-end + MCP + doc/office ingestion) and **`[languages]`**
(the front-ends alone). Deliberately not everything — `security`, `media`/`asr`,
`sql-postgres`, `tui`, `otel` and `dev` stay opt-in, because an install that pulls a
container runtime to answer "what breaks if I change X" is one nobody finishes.

## So this cannot recur quietly

Three tests. Manifest versions are asserted against `pyproject.toml`; every name in `_TOOLS`
must appear in a user-facing guide; the pitch must name all eight languages. The test this
replaces grepped the manifests for the word "Go" — written for 3.7.0, and green for every
release after it.

## Also

- **PKG is the Product Knowledge Graph, everywhere.** The acronym had two expansions in one
  repo: `CLAUDE.md`, one spec, the banner and the HTML report footer said "Program"; every
  user-facing document — and the spec file named `PRODUCT-KNOWLEDGE-GRAPH.md` — said
  "Product". Two of the four were user-visible surfaces, not prose.
- `unresolved_by_repo` moved to `pkg/joins_propose.py`; `cli.py` and the plugin server share
  it instead of carrying identical copies.

## Not in this PR

`uv.lock` — the local `uv` (0.8.0) is older than the one that wrote it and rewrites
`revision 3` back to `2` plus ~50 lines of unrelated marker churn. `pyproject.toml` declares
the new extras and CI's `uv sync` is not `--locked`, so nothing depends on it. It was
already stale before this branch (records `3.21.0` against a `pyproject` at `3.23.0`) and
wants a relock from a current `uv`.

## Verification

`mypy src tests` clean · `ruff format --check .` clean · **3109 passed, 3 skipped**
(env-gated: `tui` extra, `E2B_API_KEY`, Postgres+Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)