### PR TITLE
Tell a single-repo answer that it is one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ All notable changes to this project are documented here. Format loosely follows
   `reproducible`. The CLI prints that on stderr; a tool has to *return* it, or a caller quotes a
   number nothing can reproduce and nothing in the payload says so.
 
+### Added — a single-repo answer now says when it is one
+
+- **`multi_repo_available`.** Point a comprehension tool at a repository that declares siblings
+  in its own `.spine/repos.yaml` and the answer carries a note naming that config and the repos
+  it declares. This is the one case the multi-repo work could not make loud on its own:
+  extracting a single directory always *succeeds*, so `0 caller(s)` from an unscoped graph is
+  indistinguishable from `0 caller(s)` that was checked across every service — and the first is
+  the answer that gets a handler changed.
+- A note, not a switch. It never redirects the caller to the merged graph, because which
+  repositories an answer covers is theirs to decide. A config too broken to parse still
+  produces a note, since an unreadable config is still evidence the project is multi-repo.
+- `sdlc_approve` opts out: a decision about one repository's plan is not a question about the
+  others.
+
 ### Added — `[all]`, because the documented install under-delivered
 
 - **`pip install 'synaptixs-spine[all]'`** — every language front-end, the MCP server, doc and

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -246,6 +246,11 @@ Three things worth knowing:
   narrower graph); a missing `joins:` entry looks exactly like two services that are not
   coupled — which reads as health. Run `pkg_joins` with `mode="check"` before trusting a clean
   result, and `mode="propose"` to see what the evidence supports. Neither writes anything.
+- **A single‑repo answer will tell you when it is one.** Point a tool at a repo that declares
+  siblings in its own `.spine/repos.yaml` and the result carries a `multi_repo_available` note
+  naming the config and the repos it declares. Nothing errors — extracting one directory always
+  succeeds — so without the note a partial answer would be indistinguishable from a complete
+  one. It is a note, never a switch: which repositories an answer covers stays your decision.
 - **Every multi‑repo answer carries a `standing` block** — the repos it covers, and whether the
   result is `reproducible`. A merged graph built over a repo with uncommitted work looks
   identical to one built over clean trees, so the answer says which it was.

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -232,6 +232,11 @@ Three things worth knowing:
   narrower graph); a missing `joins:` entry looks exactly like two services that are not
   coupled — which reads as health. Run `pkg_joins` with `mode="check"` before trusting a clean
   result, and `mode="propose"` to see what the evidence supports. Neither writes anything.
+- **A single‑repo answer will tell you when it is one.** Point a tool at a repo that declares
+  siblings in its own `.spine/repos.yaml` and the result carries a `multi_repo_available` note
+  naming the config and the repos it declares. Nothing errors — extracting one directory always
+  succeeds — so without the note a partial answer would be indistinguishable from a complete
+  one. It is a note, never a switch: which repositories an answer covers stays your decision.
 - **Every multi‑repo answer carries a `standing` block** — the repos it covers, and whether the
   result is `reproducible`. A merged graph built over a repo with uncommitted work looks
   identical to one built over clean trees, so the answer says which it was.

--- a/plugins/spine/skills/understand-codebase/SKILL.md
+++ b/plugins/spine/skills/understand-codebase/SKILL.md
@@ -68,6 +68,11 @@ dependents it has **in other repositories**:
   the declared repos has uncommitted work — say so rather than quoting a number nothing can
   reproduce.
 - `map_repo` is single-repo only; there's no merged profile behind it. Call it per repository.
+- **If a single-repo answer comes back carrying `multi_repo_available`, stop and re-ask.** It
+  means the repo you pointed at declares siblings in its own `.spine/repos.yaml`, so the answer
+  you have covers one of them. Nothing errored — pointing a tool at a directory always works —
+  which is exactly why the note is there. Re-run with the `repos=` path it gives you before
+  telling anyone a symbol is safe to change.
 
 ## How to work
 

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -200,24 +200,74 @@ def _repo_store(repo_path: str) -> Iterator[tuple[Any, Any]]:
         yield FactStore(load_or_extract(repo)), repo
 
 
