### PR TITLE
Stop the pre-commit hooks rewriting uv.lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,23 +12,30 @@
 # Running from the project env means one source of truth (pyproject) and local results that
 # match CI. The cost is that these hooks need `uv sync --extra dev` first, which contributors
 # run anyway. Hooks that do not depend on the project's dependency graph stay pinned below.
+#
+# `--frozen` on every `uv run` below: without it, `uv run` re-resolves and REWRITES `uv.lock`
+# on every commit. When your uv is older than the one that last wrote the lock, that rewrite
+# downgrades the file format and churns unrelated dependency markers — pre-commit then aborts
+# with "files were modified by this hook", attributed to `ruff (lint, --fix)`, which is not
+# where the change came from. Linting has no business editing the lockfile, so it does not.
+# Relocking stays a deliberate `uv lock`.
 repos:
   - repo: local
     hooks:
       - id: ruff
         name: ruff (lint, --fix)
-        entry: uv run ruff check --fix
+        entry: uv run --frozen ruff check --fix
         language: system
         types_or: [python, pyi]
       - id: ruff-format
         name: ruff (format)
-        entry: uv run ruff format
+        entry: uv run --frozen ruff format
         language: system
         types_or: [python, pyi]
       - id: mypy
         name: mypy src tests
         # `mypy src tests`, not just `src` — typing src alone passes locally and fails CI.
-        entry: uv run mypy src tests
+        entry: uv run --frozen mypy src tests
         language: system
         pass_filenames: false
         files: ^(src|tests)/


### PR DESCRIPTION
The three local hooks run `uv run …`, which re-resolves the project — so **every commit
rewrote `uv.lock`**.

When a contributor's `uv` is older than the one that last wrote the lock (here: 0.8.0 against
a lock at `revision 3`), that rewrite downgrades the file format and churns ~50 lines of
unrelated dependency markers. pre-commit then aborts with:

```
ruff (lint, --fix).......................................................Failed
- hook id: ruff
- files were modified by this hook
```

Which is doubly misleading: ruff passed, and ruff is not what changed the file. The commit
fails, the diff looks nothing like the commit message, and the workaround people reach for is
`--no-verify` — which also skips the secret scan.

## The fix

`uv run --frozen` on all three hooks — still the project environment, one source of truth,
same results as CI, but the lockfile is off limits. Linting has no business editing a
lockfile. Relocking stays a deliberate `uv lock`.

## Verification

Measured before and after, by hash:

| command | `uv.lock` |
|---|---|
| `uv run ruff --version` | **rewritten** |
| `uv run --frozen ruff --version` | unchanged |

Then `pre-commit run --all-files`, so all three hooks actually execute:

```
ruff (lint, --fix).......................................................Passed
ruff (format)............................................................Passed
mypy src tests...........................................................Passed
✅ uv.lock UNTOUCHED
```

That last step matters: committing this change *alone* proves nothing, because a YAML-only
diff skips every hook it fixes. The first run of this was exactly that false positive.

## Note

This does not touch the lockfile itself, which is separately stale — it records `3.21.0`
against a `pyproject.toml` at `3.23.0`, and lacks the `[all]` / `[languages]` extras added in
#237. That wants a `uv lock` from a machine with a current `uv`; running it here would
reintroduce the format downgrade this PR is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)