### PR TITLE
fix(typing): two ignores that were only correct in some environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ All notable changes to this project are documented here. Format loosely follows
   saw an empty result and could not tell a skipped node from an empty one. It now says *"Not run
   for this issue type"*, and a bug that genuinely localizes nothing still says the original.
 
+### Fixed — the local gate failed on files you did not touch
+
+- **Two `type: ignore` comments were only correct in some environments.** Whether an ignore is
+  "unused" depends on whether the optional dependency it guards is installed, so
+  `mypy src tests` failed on `mcp/client.py` with `--extra dev` and on `sdlc/testrunner.py` with
+  `--all-extras` — always in a file the contributor had not touched, and never in CI, which
+  installs a set that hits neither. Both now name `unused-ignore` alongside the real code, which
+  is green in either environment. A gate that fails on someone else's file is a gate people
+  learn to distrust.
+
 ### Added — two signals that were computed and thrown away
 
 - **`--issue-type` on `sdlc autorun` and `sdlc plan`.** Overrides what the ticket says, and is

--- a/src/orchestrator/mcp/client.py
+++ b/src/orchestrator/mcp/client.py
@@ -80,7 +80,10 @@ class SessionMCPClient:
                 # v2 takes a configured http client rather than a `headers` kwarg, and
                 # yields two streams rather than three. `create_mcp_http_client` is the
                 # SDK's own factory, so MCP's recommended timeouts still apply.
-                from mcp.client.streamable_http import (  # type: ignore[attr-defined]
+                # `unused-ignore` alongside: with the `mcp` extra installed the symbols resolve
+                # and `attr-defined` is redundant, without it the module is `Any` and the ignore
+                # is required. Naming both keeps `mypy src tests` green in either environment.
+                from mcp.client.streamable_http import (  # type: ignore[attr-defined, unused-ignore]
                     create_mcp_http_client,  # re-exported here, but absent from __all__
                     streamable_http_client,
                 )

--- a/src/orchestrator/sdlc/testrunner.py
+++ b/src/orchestrator/sdlc/testrunner.py
@@ -486,7 +486,15 @@ class PostgresSqlTestRunner:
 
         def _run() -> TestRunResult:
             try:
-                from testcontainers.postgres import PostgresContainer  # type: ignore[import-not-found]
+                # `unused-ignore` because whether this ignore is needed depends on the
+                # environment: with the `sql-postgres` extra installed the import resolves and
+                # the ignore is redundant, without it the import is unfindable and the ignore is
+                # required. Naming both codes keeps `mypy src tests` green either way — CI
+                # installs one set, a contributor may have the other, and a gate that fails on a
+                # file you did not touch is a gate people learn to distrust.
+                from testcontainers.postgres import (  # type: ignore[import-not-found, unused-ignore]
+                    PostgresContainer,
+                )
             except ImportError:
                 return TestRunResult(
                     passed=False,


### PR DESCRIPTION
## What

`mypy src tests` fails locally on a file you did not touch, and **which file depends on the
extras you synced**:

```
uv sync --frozen --extra dev    → src/orchestrator/mcp/client.py:83       unused "type: ignore"
uv sync --frozen --all-extras   → src/orchestrator/sdlc/testrunner.py:489 unused "type: ignore"
```

Both reproduce on a clean `origin/develop` checkout with the matching extras.

## Why it happens, and why CI never sees it

Whether an ignore is *unused* depends on whether the optional dependency it guards is installed.
With the `mcp` extra present, `mcp.client.streamable_http` resolves and `attr-defined` is
redundant; without it the module is `Any` and the ignore is required. Same shape for
`testcontainers` and the `sql-postgres` extra, in the opposite direction. `warn_unused_ignores`
then reports whichever one is currently redundant.

CI installs a set that resolves one and not the other, so it is green on both — which is why
this has survived.

## Fix

Name `unused-ignore` alongside the real code, which is exactly what that code exists for:

```python
from mcp.client.streamable_http import (  # type: ignore[attr-defined, unused-ignore]
```

Verified green under **both** `--extra dev` and `--all-extras`. No behaviour change; the real
error codes are still enforced in the environment where they apply.

Found while preparing the release: I reported it as a CI failure on #246 and it was not one.
Worth fixing rather than tolerating — a gate that fails on a file you did not touch is a gate
people learn to run with their eyes closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)