-def _in_repo(repo_path: str, fn: Callable[[Any], dict[str, Any]]) -> dict[str, Any]:
+def _repos_note(repo: Any) -> dict[str, Any] | None:
+    """A ``.spine/repos.yaml`` sitting in the repo we were pointed at — which this answer ignored.
+
+    The single-repo path has no way to fail loudly here. Point a tool at a directory and it
+    extracts that directory; there is no error to raise, and the result looks like every other
+    answer. But if the project declares siblings, the honest reading of ``0 caller(s)`` is
+    "none *in this repository*", and nothing in the payload would have said so.
+
+    A note, not a behaviour change: it never switches the caller to the merged graph on their
+    behalf, because which repositories an answer covers is the caller's decision to make.
+    """
+    from orchestrator.pkg.repos import RepoConfigError, find_repo_config, load_repo_config
+
+    config = find_repo_config(repo)
+    if config is None:
+        return None
+    try:
+        declared = [key for key, _root in load_repo_config(config)]
+    except RepoConfigError:
+        # A config too broken to read is still evidence that this is a multi-repo project, and
+        # staying quiet about it would be the exact silence this note exists to break.
+        return {
+            "config": str(config),
+            "note": (
+                f"{config} exists but could not be read. This answer covers one repository; "
+                "fix the config and pass repos= to include the others."
+            ),
+        }
+    return {
+        "config": str(config),
+        "declares": declared,
+        "note": (
+            f"This answer covers one repository. {config} declares {len(declared)} "
+            f"({', '.join(declared)}) — pass repos='{config}' to include dependents in the others."
+        ),
+    }
+
+
+def _with_repos_note(out: dict[str, Any], repo: Any, *, hint: bool) -> dict[str, Any]:
+    """Attach the multi-repo note, unless the tool opted out or already said something."""
+    if not hint or "error" in out:
+        return out
+    note = _repos_note(repo)
+    if note is not None:
+        out.setdefault("multi_repo_available", note)
+    return out
+
+
+def _in_repo(repo_path: str, fn: Callable[[Any], dict[str, Any]], *, hint: bool = True) -> dict[str, Any]:
     """Run ``fn(repo)`` inside a resolved repo; a bad path / URL returns ``{"error": …}``."""
     from orchestrator.registry.api.workspace import RepoPathError, RepoSourceError
 
     try:
         with _open_repo(repo_path) as repo:
-            return fn(repo)
+            return _with_repos_note(fn(repo), repo, hint=hint)
     except (RepoSourceError, RepoPathError) as exc:
         return {"error": str(exc)}
 
 
-def _in_repo_store(repo_path: str, fn: Callable[[Any, Any], dict[str, Any]]) -> dict[str, Any]:
+def _in_repo_store(
+    repo_path: str, fn: Callable[[Any, Any], dict[str, Any]], *, hint: bool = True
+) -> dict[str, Any]:
     """Run ``fn(store, repo)`` inside a resolved repo; a bad path / URL returns ``{"error": …}``."""
     from orchestrator.registry.api.workspace import RepoPathError, RepoSourceError
 
     try:
         with _repo_store(repo_path) as (store, repo):
-            return fn(store, repo)
+            return _with_repos_note(fn(store, repo), repo, hint=hint)
     except (RepoSourceError, RepoPathError) as exc:
         return {"error": str(exc)}
 
@@ -716,7 +766,9 @@ def sdlc_approve(
             "path": str(save_approval(approval, root=repo)),
         }
 
-    return _in_repo(repo_path, run)
+    # No multi-repo note: an approval is a decision about one repository's plan, and a
+    # nudge toward a merged graph here would be answering a question nobody asked.
+    return _in_repo(repo_path, run, hint=False)
 
 
 def docs_for(repo_path: str, symbol: str = "") -> dict[str, Any]:

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -721,3 +721,93 @@ def test_pkg_joins_rejects_an_unknown_mode_and_a_missing_config(tmp_path: Path) 
     assert "propose" in pkg_joins(_repos_config(tmp_path), "sideways")["error"]
     assert "cannot be read" in pkg_joins(str(tmp_path / "nope.yaml"), "check")["error"]
     assert mod.pkg_joins in mod._TOOLS
