### PR TITLE
docs(specs): reconcile the status pages, and decide G6's scope

### DIFF
--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -1,16 +1,23 @@
 # Spec index — every design record, and where it stands
 
 **Generated 2026-08-15 against 3.18.1; refreshed 2026-08-21 for the completed GraphIR
-programme.** `docs/specs/` holds **70** markdown files — **67 specs** plus three navigation
-documents ([README](README.md), this index, [STATE-OF-SPINE](STATE-OF-SPINE.md)) — with 6
-archived and 10 build documents. The count read *63* until 2026-08-21, and **five specs were
-not listed at all**, including this file's own companion matrix and both measurements it
-cites as evidence. An inventory that silently omits things is the failure it was built to
-catch, so the count is now stated as a derivation anyone can re-run:
+programme; recounted 2026-08-28 at 3.25.1.** `docs/specs/` holds **77** markdown files —
+**74 specs** plus three navigation documents ([README](README.md), this index,
+[STATE-OF-SPINE](STATE-OF-SPINE.md)) — with 6 archived and 10 build documents. The count read
+*63* until 2026-08-21, and **five specs were not listed at all**, including this file's own
+companion matrix and both measurements it cites as evidence. An inventory that silently omits
+things is the failure it was built to catch, so the count is now stated as a derivation anyone
+can re-run:
 
 ```
-ls docs/specs/*.md | wc -l          # 70
+ls docs/specs/*.md | wc -l          # 77
 ```
