### PR TITLE
Relock uv.lock at 3.24.0, with the extras it was missing

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3734,7 +3734,7 @@ wheels = [
 
 [[package]]
 name = "synaptixs-spine"
-version = "3.21.0"
+version = "3.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },
@@ -3761,6 +3761,22 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "mcp" },
+    { name = "openpyxl" },
+    { name = "pypdf" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "python-docx" },
+    { name = "sqlglot" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-c" },
+    { name = "tree-sitter-c-sharp" },
+    { name = "tree-sitter-cpp" },
+    { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
+    { name = "tree-sitter-typescript" },
+]
 asr = [
     { name = "openai-whisper" },
 ]
@@ -3801,6 +3817,16 @@ go = [
 java = [
     { name = "tree-sitter" },
     { name = "tree-sitter-java" },
+]
+languages = [
+    { name = "sqlglot" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-c" },
+    { name = "tree-sitter-c-sharp" },
+    { name = "tree-sitter-cpp" },
+    { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
+    { name = "tree-sitter-typescript" },
 ]
 mcp = [
     { name = "mcp" },
@@ -3884,6 +3910,8 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "sqlglot", marker = "extra == 'dev'", specifier = ">=25" },
     { name = "sqlglot", marker = "extra == 'sql'", specifier = ">=25" },
+    { name = "synaptixs-spine", extras = ["c", "cpp", "csharp", "go", "java", "sql", "typescript"], marker = "extra == 'languages'" },
+    { name = "synaptixs-spine", extras = ["languages", "mcp", "docs", "office", "sdlc"], marker = "extra == 'all'" },
     { name = "temporalio", specifier = ">=1.7" },
     { name = "testcontainers", marker = "extra == 'sql-postgres'", specifier = ">=4" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.50" },
@@ -3904,7 +3932,7 @@ requires-dist = [
     { name = "types-pyyaml", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
-provides-extras = ["security", "java", "typescript", "csharp", "c", "cpp", "go", "sql", "sql-postgres", "docs", "office", "mcp", "media", "asr", "sdlc", "tui", "otel", "dev"]
+provides-extras = ["security", "java", "typescript", "csharp", "c", "cpp", "go", "sql", "sql-postgres", "docs", "office", "mcp", "media", "asr", "sdlc", "tui", "otel", "dev", "languages", "all"]
 
 [[package]]
 name = "temporalio"


### PR DESCRIPTION
The last outstanding item from the 3.24.0 work.

`uv.lock` recorded `synaptixs-spine 3.21.0` against a `pyproject.toml` at `3.24.0`, and had no
entry for the `all` / `languages` extras added in #237 — so `pip install 'synaptixs-spine[all]'`,
the install line now in both plugin READMEs and both guides, was one the lockfile could not
satisfy.

## Why it stayed stale

Not a decision — a tooling gap. The `uv` on this machine is **0.8.0** (July 2025); the lock was
written by something newer and carries `revision = 3`. Locking with 0.8.0 downgrades that to
`revision = 2` and rewrites ~50 lines of unrelated CUDA dependency markers, so every attempt to
fix the staleness introduced worse churn than it removed.

Resolved with `uvx uv@0.12.6 lock` — a current uv in an ephemeral environment, **without**
upgrading the machine's global install.

## The diff is 30 lines

- `synaptixs-spine` `3.21.0` → `3.24.0`
- resolved `all` and `languages` extras
- `provides-extras` gains both

No revision change. No marker churn.

## Verified

| Check | Result |
|---|---|
| `uv lock --check` (uv 0.12.6) | clean — the lock is genuinely current |
| Local `uv` 0.8.0 against a `revision 3` lock | runs fine — it only rewrites on *write* |
| `uv sync --locked --extra dev --extra mcp` (the CI path) | resolves |
| pre-commit hooks touch the lock? | no, as of #239 |
| Test suite | **3116 passed, 3 skipped** |

One note on that last row: re-syncing the venv with `--locked` prunes it to exactly the named
extras, which briefly dropped `media` and turned one passing test into a skip (3115/4). Restored
with `--extra media` and re-run to confirm the original 3116/3 baseline — the lockfile change
itself moves nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)