+
+
+# ---- the nudge: a single-repo answer in a multi-repo project ----------------
+# The single-repo path cannot fail loudly here. Point a tool at a directory and it extracts
+# that directory — there is no error to raise, and `0 caller(s)` looks like every other answer.
+
+
+def _repo_declaring_siblings(tmp_path: Path) -> Path:
+    """A billing repo whose own `.spine/repos.yaml` names it and a `web` sibling."""
+    billing = _repo_at(tmp_path / "billing", "routes.py", _BILLING)
+    web = _repo_at(tmp_path / "web", "client.py", _WEB_CLIENT)
+    (billing / ".spine").mkdir(exist_ok=True)
+    (billing / ".spine" / "repos.yaml").write_text(
+        f"repos:\n  billing: {billing}\n  web: {web}\n"
+        "joins:\n  - kind: http\n    consumer: web\n    provider: billing\n",
+        encoding="utf-8",
+    )
+    return billing
+
+
+def test_a_single_repo_answer_says_the_project_declares_more(tmp_path: Path) -> None:
+    billing = _repo_declaring_siblings(tmp_path)
+
+    out = blast_radius(repo_path=str(billing), symbol="create_order")
+
+    # The answer itself is unchanged and still true — of this repository.
+    assert out["matches"][0]["caller_count"] == 0
+    assert "cross_repo_count" not in out["matches"][0]
+    # …but it no longer reads as the whole story.
+    note = out["multi_repo_available"]
+    assert note["declares"] == ["billing", "web"]
+    assert "covers one repository" in note["note"]
+    assert "repos=" in note["note"]
+
+
+def test_the_nudge_reaches_every_comprehension_tool_that_takes_one_repo(tmp_path: Path) -> None:
+    billing = str(_repo_declaring_siblings(tmp_path))
+
+    assert "multi_repo_available" in map_repo(billing)
+    assert "multi_repo_available" in explain_symbol(billing, "create_order")
+    assert "multi_repo_available" in investigate(repo_path=billing, title="order creation")
+    assert "multi_repo_available" in regression_gaps(billing, symbol="create_order")
+
+
+def test_a_project_with_one_repo_hears_nothing(tmp_path: Path) -> None:
+    """A note on every answer everywhere is a note nobody reads."""
+    plain = _repo_at(tmp_path / "billing", "routes.py", _BILLING)
+
+    assert "multi_repo_available" not in blast_radius(repo_path=str(plain), symbol="create_order")
+    assert "multi_repo_available" not in map_repo(str(plain))
+
+
+def test_a_config_too_broken_to_read_still_speaks_up(tmp_path: Path) -> None:
+    """It is still evidence the project is multi-repo, and silence here is the failure mode."""
+    billing = _repo_declaring_siblings(tmp_path)
+    (billing / ".spine" / "repos.yaml").write_text("repos: [not, a, mapping]\n", encoding="utf-8")
+
+    note = blast_radius(repo_path=str(billing), symbol="create_order")["multi_repo_available"]
+
+    assert "could not be read" in note["note"]
+    assert "declares" not in note
+
+
+def test_the_merged_answer_does_not_nudge_toward_itself(tmp_path: Path) -> None:
+    billing = _repo_declaring_siblings(tmp_path)
+    config = str(billing / ".spine" / "repos.yaml")
+
+    out = blast_radius(symbol="create_order", repos=config)
+
+    assert "multi_repo_available" not in out
+    assert out["matches"][0]["cross_repo_count"] >= 1
+
+
+def test_an_approval_is_about_one_repo_and_is_not_nudged(tmp_path: Path) -> None:
+    """A decision on one repository's plan is not a question about the others."""
+    from orchestrator.plugin.server import sdlc_approve
+
+    billing = _repo_declaring_siblings(tmp_path)
+
+    out = sdlc_approve(str(billing), "TCK-9", decided_by="falcon")
+
+    assert "no plan at" in out["error"]
+    assert "multi_repo_available" not in out
+
+
+def test_an_unreadable_repo_reports_the_error_and_nothing_else(tmp_path: Path) -> None:
+    out = blast_radius(repo_path=str(tmp_path / "nowhere"), symbol="create_order")
+
+    assert "error" in out
+    assert "multi_repo_available" not in out


### PR DESCRIPTION
Follow-up to #237, which made cross-repo answers possible. One case it could not
make loud from the inside:

**Extracting a single directory always succeeds.** There is no error to raise. So pointing a
comprehension tool at one service of several returns `0 caller(s)` that is indistinguishable
from `0 caller(s)` checked across every service — and the first is the answer that gets a
handler changed.

Measured on `corpus/multirepo/http_join`, copied to a realistic sibling layout:

| Call | `caller_count` | `cross_repo_count` | `standing` |
|---|---|---|---|
| `blast_radius(repo_path=<one service>)` | 0 | absent | absent |
| `blast_radius(repos=<yaml>)` | 0 | **1** | present |

The two obvious wrong calls already fail loudly — `map_repo(repos=…)` is a schema error
(`repo_path Field required`) and passing the YAML as `repo_path` gives `is not a directory`.
Pointing at a plausible directory is the one that doesn't.

## What this adds

Comprehension tools called with `repo_path` attach a **`multi_repo_available`** note when the
repo declares siblings in its own `.spine/repos.yaml`:

```json
{
  "config": "…/billing/.spine/repos.yaml",
  "declares": ["billing", "web"],
  "note": "This answer covers one repository. … declares 2 (billing, web) — pass repos='…' to include dependents in the others."
}
```

`find_repo_config` already existed and **deliberately does not walk upward**, so this cannot
fire on a parent's config and silently change what a command in a subdirectory means.

## What it deliberately is not

- **A note, never a switch.** It does not redirect the caller to the merged graph. Which
  repositories an answer covers stays the caller's decision.
- **Not silent on a broken config.** A `repos.yaml` too malformed to parse still produces a
  note — an unreadable config is still evidence the project is multi-repo, and staying quiet
  there is the exact failure mode this exists for.
- **Not on every tool.** `sdlc_approve` opts out: a decision about one repository's plan is not
  a question about the others.
- **Not on errors**, and it never overwrites a key a tool already set (`docs_for` has its own
  `note`).

`map_repo` remains single-repo — merging it would mean restructuring `knowledge/analysis.py`,
which is root-based and profiles the tree. That was considered and declined as
over-engineering; the note covers the risk that motivated it.

## Verification

7 new tests covering: the nudge fires and the underlying answer is unchanged; it reaches every
single-repo comprehension tool; a one-repo project hears nothing; a broken config still speaks
up; the merged answer does not nudge toward itself; `sdlc_approve` is exempt; an error carries
no note.

`mypy src tests` clean · `ruff format --check .` clean · **3116 passed, 3 skipped** (env-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)