### PR TITLE
fix(sdlc): make the ticket gate issue-type aware

### DIFF
--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -905,6 +905,7 @@ orchestrator sdlc plan --spec ./SSPN-49.json --path .
 | `--path` | Repo to reason about — the graph the plan is grounded in. (default: `.`) |
 | `--out` | Where the document goes (default: `<repo>/.spine/plans`). |
 | `--language` | Target language named in the codegen-prompt section. (default: `python`) |
+| `--issue-type` | Override the ticket's issue type (`Bug`, `Story`, …) — it decides whether the validity section requires the ticket to localize. Default: read it from the ticket; with `--spec` there is no ticket to read. |
 | `--quiet` | Write the document without printing it. |
 
 **Section 8 takes one extra spec field.** `met_criteria` maps a stated criterion's exact
@@ -980,6 +981,7 @@ orchestrator sdlc autorun --source jira://PROJ-14 --issue PROJ-14 --path . --saf
 | `--review` / `--no-review` | Show the diff and ask before committing or pushing anything. (default: `--no-review`) |
 | `--base` | Branch to build on **and** open the PR into (default `$SDLC_PR_BASE`, else the remote's default branch). The run's worktree is cut from this, so on a repo that merges to `develop`, leaving it unset builds the change on `main`. |
 | `--language` | Target language (auto detects). (default: `auto`) |
+| `--issue-type` | Override the ticket's issue type (`Bug`, `Story`, …), which selects the workflow profile and decides whether the ticket must localize. Default: read it from the ticket. With `--spec` there is no ticket to read, so this is the only way to type that run. |
 | `--out` | Where run artifacts go (default: a run dir under the temp dir). |
 | `--resume` | Continue a run by id — adopts the issue it already created. |
 | `--max-cost` | Cap LLM spend (USD) for this run; exhausting it parks the run. |

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -1219,7 +1219,14 @@ and the run says so rather than skipping research silently.
 **The enhancement profile has no `n_rca`.** Root-cause analysis localizes a *symptom*, and a
 feature request has none — it would resolve nothing and print "not localized", an empty section
 that reads as a finding. An enhancement run records RCA as *not run for this issue type*, which
-is a different statement.
+is a different statement, and its evidence says so in those words.
+
+**It has `n_churn` instead.** `build_rca` also carries a `git log` recency pass, and dropping the
+whole node dropped that with it for half of all tickets — "is this area moving?" does not depend
+on a symptom. The enhancement's churn is crossed with its **landing sites** rather than a fault
+site, which makes it the weaker of the two readings: where a ticket's vocabulary already lives is
+what it will attach to, not what it will touch. It is worded accordingly and never says
+"regression". One implementation (`sdlc/churn.py`) serves both profiles.
 
 ### `orchestrator sdlc workflow`
 
@@ -1235,7 +1242,7 @@ model. `n_design` is declared an agent node because that is the target state; it
 `llm=None` today.
 
 **`sdlc autorun` executes this graph.** Its deterministic research nodes — `n_investigate`,
-`n_rca`, `n_blast_radius` — run through the tool registry and compose one `Evidence` artifact
+`n_rca` (or `n_churn`), `n_blast_radius` — run through the tool registry and compose one `Evidence` artifact
 that `validity`, `design` and the acceptance criteria are all judged against. Set
 `SPINE_SDLC_IMPERATIVE=1` to fall back to the pre-graph path, which stays available for one
 release.

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -1071,6 +1071,13 @@ def sdlc_autorun(
     ] = False,
     base: Annotated[str | None, typer.Option("--base", help="PR target branch.")] = None,
     language: Annotated[str, typer.Option("--language", help="Target language (auto detects).")] = "auto",
+    issue_type: Annotated[
+        str,
+        typer.Option(
+            "--issue-type",
+            help="Override the ticket's issue type (Bug, Story, …). Default: read it from the ticket.",
+        ),
+    ] = "",
     out: Annotated[
         Path | None,
         typer.Option("--out", help="Where run artifacts go (default: a run dir under the temp dir)."),
@@ -1133,6 +1140,7 @@ def sdlc_autorun(
                 gate=_terminal_gate() if review else None,
                 base_branch=base,
                 language=language,
+                issue_type=issue_type,
                 artifacts_dir=out,
                 resume=resume,
                 max_cost_usd=max_cost,
@@ -1167,6 +1175,13 @@ def sdlc_plan(
         typer.Option("--out", help="Where the document goes (default: <repo>/.spine/plans)."),
     ] = None,
     language: Annotated[str, typer.Option("--language", help="Target language for the prompt.")] = "python",
+    issue_type: Annotated[
+        str,
+        typer.Option(
+            "--issue-type",
+            help="Override the ticket's issue type (Bug, Story, …). Default: read it from the ticket.",
+        ),
+    ] = "",
     quiet: Annotated[bool, typer.Option("--quiet", help="Write the document without printing it.")] = False,
 ) -> None:
     """Produce the build document for ONE ticket and stop. No worktree, no code, no spend.
@@ -1194,6 +1209,9 @@ def sdlc_plan(
 
     async def _go() -> None:
         resolved = injected
+        # The flag wins; otherwise the ticket answers. An injected spec has no ticket behind
+        # it, so with `--spec` and no flag the document is honestly untyped.
+        resolved_type = issue_type
         if resolved is None:
             from orchestrator.core.env import load_local_env
             from orchestrator.core.llm.client import LLMError
@@ -1225,12 +1243,17 @@ def sdlc_plan(
                 typer.echo(f"Intent {intent!r} not found. Available: {ids}", err=True)
                 raise typer.Exit(code=3)
             resolved = chosen.model_dump()
+            if not resolved_type:
+                from orchestrator.intake.ticket_meta import resolve_ticket_meta
+
+                resolved_type = resolve_ticket_meta(plan_result, chosen).issue_type
 
         intent_key = str(resolved.get("intent_id") or "spec")
         document = await build_plan(
             resolved,
             root=path,
             language=language,
+            issue_type=resolved_type,
             # Rendered, never stored in the document: a plan that changed since it was
             # approved shows as stale rather than carrying an approval it outgrew.
             approval=load_approval(intent_key, root=path, out=out),

--- a/src/orchestrator/intake/cache.py
+++ b/src/orchestrator/intake/cache.py
@@ -34,7 +34,12 @@ from orchestrator.intake.specs import FeatureSpec
 logger = logging.getLogger("orchestrator.intake.cache")
 
 # Bump when the serialized shape changes so stale files are ignored, not crashed on.
-_CACHE_VERSION = 1
+#
+# 2: `SourceDocument.issue_type`. A new optional field would not *crash* a v1 read — it
+# defaults to "" — and that is exactly the problem: a warm cache would keep serving untyped
+# documents, every run would keep selecting the `default` profile, and nothing would say why.
+# Bumping turns a silent wrong answer into a refetch.
+_CACHE_VERSION = 2
 
 
 def default_cache_dir() -> Path:

--- a/src/orchestrator/intake/jira_source.py
+++ b/src/orchestrator/intake/jira_source.py
@@ -80,21 +80,37 @@ def _description_text(description: Any) -> str:
     return ""
 
 
+def issue_type_of(fields: dict[str, Any]) -> str:
+    """``"Bug"`` from a Jira issue's fields, or ``""``.
+
+    Accepts **both spellings of the type key**, because the two transports disagree: Jira REST
+    returns ``issuetype``, while ``mcp-atlassian`` returns ``issue_type``. Reading only the
+    REST spelling is how the meta header silently produced nothing at all over MCP — the tests
+    mocked REST's shape, so they agreed with the code and both were wrong about the real
+    server.
+
+    One function so the *header* and the ``SourceDocument.issue_type`` *field* cannot disagree
+    about what type an issue is. They feed different consumers — the header is prose for the
+    intent extractor, the field is data for the deterministic pipeline — and a ticket whose
+    two answers differed would be a defect nobody could see from either one alone.
+    """
+    type_obj = fields.get("issuetype") or fields.get("issue_type") or {}
+    return str(type_obj.get("name") or "") if isinstance(type_obj, dict) else str(type_obj)
+
+
 def issue_meta_header(fields: dict[str, Any]) -> str:
     """``"Bug · status: Open · priority: High"`` from a Jira issue's fields, or ``""``.
 
     Shared by the REST adapter and the MCP one so an issue reads the same whichever
-    transport fetched it. The header is how issue *type* reaches the extractor at all —
-    :class:`SourceDocument` has no field for it, so it is prepended to the body, and a Bug
-    genuinely reads differently from a Story.
+    transport fetched it. This is how issue type, status and priority reach the *extractor* —
+    prepended to the body, because a Bug genuinely reads differently from a Story and the
+    model only sees prose.
 
-    Accepts **both spellings of the type key**, because the two transports disagree: Jira REST
-    returns ``issuetype``, while ``mcp-atlassian`` returns ``issue_type``. Reading only the
-    REST spelling is how this silently produced no header at all over MCP — the tests mocked
-    REST's shape, so they agreed with the code and both were wrong about the real server.
+    The type also travels as ``SourceDocument.issue_type``, which is what selects a workflow
+    profile. This header cannot serve that: parsing a profile decision back out of a body
+    string would make the pipeline depend on prose formatting.
     """
-    type_obj = fields.get("issuetype") or fields.get("issue_type") or {}
-    itype = str(type_obj.get("name") or "") if isinstance(type_obj, dict) else str(type_obj)
+    itype = issue_type_of(fields)
     status = str((fields.get("status") or {}).get("name") or "")
     priority = str((fields.get("priority") or {}).get("name") or "")
     parts = (itype, f"status: {status}" if status else "", f"priority: {priority}" if priority else "")
@@ -131,7 +147,15 @@ class JiraSourceAdapter:
         body = _collapse("\n\n".join(p for p in (header, _description_text(fields.get("description"))) if p))
         url = f"{self._config.base_url.rstrip('/')}/browse/{key}" if key else ""
         project = project_key_of(key)
-        return SourceDocument(id=key, title=summary, body=body, url=url, space=project, labels=labels)
+        return SourceDocument(
+            id=key,
+            title=summary,
+            body=body,
+            url=url,
+            space=project,
+            labels=labels,
+            issue_type=issue_type_of(fields),
+        )
 
     async def fetch_document(self, doc_id: str) -> SourceDocument:
         data = await self._get(f"/issue/{doc_id}", params={"fields": _FIELDS})

--- a/src/orchestrator/intake/mcp_source.py
+++ b/src/orchestrator/intake/mcp_source.py
@@ -29,7 +29,12 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-from orchestrator.intake.jira_source import _description_text, issue_meta_header, project_key_of
+from orchestrator.intake.jira_source import (
+    _description_text,
+    issue_meta_header,
+    issue_type_of,
+    project_key_of,
+)
 from orchestrator.intake.source import (
     DEFAULT_MAX_DEPTH,
     DEFAULT_MAX_DOCS,
@@ -135,11 +140,10 @@ def _parse_document(doc_id: str, data: Any, raw_text: str) -> SourceDocument:
         body = _description_text(fields.get("description"))
     body = body.strip()
 
-    # Jira issues carry type/status/priority, and SourceDocument has no field for them — the
-    # REST adapter prepends them to the body so the extractor can tell a Bug from a Story and
-    # done from open. Do the same here, from the same helper, or the identical epic ingested
-    # over MCP arrives untyped while the REST path types it. Guarded on `fields` so Confluence
-    # pages (which have no such shape) are untouched.
+    # Jira issues carry type/status/priority; the REST adapter prepends them to the body so the
+    # extractor can tell a Bug from a Story and done from open. Do the same here, from the same
+    # helper, or the identical epic ingested over MCP arrives untyped while the REST path types
+    # it. Guarded on `fields` so Confluence pages (which have no such shape) are untouched.
     header = issue_meta_header(fields) if fields else ""
 
     # The raw-text fallback is for a payload we did not recognise AT ALL — not for one we
@@ -166,7 +170,17 @@ def _parse_document(doc_id: str, data: Any, raw_text: str) -> SourceDocument:
     # mcp-atlassian hands back the browse link, so the `url` the REST adapter builds from its
     # base URL is available here after all — no need to know the host.
     url = str(doc.get("browse_url") or doc.get("url") or "")
-    return SourceDocument(id=resolved_id, title=title, body=body, labels=labels, space=space, url=url)
+    return SourceDocument(
+        id=resolved_id,
+        title=title,
+        body=body,
+        labels=labels,
+        space=space,
+        url=url,
+        # Same helper as the header above, and the same `fields` guard: an issue ingested over
+        # MCP must select the same workflow profile as the identical issue over REST.
+        issue_type=issue_type_of(fields) if fields else "",
+    )
 
 
 def _parse_children(data: Any) -> list[SourceRef]:

--- a/src/orchestrator/intake/source.py
+++ b/src/orchestrator/intake/source.py
@@ -46,6 +46,16 @@ class SourceDocument:
     url: str = ""
     space: str = ""
     labels: tuple[str, ...] = ()
+    #: The tracker's own type string — ``Bug``, ``Story``, ``New Feature``, whatever a team
+    #: typed into the dropdown. Carried **unnormalised**: mapping it to a workflow profile is
+    #: `sdlc.profile_select`'s job, and a source that silently canonicalised it would give the
+    #: run a type the tracker never used.
+    #:
+    #: It is also prepended to ``body`` (see ``jira_source.issue_meta_header``) so the intent
+    #: extractor reads it as prose. That is a different consumer: the header is for the model,
+    #: this field is for the deterministic pipeline, and only the second can select a profile
+    #: or decide whether a ticket must localize. Empty for sources that have no such notion.
+    issue_type: str = ""
 
     @property
     def is_empty(self) -> bool:

--- a/src/orchestrator/intake/ticket_meta.py
+++ b/src/orchestrator/intake/ticket_meta.py
@@ -1,0 +1,111 @@
+"""Resolve a run's tracker metadata — issue type and labels — from the intake plan.
+
+**The defect this closes.** The pipeline is issue-type shaped: `sdlc.profile_select` picks a
+workflow profile from the type, `validity` decides whether a ticket must localize by it, and
+the `bug`/`enhancement` profiles exist to be selected by it. None of that ever fired. The
+only thing intake hands a run is a ``FeatureSpec``, which forbids extra keys and has no field
+for a type — so ``spec.get("issue_type")`` was always ``""``, every run took the ``default``
+profile, and the localization check never once ran outside its tests.
+
+**Why not a field on ``FeatureSpec``.** A spec says *what to build*; the issue type is a fact
+about the ticket, and the spec is written by a model. Putting the type there would let the
+model decide which research a ticket gets, which is precisely what `profile_select`'s
+docstring exists to prevent — the Evidence would stop being reproducible at a commit.
+
+**So it is resolved, not carried.** ``BacklogPlan`` already holds the documents, the intents
+and the specs together, and ``Intent.source_doc_ids`` already links the middle to the left.
+The walk ``spec.intent_id → Intent → source_doc_ids → SourceDocument`` is a lookup over data
+already fetched: no model, no network, no new request.
+
+**One document or nothing.** Where the walk lands on several documents that disagree, this
+returns empty and says why rather than picking. An issue type chosen by tie-break would
+select a profile, and a run whose research was decided by list order is not reproducible in
+any sense worth the word.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from orchestrator.intake.service import BacklogPlan
+    from orchestrator.intake.source import SourceDocument
+
+__all__ = ["TicketMeta", "resolve_ticket_meta"]
+
+
+@dataclass(frozen=True)
+class TicketMeta:
+    """What the tracker says about a ticket, and where the answer came from."""
+
+    issue_type: str = ""
+    labels: tuple[str, ...] = ()
+    #: Provenance, for the run to print: a document id, ``"--issue-type"`` when an operator
+    #: overrode it, or a sentence explaining why nothing was resolved. Never empty when
+    #: something *could* have been resolved and was not — "why did it choose `default`?" is
+    #: the question this whole module exists to keep answerable.
+    origin: str = ""
+    #: Notes worth emitting: the ambiguity that stopped a resolution, and nothing else.
+    detail: str = ""
+
+    @property
+    def known(self) -> bool:
+        return bool(self.issue_type)
+
+
+def _spec_field(spec: Any, name: str) -> str:
+    if isinstance(spec, Mapping):
+        return str(spec.get(name) or "")
+    return str(getattr(spec, name, "") or "")
+
+
+def _documents_for(plan: BacklogPlan, intent_id: str) -> list[SourceDocument]:
+    """The documents an intent came from, in plan order.
+
+    Falls back to every document the plan holds when the intent is unknown or names no
+    source: the extractor may omit ``source_doc_ids``, and a single-document plan is still
+    unambiguous. With more than one document and no link, the caller gets the ambiguity
+    rather than a guess.
+    """
+    by_id = {d.id: d for d in plan.documents}
+    intent = next((i for i in plan.intents if i.id == intent_id), None)
+    if intent is not None:
+        named = [by_id[ref] for ref in intent.source_doc_ids if ref in by_id]
+        if named:
+            return named
+    return list(plan.documents)
+
+
+def resolve_ticket_meta(plan: BacklogPlan, spec: Any) -> TicketMeta:
+    """The tracker metadata behind one spec. Deterministic; no model, no network.
+
+    ``spec`` is a ``FeatureSpec`` or the dict it dumps to — the pipeline carries both shapes.
+    """
+    intent_id = _spec_field(spec, "intent_id")
+    docs = _documents_for(plan, intent_id)
+    if not docs:
+        return TicketMeta(origin="", detail="the plan carries no source document")
+    if len(docs) > 1:
+        types = sorted({d.issue_type for d in docs if d.issue_type})
+        # Agreement is not ambiguity: three subtasks all filed as Bug answer the question.
+        if len(types) != 1:
+            return TicketMeta(
+                origin="",
+                detail=(
+                    f"{len(docs)} source documents for intent `{intent_id}`"
+                    + (f" disagree on issue type ({', '.join(types)})" if types else " carry no issue type")
+                ),
+            )
+        labels = tuple(sorted({label for d in docs for label in d.labels}))
+        return TicketMeta(issue_type=types[0], labels=labels, origin=", ".join(d.id for d in docs))
+    doc = docs[0]
+    return TicketMeta(
+        issue_type=doc.issue_type,
+        # Sorted, because a label set is unordered and `select_profile` matches over it. "First
+        # match wins" over an arrival-ordered set is not reproducible.
+        labels=tuple(sorted(doc.labels)),
+        origin=doc.id,
+        detail="" if doc.issue_type else f"`{doc.id}` carries no issue type",
+    )

--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -623,10 +623,11 @@ async def _stage_intake(
 _IMPERATIVE_ENV = "SPINE_SDLC_IMPERATIVE"
 
 # Node ids in the profile, so the two paths agree on what to call each step.
-_N_INVESTIGATE, _N_RCA, _N_BLAST, _N_VALIDITY = (
+_N_INVESTIGATE, _N_RCA, _N_BLAST, _N_CHURN, _N_VALIDITY = (
     "n_investigate",
     "n_rca",
     "n_blast_radius",
+    "n_churn",
     "n_validity",
 )
 
@@ -756,6 +757,25 @@ async def _research_pass(
             seconds=time.monotonic() - started,
         )
 
+        # The churn node, where the profile declares one. `bug` and `default` get the same
+        # question answered inside `n_rca`, keyed to the fault site; this is the landing-site
+        # reading, which is what an enhancement can have. One implementation behind both.
+        churn_value: dict[str, Any] = {}
+        if any(node.id == _N_CHURN for node in ir.spec.nodes):
+            started = time.monotonic()
+            churn = await registry.run("sdlc.churn", files=list(files), root=ctx.root)
+            churn_value = churn.value
+            ctx.case.record(
+                _N_CHURN,
+                kind="tool",
+                status="ok",
+                digest=churn.digest,
+                tool=churn.name,
+                detail=f"{len(churn.value.get('files') or [])} of {len(files)} landing file(s) "
+                f"changed in the last {churn.value.get('commits', 0)} commits",
+                seconds=time.monotonic() - started,
+            )
+
         evidence = evidence_from_parts(
             title=title,
             problem=summary,
@@ -763,6 +783,7 @@ async def _research_pass(
             investigate=investigate.value,
             rca=rca_value,
             blast=blast.value,
+            churn=churn_value,
         )
         ctx.evidence = evidence
         ctx.case.evidence = to_dict(evidence)

--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -79,6 +79,14 @@ class RunContext:
     worktree: str = ""
     pr_url: str | None = None
     spec: dict[str, Any] | None = None
+    # What the tracker says about this ticket, resolved once at intake and read by everything
+    # that is issue-type shaped: which profile runs, whether the ticket must localize, whether
+    # an unbound criterion parks the run. It is *not* on the spec — a spec is written by a
+    # model, and a model choosing which research a ticket gets is the one thing
+    # `profile_select` exists to prevent. Empty is a legitimate answer and behaves as it
+    # always did: the `default` profile, and a reason printed at intake.
+    issue_type: str = ""
+    labels: tuple[str, ...] = ()
     # The design, rendered — handed to codegen so the implement stage acts on what the
     # design stage decided rather than re-deriving its own view of the ticket.
     plan: str = ""
@@ -255,6 +263,10 @@ async def autorun(
     does today: the brief and design are written to the run directory, the code is committed
     locally, and no tracker or forge is touched.
 
+    ``issue_type`` **overrides** what intake resolves from the ticket, and is the only way the
+    ``spec=`` path can be typed at all — an injected spec has no source document behind it.
+    Empty means "ask the ticket", which is the normal case.
+
     ``resume`` continues a run that already exists: it keeps the run id, and adopts the
     tracker issue that run already created rather than creating a second one. ``max_cost_usd``
     caps LLM spend for the run; exhausting it parks the run instead of shipping half a change.
@@ -339,7 +351,7 @@ async def autorun(
     ):
         try:
             with ctx.stage_span("intake"):
-                await _stage_intake(ctx, intent_id=intent_id, spec=spec, emit=emit)
+                await _stage_intake(ctx, intent_id=intent_id, spec=spec, issue_type=issue_type, emit=emit)
             # Before the graph, before any spend: was this plan read and approved? The gate
             # is here rather than before intake because it needs the spec to know which plan
             # it is asking about.
@@ -347,11 +359,13 @@ async def autorun(
             store_graph, overview = _load_graph(ctx, emit=emit)
             # Research first, and before validity: a run that parks still leaves its Evidence
             # behind, which is the artifact a human is asked to judge the park on.
-            await _research_pass(ctx, store=store_graph, issue_type=issue_type, emit=emit)
+            # `ctx.issue_type`, not the parameter: intake resolved it from the ticket, and the
+            # parameter is only the operator's override into that resolution.
+            await _research_pass(ctx, store=store_graph, issue_type=ctx.issue_type, emit=emit)
             with ctx.stage_span("investigate"):
                 _stage_investigate(ctx, store=store_graph, emit=emit)
             with ctx.stage_span("validity"):
-                _stage_validity(ctx, store=store_graph, issue_type=issue_type, emit=emit)
+                _stage_validity(ctx, store=store_graph, issue_type=ctx.issue_type, emit=emit)
             with ctx.stage_span("design"):
                 await _stage_design(ctx, store=store_graph, overview=overview, emit=emit)
             with ctx.stage_span("implement"):
@@ -516,11 +530,30 @@ async def _require_plan(ctx: RunContext, *, enabled: bool, emit: Callable[[str],
 # ---- stages ----------------------------------------------------------------
 
 
+def _adopt_issue_type(
+    ctx: RunContext, issue_type: str, *, origin: str, detail: str = "", emit: Callable[[str], None]
+) -> None:
+    """Record the resolved issue type on the run, and say where it came from.
+
+    Always emits, including when nothing resolved. "Why did this run take the `default`
+    profile?" has to be answerable from the run's own output; an untyped run that says
+    nothing is how the whole issue-type-shaped pipeline sat unreachable without anyone
+    noticing.
+    """
+    resolved = issue_type.strip()
+    ctx.issue_type = resolved
+    if resolved:
+        emit(f"[intake] issue type `{resolved}`" + (f" (from {origin})" if origin else ""))
+        return
+    emit("[intake] no issue type" + (f" — {detail}" if detail else ""))
+
+
 async def _stage_intake(
     ctx: RunContext,
     *,
     intent_id: str | None,
     spec: dict[str, Any] | None = None,
+    issue_type: str = "",
     emit: Callable[[str], None],
 ) -> None:
     """Resolve the source to one spec, once, and hand it to every later stage.
@@ -532,10 +565,19 @@ async def _stage_intake(
     A caller-supplied ``spec`` replaces that derivation outright: intake does not run, and
     the stage records *skipped* rather than *ok*, so the summary never implies a source
     document was read. The source URI is still what the run is filed against.
+
+    It is also where the ticket's **issue type** is resolved, from the plan's own documents
+    (:func:`orchestrator.intake.ticket_meta.resolve_ticket_meta`). Once, here, so every later
+    stage reads one answer: the profile selector and the validity gate disagreeing about
+    whether a ticket is a bug would be a defect visible from neither side alone.
     """
     if spec is not None:
         ctx.spec = dict(spec)
         ctx.spec.setdefault("intent_id", intent_id or "injected")
+        # An injected spec has no source document behind it, so `--issue-type` is the only
+        # way this path can reach the bug profile at all. Silence here is what made a
+        # spec-file run untyped and unexplained.
+        _adopt_issue_type(ctx, issue_type, origin="--issue-type", emit=emit)
         ctx.record_stage("intake", "skipped", "spec supplied by the caller")
         emit(f"[intake] skipped — spec supplied: {ctx.spec.get('title', '')}")
         return
@@ -544,6 +586,7 @@ async def _stage_intake(
     from orchestrator.intake.cache import analyze_cached
     from orchestrator.intake.factory import IntakeNotConfiguredError, build_service_for
     from orchestrator.intake.service import parse_source_uri
+    from orchestrator.intake.ticket_meta import resolve_ticket_meta
 
     load_local_env()
     parse_source_uri(ctx.source)
@@ -565,6 +608,12 @@ async def _stage_intake(
         raise AutorunError(f"Intent {intent_id!r} not found. Available: {ids}", code=3)
 
     ctx.spec = chosen.model_dump()
+    if issue_type.strip():
+        _adopt_issue_type(ctx, issue_type, origin="--issue-type", emit=emit)
+    else:
+        meta = resolve_ticket_meta(plan, chosen)
+        ctx.labels = meta.labels
+        _adopt_issue_type(ctx, meta.issue_type, origin=meta.origin, detail=meta.detail, emit=emit)
     ctx.record_stage("intake", "ok", f"spec: {ctx.spec.get('title', '')}")
     emit(f"[intake] {ctx.spec.get('title', '')} (intent {ctx.spec.get('intent_id', '')})")
 
@@ -615,7 +664,9 @@ async def _research_pass(
 
     spec = ctx.spec or {}
     title, summary = str(spec.get("title", "")), str(spec.get("summary", ""))
-    resolved_type = issue_type or str(spec.get("issue_type", ""))
+    # No `spec.get("issue_type")` fallback: `FeatureSpec` forbids extra keys and has no such
+    # field, so that read was always "" and made an unreachable path look supplied.
+    resolved_type = issue_type
     ctx.case = Case(
         run_id=ctx.run_id,
         issue_key=ctx.issue_key,
@@ -829,7 +880,7 @@ def _stage_validity(ctx: RunContext, *, store: Any, issue_type: str, emit: Calla
         ctx.spec or {},
         store=store,
         landing=ctx.landing,
-        issue_type=issue_type or str((ctx.spec or {}).get("issue_type", "")),
+        issue_type=issue_type,
         issue_key=ctx.issue_key,
         prior_runs=ctx.store.all() if ctx.store is not None else [],
         # The gate can only weigh the context budget if it can measure the files. Passing

--- a/src/orchestrator/sdlc/autorun.py
+++ b/src/orchestrator/sdlc/autorun.py
@@ -681,7 +681,10 @@ async def _research_pass(
         # Which research this ticket gets is a lookup on its issue type, not a judgement — and
         # it stays one. A model choosing would make the Evidence unreproducible at a commit,
         # which is the guarantee everything downstream rests on.
-        selection = select_profile(resolved_type, available=profile_names(ctx.root))
+        # Labels are the fallback, not an override: `select_profile` reads them only where the
+        # issue type maps to nothing. They have been fetched with every Jira issue since the
+        # adapter was written and read by nothing until now.
+        selection = select_profile(resolved_type, labels=ctx.labels, available=profile_names(ctx.root))
         emit(f"[research] {selection.reason}")
         ir = load_profile(selection.profile, ctx.root)
         report = await IRValidator().validate(ir)

--- a/src/orchestrator/sdlc/builddoc.py
+++ b/src/orchestrator/sdlc/builddoc.py
@@ -1129,6 +1129,7 @@ async def build_plan(
     *,
     root: Path | str = ".",
     language: str = "python",
+    issue_type: str = "",
     approval: PlanApproval | None = None,
     journey: list[JourneyEntry] | None = None,
 ) -> str:
@@ -1170,7 +1171,10 @@ async def build_plan(
         spec,
         store=store,
         landing=landing,
-        issue_type=str(spec.get("issue_type") or ""),
+        # Passed in, not read off the spec: `FeatureSpec` forbids extra keys and has no such
+        # field, so `spec["issue_type"]` was always "" and the localization check never ran.
+        # The caller resolves it from the ticket (`intake.ticket_meta`) or is handed it.
+        issue_type=issue_type,
         root=root_path,
         context_budget=_MAX_CONTEXT_BYTES,
     )

--- a/src/orchestrator/sdlc/churn.py
+++ b/src/orchestrator/sdlc/churn.py
@@ -1,0 +1,78 @@
+"""Recent git churn: which of these files changed lately, and how often.
+
+Lifted out of ``rca.py``, where it was computed and then thrown away for half of all tickets.
+``build_rca`` runs ``git log`` over the repo and intersects the result with the **fault file**,
+which localizes a symptom — so the enhancement profile, having no fault to localize, drops the
+whole node and the churn answer with it. "Is this area actively changing?" is not a
+symptom-dependent question, and an enhancement's author wants it as much as a bug's.
+
+**What it is intersected with is the whole design decision.** A repo-wide ``git log`` is not a
+signal; it becomes one when crossed with the files a ticket is about. For a bug those are the
+fault site. For an enhancement they are the landing sites — where the ticket's vocabulary
+already lives in the code — which is a **weaker** claim and must be worded like one. A feature's
+landing sites are what it will attach to, not what it will touch, so a hot landing site says
+"the area you are building into is moving", never "expect a regression". Borrowing RCA's
+regression framing here would state something this evidence does not support.
+
+Best-effort by construction: no git, a shallow clone, or a repo with no history yields nothing
+and says nothing. The one impurity in an otherwise pure-function pipeline is that this reads
+history, so the digest is a function of *the commit* rather than of the working tree — see the
+caveat in ``evidence.py``'s preamble, which this shares.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+__all__ = ["DEFAULT_COMMITS", "changed_recently", "recently_changed_files"]
+
+#: How far back "recently" reaches. Forty commits is what `build_rca` has always used; keeping
+#: the number in one place is what stops the bug path and the enhancement path from quietly
+#: meaning two different things by the same word.
+DEFAULT_COMMITS = 40
+
+
+def recently_changed_files(root: Path | str | None, *, commits: int = DEFAULT_COMMITS) -> set[str]:
+    """Repo-relative files touched in the last ``commits`` commits (best-effort)."""
+    if root is None:
+        return set()
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "log", "--name-only", "--pretty=format:", "-n", str(commits)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    if out.returncode != 0:
+        return set()
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+def changed_recently(
+    paths: list[str] | tuple[str, ...],
+    root: Path | str | None,
+    *,
+    commits: int = DEFAULT_COMMITS,
+) -> tuple[str, ...]:
+    """Which of ``paths`` are in that set, in the order given, de-duplicated.
+
+    Suffix-matched on a path boundary, because the two sides are named differently: git reports
+    ``src/orchestrator/pkg/store.py`` while a landing site may carry only ``store.py``. The
+    boundary is what keeps ``store.py`` from matching ``my_store.py``.
+    """
+    if not paths:
+        return ()
+    changed = recently_changed_files(root, commits=commits)
+    if not changed:
+        return ()
+    out: list[str] = []
+    for raw in paths:
+        path = str(raw).strip()
+        if not path or path in out:
+            continue
+        if any(c == path or c.endswith("/" + path) or path.endswith("/" + c) for c in changed):
+            out.append(path)
+    return tuple(out)

--- a/src/orchestrator/sdlc/criteria_binding.py
+++ b/src/orchestrator/sdlc/criteria_binding.py
@@ -14,13 +14,20 @@ so this module reuses that extractor and that binder rather than defining a seco
 "names a symbol". Two definitions would be two things that can disagree, and the first
 disagreement would be reported as a defect in the pipeline.
 
-**What parks a run, precisely.** Only a criterion that *makes a claim and gets it wrong*:
+**What parks a run, precisely.** Only a criterion that *makes a claim and gets it wrong*, and
+only on a ticket whose subject is code that already exists:
 
 | Criterion | Status | Parks? |
 |---|---|---|
 | names a symbol/file the graph holds | `bound` | no |
-| names a symbol/file with **code intent** that resolves to nothing | `unbound` | **yes** |
+| names a symbol/file with **code intent** that resolves to nothing | `unbound` | **on a bug** |
 | prose, or a mention that cannot carry code intent | `no-claim` | no |
+
+The middle row is a false premise on a bug and the *deliverable* on an enhancement — the same
+binding, two meanings — so `validity.assess` refuses the first and reports the second. Refusing
+both would mean the better-written criterion is the one that parks a feature: "the compiler
+returns >= 70 rules" is prose and proceeds, while "`rule_compiler` returns >= 70 rules" names
+its subject, is more testable, and would be the one to stop the run.
 
 The third row is what keeps this from parking everything. `_can_drift` in `pkg/docs.py` is the
 arbiter: CamelCase prose ("GitHub", "Python"), ALL-CAPS tokens (env vars, config keys), plain
@@ -80,7 +87,13 @@ class CriterionBinding:
 
     @property
     def parks(self) -> bool:
-        """Only an unbound *claim* stops a run. Prose never does."""
+        """Only an unbound *claim* can stop a run. Prose never can.
+
+        **Can**, not does: `validity.assess` makes that call, and it depends on the issue
+        type. A bug's subject is code that already exists, so an unbound claim is a false
+        premise and parks. An enhancement's unbound claim names the deliverable, and is
+        reported without stopping the run. This flag is the gate's input, not its verdict.
+        """
         return self.status == "unbound"
 
 

--- a/src/orchestrator/sdlc/evidence.py
+++ b/src/orchestrator/sdlc/evidence.py
@@ -7,6 +7,9 @@ Three deterministic passes compose into one artifact:
 * **rca** — fault site, regression surface, recently-changed, ranked hypotheses. Deterministic;
   ``build_rca`` only reaches a model when handed one, and nothing here hands it one.
 * **blast radius** — computed from **the landing sites**, not from a design's proposal.
+* **churn** — which of those landing files git touched lately, for the profiles that skip rca.
+  The same question rca answers about a *fault site*, asked about the area a ticket attaches
+  to, which is a weaker claim and worded as one.
 
 That last point is the reason this module exists rather than a helper inside ``design.py``.
 Today ``design.py`` calls ``blast_radius(store, design["files_to_touch"])`` — the impact
@@ -20,10 +23,10 @@ first is deliberate: it ships in shadow with zero behaviour change, and every la
 something true to be judged against.
 
 **Determinism, and one honest caveat.** Everything here is a pure function of the tree except
-``rca``'s recently-changed check, which shells out to ``git log -n 40``. That makes the digest a
-pure function of *the commit* rather than of the working tree alone — stable at a given commit,
-different if history is rewritten. That satisfies the boundary's ``(commit, inputs) → identical
-output`` wording, and is said here rather than discovered later.
+the recently-changed checks — ``rca``'s and ``churn``'s — which shell out to ``git log -n 40``.
+That makes the digest a pure function of *the commit* rather than of the working tree alone —
+stable at a given commit, different if history is rewritten. That satisfies the boundary's
+``(commit, inputs) → identical output`` wording, and is said here rather than discovered later.
 """
 
 from __future__ import annotations
@@ -34,6 +37,8 @@ from typing import Any
 
 from orchestrator.core.digest import SupportsRegister, digest_of
 from orchestrator.pkg import FactStore
+from orchestrator.sdlc.churn import DEFAULT_COMMITS as _CHURN_COMMITS
+from orchestrator.sdlc.churn import changed_recently
 
 __all__ = [
     "Evidence",
@@ -85,6 +90,10 @@ class Evidence:
     files: tuple[str, ...] = ()
     rca: dict[str, Any] = field(default_factory=dict)
     blast_radius: dict[str, Any] = field(default_factory=dict)
+    #: Landing files touched in the last `churn.DEFAULT_COMMITS` commits. Distinct from
+    #: ``rca["recently_changed"]``, which is the *fault file* and therefore a regression
+    #: signal; this is the area a ticket attaches to, and says only that it is moving.
+    recently_changed: tuple[str, ...] = ()
     # The PKG had grounded nodes at all. When false, every section below is legitimately empty
     # and says so — an empty Evidence that announces itself beats a confident-looking one
     # assembled from nothing.
@@ -132,6 +141,7 @@ def evidence_from_parts(
     investigate: dict[str, Any],
     rca: dict[str, Any],
     blast: dict[str, Any],
+    churn: dict[str, Any] | None = None,
 ) -> Evidence:
     """Assemble Evidence from the three tool outputs.
 
@@ -160,6 +170,7 @@ def evidence_from_parts(
         files=landing_files(rows),
         rca=dict(rca),
         blast_radius=dict(blast),
+        recently_changed=tuple(str(f) for f in (churn or {}).get("files") or ()),
         grounded=bool(investigate.get("grounded", False)),
     )
 
@@ -182,6 +193,7 @@ async def build_evidence(
     rca = await _tool_rca(store=store, problem=rca_problem(title, problem), root=root)
     files = landing_files(list(investigate.get("landing") or []))
     blast = _tool_blast_radius(store=store, files=list(files))
+    churn = _tool_churn(files=list(files), root=root)
     return evidence_from_parts(
         title=title,
         problem=problem,
@@ -189,6 +201,7 @@ async def build_evidence(
         investigate=investigate,
         rca=rca,
         blast=blast,
+        churn=churn,
     )
 
 
@@ -233,6 +246,7 @@ def to_dict(ev: Evidence) -> dict[str, Any]:
         ],
         "rca": ev.rca,
         "blast_radius": ev.blast_radius,
+        "recently_changed": list(ev.recently_changed),
     }
 
 
@@ -262,6 +276,14 @@ def render_evidence_md(ev: Evidence) -> str:
             out.append(f"- `{hit.name}` ({hit.kind}, {hit.callers} caller(s)){in_mod}{loc}")
         if ev.areas:
             out.append(f"\n_Areas: {', '.join(ev.areas)}_")
+        if ev.recently_changed:
+            # Deliberately not RCA's "treat a regression as the leading hypothesis": these are
+            # landing sites, which for a feature are where its vocabulary already lives rather
+            # than what it will touch. The weaker sentence is the true one.
+            out.append(
+                f"\n_Changing lately ({len(ev.recently_changed)} of these files were touched in "
+                f"the last {_CHURN_COMMITS} commits): {', '.join(ev.recently_changed[:10])}_"
+            )
     else:
         out.append("_No symbol matched the ticket's terms._")
     out.append("")
@@ -272,6 +294,13 @@ def render_evidence_md(ev: Evidence) -> str:
         out.append(f"**Fault site:** {rca['fault_site']}")
         if rca.get("recently_changed"):
             out.append("\n⚠ This module changed recently — a regression is the leading hypothesis.")
+    elif not rca:
+        # An empty dict means the node did not run — `_tool_rca` always returns its keys, so
+        # there is no other way to get here. That is a different statement from "we ran it and
+        # found nothing", and `enhancement.yaml` drops `n_rca` precisely to avoid printing the
+        # second: an empty section reads as a finding and is not one. The profile made the
+        # honest choice and the renderer went on printing the misleading sentence anyway.
+        out.append("_Not run for this issue type — root-cause analysis localizes a symptom._")
     else:
         out.append("_Not localized to a repo symbol._")
     hypotheses = rca.get("hypotheses") or []
@@ -373,9 +402,20 @@ def _tool_validity(
     }
 
 
+def _tool_churn(*, files: list[str], root: Path | str | None = None) -> dict[str, Any]:
+    """Which landing files changed lately. The signal `n_rca` computes and an enhancement lost.
+
+    Keyed off the landing sites, not a fault site: a feature has none. That makes this the
+    weaker of the two churn readings — the area a ticket attaches to is moving — and the
+    renderer says so rather than borrowing RCA's regression wording.
+    """
+    return {"files": list(changed_recently(list(files), root)), "commits": _CHURN_COMMITS}
+
+
 def register_sdlc_tools(registry: SupportsRegister) -> None:
     """Register the SDLC's deterministic tools. Called lazily by ``default_registry()``."""
     registry.register("sdlc.investigate", _tool_investigate)
     registry.register("sdlc.rca", _tool_rca)
     registry.register("sdlc.blast_radius", _tool_blast_radius)
+    registry.register("sdlc.churn", _tool_churn)
     registry.register("sdlc.validity", _tool_validity)

--- a/src/orchestrator/sdlc/profile_select.py
+++ b/src/orchestrator/sdlc/profile_select.py
@@ -10,23 +10,36 @@ goes with it.
 team renamed a dropdown, which is not a reason to refuse work. But a *silent* fallback is how
 "why did it skip RCA?" becomes unanswerable, so the reason is returned alongside the choice and
 the run prints it. Phase 3 of ``docs/specs/graphir-sdlc-workflow.md``.
+
+**Labels are the second question, never the first.** A tracker's labels are fetched with every
+issue and were read by nothing. They are consulted **only** where the issue type resolves to
+nothing — a renamed dropdown, a tracker with no type field, an issue filed as `Escalation` — and
+a known type always wins outright. That ordering is the whole safety property: a team that
+labels a feature request `bug` for triage reasons must not thereby get root-cause analysis on a
+ticket their tracker plainly calls a Story.
+
+Labels arrive as an unordered set, so they are **sorted before matching**. "First match wins"
+over an arrival-ordered set would make the profile depend on iteration order, and a run whose
+research was decided that way is not reproducible at a commit — which is the guarantee this
+module exists to protect.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-__all__ = ["Selection", "select_profile"]
+__all__ = ["Selection", "is_bug", "select_profile"]
 
 # Issue type → profile. Lowercased and stripped before lookup, so `Bug`, `bug` and ` BUG ` agree.
 #
-# The bug list matches `validity._check_localization`, which already decides that "bug" and
-# "defect" are the types a ticket must localize for. Two different answers to "is this a bug?"
-# in one pipeline would be a bug of its own.
+# This table is the single answer to "is this a bug?" — `validity` asks it through `is_bug`
+# below rather than keeping a list of its own. It used to keep one, and the two had already
+# drifted: `incident` selected the bug profile here while `validity` did not treat it as a
+# bug, so an incident got root-cause analysis and was then excused from having to localize.
 _BY_TYPE: dict[str, str] = {
     "bug": "bug",
     "defect": "bug",
-    "incident": "bug",
+    "incident": "bug",  # `is_bug` too: it selects the bug profile, so it localizes like one
     "story": "enhancement",
     "task": "enhancement",
     "feature": "enhancement",
@@ -37,6 +50,49 @@ _BY_TYPE: dict[str, str] = {
 
 DEFAULT = "default"
 
+#: The profile a bug-shaped ticket gets. Named so `is_bug` and the table cannot drift.
+BUG = "bug"
+ENHANCEMENT = "enhancement"
+
+# Label → profile, for the fallback only. Deliberately short and literal: these are the forms
+# teams actually type, not a pattern language. A label nobody listed simply does not match, and
+# the run says `default` — which is the honest answer, and a cheaper failure than a regex that
+# reads `not-a-bug` as `bug`.
+#
+# Not a place to be clever. Every entry here can override nothing: by the time this table is
+# consulted the tracker has already failed to say what kind of ticket this is.
+_BY_LABEL: dict[str, str] = {
+    "bug": BUG,
+    "defect": BUG,
+    "incident": BUG,
+    "type:bug": BUG,
+    "type/bug": BUG,
+    "kind/bug": BUG,
+    "enhancement": ENHANCEMENT,
+    "feature": ENHANCEMENT,
+    "story": ENHANCEMENT,
+    "type:feature": ENHANCEMENT,
+    "type/feature": ENHANCEMENT,
+    "kind/feature": ENHANCEMENT,
+    "type:enhancement": ENHANCEMENT,
+    "kind/enhancement": ENHANCEMENT,
+}
+
+
+def is_bug(issue_type: str) -> bool:
+    """Does this issue type describe something that already exists?
+
+    The question two stages need and must not answer separately: `validity` refuses a bug it
+    cannot localize (there is no fault site to work from) and parks a bug whose criteria name
+    symbols the graph does not hold (a bug's subject is existing code, so an unbound claim is
+    a false premise). Neither is true of an enhancement, whose subject is the deliverable.
+
+    Unknown and empty types answer **False**. A run that cannot say what kind of ticket it has
+    should not be held to a bug's standard of evidence — and empty is the honest state for a
+    source with no such notion (a wiki page, a `--spec` file), not a reason to refuse it.
+    """
+    return _BY_TYPE.get((issue_type or "").strip().lower()) == BUG
+
 
 @dataclass(frozen=True)
 class Selection:
@@ -44,10 +100,24 @@ class Selection:
 
     profile: str
     issue_type: str
-    matched: bool  # False when the type was unknown and `default` was used
+    matched: bool  # False when nothing mapped and `default` was used
+    #: Which question answered: ``"issue-type"``, ``"label"``, or ``""`` for the fallback. A
+    #: reader has to be able to tell a profile chosen from the tracker's own type from one
+    #: inferred off a label, because the second is a guess the first is not.
+    via: str = ""
+    #: The label that answered, when ``via`` is ``"label"``. Named, not counted: "matched a
+    #: label" is not something a reader can check.
+    label: str = ""
 
     @property
     def reason(self) -> str:
+        if self.via == "label":
+            preamble = (
+                f"issue type `{self.issue_type}` is not one this repo maps"
+                if self.issue_type
+                else "no issue type on the ticket"
+            )
+            return f"{preamble}; label `{self.label}` → `{self.profile}`"
         if not self.issue_type:
             return f"no issue type on the ticket — using `{self.profile}`"
         if self.matched:
@@ -55,17 +125,38 @@ class Selection:
         return f"issue type `{self.issue_type}` is not one this repo maps — using `{self.profile}`"
 
 
-def select_profile(issue_type: str, *, available: tuple[str, ...] | None = None) -> Selection:
-    """Map an issue type to a profile name.
+def _from_labels(labels: tuple[str, ...]) -> tuple[str, str]:
+    """The first profile any label maps to, and the label that did it. Sorted, so reproducible."""
+    for label in sorted({(x or "").strip().lower() for x in labels if (x or "").strip()}):
+        name = _BY_LABEL.get(label)
+        if name is not None:
+            return name, label
+    return "", ""
+
+
+def select_profile(
+    issue_type: str, *, labels: tuple[str, ...] = (), available: tuple[str, ...] | None = None
+) -> Selection:
+    """Map an issue type — or, failing that, a label — to a profile name.
+
+    ``labels`` is the ticket's own label set, consulted **only** when the issue type maps to
+    nothing. It is a fallback for a misconfigured or type-less tracker, never an override: a
+    ticket the tracker calls a Story stays an enhancement however it is labelled.
 
     ``available`` is the set of profiles that actually exist — shipped plus any the repo carries.
     A mapping that names a profile nobody has falls back rather than raising: a repo may delete
-    or rename a profile, and the run should continue on the default and say what happened.
+    or rename a profile, and the run should continue on the default and say what happened. That
+    applies to a label's profile too, and the type is not re-asked afterwards — one question is
+    answered per selection, so the reason a run prints is the reason it chose.
     """
     raw = (issue_type or "").strip()
     name = _BY_TYPE.get(raw.lower())
-    if name is None:
-        return Selection(profile=DEFAULT, issue_type=raw, matched=False)
-    if available is not None and name not in available:
-        return Selection(profile=DEFAULT, issue_type=raw, matched=False)
-    return Selection(profile=name, issue_type=raw, matched=True)
+    if name is not None:
+        if available is not None and name not in available:
+            return Selection(profile=DEFAULT, issue_type=raw, matched=False)
+        return Selection(profile=name, issue_type=raw, matched=True, via="issue-type")
+
+    by_label, label = _from_labels(labels)
+    if by_label and not (available is not None and by_label not in available):
+        return Selection(profile=by_label, issue_type=raw, matched=True, via="label", label=label)
+    return Selection(profile=DEFAULT, issue_type=raw, matched=False)

--- a/src/orchestrator/sdlc/profiles/enhancement.yaml
+++ b/src/orchestrator/sdlc/profiles/enhancement.yaml
@@ -2,8 +2,11 @@
 #
 # `n_rca` is absent, and that is the whole point of this file. Root-cause analysis localizes a
 # *symptom*; a feature request has none, so `localize_trace` resolves nothing and the report says
-# "Not localized to a repo symbol" — an empty section that reads as a finding and is not one. It
-# also costs a `git log` subprocess per run to say nothing.
+# "Not localized to a repo symbol" — an empty section that reads as a finding and is not one.
+#
+# Dropping the node used to drop `build_rca`'s `git log` recency pass with it. That question —
+# is this area actively changing? — is not symptom-dependent, so it comes back as `n_churn`
+# below, over the landing sites.
 #
 # So an enhancement's evidence records that RCA was **not run for this issue type**, which is a
 # different statement from "we ran it and found nothing", and the honest one.
@@ -63,6 +66,21 @@ spec:
         summary: Impact of the landing sites — not of a design's proposal.
         new_in_graph: true
 
+    # The half of `n_rca` an enhancement can actually use. RCA localizes a symptom and a
+    # feature has none, so this profile drops that node — and used to drop the `git log`
+    # recency pass with it, for half of all tickets. "Is this area moving?" does not depend on
+    # a symptom. Keyed off the landing sites rather than a fault site, which makes it the
+    # weaker of the two readings: where this ticket's vocabulary already lives is what it will
+    # attach to, not what it will touch, so the rendering says that and not "expect a
+    # regression". `bug` and `default` keep getting churn through `n_rca`, from the same
+    # implementation in `sdlc/churn.py`.
+    - id: n_churn
+      type: tool
+      template_id: sdlc.churn
+      config:
+        stage: churn
+        summary: Which landing files changed in the last 40 commits.
+
     - id: n_validity
       type: tool
       template_id: sdlc.validity
@@ -98,6 +116,8 @@ spec:
     - source: n_investigate
       target: n_blast_radius
     - source: n_blast_radius
+      target: n_churn
+    - source: n_churn
       target: n_validity
     - source: n_validity
       target: n_design

--- a/src/orchestrator/sdlc/rca.py
+++ b/src/orchestrator/sdlc/rca.py
@@ -18,12 +18,12 @@ text — all reduce to "text we localize + ground against the PKG".
 from __future__ import annotations
 
 import logging
-import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from orchestrator.pkg import FactStore
+from orchestrator.sdlc.churn import changed_recently
 from orchestrator.sdlc.localize import Localization, localize_trace
 
 logger = logging.getLogger("orchestrator.sdlc.rca")
@@ -63,24 +63,6 @@ class RCAReport:
     fix_approach: str = ""
     grounded: bool = False
     llm: bool = False
-
-
-def _recently_changed_files(root: Path | str | None, *, commits: int = 40) -> set[str]:
-    """Repo-relative files touched in the last ``commits`` commits (best-effort)."""
-    if root is None:
-        return set()
-    try:
-        out = subprocess.run(
-            ["git", "-C", str(root), "log", "--name-only", "--pretty=format:", "-n", str(commits)],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return set()
-    if out.returncode != 0:
-        return set()
-    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
 
 
 def _exception_class(exception: str) -> str:
@@ -237,10 +219,11 @@ async def build_rca(
     # regression surface and a recently-changed check for the majority of bug tickets,
     # which arrive as prose and not as tracebacks.
     fault_file = fault.where.split(":", 1)[0] if fault else (loc.stated_files[0] if loc.stated_files else "")
-    changed = _recently_changed_files(root)
-    recently_changed = bool(
-        fault_file and any(c == fault_file or c.endswith("/" + fault_file) for c in changed)
-    )
+    # The same churn pass the enhancement profile now runs on its landing sites, from one
+    # implementation — a bug and a feature asking "has this changed lately?" must not get two
+    # different answers. Here it is crossed with the fault file, which is what makes it a
+    # regression signal rather than a note about a busy area.
+    recently_changed = bool(changed_recently([fault_file], root)) if fault_file else False
 
     report = RCAReport(
         problem=problem.strip(),

--- a/src/orchestrator/sdlc/validity.py
+++ b/src/orchestrator/sdlc/validity.py
@@ -31,6 +31,7 @@ from typing import Any
 
 from orchestrator.pkg import FactStore
 from orchestrator.pkg.facts import NodeKind
+from orchestrator.sdlc.profile_select import is_bug
 
 
 class Verdict(str, Enum):
@@ -171,19 +172,37 @@ def _check_countable_claims(spec: dict[str, Any], store: FactStore) -> list[Find
     return findings
 
 
-def _check_unbound_criteria(criteria: Any) -> list[Finding]:
+def _check_unbound_criteria(criteria: Any, issue_type: str = "") -> list[Finding]:
     """A criterion naming code the graph does not hold.
 
     Only claims can fail here — prose, CamelCase, env vars and tool names are not claims about
     this repository and never refuse a ticket. That rule lives in `criteria_binding`, which
     borrows it from the doc-drift reconciler rather than inventing a second one.
+
+    **What the finding means depends on the ticket**, and `assess` acts on it accordingly. For
+    a bug it is a false premise: the subject is code that already exists, so a criterion naming
+    a symbol nobody can find describes a repository this is not. For an enhancement the missing
+    symbol *is the deliverable* — and the better-written the criterion, the more precisely it
+    names something not built yet. So the wording says which case the reader is in, rather than
+    leaving one sentence to serve two opposite meanings.
     """
     rows = getattr(criteria, "unbound", ()) if criteria is not None else ()
+    expected = not is_bug(issue_type)
     return [
         Finding(
             check="criterion-unbound",
-            detail=(f"the criterion names {', '.join(row.claims)}, which the graph does not hold"),
-            evidence=row.text,
+            detail=(
+                f"the criterion names {', '.join(row.claims)}, which the graph does not hold"
+                + (" — expected for something not built yet" if expected else "")
+            ),
+            evidence=(
+                row.text
+                if not expected
+                # One fact, reported twice, two stages apart: the design stage lists the same
+                # absent name under unverified references (`impact.unverified_references`). A
+                # reviewer who cannot tell it is one fact starts discounting both.
+                else f"{row.text} — the design stage lists it again under unverified references"
+            ),
         )
         for row in rows
     ]
@@ -306,7 +325,7 @@ def _check_invariants(spec: dict[str, Any]) -> list[Finding]:
 def _check_localization(spec: dict[str, Any], landing: list[str], issue_type: str) -> list[Finding]:
     """A Bug describes something that already exists. If nothing in the graph matches it, the
     run has nowhere to start, and guessing a fault site is the failure RCA exists to avoid."""
-    if issue_type.strip().lower() not in {"bug", "defect"}:
+    if not is_bug(issue_type):
         return []
     if landing:
         return []
@@ -476,12 +495,24 @@ def assess(
         # code built to a false premise passes its own tests and is still wrong.
         return Assessment(verdict=Verdict.CRITERIA_WRONG, findings=wrong)
 
-    unbound = _check_unbound_criteria(criteria)
-    if unbound:
-        # Same family as a false count, and ordered beside it: a criterion nobody can locate
-        # is a test nobody can write, so anything built to it is graded by a test that had to
-        # invent its own subject.
+    unbound = _check_unbound_criteria(criteria, issue_type)
+    if unbound and is_bug(issue_type):
+        # For a bug, the same family as a false count and ordered beside it: a criterion nobody
+        # can locate is a test nobody can write, so anything built to it is graded by a test
+        # that had to invent its own subject.
         return Assessment(verdict=Verdict.CRITERIA_WRONG, findings=unbound)
+    # For anything else it is reported and the run continues. An enhancement's criterion names
+    # what the run is about to build, so refusing it means the *better-written* criterion is
+    # the one that parks the ticket:
+    #
+    #     the compiler returns >= 70 rules        → no claim → PROCEED
+    #     `rule_compiler` returns >= 70 rules     → unbound  → parked
+    #
+    # The second is more precise and more testable. `_check_localization` two functions above
+    # already takes this position — an enhancement lands nowhere in the graph because it has
+    # not been built — and one gate holding two stances on one question is the defect here.
+    # Riding along with PROCEED is what `_check_context_budget` already does below.
+    findings.extend(unbound)
 
     unlocalized = _check_localization(spec, landing, issue_type)
     if unlocalized:

--- a/tests/intake/test_cache.py
+++ b/tests/intake/test_cache.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from orchestrator.intake.cache import (
+    _CACHE_VERSION,
     analyze_cached,
     cache_path,
     complete_by_pr,
@@ -26,7 +27,9 @@ _SOURCE = "confluence://1234567890"
 
 def _plan() -> BacklogPlan:
     return BacklogPlan(
-        documents=[SourceDocument(id="1234567890", title="Reqs", body="text", labels=("a", "b"))],
+        documents=[
+            SourceDocument(id="1234567890", title="Reqs", body="text", labels=("a", "b"), issue_type="Bug")
+        ],
         intents=[Intent(id="intent-x", title="X", description="do x", acceptance_criteria=["c1"])],
         gaps=[
             GapFinding(
@@ -59,6 +62,9 @@ def test_round_trip_preserves_the_plan(tmp_path: Path) -> None:
     assert [s.intent_id for s in loaded.specs] == ["intent-x"]
     assert loaded.gaps[0].severity is GapSeverity.WARNING  # enum survives, not bare str
     assert loaded.documents[0].labels == ("a", "b")  # tuple restored
+    # A cached document that lost its type would send every resumed run to the `default`
+    # profile, silently — the reason the cache version was bumped rather than left compatible.
+    assert loaded.documents[0].issue_type == "Bug"
 
 
 def test_miss_returns_none(tmp_path: Path) -> None:
@@ -68,7 +74,10 @@ def test_miss_returns_none(tmp_path: Path) -> None:
 def test_version_mismatch_is_ignored(tmp_path: Path) -> None:
     save_plan(_SOURCE, _plan(), tmp_path)
     p = cache_path(_SOURCE, tmp_path)
-    p.write_text(p.read_text().replace('"version": 1', '"version": 999'))
+    # Written against the *current* version, not a literal: hard-coding `"version": 1` made
+    # this test silently stop testing anything the first time the version was bumped — the
+    # replace matched nothing and the file it loaded was simply valid.
+    p.write_text(p.read_text().replace(f'"version": {_CACHE_VERSION}', '"version": 999'))
     assert load_cached_plan(_SOURCE, tmp_path) is None
 
 

--- a/tests/intake/test_jira_source.py
+++ b/tests/intake/test_jira_source.py
@@ -130,6 +130,31 @@ async def test_fetch_document_maps_issue_to_document() -> None:
     # metadata header + description prose both land in the body
     assert "Bug" in doc.body and "status: To Do" in doc.body
     assert "Crashes on login." in doc.body and "- repro step" in doc.body
+    # …and the type also travels as data. The header is prose for the extractor; only the
+    # field can select a workflow profile or decide whether the ticket must localize.
+    assert doc.issue_type == "Bug"
+
+
+async def test_the_meta_header_and_the_issue_type_field_cannot_disagree() -> None:
+    """Two answers to "what type is this?" would be a defect visible from neither alone."""
+    mock = _JiraMock({"PROJ-1": _fields("Login fails", itype="New Feature")})
+    adapter, http = _adapter(mock)
+    try:
+        doc = await adapter.fetch_document("PROJ-1")
+    finally:
+        await http.aclose()
+    assert doc.issue_type == "New Feature"
+    assert doc.body.startswith("New Feature"), "same value, one helper, both consumers"
+
+
+async def test_an_untyped_issue_carries_an_empty_type_rather_than_a_guess() -> None:
+    mock = _JiraMock({"PROJ-1": _fields("Login fails", itype="")})
+    adapter, http = _adapter(mock)
+    try:
+        doc = await adapter.fetch_document("PROJ-1")
+    finally:
+        await http.aclose()
+    assert doc.issue_type == ""
 
 
 # ---- children + tree walk -------------------------------------------------

--- a/tests/intake/test_mcp_source.py
+++ b/tests/intake/test_mcp_source.py
@@ -207,6 +207,10 @@ async def test_mcp_jira_carries_issue_type_status_and_priority() -> None:
     assert doc.body.startswith("Bug · status: Open · priority: High")
     assert "stack trace" in doc.body
     assert doc.space == "ENG", "project key should come from the issue key, as in REST"
+    # The same parity requirement, one layer down: an issue ingested over MCP must select the
+    # same workflow profile as the identical issue over REST, which means the *field* agrees
+    # and not just the prose header.
+    assert doc.issue_type == "Bug"
 
 
 async def test_mcp_jira_matches_the_rest_adapter_byte_for_byte() -> None:
@@ -273,6 +277,8 @@ def test_parses_the_flattened_mcp_atlassian_shape() -> None:
 
     doc = _parse_document("CB-676", _REAL_MCP_ATLASSIAN_ISSUE, "")
     assert doc.body.startswith("Sub-task · status: Business Requirements · priority: Medium")
+    # `issue_type`, the mcp-atlassian spelling — the field reads it as the header does.
+    assert doc.issue_type == "Sub-task"
 
 
 def test_prefers_the_issue_key_over_the_opaque_numeric_id() -> None:

--- a/tests/intake/test_ticket_meta.py
+++ b/tests/intake/test_ticket_meta.py
@@ -1,0 +1,134 @@
+"""Resolving a run's issue type and labels from the intake plan.
+
+The defect behind this module: nothing carried the issue type from the ticket to the run, so
+`select_profile` always saw `""`, every run took the `default` profile, and the localization
+check never fired outside its own tests. These assertions are what would have caught it.
+"""
+
+from __future__ import annotations
+
+from orchestrator.intake.gaps import GapFinding, GapSeverity
+from orchestrator.intake.intents import Intent
+from orchestrator.intake.service import BacklogPlan
+from orchestrator.intake.source import SourceDocument
+from orchestrator.intake.specs import FeatureSpec
+from orchestrator.intake.ticket_meta import resolve_ticket_meta
+
+
+def _doc(doc_id: str, *, issue_type: str = "", labels: tuple[str, ...] = ()) -> SourceDocument:
+    return SourceDocument(id=doc_id, title=doc_id, body="text", issue_type=issue_type, labels=labels)
+
+
+def _plan(
+    documents: list[SourceDocument],
+    *,
+    source_doc_ids: list[str] | None = None,
+    intent_id: str = "intent-a",
+) -> BacklogPlan:
+    return BacklogPlan(
+        documents=documents,
+        intents=[Intent(id=intent_id, title="X", description="do x", source_doc_ids=source_doc_ids or [])],
+        gaps=[],
+        specs=[FeatureSpec(intent_id=intent_id, title="X")],
+    )
+
+
+def _spec(intent_id: str = "intent-a") -> FeatureSpec:
+    return FeatureSpec(intent_id=intent_id, title="X")
+
+
+def test_resolves_the_type_and_labels_from_the_linked_document() -> None:
+    plan = _plan([_doc("PROJ-1", issue_type="Bug", labels=("backend", "sev1"))], source_doc_ids=["PROJ-1"])
+
+    meta = resolve_ticket_meta(plan, _spec())
+
+    assert meta.issue_type == "Bug"
+    assert meta.labels == ("backend", "sev1")
+    assert meta.origin == "PROJ-1", "the run has to be able to say where the answer came from"
+    assert meta.known
+
+
+def test_follows_the_intent_link_rather_than_taking_the_first_document() -> None:
+    """The plan holds every document the walk fetched; only one of them is this ticket."""
+    plan = _plan(
+        [_doc("PROJ-1", issue_type="Story"), _doc("PROJ-2", issue_type="Bug")],
+        source_doc_ids=["PROJ-2"],
+    )
+
+    assert resolve_ticket_meta(plan, _spec()).issue_type == "Bug"
+
+
+def test_a_single_document_resolves_even_with_no_intent_link() -> None:
+    """`source_doc_ids` is model-produced and may be missing. One document is still unambiguous."""
+    plan = _plan([_doc("PROJ-1", issue_type="Bug")], source_doc_ids=[])
+
+    meta = resolve_ticket_meta(plan, _spec())
+
+    assert meta.issue_type == "Bug" and meta.origin == "PROJ-1"
+
+
+def test_unlinked_documents_that_disagree_resolve_to_nothing_and_say_why() -> None:
+    """A type picked by list order would select a workflow profile. Refusing to guess is the
+    whole contract: a run whose research was decided by iteration order is not reproducible."""
+    plan = _plan([_doc("PROJ-1", issue_type="Story"), _doc("PROJ-2", issue_type="Bug")], source_doc_ids=[])
+
+    meta = resolve_ticket_meta(plan, _spec())
+
+    assert not meta.known
+    assert "Bug" in meta.detail and "Story" in meta.detail
+    assert "2 source documents" in meta.detail
+
+
+def test_documents_that_agree_are_not_an_ambiguity() -> None:
+    """Three subtasks all filed as Bug answer the question; only disagreement is ambiguous."""
+    plan = _plan(
+        [_doc("PROJ-1", issue_type="Bug", labels=("b",)), _doc("PROJ-2", issue_type="Bug", labels=("a",))],
+        source_doc_ids=["PROJ-1", "PROJ-2"],
+    )
+
+    meta = resolve_ticket_meta(plan, _spec())
+
+    assert meta.issue_type == "Bug"
+    assert meta.labels == ("a", "b"), "unioned and sorted, not concatenated in arrival order"
+
+
+def test_labels_come_back_sorted_whatever_order_they_arrived_in() -> None:
+    """`select_profile` matches over this set (labels-as-fallback). First-match-wins over an
+    arrival-ordered set is not reproducible, which is the property that must not be lost."""
+    forward = _plan([_doc("PROJ-1", labels=("zeta", "alpha"))], source_doc_ids=["PROJ-1"])
+    reverse = _plan([_doc("PROJ-1", labels=("alpha", "zeta"))], source_doc_ids=["PROJ-1"])
+
+    assert resolve_ticket_meta(forward, _spec()).labels == ("alpha", "zeta")
+    assert resolve_ticket_meta(reverse, _spec()).labels == ("alpha", "zeta")
+
+
+def test_an_untyped_document_says_so_rather_than_going_quiet() -> None:
+    """ "Why did this take the default profile?" must be answerable from the run's output."""
+    plan = _plan([_doc("PROJ-1")], source_doc_ids=["PROJ-1"])
+
+    meta = resolve_ticket_meta(plan, _spec())
+
+    assert not meta.known
+    assert "PROJ-1" in meta.detail
+
+
+def test_an_empty_plan_resolves_to_nothing() -> None:
+    meta = resolve_ticket_meta(BacklogPlan(), _spec())
+
+    assert not meta.known and meta.detail
+
+
+def test_accepts_the_dumped_spec_dict_as_well_as_the_model() -> None:
+    """The pipeline carries both shapes — `ctx.spec` is the dump, intake holds the model."""
+    plan = _plan([_doc("PROJ-1", issue_type="Bug")], source_doc_ids=["PROJ-1"])
+
+    assert resolve_ticket_meta(plan, _spec().model_dump()).issue_type == "Bug"
+
+
+def test_a_gap_finding_in_the_plan_does_not_disturb_the_walk() -> None:
+    plan = _plan([_doc("PROJ-1", issue_type="Bug")], source_doc_ids=["PROJ-1"])
+    plan.gaps = [
+        GapFinding(rule_id="nfrs_missing", intent_id="intent-a", severity=GapSeverity.WARNING, message="m")
+    ]
+
+    assert resolve_ticket_meta(plan, _spec()).issue_type == "Bug"

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -46,21 +46,35 @@ class _Spec:
 
 
 class _Plan:
-    def __init__(self, specs: list[_Spec]) -> None:
+    def __init__(
+        self,
+        specs: list[_Spec],
+        *,
+        documents: list[Any] | None = None,
+        intents: list[Any] | None = None,
+    ) -> None:
         self.specs = specs
-        self.documents: list[Any] = []
-        self.intents: list[Any] = []
+        self.documents: list[Any] = documents or []
+        self.intents: list[Any] = intents or []
         self.gaps: list[Any] = []
         self.blocked = False
         self.truncated = False
 
 
 class _Service:
-    def __init__(self, specs: list[_Spec]) -> None:
+    def __init__(
+        self,
+        specs: list[_Spec],
+        *,
+        documents: list[Any] | None = None,
+        intents: list[Any] | None = None,
+    ) -> None:
         self._specs = specs
+        self._documents = documents
+        self._intents = intents
 
     async def analyze(self, root_id: str) -> _Plan:
-        return _Plan(self._specs)
+        return _Plan(self._specs, documents=self._documents, intents=self._intents)
 
 
 def _install(
@@ -68,6 +82,8 @@ def _install(
     tmp_path: Path,
     *,
     specs: list[_Spec] | None = None,
+    documents: list[Any] | None = None,
+    intents: list[Any] | None = None,
     feature: Any = None,
     calls: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -76,7 +92,9 @@ def _install(
     monkeypatch.setattr("orchestrator.core.env.load_local_env", lambda *a, **k: 0)
     monkeypatch.setattr(
         "orchestrator.intake.factory.build_service_for",
-        lambda *a, **k: _Service(specs if specs is not None else [_Spec()]),
+        lambda *a, **k: _Service(
+            specs if specs is not None else [_Spec()], documents=documents, intents=intents
+        ),
     )
 
     async def _feature(source: str, **kwargs: Any) -> Any:  # noqa: ARG001
@@ -555,6 +573,8 @@ def _run(
     issue: str | None = None,
     max_cost_usd: float | None = None,
     spec: dict[str, Any] | None = None,
+    issue_type: str = "",
+    log: Any = None,
 ) -> RunContext:
     """Run the skeleton against a tiny real repo, so the graph stages do real work."""
     import asyncio
@@ -576,10 +596,137 @@ def _run(
             issue=issue,
             max_cost_usd=max_cost_usd,
             spec=spec,
+            issue_type=issue_type,
+            log=log,
             # These tests exercise the rest of the run; the plan gate has its own below.
             plan_gate=False,
         )
     )
+
+
+# --- the ticket's issue type reaches the run ----------------------------------------
+#
+# It did not, for the whole life of the issue-type-shaped pipeline: `FeatureSpec` forbids
+# extra keys and has no field for a type, so `spec.get("issue_type")` was always "" and the
+# CLI passed nothing. Every run took the `default` profile and the localization check never
+# fired. These are the assertions that would have caught it — they exercise the real
+# resolution, not a stubbed one.
+
+
+def _typed_source(issue_type: str = "Bug", *, labels: tuple[str, ...] = ()) -> dict[str, Any]:
+    """A plan shaped like a real Jira ingest: one document, one intent that links to it."""
+    from orchestrator.intake.intents import Intent
+    from orchestrator.intake.source import SourceDocument
+
+    return {
+        "documents": [
+            SourceDocument(
+                id="PROJ-1", title="Add CSV export", body="text", issue_type=issue_type, labels=labels
+            )
+        ],
+        "intents": [Intent(id="intent-a", title="X", description="do x", source_doc_ids=["PROJ-1"])],
+    }
+
+
+def test_the_issue_type_travels_from_the_ticket_to_the_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install(monkeypatch, tmp_path, **_typed_source("Bug"))
+
+    ctx = _run(tmp_path)
+
+    assert ctx.issue_type == "Bug"
+    assert ctx.case is not None and ctx.case.issue_type == "Bug"
+
+
+def test_the_labels_travel_with_it(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Fetched by the Jira adapter since it was written, and read by nothing until now."""
+    _install(monkeypatch, tmp_path, **_typed_source("Bug", labels=("sev1", "backend")))
+
+    ctx = _run(tmp_path)
+
+    assert ctx.labels == ("backend", "sev1"), "sorted — `select_profile` matches over this set"
+
+
+def test_a_typed_ticket_selects_the_matching_profile(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The point of the plumbing: `bug`/`enhancement` were unreachable in every real run."""
+    _install(monkeypatch, tmp_path, **_typed_source("Story"))
+
+    ctx = _run(tmp_path)
+
+    assert ctx.case is not None and ctx.case.profile == "sdlc.enhancement"
+
+
+def test_an_untyped_ticket_still_takes_the_default_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unchanged behaviour for a source with no such notion — a file:// spec, a wiki page."""
+    _install(monkeypatch, tmp_path)
+
+    ctx = _run(tmp_path)
+
+    assert ctx.issue_type == ""
+    assert ctx.case is not None and ctx.case.profile == "sdlc.default"
+
+
+def test_the_operator_flag_overrides_what_the_ticket_says(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install(monkeypatch, tmp_path, **_typed_source("Story"))
+
+    ctx = _run(tmp_path, issue_type="Bug")
+
+    assert ctx.issue_type == "Bug"
+    assert ctx.case is not None and ctx.case.profile == "sdlc.bug"
+
+
+def test_the_flag_is_the_only_way_to_type_an_injected_spec(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`--spec` skips intake entirely, so there is no ticket to ask."""
+    _install(monkeypatch, tmp_path)
+    # Words that land in the test repo (`mod.py` defines `export_csv`): typing a spec as a
+    # Bug now makes the localization check live, and it refuses a bug it cannot localize.
+    injected = {**_INJECTED, "title": "Add CSV export", "summary": "export_csv drops rows"}
+
+    assert _run(tmp_path, spec=injected).issue_type == ""
+    assert _run(tmp_path, spec=injected, issue_type="Bug").issue_type == "Bug"
+
+
+def test_typing_a_ticket_as_a_bug_makes_the_localization_check_live(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The check has existed since Phase 3 and never once fired: it is guarded on an issue
+    type nothing supplied. A Bug whose words match nothing in the graph has no fault site to
+    work from, and guessing one is the failure RCA exists to avoid."""
+    _install(monkeypatch, tmp_path)
+    unrelated = {**_INJECTED, "title": "Keep invented criteria separable", "summary": "quarantine them"}
+
+    with pytest.raises(AutorunError, match="UNLOCALIZED"):
+        _run(tmp_path, spec=unrelated, issue_type="Bug")
+
+    # …and the same ticket, untyped, still proceeds exactly as it did before this branch.
+    assert _run(tmp_path, spec=unrelated).passed
+
+
+def test_the_run_says_where_the_issue_type_came_from(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """ "Why did this run take the `default` profile?" has to be answerable from the output —
+    an untyped run that says nothing is how this sat unreachable without anyone noticing."""
+    _install(monkeypatch, tmp_path, **_typed_source("Bug"))
+    lines: list[str] = []
+
+    _run(tmp_path, log=lines.append)
+
+    assert any("issue type `Bug`" in line and "PROJ-1" in line for line in lines)
+
+
+def test_an_untyped_run_says_that_too(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install(monkeypatch, tmp_path)
+    lines: list[str] = []
+
+    _run(tmp_path, log=lines.append)
+
+    assert any("no issue type" in line for line in lines)
 
 
 # --- A hand-written spec replaces intake (--spec) -----------------------------------

--- a/tests/sdlc/test_autorun.py
+++ b/tests/sdlc/test_autorun.py
@@ -648,6 +648,27 @@ def test_the_labels_travel_with_it(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     assert ctx.labels == ("backend", "sev1"), "sorted — `select_profile` matches over this set"
 
 
+def test_a_label_selects_the_profile_when_the_ticket_has_no_type(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End of the second half of the plumbing: labels were fetched by the Jira adapter and read
+    by nothing. A tracker with no type field, or a renamed dropdown, still gets its profile."""
+    _install(monkeypatch, tmp_path, **_typed_source("", labels=("customer", "type:bug")))
+
+    ctx = _run(tmp_path)
+
+    assert ctx.issue_type == ""
+    assert ctx.case is not None and ctx.case.profile == "sdlc.bug"
+
+
+def test_the_tickets_own_type_still_beats_its_labels(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _install(monkeypatch, tmp_path, **_typed_source("Story", labels=("bug",)))
+
+    ctx = _run(tmp_path)
+
+    assert ctx.case is not None and ctx.case.profile == "sdlc.enhancement"
+
+
 def test_a_typed_ticket_selects_the_matching_profile(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The point of the plumbing: `bug`/`enhancement` were unreachable in every real run."""
     _install(monkeypatch, tmp_path, **_typed_source("Story"))

--- a/tests/sdlc/test_churn.py
+++ b/tests/sdlc/test_churn.py
@@ -1,0 +1,88 @@
+"""Recent git churn, and what it is honestly allowed to say.
+
+The gap: the recency pass lived inside `build_rca`, keyed to a fault site. The enhancement
+profile drops `n_rca` — a feature has no symptom to localize — and dropped this with it, for
+half of all tickets. The question is not symptom-dependent; the *intersection* is, which is why
+the two paths cross the same `git log` with different file sets and word the result differently.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from orchestrator.sdlc.churn import changed_recently, recently_changed_files
+
+
+def _repo(tmp_path: Path, *files: str) -> Path:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    for name in files:
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "c"],
+        cwd=tmp_path,
+        check=True,
+    )
+    return tmp_path
+
+
+def test_it_reports_the_files_history_touched(tmp_path: Path) -> None:
+    _repo(tmp_path, "src/app/store.py", "README.md")
+
+    assert recently_changed_files(tmp_path) == {"src/app/store.py", "README.md"}
+
+
+def test_a_directory_that_is_not_a_repo_yields_nothing_and_does_not_raise(tmp_path: Path) -> None:
+    """Best-effort by construction: no git, a shallow clone, a fresh checkout. A missing signal
+    must never be the thing that fails a run."""
+    assert recently_changed_files(tmp_path) == set()
+    assert recently_changed_files(None) == set()
+    assert changed_recently(["store.py"], tmp_path) == ()
+
+
+def test_it_crosses_history_with_the_files_the_ticket_is_about(tmp_path: Path) -> None:
+    _repo(tmp_path, "src/app/store.py", "src/app/quiet.py")
+    (tmp_path / "src/app/store.py").write_text("y\n", encoding="utf-8")
+
+    assert changed_recently(["src/app/store.py"], tmp_path) == ("src/app/store.py",)
+    assert changed_recently(["src/app/absent.py"], tmp_path) == ()
+
+
+def test_a_bare_filename_matches_the_path_git_reports(tmp_path: Path) -> None:
+    """The two sides are named differently: git reports `src/app/store.py`, a landing site may
+    carry only `store.py`."""
+    _repo(tmp_path, "src/app/store.py")
+
+    assert changed_recently(["store.py"], tmp_path) == ("store.py",)
+
+
+def test_a_suffix_that_is_not_a_path_boundary_does_not_match(tmp_path: Path) -> None:
+    """`store.py` must not match `my_store.py` — that is a different file, and a churn signal
+    naming the wrong one is worse than none."""
+    _repo(tmp_path, "src/app/my_store.py")
+
+    assert changed_recently(["store.py"], tmp_path) == ()
+
+
+def test_the_order_asked_for_is_the_order_returned_and_repeats_collapse(tmp_path: Path) -> None:
+    """Deterministic output for a deterministic input — the evidence digest depends on it."""
+    _repo(tmp_path, "a.py", "b.py")
+
+    assert changed_recently(["b.py", "a.py", "b.py"], tmp_path) == ("b.py", "a.py")
+
+
+def test_no_paths_asks_git_nothing(tmp_path: Path) -> None:
+    assert changed_recently([], tmp_path) == ()
+
+
+def test_the_bug_path_and_the_enhancement_path_share_one_implementation() -> None:
+    """`build_rca` used to inline its own intersection. Two implementations of "has this changed
+    lately?" would be two answers, and nothing would say which run got which."""
+    import orchestrator.sdlc.rca as rca
+
+    # Read out of the module namespace: `changed_recently` is not part of `rca`'s public API
+    # (it is imported, not re-exported), and asserting through `vars` says exactly that.
+    assert vars(rca)["changed_recently"] is changed_recently

--- a/tests/sdlc/test_profile_select.py
+++ b/tests/sdlc/test_profile_select.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from orchestrator.sdlc.profile_select import select_profile
+from orchestrator.sdlc.profile_select import _BY_TYPE, is_bug, select_profile
 
 
 @pytest.mark.parametrize(
@@ -55,13 +55,95 @@ def test_a_mapping_naming_a_profile_nobody_has_falls_back() -> None:
 
 
 def test_bug_agrees_with_the_validity_gate() -> None:
-    """`validity._check_localization` already decides that "bug" and "defect" are the types a
-    ticket must localize for. Two different answers to "is this a bug?" in one pipeline would be
-    a bug of its own."""
+    """Two different answers to "is this a bug?" in one pipeline would be a bug of its own.
+    They *had* diverged — `incident` selected the bug profile while the gate's own list did
+    not mention it — so both now ask `is_bug`, and this asserts across the whole table."""
     from orchestrator.sdlc.validity import _check_localization
 
-    for issue_type in ("bug", "defect"):
-        assert select_profile(issue_type).profile == "bug"
-        # A bug that landed nowhere is a finding for the gate; a story is not.
-        assert _check_localization({"title": "x", "summary": "y"}, [], issue_type)
-    assert not _check_localization({"title": "x", "summary": "y"}, [], "story")
+    for issue_type, profile in _BY_TYPE.items():
+        assert select_profile(issue_type).profile == profile
+        # A bug that landed nowhere is a finding for the gate; anything else is not.
+        landed_nowhere = _check_localization({"title": "x", "summary": "y"}, [], issue_type)
+        assert bool(landed_nowhere) is (profile == "bug"), issue_type
+
+
+def test_is_bug_answers_for_the_whole_table() -> None:
+    for issue_type, profile in _BY_TYPE.items():
+        assert is_bug(issue_type) is (profile == "bug"), issue_type
+
+
+def test_is_bug_normalises_the_way_the_lookup_does() -> None:
+    """`Bug`, `bug` and ` BUG ` are one dropdown value typed three ways."""
+    assert is_bug("Bug") and is_bug(" DEFECT ") and is_bug("incident")
+
+
+def test_an_unknown_or_empty_type_is_not_a_bug() -> None:
+    """A run that cannot say what kind of ticket it has must not be held to a bug's standard
+    of evidence. Empty is the honest state for a wiki page or a `--spec` file — the gate is
+    then at its least informed, and refusing there is how a gate teaches people to switch it
+    off."""
+    assert not is_bug("") and not is_bug("   ") and not is_bug("Escalation")
+
+
+# ---- labels: the second question, never the first ---------------------------
+#
+# A tracker's labels have been fetched with every Jira issue since the adapter was written and
+# read by nothing. They matter exactly when the issue type does not answer — a renamed dropdown,
+# a tracker with no type field, an issue filed as `Escalation`.
+
+
+def test_a_label_answers_when_the_issue_type_does_not() -> None:
+    selection = select_profile("Escalation", labels=("type:bug", "customer"))
+
+    assert selection.profile == "bug"
+    assert selection.via == "label" and selection.label == "type:bug"
+    assert "Escalation" in selection.reason and "type:bug" in selection.reason
+
+
+def test_a_label_answers_when_there_is_no_issue_type_at_all() -> None:
+    selection = select_profile("", labels=("enhancement",))
+
+    assert selection.profile == "enhancement"
+    assert "no issue type" in selection.reason and "enhancement" in selection.reason
+
+
+def test_a_known_issue_type_beats_a_contradicting_label() -> None:
+    """The safety property. A team that labels a feature request `bug` for triage must not
+    thereby get root-cause analysis on a ticket their tracker plainly calls a Story."""
+    selection = select_profile("Story", labels=("bug", "defect"))
+
+    assert selection.profile == "enhancement"
+    assert selection.via == "issue-type"
+
+
+def test_contradicting_labels_resolve_the_same_whatever_order_they_arrive_in() -> None:
+    """A label set is unordered. "First match wins" over an arrival-ordered set would make the
+    profile depend on iteration order, and that run is not reproducible at a commit."""
+    forward = select_profile("Escalation", labels=("story", "bug"))
+    reverse = select_profile("Escalation", labels=("bug", "story"))
+
+    assert forward.profile == reverse.profile == "bug"  # `bug` sorts before `story`
+    assert forward.label == reverse.label == "bug"
+
+
+def test_no_usable_label_still_falls_back_and_says_so() -> None:
+    selection = select_profile("Escalation", labels=("customer", "q3", "not-a-bug"))
+
+    assert selection.profile == "default"
+    assert not selection.matched and selection.via == ""
+    assert "Escalation" in selection.reason and "not one this repo maps" in selection.reason
+
+
+def test_a_label_naming_a_profile_nobody_has_falls_back_too() -> None:
+    """Same rule as the issue-type path: a repo may carry only some profiles."""
+    selection = select_profile("Escalation", labels=("bug",), available=("default",))
+
+    assert selection.profile == "default" and not selection.matched
+
+
+def test_the_run_can_tell_a_type_from_a_guess() -> None:
+    """`via` is why this is not just a boolean: a profile inferred off a label is a guess the
+    tracker's own type is not, and the run has to be able to say which it made."""
+    assert select_profile("Bug").via == "issue-type"
+    assert select_profile("Escalation", labels=("bug",)).via == "label"
+    assert select_profile("Escalation").via == ""

--- a/tests/sdlc/test_rca.py
+++ b/tests/sdlc/test_rca.py
@@ -63,7 +63,9 @@ async def test_unresolved_bug_gives_low_confidence_hypothesis() -> None:
 
 
 async def test_recent_churn_raises_regression_hypothesis(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("orchestrator.sdlc.rca._recently_changed_files", lambda root, **k: {"auth.py"})
+    # Patched at the git boundary in `sdlc.churn`, which both the bug path and the enhancement
+    # profile's churn node now share — one implementation, so they cannot answer differently.
+    monkeypatch.setattr("orchestrator.sdlc.churn.recently_changed_files", lambda root, **k: {"auth.py"})
     report = await build_rca(_TRACEBACK, store=FactStore(_graph()), root="/repo")
     assert report.recently_changed is True
     top = report.hypotheses[0]

--- a/tests/sdlc/test_research_pass.py
+++ b/tests/sdlc/test_research_pass.py
@@ -250,3 +250,98 @@ async def test_an_unmapped_issue_type_uses_default_and_says_why(tmp_path: Path) 
 
     assert ctx.case.profile == "sdlc.default"
     assert any("Spike" in line and "default" in line for line in said), said
+
+
+# ---- churn: the signal an enhancement used to lose ---------------------------
+#
+# `build_rca` computes a `git log` recency pass and crosses it with the fault site. The
+# enhancement profile drops `n_rca` — a feature has no symptom — and dropped the recency answer
+# with it, for half of all tickets.
+
+
+def _git_repo(root: Path) -> None:
+    import subprocess
+
+    (root / "report.py").write_text("def render():\n    return 1\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "c"],
+        cwd=root,
+        check=True,
+    )
+
+
+async def test_an_enhancement_runs_the_churn_node(tmp_path: Path) -> None:
+    _git_repo(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    await _research_pass(ctx, store=_store(), issue_type="Story", emit=lambda _s: None)
+
+    assert "n_churn" in {n.node for n in ctx.case.nodes}
+    assert ctx.evidence is not None
+    assert "report.py" in ctx.evidence.recently_changed
+
+
+async def test_the_bug_profile_has_no_churn_node_because_rca_answers_it(tmp_path: Path) -> None:
+    """One question, two keyings: the bug path crosses history with the *fault site*, which is
+    what makes it a regression signal rather than a note about a busy area."""
+    _git_repo(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    await _research_pass(ctx, store=_store(), issue_type="Bug", emit=lambda _s: None)
+
+    assert "n_churn" not in {n.node for n in ctx.case.nodes}
+    assert "n_rca" in {n.node for n in ctx.case.nodes}
+
+
+async def test_the_enhancement_rendering_does_not_borrow_rcas_regression_wording(
+    tmp_path: Path,
+) -> None:
+    """A feature's landing sites are where its vocabulary already lives — what it will attach
+    to, not what it will touch. "Treat a regression as the leading hypothesis" is a claim this
+    evidence does not support."""
+    _git_repo(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    await _research_pass(ctx, store=_store(), issue_type="Story", emit=lambda _s: None)
+
+    rendered = (ctx.artifacts_dir / "evidence.md").read_text(encoding="utf-8")
+    assert "Changing lately" in rendered and "report.py" in rendered
+    assert "regression" not in rendered.lower()
+
+
+async def test_an_enhancements_evidence_says_rca_was_not_run_not_that_it_found_nothing(
+    tmp_path: Path,
+) -> None:
+    """`enhancement.yaml` drops `n_rca` to avoid a "Not localized to a repo symbol" section that
+    reads as a finding and is not one — and the renderer printed it regardless, because it saw
+    an empty dict and could not tell a skipped node from an empty result."""
+    _git_repo(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    await _research_pass(ctx, store=_store(), issue_type="Story", emit=lambda _s: None)
+
+    rendered = (ctx.artifacts_dir / "evidence.md").read_text(encoding="utf-8")
+    assert "Not run for this issue type" in rendered
+    assert "Not localized to a repo symbol" not in rendered
+
+
+async def test_a_bug_that_localizes_nothing_still_says_so(tmp_path: Path) -> None:
+    """The other half: the node ran and found nothing, which is a finding a reader must see."""
+    ctx = _ctx(tmp_path)
+    ctx.spec = {"title": "nothing here", "summary": "matches no symbol", "acceptance_criteria": []}
+
+    await _research_pass(ctx, store=_store(), issue_type="Bug", emit=lambda _s: None)
+
+    rendered = (ctx.artifacts_dir / "evidence.md").read_text(encoding="utf-8")
+    assert "Not localized to a repo symbol" in rendered
+
+
+async def test_a_repo_with_no_history_says_nothing_rather_than_failing(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+
+    await _research_pass(ctx, store=_store(), issue_type="Story", emit=lambda _s: None)
+
+    assert ctx.evidence is not None and ctx.evidence.recently_changed == ()
+    assert "Changing lately" not in (ctx.artifacts_dir / "evidence.md").read_text(encoding="utf-8")

--- a/tests/sdlc/test_validity.py
+++ b/tests/sdlc/test_validity.py
@@ -116,6 +116,132 @@ def test_a_story_that_lands_nowhere_still_proceeds() -> None:
     assert assessment.verdict is Verdict.PROCEED
 
 
+# ---- an unbound criterion, and who it is fatal to ---------------------------
+#
+# The gap: `_check_localization` excuses an enhancement from landing anywhere in the graph —
+# a feature has no existing behaviour to localize — while the unbound-criteria check refused
+# every ticket alike. One gate, two stances on one question, and the perverse consequence was
+# that writing an enhancement's criterion *well* is what parked it.
+
+
+def _binding(*criteria: str) -> Any:
+    """A real `CriteriaBinding` against a graph holding one symbol. No fake to drift."""
+    from orchestrator.pkg.facts import FactBatch, Node, NodeKind, Provenance
+    from orchestrator.sdlc.criteria_binding import bind_criteria
+
+    batch = FactBatch()
+    batch.add_node(Node("py:report", NodeKind.MODULE, "report.py", "python", Provenance("report.py", 1)))
+    batch.add_node(
+        Node("py:report.render", NodeKind.FUNCTION, "render", "python", Provenance("report.py", 10))
+    )
+    return bind_criteria({"acceptance_criteria": list(criteria)}, store=FactStore(batch))
+
+
+def test_a_bug_naming_a_symbol_that_does_not_exist_is_still_refused() -> None:
+    """Unchanged, and the reason the check exists: a bug's subject is code that already runs,
+    so a criterion naming a symbol nobody can find describes a repository this is not."""
+    assessment = assess(
+        _spec("`GhostWidget` no longer double-counts"),
+        store=_graph(),
+        issue_type="Bug",
+        landing=["report.py"],
+        criteria=_binding("`GhostWidget` no longer double-counts"),
+    )
+
+    assert assessment.verdict is Verdict.CRITERIA_WRONG
+    assert assessment.findings[0].check == "criterion-unbound"
+
+
+def test_an_enhancement_naming_the_module_it_will_create_proceeds() -> None:
+    """The deliverable is allowed not to exist yet. This is the verdict that changed."""
+    assessment = assess(
+        _spec("`rule_compiler` returns at least 70 rules"),
+        store=_graph(),
+        issue_type="Story",
+        criteria=_binding("`rule_compiler` returns at least 70 rules"),
+    )
+
+    assert assessment.verdict is Verdict.PROCEED
+
+
+def test_the_enhancement_still_hears_about_it() -> None:
+    """Proceeding is not the same as saying nothing. A criterion naming a symbol that will
+    never exist — a typo, a renamed module — is worth a reviewer's eye either way."""
+    assessment = assess(
+        _spec("`rule_compiler` returns at least 70 rules"),
+        store=_graph(),
+        issue_type="Story",
+        criteria=_binding("`rule_compiler` returns at least 70 rules"),
+    )
+
+    (finding,) = [f for f in assessment.findings if f.check == "criterion-unbound"]
+    assert "rule_compiler" in finding.detail
+    assert "expected for something not built yet" in finding.detail
+    # One fact, two stages: the design stage lists the same absent name under unverified
+    # references, and a reviewer who cannot tell it is one fact discounts both.
+    assert "unverified references" in finding.evidence
+    assert "**Verdict:** PROCEED" in assessment.render()
+    assert "rule_compiler" in assessment.render()
+
+
+def test_the_precise_criterion_is_no_longer_the_one_that_parks_the_ticket() -> None:
+    """The perverse consequence, stated as a test. Both forms describe the same feature; the
+    second names its subject, is more testable, and used to be the one that stopped the run."""
+    prose = assess(
+        _spec("the compiler returns at least 70 rules"),
+        store=_graph(),
+        issue_type="Story",
+        criteria=_binding("the compiler returns at least 70 rules"),
+    )
+    precise = assess(
+        _spec("`rule_compiler` returns at least 70 rules"),
+        store=_graph(),
+        issue_type="Story",
+        criteria=_binding("`rule_compiler` returns at least 70 rules"),
+    )
+
+    assert prose.verdict is precise.verdict is Verdict.PROCEED
+
+
+def test_an_untyped_ticket_is_not_held_to_a_bugs_standard() -> None:
+    """Empty is the honest state for a source with no issue types — a wiki page, a `--spec`
+    file. Refusing those would make the gate strictest exactly where it knows least."""
+    assessment = assess(
+        _spec("`rule_compiler` returns at least 70 rules"),
+        store=_graph(),
+        criteria=_binding("`rule_compiler` returns at least 70 rules"),
+    )
+
+    assert assessment.verdict is Verdict.PROCEED
+
+
+def test_an_incident_is_judged_as_a_bug() -> None:
+    """`profile_select` has always mapped `incident` to the bug profile; validity kept its own
+    list and did not. One predicate now answers for both — an incident that gets root-cause
+    analysis is an incident that must localize."""
+    assessment = assess(
+        _spec("`GhostWidget` no longer double-counts"),
+        store=_graph(),
+        issue_type="Incident",
+        landing=["report.py"],
+        criteria=_binding("`GhostWidget` no longer double-counts"),
+    )
+
+    assert assessment.verdict is Verdict.CRITERIA_WRONG
+
+
+def test_a_bound_criterion_proceeds_whatever_the_issue_type() -> None:
+    for issue_type in ("Bug", "Story", ""):
+        assessment = assess(
+            _spec("`render` keeps its signature"),
+            store=_graph(),
+            issue_type=issue_type,
+            landing=["report.py"],
+            criteria=_binding("`render` keeps its signature"),
+        )
+        assert assessment.verdict is Verdict.PROCEED, issue_type
+
+
 # ---- size and duplication --------------------------------------------------
 
 


### PR DESCRIPTION
## What

Makes the ticket→PKG pipeline actually issue-type aware. Four changes, in three commits.

Found by walking one real enhancement end to end against another repo and triaging what the
pipeline did with it. Three gaps were confirmed; a fourth — the plumbing all three rest on —
turned up while planning the fix.

## Why

**The pipeline is issue-type shaped, and the type never arrived.** `select_profile` picks a
workflow profile from it, `validity._check_localization` decides by it whether a ticket must
localize, and the `bug`/`enhancement` profiles exist to be selected by it. None of it fired.

The only thing intake hands a run is a `FeatureSpec`, which forbids extra keys and has no field
for a type, so `spec.get("issue_type")` was always `""` and no CLI passed one. Every real run
took the `default` profile and the localization check never once ran outside its own tests.
`jira_source` said as much in its own docstring: the type reached the *extractor*, as prose
prepended to the body, and nothing else.

**An enhancement was refused for naming what it was about to build.** `_check_localization`
excuses a feature from landing anywhere in the graph — it has no existing behaviour to localize
— while the unbound-criteria check refused every ticket alike. One gate, two stances on one
question, and the consequence was perverse:

```
the compiler returns >= 70 rules        → no claim → PROCEED
`rule_compiler` returns >= 70 rules     → unbound  → parked
```

The second is more precise and more testable, and it was the one that stopped the run.

**Two signals were computed and thrown away.** Jira labels have been fetched with every issue
since the adapter was written and read by nothing. `build_rca`'s `git log` recency pass was
dropped along with the whole node for every enhancement, though "is this area moving?" does not
depend on a symptom.

## The changes

| | | |
|---|---|---|
| **Plumbing** | `SourceDocument.issue_type` + a deterministic resolver | `spec.intent_id → Intent → source_doc_ids → SourceDocument`, over data already fetched. Not a `FeatureSpec` field: a spec is written by a model, and a model choosing which research a ticket gets is what `profile_select` exists to prevent. `--issue-type` overrides, and is the only way a `--spec` run can be typed |
| **Gap A** | an unbound criterion parks a bug, advises anything else | A bug's subject is code that already exists, so an unbound claim is a false premise. An enhancement's names the deliverable. The advisory rides along with PROCEED, as `_check_context_budget` already does |
| **Gap C** | labels as a profile fallback | Consulted **only** where the issue type resolves to nothing, so a feature request labelled `bug` for triage does not thereby get RCA. Sorted before matching — first-match-wins over an unordered set is not reproducible |
| **Gap B** | `n_churn` for the enhancement profile | Crossed with **landing sites**, not a fault site, which makes it the weaker reading: where a ticket's vocabulary lives is what it attaches to, not what it touches. Worded accordingly, and a test asserts the word "regression" never appears in an enhancement's evidence |

**One predicate.** `profile_select.is_bug`, from the `_BY_TYPE` table `select_profile` already
uses. The two had drifted: `incident` selected the bug profile while validity's own list did not
mention it, so an incident got root-cause analysis and was then excused from having to localize.

## Two things this changes in behaviour

1. **The localization check is now live.** A ticket typed `Bug` whose words match nothing in the
   graph parks as `UNLOCALIZED`. That is the check working on the first ticket that ever reached
   it, and it is why the plumbing landed as its own commit. Both sides are pinned by tests.
2. **A typed ticket selects `bug`/`enhancement`** where it silently took `default`.

## Also fixed, found while building the churn node

`enhancement.yaml` drops `n_rca` specifically so the evidence does not print *"Not localized to
a repo symbol"* — its own comment says an empty section reads as a finding and is not one.
`render_evidence_md` printed it anyway: it saw an empty dict and could not tell a skipped node
from an empty result. An enhancement now reads *"Not run for this issue type"*; a bug that
genuinely localizes nothing still gets the original sentence.

## Tests

31 added. Nothing covered the old gap-A behaviour at the `assess` level, so those are the first
tests either way rather than a rewrite. `tests/intake/test_cache.py` also stopped hard-coding
`"version": 1`, which would have made it silently test nothing from the first version bump on.

## Note for anyone running the gate locally

CI is green on this branch. Two stale `type: ignore` comments will fail `mypy src tests`
locally depending on **which optional extras are installed**, and neither is touched here:

- `src/orchestrator/mcp/client.py:83` — fails with `--extra dev` alone
- `src/orchestrator/sdlc/testrunner.py:489` — fails with `--all-extras` (testcontainers present)

Both reproduce on a clean `origin/develop` checkout with the matching extras, so they are
pre-existing and environment-dependent, not from this branch. CI installs a set that hits
neither. Worth a small separate cleanup on `develop` rather than carrying it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