+
+**It rotted anyway.** The line read *70* from 2026-08-21 until 2026-08-28 while the directory
+grew to 76 — six specs listed in the table below but not in the count above it. A derivation a
+reader *can* re-run is not a derivation anything *does* re-run, and nothing here fails when the
+two disagree. [STATE-OF-SPINE](STATE-OF-SPINE.md) §8 tracks the missing gate ("CI gate on
+spec-status drift"); until it exists, re-run the command above when adding a spec.
 
 **How to read the Verified column — this matters.** Status is **self-reported by each spec**
 unless marked ✔. This index was built after three separate cases in one session where a status
@@ -33,8 +40,8 @@ Graphify-gap series only. This file is the complete inventory.
 
 ---
 
-> **Start with [STATE-OF-SPINE.md](STATE-OF-SPINE.md)** — one page, verified 2026-08-18 against
-> 3.19.0, covering where the product stands, what is measured, the active programme, and what is
+> **Start with [STATE-OF-SPINE.md](STATE-OF-SPINE.md)** — one page, verified 2026-08-28 against
+> 3.25.1, covering where the product stands, what is measured, the active programme, and what is
 > outstanding. Come here for the per-spec inventory.
 
 ---
@@ -53,6 +60,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [bet2c-in-loop-approval](bet2c-in-loop-approval.md) | Implemented — in-loop approval gate | |
 | [bet2c-rbac-multitenancy](bet2c-rbac-multitenancy.md) | Implemented **as-built** — `Principal`, roles, tenant scoping | **✔** |
 | [doc-ingestion-spec](doc-ingestion-spec.md) | Phases 1–3 — `Doc` + `MENTIONS` + PDF + drift | **✔** |
+| [multi-repo-roadmap](multi-repo-roadmap.md) | **3.23.0** — all four phases: `.spine/repos.yaml`, three joiners, one scoped merged graph. Multi-repo *delivery* remains an explicit non-goal. **Was filed under 📋 "not started or proposal only" until 2026-08-30** while `pkg/repos.py`, `pkg/join_link.py` and `pkg/joins_propose.py` were in source — the §9 failure mode, found by re-reading the row against the code | **✔** |
 | [shareable-report-spec](shareable-report-spec.md) | Phases 1–3 | |
 | [comprehension-skill-spec](comprehension-skill-spec.md) | Phases 1–3 | |
 | [live-observability-otel](live-observability-otel.md) | Phases 1–3 — OTel tracing end-to-end | **✔** |
@@ -93,7 +101,6 @@ Graphify-gap series only. This file is the complete inventory.
 | [pkg-code-grounded-understanding](pkg-code-grounded-understanding.md) | Proposed, for review | |
 | [language-support-roadmap](language-support-roadmap.md) | Design/blueprint, not started | Three new front-ends |
 | [language-expansion-roadmap](language-expansion-roadmap.md) | Prioritization only | Go ✅ · Rust · Kotlin · Ruby |
-| [multi-repo-roadmap](multi-repo-roadmap.md) | One graph across several repositories — comprehension only. **Spec only; Phase 1 is a blocking identity decision.** Multi-repo *delivery* is an explicit non-goal |
 | [tri-repo-integration](tri-repo-integration.md) | Design only | Spans ontomesh + infodrift |
 | [ontomesh-integration-analysis](ontomesh-integration-analysis.md) | Analysis for decision | Nothing built |
 | **watch-items** | ⚠️ **Spec missing** | `watch-items-roadmap.md` does not exist in `docs/specs/` or `archive/`; the index linked it as a live track | **✔** |
@@ -119,6 +126,7 @@ Analysis, comparisons, test plans and assets. No completion state applies.
 | [capability-matrix](capability-matrix.md) | **The** capability matrix — 47 scored rows, 22 of them rows no competitor's public docs fill. Counts checked by `scripts/matrix-count.py --check` (2026-08-21) |
 | [codegen-model-comparison-results](codegen-model-comparison-results.md) · [external-repo-grounding-results](external-repo-grounding-results.md) | The two measurements behind the matrix's ⁴ rows — 200 and 60 ticket-runs (2026-08-16) |
 | [parsing-and-the-pkg](parsing-and-the-pkg.md) | How source becomes graph facts, front-end by front-end (2026-08-16) |
+| [document-ingestion-reference](document-ingestion-reference.md) | How *prose* becomes graph facts, format by format — the five stages, per-format behaviour, bounds, and the measured cost of losing headings (2026-08-29) |
 | [ticket-to-landing-sites](ticket-to-landing-sites.md) | How a ticket's words become `file:line` landing sites — tokenising, scoring, and what the result is bound to (2026-08-25) |
 | [competitive-landscape](competitive-landscape.md) | Competitive **narrative and strategy** (2026-08-21). Its duplicate scored matrix was removed — see `capability-matrix.md` |
 | [graphify-vs-spine-comparison](graphify-vs-spine-comparison.md) | One competitor in depth — **at v3.7.0, stale** |
@@ -143,11 +151,17 @@ Analysis, comparisons, test plans and assets. No completion state applies.
 
 | State | Count |
 |---|---|
-| ✅ Complete | 16 |
+| ✅ Complete | 17 |
 | 🟡 Partial | 12 |
-| 📋 Outstanding | 15 *(incl. 1 missing spec)* |
+| 📋 Outstanding | 14 *(incl. 1 missing spec)* |
 | ⚠️ Stale status | 2 |
-| 📖 Reference | 23 |
+| 📖 Reference | 24 |
+
+> **These five numbers have no derivation.** Unlike the file count above them, nothing re-runs
+> them and they do not reconcile to the 74 specs in the header — reference rows double-count
+> specs listed above and fold `archive/` and `build-documents/` into single lines. Treat them as
+> a shape, not an inventory; the "CI gate on spec-status drift" in
+> [STATE-OF-SPINE](STATE-OF-SPINE.md) §8 is what would make them checkable.
 
 **The programme is further along than its own paperwork says.** Every discrepancy found this
 session ran the same direction — work shipped, the status line didn't move. Nothing was claimed

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -3,7 +3,7 @@
 **The one document to read.** Verified against source on **2026-08-28**, at the 3.25.1 release
 cut. Every number below was re-measured that day.
 
-> **Why this exists.** `docs/specs/` holds **76** markdown files — **73 specs** plus this
+> **Why this exists.** `docs/specs/` holds **77** markdown files — **74 specs** plus this
 > page, [`README`](README.md) and [`SPEC-INDEX`](SPEC-INDEX.md) — with 6 archived, 10 build
 > documents, and 17 root-level user documents.
 > Answering "where do we stand?" required opening five of them and reconciling three that
@@ -347,6 +347,13 @@ its output edge, and inside the model-call budget.
 
 ## 8. Outstanding, everything else
 
+*This table is the authority.* [`enhancement-index`](enhancement-index.md) and
+[`gap-roadmap-index`](gap-roadmap-index.md) are snapshots that feed it — seven rows below were
+merged in on 2026-08-30 from those two pages and from
+[`document-ingestion-reference`](document-ingestion-reference.md), where they had been recorded
+and never promoted. A list that claims to be the authority has to actually absorb them.
+
+
 | Item | State |
 |---|---|
 | Upgrade local `uv` past 0.8.0 | user's machine |
@@ -356,8 +363,15 @@ its output edge, and inside the model-call budget.
 | Rust front-end | not started |
 | Express endpoint extraction (TypeScript) | unscheduled |
 | Deployment image + reusable CI workflow for central adoption | not started. **Not a G4 phase** — it was recommended as though it were; it needs adding to that spec before it can be scheduled |
-| `SPEC-INDEX.md` links `watch-items-roadmap.md`, which does not exist | not started |
+| **Watch-items (WI): write the spec or drop the track** | **decision, not a task.** `watch-items-roadmap.md` was never written. Both indexes now carry it as ⚠️ *spec missing* rather than as a link, so the broken reference this row used to describe is gone — what remains is the choice. WI-2 (doc drift) is the half with a live argument: [`gap-roadmap-index`](gap-roadmap-index.md) ranks it second of everything remaining, as *a lead, not a moat* |
 | `docs/specs/current-state.md` has a mermaid block that falls back to `<pre>` in our own UI | not started |
+| **G6 comprehension benchmark — decided, unstaffed** | **scope decided 2026-08-30.** D1–D4 taken and written into [`gap6-benchmarks-roadmap.md`](gap6-benchmarks-roadmap.md): hand-labelled gold set only, two metrics (top-k localization + provenance validity), five pinned repositories, ratchet gate. Nothing blocks the work but the ~3 days of hand-labelling and an owner. **The corpus pins live in one markdown table and nothing reads them** — Phase 1 must land a manifest |
+| LLM temperature refusal is re-learned every call | not started. [`litellm_client.py:226`](../../src/orchestrator/core/llm/litellm_client.py) pops `temperature` from a **local** dict, so every call to a model that rejects it costs a failed round-trip and a warning. A per-model refusal cache halves the request count on those models. Was E4 in [`enhancement-index`](enhancement-index.md) and had never reached this list |
+| MCP server spawned per operation | not started. [`mcp/client.py`](../../src/orchestrator/mcp/client.py) `_session()` starts and tears down a fresh `stdio_client` per call — no pooling. E4's second half |
+| Stale second `## Unreleased` heading in the changelog | not started. `CHANGELOG.md:1182`, between the 3.14-era entries and `## 3.13.0`. Trivial, but it needs someone who knows which release those entries actually shipped in — which is why it was flagged rather than guessed at |
+| **56% of `Doc` sections bind to nothing** | not started, and **not a parsing defect** — those sections are perfectly-parsed markdown with no identifier in them. Closing it needs semantic matching, which means a model, which collides with the determinism that makes `understand --check` a gate. Any fix belongs in a labelled second tier, measured and declared the way GraphIR Phase 2b was. [Record](document-ingestion-reference.md) |
+| PDF, `.rst`/`.txt` and media collapse to one `Doc` node per file | unscheduled. Media is the one fixable without a new dependency — its segments already carry `start_ms`/`end_ms` and could become timestamped sections. **Unmeasured** |
+| Diagram arrows never become graph edges | **idea, no spec.** A mermaid flowchart is read as text; its labels bind to nothing and `intake --> design` produces no relationship. The more promising framing is the inverse — a diagram as a set of assertions to *check* against the graph rather than facts to add to it |
 | Shadowed-name `CALLS` invention in TypeScript, Go, C++, C# | ✅ **closed 2026-08-24** — oracle widened to 6 front-ends, all four fixed, 4 corpus cases added, `invention` gated `strict` at zero per language. 47 fabricated edges removed with no true edge lost. [Record](invention-oracle-cross-language.md) |
 | TypeScript resolution via the TS compiler API | **idea, not scheduled** (2026-08-21). `CALLS` recall is **0.50** for TypeScript against 1.00 for C and SQL — tree-sitter parses the syntax correctly but has no symbol table, so a call site resolves to the wrong target or none. The language's own toolchain would fix that. Costs: a Node runtime dependency, loss of tree-sitter's error tolerance, and a determinism risk if resolution depends on installed packages — the same commit could then give different graphs on different machines |
 | G4 adoption — friction audit | ✅ **Phase 1 done 2026-08-19** — ≈28s cold start, no key; channels/proof/measurement outstanding |

--- a/docs/specs/document-ingestion-reference.md
+++ b/docs/specs/document-ingestion-reference.md
@@ -1,0 +1,235 @@
+# Document ingestion reference — how a document becomes graph facts, format by format
+
+**Verified against source 2026-08-29 at 3.25.1.** Companion to
+[`doc-ingestion-spec.md`](doc-ingestion-spec.md), which is the *design record* — why doc
+ingestion exists and what shipped in which phase. This page is the *behavioural* reference:
+what each format does, what it costs, and what a document has to look like to be worth
+ingesting at all. Every number here was measured on this repository the day it was written,
+and the commands are given so they can be re-run rather than trusted.
+
+Its sibling for code is [`parsing-and-the-pkg.md`](parsing-and-the-pkg.md) — that page covers
+how *source* becomes graph facts, front-end by front-end. This one covers *prose*.
+
+---
+
+## The one thing to know
+
+**Spine has no pipeline per format.** It has one pipeline, and each format has a small
+converter into a common shape: **markdown-shaped text**. HTML's `<h1>`, Word's `Heading 1`
+style and a spreadsheet's sheet name all become an ATX `#` heading; HTML's `<code>` becomes a
+backtick span. Everything downstream — splitting, mention extraction, binding — reads that one
+shape and never learns which format it came from.
+
+That is why the per-format table below looks asymmetric but isn't. A format splits into
+sections exactly when its converter can recover headings. PDF and plain text carry nothing a
+heading can be built from, so they don't. Nothing is special-cased; the asymmetry is a property
+of the formats.
+
+## The five stages
+
+```mermaid
+flowchart LR
+    walk["1 · Walk<br/>deterministic order"]
+    read["2 · Read<br/>format to markdown shape"]
+    split["3 · Split<br/>one Doc node per heading"]
+    bind["4 · Bind<br/>mention to code anchor"]
+    add["5 · Add<br/>Doc nodes + MENTIONS"]
+    walk --> read
+    read --> split
+    split --> bind
+    bind --> add
+```
+
+### 1 · Walk
+
+`read_doc_pages` walks from the repo root with `os.walk`, **sorted at every level** so the
+output is deterministic, skipping `DEFAULT_IGNORE_DIRS` (`.git`, `node_modules`, build output)
+and **any directory whose name starts with a dot**. A file is visited only if some registered
+reader claims its suffix; everything else is invisible to doc ingestion.
+
+> The leading-dot rule is load-bearing elsewhere: it is why every on-disk test fixture root in
+> `corpus/` is named `.repo/`. See the corpus note in [`CLAUDE.md`](../../CLAUDE.md).
+
+### 2 · Read — and normalise into markdown shape
+
+Formats **register** rather than branch. A `DocReader` is `(name, suffixes, read, sections)`
+on a module-level registry, so adding a format touches no existing reader and no dispatch code.
+
+| Format | Needs | How structure is recovered | Sections |
+|---|---|---|---|
+| `.md` `.markdown` | — (stdlib) | native ATX headings; front matter values kept as prose, keys and fences dropped | **yes** |
+| `.html` `.htm` | — (stdlib `HTMLParser`) | `<h1>`–`<h6>` → `#`–`######`; `<code>`/`<tt>`/`<kbd>`/`<samp>`/`<var>` → backtick spans; `<script>`/`<style>` dropped | **yes** |
+| `.docx` | `[office]` (`python-docx`) | Word's `Heading 1`–`Heading 6` and `Title` styles → `#`–`######` | **yes** |
+| `.xlsx` | `[office]` (`openpyxl`) | each sheet name → `# Sheet`; **string cells only**, joined with `·` | **yes** |
+| `.rst` `.txt` | — | nothing to recover | no |
+| `.pdf` | `[docs]` (`pypdf`) | nothing — text extraction only, no structure | no |
+| audio / video | `[media]` / `[asr]` + `media extract` | nothing — transcript segments joined as paragraphs | no |
+
+**`.xlsx` keeps string cells only** — numbers, dates and formula results are data, not prose
+about code, and would add noise without ever binding.
+
+**Not registered on purpose: standalone `.yaml`/`.yml`.** A repo's YAML is overwhelmingly
+configuration, not documentation.
+
+**`read` returns `str | None`, and `None` always means skip.** Too large, unparseable, an
+optional dependency missing, an encrypted workbook — every one of them is non-fatal. A format
+Spine cannot read is simply **absent** from the graph, never an error. This is the `pypdf`
+precedent, and it is what makes every extra genuinely optional.
+
+### 3 · Split
+
+`split_sections` runs only when the reader declared `sections=True`. Each heading becomes its
+own `Doc` node keyed `path#slug` (`doc:README.md#usage`), with **provenance at the heading's own
+line** — so a `MENTIONS` edge points at the paragraph that made the claim, not at a file.
+Content before the first heading becomes a section keyed by the bare path, so nothing is
+dropped. Slugs are de-duplicated with a numeric suffix; the whole thing is deterministic.
+
+A document with more than `_MAX_SECTIONS` (40) headings **stays whole** rather than fragmenting
+the graph.
+
+### 4 · Extract and bind
+
+Mentions are the spans with *code intent*, de-duplicated per page with backticks taking
+precedence: backticked spans, dotted paths (`a.b.C`), `snake_case`, `CamelCase`, and file
+paths. Bare CamelCase words ("GitHub", "Python") bind when they resolve but never count as
+drift — prose capitalisation is not a code claim.
+
+Each mention is then bound against the **already-built code graph**, with three outcomes:
+
+| Anchors | Result | Why |
+|---|---|---|
+| exactly 1 | **`MENTIONS` edge** | unambiguous claim about a symbol |
+| more than 1 | **skipped** | an ambiguous edge poisons grounding — the same skip-rather-than-guess rule that holds `CALLS` precision at 1.00 |
+| 0 | **doc-drift finding** | the docs name something the code does not define |
+
+Drift is filtered by `symbolish_drift` to identifier-shaped claims, so paths, filenames and
+URLs in backticks (`episteme/`, `graph.html`, `foo_test.go`) do not drown the signal.
+
+### 5 · Add — and only add
+
+`link_docs` is a post-pass over a finished code graph. It calls `add_node` for `Doc` and
+`add_edge` for `MENTIONS`, and nothing else: **no code node, edge or provenance is modified**,
+and a repo with no docs comes back unchanged. That is what makes wiring it into every
+comprehension surface safe.
+
+One nuance worth stating, because it looks like an exception and isn't: a `MENTIONS` edge
+counts as a *use* in dead-code detection, alongside `CALLS` and `IMPLEMENTS`, so a
+documented-but-uncalled symbol stops being flagged. That is an inference over the graph
+changing, not the graph being rewritten.
+
+## Media — the two-phase exception
+
+Media is the only input whose text is produced by a **model**, and it is the pattern to copy if
+another one ever is. It runs in two phases:
+
+1. **`media extract`** — an explicit, separate step. Runs OCR (`pytesseract`) or ASR (Whisper
+   locally, or a remote API only with per-run `--allow-remote` consent) and writes a committed
+   artifact carrying `schema_version`, `source_sha256`, and the transcript segments with
+   `start_ms`/`end_ms`.
+2. **`read_media_artifact`** — the reader the PKG actually calls. Pure and deterministic: it
+   hashes the media file, finds the artifact, and returns its text. It returns `None` — skip —
+   for an unknown `schema_version`, a hash mismatch (the media changed since extraction), a
+   malformed artifact, or no artifact at all.
+
+So a model contributes the *text* while the *graph build* stays deterministic, cacheable and
+gateable by `understand --check`. No model runs inside `understand`.
+
+## Bounds
+
+Every limit fails to **skip**, never to an error.
+
+| Bound | Value |
+|---|---|
+| Text file bytes | `_MAX_DOC_BYTES` |
+| PDF | 25 MB and 500 pages |
+| Office files | `_MAX_OFFICE_BYTES` |
+| Workbook | `_MAX_SHEETS` sheets, `_MAX_SHEET_ROWS` rows |
+| Sections per document | 40 |
+
+## What it costs today, measured
+
+On this repository, 2026-08-29 at 3.25.1:
+
+| | Value |
+|---|---|
+| Registered readers | **7** (`grep -c 'register_reader(DocReader' src/orchestrator/pkg/doc_source.py`) |
+| …of which split into sections | **4** — markdown, html, docx, xlsx |
+| `Doc` nodes | **1,505** |
+| `MENTIONS` edges | **2,300** |
+| `Doc` nodes with at least one edge | **662** |
+| **Orphan `Doc` nodes — prose reachable from no symbol** | **843 = 56%** |
+
+The orphan figure is the honest headline. The sections it names are not junk — they are
+`ARCHITECTURE.md#the-one-sentence-version`, `#the-layers`, `#the-two-gates`: the prose that
+explains *why*, which names no identifier and therefore reaches no symbol. See
+[Known limits](#known-limits).
+
+### The cost of losing headings, measured
+
+The same content ingested twice — once as markdown, once converted to PDF:
+
+| | `Doc` nodes | mentions | bound edges |
+|---|---|---|---|
+| markdown | **8** (per heading) | 80 | **30** |
+| PDF | **1** (whole file) | 51 | **16** |
+
+Two distinct causes, and the smaller one is the obvious-looking one:
+
+- **Granularity dominates.** `extract_mentions` de-duplicates per page, so one `Doc` node
+  yields at most one edge per symbol. Eight section nodes let a symbol discussed in three
+  sections produce three edges, each addressable at its own heading line.
+- **Line-wrapping costs a little.** `_BACKTICK_RE` forbids a newline inside a span, so an
+  identifier broken across lines is lost: 104 backtick spans in the markdown against 96 in the
+  PDF — 9 lost, including `docs_for(symbol)` and `mentions_of(doc_id)`.
+
+So what a structure-less format loses is **pointer resolution**, not comprehension: `docs_for`
+can say "described in this 4-page document" instead of "described at
+`doc-ingestion-spec.md#components-where-the-code-goes`, line 116" — and it is the second form
+that is worth putting in a prompt.
+
+## Writing a document that binds
+
+Applies to any format; it matters most for the ones that cannot carry headings.
+
+1. **Name symbols exactly**, in backticks or as dotted paths. `extract_media`, not "the media
+   extractor".
+2. **Qualify anything ambiguous.** `off_machine` exists on four classes and is *skipped*;
+   `AsrBackend.off_machine` binds. Ambiguity is refused, not guessed.
+3. **Keep identifiers on one line.** A backtick span broken by a line break is not a mention.
+4. **Put the explanation beside the symbols it explains.** Prose travels attached to the
+   symbols in its own section, so rationale separated from its identifiers reaches nothing.
+5. **Use real headings** where the format has them — that is what buys section granularity.
+
+## Where these facts are consumed
+
+| Consumer | What it does with them |
+|---|---|
+| `PKGCodegenGrounder._doc_block` (`sdlc/grounding.py`) | attaches up to 500 chars of a `MENTIONS`-linked section's prose to that symbol's source in the codegen context — the model gets the code *and what it is for* |
+| `doc_drift` → `state` | reports code-intent claims the graph does not support |
+| `insights.py` dead-code | treats a `MENTIONS` edge as a use |
+| `sdlc/builddoc.py` | lists the docs covering in-scope symbols, so a change plan names the prose that will need updating |
+| `docs_for` / `mentions_of` (`pkg/store.py`, MCP `plugin/server.py`) | "which docs describe `X`?", answerable by an assistant |
+| `renderers.py` glossary | the *Explained in* column — the same query in bulk |
+
+## Known limits
+
+- **PDF, `.rst`/`.txt` and media collapse to one `Doc` node per file**, because none of them
+  can express a heading. Media is the one where the fix needs no new dependency: its segments
+  already carry `start_ms`/`end_ms` and could become timestamped sections. **Unmeasured and
+  unscheduled.**
+- **56% of `Doc` sections bind to nothing.** This is not a parsing problem — those sections are
+  perfectly-parsed markdown. Connecting intent-bearing prose to code without an identifier
+  needs semantic matching, which means a model, which collides with the determinism that makes
+  `understand --check` a gate. Any fix belongs in a clearly-labelled second tier, measured and
+  declared the way GraphIR Phase 2b was, never smuggled into the deterministic path.
+- **Diagrams contribute almost nothing.** A mermaid flowchart is read as text, but its labels
+  are prose and bind to nothing, and **its arrows never become edges** — a diagram saying
+  "intake → design" produces no relationship. A diagram embedded in a PDF yields loose label
+  tokens with no structure. *A diagram is better used as a set of assertions to check against
+  the graph than as a source of facts to add to it; that idea has no spec.*
+- **A layout-aware extractor was considered and not pursued** (2026-08-29). Docling-class tools
+  recover headings, reading order and tables. Headings are the only part this pipeline can use,
+  and HTML, DOCX and XLSX already get them for free — leaving PDF, where the measured ceiling
+  is roughly the doubling shown above, against a torch-sized dependency and a two-phase
+  artifact seam. Revisit if a target environment is shown to keep most of its
+  identifier-bearing prose in PDF.

--- a/docs/specs/enhancement-index.md
+++ b/docs/specs/enhancement-index.md
@@ -25,7 +25,7 @@ cadence; this one is a snapshot of a conversation.
 |---|---|---|---|---|
 | **E1** | [Project constitution](#e1--project-constitution) | **Spec written, needs rewrite** — [`constitution-roadmap.md`](constitution-roadmap.md), branch `docs/constitution-spec` | Unknown until Phase 0 | A blocking trigger probe that may close it unbuilt |
 | **E2** | [Multi-repo comprehension](#e2--multi-repo-comprehension) | ✅ **Complete — all four phases** — [`multi-repo-roadmap.md`](multi-repo-roadmap.md), branch `feat/multi-repo-identity` | — | Unmeasured on real repos; delivery still a non-goal |
-| **E3** | [G6 — comprehension benchmark](#e3--g6--comprehension-benchmark) | **Spec exists, not started.** Branch `feat/g6-comprehension-metrics` cut, empty | ~3 days if descoped | **Four open decisions** — corpus scope, metric set, repo mix, gate tier |
+| **E3** | [G6 — comprehension benchmark](#e3--g6--comprehension-benchmark) | **Spec exists, not started. Scope decided 2026-08-30** — D1–D4 taken and written into the spec. Branch `feat/g6-comprehension-metrics` cut, empty | ~2 d harness + ~3 d labelling | **Nothing but staffing.** The gold set is hand-labelling time and the spec's Owner is unassigned |
 | **E4** | [Per-run caching: temperature + MCP](#e4--per-run-caching-temperature-refusal-and-mcp-sessions) | **Observed in the field.** No ticket | Small | Nothing |
 | **E5** | [Oracle coverage gaps](#e5--oracle-coverage-gaps) | **Named in `STATE-OF-SPINE` §3** | Medium | Nothing |
 | **E6** | [Stale `## Unreleased` in the changelog](#e6--stale-unreleased-heading) | **Known defect** | Trivial | Someone who knows which release those entries shipped in |
@@ -215,17 +215,22 @@ Directly relevant to [`ticket-to-landing-sites.md`](ticket-to-landing-sites.md):
 true fix site lands in the top *k* is **unmeasured**, and a `0` there would not distinguish *bad*
 from *never measured*.
 
-**Four decisions block the work, all recommended, none taken:**
+**All four decisions were taken 2026-08-30** and are now recorded in the spec itself, which was
+rewritten to match — Phase 1, the corpus table and two open questions had said the opposite.
+[`gap6-benchmarks-roadmap.md`](gap6-benchmarks-roadmap.md) is the authority; this is the summary:
 
-| | Decision | Recommendation |
+| | Decision | Taken |
 |---|---|---|
-| D1 | Gold set only, or also mined PRs? | **Gold set only** — 30–50 hand-labelled. The spec admits mined PRs are a dirty denominator, so a bad number could not be attributed. Cuts Phase 1 to ~3 days |
-| D2 | Which of the five metrics ship in v1? | **Two** — top-k localization and provenance validity. The first is the claim that matters; the second is nearly free (`stale_findings`). Impact recall depends on D1; fault-site top-1 needs a traceback corpus that does not exist |
-| D3 | Which repos? | **Reuse the eleven pinned for the invention work** — already SHA-pinned, already exercised against 3.22.0, and the language mix is right (the spec is explicit the corpus must not be Python-heavy) |
-| D4 | Gate tier? | **Ratchet** — but not for the spec's stated reason. A SHA-pinned corpus does not churn; the real reason is that this is a *ratio*, not a defect count, so unlike `invention` there is no correct value to hold at zero |
+| D1 | Gold set only, or also mined PRs? | **Gold set only** — 30–50 hand-labelled. Mined PRs are a dirty denominator, so a bad number could not be attributed |
+| D2 | Which of the five metrics ship in v1? | **Two** — top-k localization and provenance validity. The other three are removed *by D1*, not chosen against: impact recall needs the PR changed-file list, fault-site top-1 needs a traceback corpus that does not exist, `regression_gaps` precision needs per-repo coverage runs |
+| D3 | Which repos? | **Five, one per front-end** — vuejs/core, gin, fmt, libuv from the eleven invention pins, plus flask for Python (to be pinned in Phase 1). Not all eleven: 30–50 issues over eleven repositories is too thin per repository. **C# gets no slot in v1** and the published page must say so |
+| D4 | Gate tier? | **Ratchet** — because the metric is a *ratio* with no correct value, not because a pinned corpus churns |
 
-**One stale line in the spec:** open question 3 asks whether to publish before or after G3/G5
-land. Both landed — 3.10.0 and 3.11.0 — so it resolves to *publish now* and should be struck.
+**Open question 3 was struck at the same time:** it asked whether to publish before or after G3/G5
+land; both landed (3.10.0, 3.11.0), so it resolves to *publish now*.
+
+**What remains is staffing, not design.** D1 turns Phase 1's cost into ~3 days of human
+labelling, and the spec's Owner is still unassigned.
 
 ## E4 — Per-run caching: temperature refusal and MCP sessions
 
@@ -277,15 +282,28 @@ adoption do not qualify.
 
 E1 is the one idea taken from it.
 
+**A layout-aware document extractor** (Docling-class) — considered 2026-08-29 and declined:
+[`document-ingestion-reference.md`](document-ingestion-reference.md). Such tools recover headings,
+reading order and tables, but **headings are the only part this pipeline can use**, and HTML, DOCX
+and XLSX already get them free from their own converters. That leaves PDF alone, where the measured
+ceiling is roughly a doubling of bound sections — against a torch-sized dependency and a two-phase
+artifact seam. **Revisit condition:** a target environment is shown to keep most of its
+identifier-bearing prose in PDF.
+
 ## If you are sequencing these
 
 Not a queue, but the argument as it stands:
 
-1. **E4** — small, real, and found in the field. Cheap to clear.
+1. **E4** — small, real, and found in the field. Cheap to clear, and now on
+   [`STATE-OF-SPINE` §8](STATE-OF-SPINE.md) where it can be scheduled.
 2. **E3 (descoped)** — the only one that adds a *standing check* where none exists, and this
-   week showed what a missing check costs.
+   week showed what a missing check costs. **Its four decisions are taken (2026-08-30)**; what it
+   needs now is an owner for ~3 days of labelling, not a design session.
 3. **E1 Phase 0** — a probe, not a build. It is allowed to close the spec, and that is a
    successful outcome.
-4. **E5**, then **E2**, which needs a spec before it needs a decision.
+4. **E5** — the oracle coverage gaps, which need a fixture as well as a detector.
+
+**E2 is done** — all four phases shipped in 3.23.0; it left this list on 2026-08-30 and the
+`SPEC-INDEX` row that still called it *"spec only"* was corrected the same day.
 
 **E6** whenever someone with the history is passing.

--- a/docs/specs/gap-roadmap-index.md
+++ b/docs/specs/gap-roadmap-index.md
@@ -4,7 +4,8 @@
 prerequisites, invariants, phases and exit criteria. This page exists only to say what the specs
 *are* and which files each one owns. If you're picking up a track, open its spec and start there.
 
-**Date:** 2026-07-22 · spine v3.8.2
+**Date:** 2026-07-22 · spine v3.8.2. **Statuses refreshed 2026-08-30 at 3.25.1** — the G4 and G6
+rows had not moved since the page was written, and both had.
 **Source:** the gaps in [graphify-vs-spine-comparison.md](graphify-vs-spine-comparison.md).
 
 ---
@@ -18,9 +19,9 @@ prerequisites, invariants, phases and exit criteria. This page exists only to sa
 |---|---|---|
 | **G2** — [document modality](gap2-document-modality-roadmap.md) | HTML + Office (`.docx`/`.xlsx`) ingestion | ✅ **Shipped in 3.8.2** |
 | **G3** — [media ingestion](gap3-media-ingestion-roadmap.md) | Images, audio, video (OCR / transcription) | ✅ **Shipped in 3.10.0** — all three phases |
-| **G4** — [adoption & distribution](gap4-adoption-distribution-roadmap.md) | Install friction, channels, proof assets | Not started — **no prerequisites** (Phase 3 excepted) |
+| **G4** — [adoption & distribution](gap4-adoption-distribution-roadmap.md) | Install friction, channels, proof assets | 🟡 **Phase 1 done 2026-08-19** — friction audit: ≈28s cold start, no key required, two findings fixed. **2** channels · **3** proof assets · **4** measurement outstanding |
 | **G5** — [visualization](gap5-visualization-roadmap.md) | Graph exports + richer deterministic visuals | ✅ **Shipped in 3.11.0** — Phases 1–2; **Phase 3 deliberately dropped** (Gephi does it better on our export) |
-| **G6** — [benchmarks](gap6-benchmarks-roadmap.md) | Retrieval/localization measurement + publication | Not started — **no prerequisites; best done first**. Rewritten 2026-08-15 against 3.18.1 |
+| **G6** — [benchmarks](gap6-benchmarks-roadmap.md) | Retrieval/localization measurement + publication | Not started — **no prerequisites; best done first**. Rewritten 2026-08-15 against 3.18.1; **scope decided 2026-08-30** (D1–D4: gold set only, two metrics, five repos, ratchet gate). Nothing blocks it but staffing the ~3 days of labelling |
 | **CB** — [codegen benchmark](codegen-benchmark-roadmap.md) | SWE-bench comparability, then the `resolved`-vs-`mergeable` delta | Not started — **no prerequisites**. Explicit non-goal of G6; it had no home before |
 | **KL** — [codex plugin keyless](codex-plugin-keyless-roadmap.md) | Remove the API-key requirement via MCP sampling / Ollama | Not started — **Phase 0 is a blocking spike** (does Codex support sampling?) |
 | **WI** — watch-items | PR-workflow defense; doc-drift durability | ⚠️ **Spec missing.** `watch-items-roadmap.md` does not exist in `docs/specs/` or `archive/` — this row linked a file that was never written or was deleted. Write it or drop the row |
@@ -38,7 +39,8 @@ branching — **shipped with G2 in 3.8.2**, so it's no longer pending on anyone.
 Suggested starting order if you're picking, rather than staffing everything:
 
 1. **G6 Phase 1** (baseline) — G2 shipped without one, so its effect is unmeasured, and every later
-   track inherits that problem.
+   track inherits that problem. **Its four blocking decisions were taken 2026-08-30**, so the spec
+   is now actionable as written.
 2. **WI-2** (doc drift) — the comparison flags drift as *a lead, not a moat*: cheap for a competitor
    to copy once they have doc→code edges, which Graphify already does.
 3. Anything else, in whatever order suits the people you have.

--- a/docs/specs/gap6-benchmarks-roadmap.md
+++ b/docs/specs/gap6-benchmarks-roadmap.md
@@ -3,8 +3,11 @@
 > **"G6" is a label, not a position in a queue.** It's gap #6 in the Graphify comparison. The specs
 > are not ordered and do not run in sequence.
 
-**Status:** Not started. **Rewritten 2026-08-15 against 3.18.1.**
-**Owner:** _unassigned_
+**Status:** Not started — **scope decided 2026-08-30** (D1–D4 below).
+**Rewritten 2026-08-15 against 3.18.1**; decisions taken and the text reconciled to them
+2026-08-30.
+**Owner:** _unassigned_ — and that is the binding constraint, not the code. D1 makes the gold set
+**hand-labelling time**, which is the one cost nobody has agreed to spend.
 
 > **What changed in this rewrite.** The original opened with *"we make strong claims and publish
 > **zero** evidence."* That was true when written and is **false now** — 3.17.0 and 3.18.0 shipped
@@ -22,6 +25,27 @@ right. Extend the existing scoreboard to comprehension metrics on pinned **publi
 them, publish.
 
 ---
+
+## Decisions taken — 2026-08-30
+
+Four decisions had blocked this spec since the rewrite. All four are now taken, and together they
+**narrow v1**: a hand-labelled gold set, two metrics, five repositories, a ratchet gate.
+
+They are recorded here because the rest of this page is the *result* of them — the previous text
+said the opposite in three places (Phase 1 mined PRs, the corpus table named four other repos,
+open question 2 leaned "both") and has been rewritten to match rather than left to disagree with
+its own decisions.
+
+| | Decision | Taken | Why |
+|---|---|---|---|
+| **D1** | Ground truth | **Hand-labelled gold set only** — 30–50 issues. PR mining **dropped** | A merged PR touches files unrelated to its fix, so a poor localization score could not be attributed to Spine rather than to the label. A small hand-labelled set is attributable, and it is the discipline that has now worked twice in this repository (`corpus/`, the shadowed-call fixtures). Phase 1 drops from ~5–7 d to ~3 d — but see the Owner line: that is *labelling* time, not machine time |
+| **D2** | Metrics in v1 | **Two — top-k localization and provenance validity** | Localization is the claim that matters and is wholly unmeasured today; a `0` from `ticket-to-landing-sites` cannot currently be told apart from *never measured*. Provenance validity is nearly free (`stale_findings`). The other three are not cut so much as **removed by D1**: impact recall needs exactly the PR changed-file list that D1 dropped, fault-site top-1 needs a traceback corpus that does not exist, and `regression_gaps` precision needs a coverage run per repository |
+| **D3** | Corpus | **Five repositories**, one per front-end — see the corpus section below | A subset of the eleven already SHA-pinned for the invention oracle: pinned, exercised at 3.22.0, right language mix. Not all eleven — 30–50 labelled issues spread over eleven repositories is too thin per repository to say anything about any of them |
+| **D4** | Gate tier | **Ratchet** | Not for the reason the spec first gave — a SHA-pinned corpus does *not* churn. The real reason: this is a **ratio**, not a defect count, so unlike `invention` there is no correct value to hold at zero. `strict` would freeze whatever v1 happened to score into the definition of correct |
+
+**What D1 costs, stated plainly.** Volume. A gold set of 30–50 gives headline numbers with a clean
+denominator and no trend signal worth reading at that size. If a trend series is later wanted, it
+is a second decision with its own measurement — not a quiet re-introduction of mined PRs.
 
 ## What 3.18.1 already measures — do not rebuild any of this
 
@@ -48,13 +72,16 @@ an irrelevant axis, or good numbers that prove nothing a buyer cares about.
 
 **Measure what we actually claim:**
 
-| Our claim | Measurable as |
-|---|---|
-| "`investigate` finds where a ticket lands" | **Localization accuracy** — given a real issue, is the true fix site in the top-k returned symbols? |
-| "`localize` resolves a trace to the fault site" | **Fault-site top-1 accuracy** on real tracebacks |
-| "`blast_radius` tells you what breaks" | **Impact recall** — of the files a real PR actually touched, how many were in the predicted radius? |
-| "`regression_gaps` finds untested reach" | **Precision** — are flagged symbols genuinely uncovered? |
-| "grounded, `file:line`" | **Provenance validity** — sampled facts still resolve to the claimed line |
+| Our claim | Measurable as | In v1? |
+|---|---|---|
+| "`investigate` finds where a ticket lands" | **Localization accuracy** — given a real issue, is the true fix site in the top-k returned symbols? | ✅ **ships** (D2) |
+| "grounded, `file:line`" | **Provenance validity** — sampled facts still resolve to the claimed line | ✅ **ships** (D2) — nearly free |
+| "`blast_radius` tells you what breaks" | **Impact recall** — of the files a real PR actually touched, how many were in the predicted radius? | ❌ needs the PR changed-file list **D1 dropped** |
+| "`localize` resolves a trace to the fault site" | **Fault-site top-1 accuracy** on real tracebacks | ❌ no traceback corpus exists |
+| "`regression_gaps` finds untested reach" | **Precision** — are flagged symbols genuinely uncovered? | ❌ needs a coverage run per repository |
+
+**Three of five are deferred, and the page says so rather than implying five.** Anything published
+from v1 quotes two metrics and names the other three as not measured.
 
 The last one is the differentiator nobody else reports, and we can already compute it
 (`GroundingVerifier.stale_findings`, `pkg/verifier.py:122`, is most of it). A competitive sweep in
@@ -78,26 +105,48 @@ efficiency metric** — token savings, tool-call reduction — and none reports 
 published figure. `synaptixs/NN` is therefore excluded from anything published, though it remains
 useful privately.
 
-Two of the four validation repos are already public OSS and should be pinned as-is:
+**D3 (2026-08-30) replaced the corpus this section used to name.** It listed open5gs, dlib,
+flask/httpx and two TBD repositories — none of them pinned, two of them unexercised. Four of the
+five below instead come from the eleven repositories already SHA-pinned and run against 3.22.0 for
+the invention oracle ([`invention-oracle-cross-language.md`](invention-oracle-cross-language.md)),
+so the corpus arrives pinned and already known to extract.
 
-| Repo | Language | Why it earns a slot |
-|---|---|---|
-| **open5gs** | C | Large, real, and C is where `invention` cannot see |
-| **dlib** | C++ | Heavy templates — the hardest extraction shape we ship |
-| **flask**, **httpx** | Python | Small, fast, already exercised against 3.17/3.18 in Aug 2026 |
-| a Go and a TypeScript repo, TBD | Go, TS | TS has the weakest `CALLS` recall (0.50) — measure it or it hides |
+| Repo | Language | Pin | Why this one earns a slot |
+|---|---|---|---|
+| **vuejs/core** | TypeScript | `e2bede96134f` | TS has the weakest `CALLS` recall we ship — **0.50**. Measure it or it hides |
+| **gin-gonic/gin** | Go | `dcaa4296d111` | Mid-size, dense HTTP routing — exercises `Endpoint`/`EXPOSES` alongside localization |
+| **fmtlib/fmt** | C++ | `e27cc20bd93a` | The hardest extraction shape we ship, and it carried 43 of the 47 fabricated edges the invention widening found |
+| **libuv/libuv** | C | `f87c8e4f70f2` | C is where `invention` originally could not see; it is also the front-end with `CALLS` recall 1.00, so a poor localization score here is *not* a recall artefact |
+| **pallets/flask** | Python | **to be pinned in Phase 1** | The largest front-end and the language most users point Spine at. The one slot with no recorded SHA — pinning it is Phase 1's first act, not an assumption |
 
-**The corpus must not be Python-heavy.** The `runtime` and `invention` oracles are Python-only, so
-a Python-dominated corpus would report health it has not measured. Non-Python repos are what make
-that limit visible rather than invisible.
+**Excluded, and why — required by "bound honestly".**
+
+- **C# has no slot.** Dapper (`6d48ef664acc`) and Newtonsoft.Json (`09bb545d7296`) stay pinned and
+  can join when the gold set grows; five slots cannot cover six front-ends, and C# produced the
+  fewest extraction surprises of the six in the invention sweep. **v1 therefore publishes no C#
+  localization number, and must say so rather than let five repositories imply the matrix.**
+- **The other six pinned repositories** — leveldb, zod, nest, cobra, grpc-go, and the C files of
+  leveldb/fmt — are dropped for spread, not for quality: one repository per front-end keeps
+  30–50 labelled issues thick enough per repository to mean something.
+- **`synaptixs/spine` itself is excluded from anything published.** Self-measurement cannot back a
+  public claim, and the Python slot exists precisely so the number does not come from us.
+
+**The corpus must not be Python-heavy** — one of five. The `runtime` and `invention` oracles are
+Python-only, so a Python-dominated corpus would report health it has not measured. Non-Python
+repositories are what make that limit visible rather than invisible.
+
+> **The pins live in prose today.** Those SHAs exist in exactly one place: a markdown table in
+> `invention-oracle-cross-language.md`. Nothing in `src/` or `evals/` reads them, so "pinned" is
+> currently a claim a human keeps. **Phase 1 must land a real manifest** — a checked-in file the
+> harness reads — or the pinning invariant is honoured by memory alone.
 
 ## Phases
 
 | Phase | Work | Effort | Exit |
 |---|---|---|---|
-| **1 — Comprehension metrics into the existing scoreboard** | Ground truth mined from **merged PRs and closed bug issues** (the PR's changed files = truth for impact; the fixing commit = truth for localization) on the pinned public corpus. Metrics: top-k localization, fault-site top-1, impact recall/precision, provenance validity. Deterministic, no LLM in scoring. Land them as a **`comprehension` key in `scoreboard.json`**, written by `pkg accuracy --scoreboard`. | ~5–7 d | `pkg accuracy` prints comprehension alongside corpus/invention/parity; one baseline, one file |
-| **2 — Gate + trend** | Extend `pkg accuracy --check` to the new key. Ratchet, not strict — these move with repo churn, like parity. Track a trend series across releases. | ~2–3 d | A PR that degrades localization is visible before merge, using the gate that already exists |
-| **3 — Publish** | Public methodology + results: corpus (with commit SHAs), ground-truth derivation, metrics, numbers, and a **reproducible command**. State what we did *not* measure — the Python-only oracles especially — rather than implying broader coverage. | ~3–4 d | A public benchmark page and a command an outsider can run |
+| **1 — A gold set, two metrics, into the existing scoreboard** | Pin the corpus in a **manifest the harness reads** (five repositories, D3), then hand-label **30–50 real issues** — one fix site per issue, taken from the fixing commit, recorded with the issue URL and the commit SHA so anyone can re-derive it. Metrics: **top-k localization** and **provenance validity** (D2). Deterministic, no LLM anywhere in scoring or in labelling. Land them as a **`comprehension` key in `scoreboard.json`**, written by `pkg accuracy --scoreboard`. | ~2 d harness + **~3 d labelling** | `pkg accuracy` prints comprehension alongside corpus/invention/parity; one baseline, one file; every label re-derivable from its recorded SHA |
+| **2 — Gate + trend** | Extend `pkg accuracy --check` to the new key on the **ratchet** tier (D4). Track a trend series across releases — with the honest caveat that at n=30–50 a small move is noise, so the gate is a floor, not a graph. | ~2–3 d | A PR that degrades localization is visible before merge, using the gate that already exists |
+| **3 — Publish** | Public methodology + results: the corpus **with its commit SHAs**, how each label was derived, the two metrics, the numbers, and a **reproducible command**. States what was *not* measured — impact recall, fault-site top-1, `regression_gaps` precision, C#, and the Python-only oracles — rather than implying broader coverage. | ~3–4 d | A public benchmark page and a command an outsider can run |
 
 **Which phase buys what.** Phases 1–2 make the claim *checkable*; Phase 3 makes it *a market
 position*. Phase 3 is not optional polish — an unpublished benchmark changes nothing outside the
@@ -124,12 +173,14 @@ repo, and "measured correctness" is the only axis on which Spine currently leads
 
 ## Open questions
 
+**All four are closed.** Nothing below blocks the work; the only unresolved item is who spends
+Phase 1's labelling days, which is a staffing call and sits on the Owner line, not here.
+
 1. ~~Public corpus or private?~~ **Closed: public only** for anything published (see Corpus above).
-2. Ground truth from merged PRs is noisy (PRs touch unrelated files). Do we hand-curate a small gold
-   set instead? (Lean: **both** — a curated gold set of ~50 for headline numbers, mined PRs for
-   volume/trend.)
-3. Do we publish before or after G3/G5 land? (Lean: **baseline privately now, publish once they
-   land**, so the numbers reflect the improved product.)
-4. **New:** does a comprehension regression gate belong on the `strict` tier or the `ratchet` tier?
-   Leaning ratchet — the corpus is real repos, so churn moves it, and the invention metric is
-   ungated for exactly this reason.
+2. ~~Ground truth from merged PRs is noisy — hand-curate a small gold set instead?~~ **Closed by D1
+   (2026-08-30): gold set only.** The lean was "both"; the decision dropped the mining half, and
+   with it impact recall.
+3. ~~Publish before or after G3/G5 land?~~ **Closed: publish now.** Both landed — G3 in 3.10.0 and
+   G5 in 3.11.0 — so the condition the lean waited on is already met.
+4. ~~`strict` tier or `ratchet` tier?~~ **Closed by D4 (2026-08-30): ratchet** — because the metric
+   is a ratio with no correct value, not because a pinned corpus churns.


### PR DESCRIPTION
Six documents disagreed with the code or with each other. This makes them agree, and records the four decisions that had blocked G6 since its rewrite. **Docs only — no source changes.**

## Status drift

Every case ran the same direction: work shipped, the status line did not move — the failure mode `STATE-OF-SPINE` §9 describes.

- **`multi-repo-roadmap` was filed under "not started or proposal only"** in `SPEC-INDEX` while `pkg/repos.py`, `pkg/join_link.py` and `pkg/joins_propose.py` were in source and 3.23.0 had shipped all four phases. Moved to ✅; tally 16 → 17 and 15 → 14.
- **`gap-roadmap-index` still scored G4 "Not started"** seven weeks after Phase 1 landed (2026-08-19).
- **`SPEC-INDEX` pointed at `STATE-OF-SPINE` as "verified 2026-08-18 against 3.19.0"** — it is 2026-08-28 against 3.25.1.
- **The watch-items row in §8 described a broken link that no longer exists.** Rewritten as the write-or-drop decision it actually is.
- **The `SPEC-INDEX` tally is now labelled as having no derivation.** Its five numbers do not reconcile to the 74 specs in the header — reference rows double-count specs listed above and fold `archive/` and `build-documents/` into single lines.

## Outstanding items promoted to §8

§8 claims to be the authority, so it now absorbs what was recorded elsewhere and never promoted: both E4 caching findings (temperature refusal re-learned per call; MCP server spawned per operation), E6's stale changelog heading, and the four limits from the new ingestion reference — 56% of `Doc` sections bind to nothing, PDF/rst/txt/media collapse to one node per file, diagram arrows are not edges. The declined layout-aware extractor is recorded beside spec-kit so it does not come back unargued.

## G6 — four decisions taken

The spec had said the opposite in three places (Phase 1 mined PRs, the corpus table named four other repos, open question 2 leaned "both"); it is rewritten to match.

| | Decision | Taken |
|---|---|---|
| D1 | Ground truth | Gold set only, 30–50 hand-labelled; PR mining dropped |
| D2 | Metrics | Two — top-k localization, provenance validity |
| D3 | Corpus | Five repos, one per front-end; four already SHA-pinned |
| D4 | Gate tier | Ratchet — the metric is a ratio with no correct value |

Phase 1, the corpus table and open questions 2–4 are rewritten accordingly. The spec now also notes that the corpus SHAs live in **one markdown table nothing reads**, so Phase 1 must land a manifest or "pinned" stays an invariant kept by memory.

## Also

`document-ingestion-reference.md` is tracked here rather than left untracked, per the `CLAUDE.md` rule that untracked `docs/specs/` files make `understand --check` fail on a diff CI cannot reproduce.

## Gate

`mypy src tests` — 652 files, no issues. `ruff format --check .` — 680 files formatted. `scripts/check-mermaid.js` — the one mermaid block in the new reference renders as inline SVG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)