### PR TITLE
feat(codereview): let the PKG-grounded review actually reach a pull request

### DIFF
--- a/src/orchestrator/codereview/checkout.py
+++ b/src/orchestrator/codereview/checkout.py
@@ -1,0 +1,127 @@
+"""Give the PKG-grounded review a tree to read.
+
+The impact brief and the grounding verifiers all need a **checkout** —
+``PKGReviewGrounder.from_repo(root)``, ``PKGGroundingVerifier.from_repo(root)`` — and the
+webhook path had none: it works from the GitHub API's diff alone. So neither was ever
+constructed in production, and the freshness check and the doc-drift finding never reached a
+pull request (``STATE-OF-SPINE`` §8). This is the missing half.
+
+**Opt-in.** Cloning turns a stateless webhook into one that fetches a repository per review:
+real cost, a real failure surface, and it needs the App's token for a private repo. Enabling it
+is an operator's deliberate choice, not a behaviour change that arrives with an upgrade —
+``ORCHESTRATOR_REVIEW_CHECKOUT=1``.
+
+**Degrade loudly, never silently.** A checkout that fails does not block the review: the LLM
+and the three diff-only verifiers still have everything they need. But the review then says so
+in its body, because a degraded review that looks identical to a clean one is the failure this
+codebase keeps finding — a check that confirms the expected path and stays quiet about the rest.
+
+**Depth 1 at the head SHA.** Extraction reads a tree, not a history. The commit comes from
+``PRDiff.head_sha``, so the graph is built from exactly what the review is about.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import tempfile
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from orchestrator.codereview.github_client import PRDiff
+from orchestrator.core.pinned_checkout import CheckoutError, materialize_at
+
+logger = logging.getLogger("orchestrator.codereview")
+
+ENABLE_ENV = "ORCHESTRATOR_REVIEW_CHECKOUT"
+
+
+def checkout_enabled() -> bool:
+    """Whether an operator has opted this deployment into PKG-grounded review."""
+    return os.getenv(ENABLE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class Grounding:
+    """What a materialised checkout buys a review: an impact brief and extra verifiers."""
+
+    impact_source: Any
+    verifiers: list[Any]
+
+
+class PRCheckoutGrounding:
+    """Materialises a PR's head and builds the PKG-grounded review pieces from it.
+
+    Stateless between reviews on purpose: the checkout lives for one review and is removed,
+    so nothing survives to be half-trusted by the next one. That costs a fetch per review and
+    buys the guarantee that a graph is never read from a tree whose provenance is unclear.
+    """
+
+    def __init__(self, *, clone_url_for: Any, enabled: bool | None = None) -> None:
+        #: ``(repo) -> str | None`` — the URL to fetch, with credentials embedded when the
+        #: deployment has them. Injected rather than imported so a test needs no network and
+        #: no GitHub App.
+        self._clone_url_for = clone_url_for
+        self._enabled = checkout_enabled() if enabled is None else enabled
+
+    @contextlib.asynccontextmanager
+    async def for_diff(self, diff: PRDiff) -> AsyncIterator[Grounding | None]:
+        """Yield the grounding for ``diff``, or ``None`` if it is off or unavailable.
+
+        ``None`` is a *result*, not an error: the caller posts the review without the grounded
+        findings and says so. Raising here would let a transient network failure block a review
+        that three verifiers and a model could still produce.
+        """
+        if not self._enabled:
+            yield None
+            return
+
+        url = await self._clone_url_for(diff.repo)
+        if not url:
+            logger.warning(
+                "review checkout skipped: no clone URL for %s",
+                diff.repo,
+                extra={"event": "codereview.checkout_unavailable", "repo": diff.repo},
+            )
+            yield None
+            return
+
+        with tempfile.TemporaryDirectory(prefix="spine-review-") as tmp:
+            try:
+                root = materialize_at(url, diff.head_sha, Path(tmp) / "head")
+            except CheckoutError as exc:
+                # Loud in the log, and the caller says it in the review body. Silence here
+                # would make "the graph found nothing" and "the graph was never built" look
+                # the same to a reader.
+                logger.warning(
+                    "review checkout failed for %s@%s: %s",
+                    diff.repo,
+                    diff.head_sha[:12],
+                    exc,
+                    extra={"event": "codereview.checkout_failed", "repo": diff.repo},
+                )
+                yield None
+                return
+
+            from orchestrator.codereview.grounding import PKGGroundingVerifier, PKGReviewGrounder
+
+            try:
+                grounder = PKGReviewGrounder.from_repo(root)
+                verifier = PKGGroundingVerifier.from_repo(root)
+            except Exception as exc:  # noqa: BLE001 — extraction failure must not fail a review
+                logger.warning(
+                    "review grounding failed for %s: %s",
+                    diff.repo,
+                    exc,
+                    extra={"event": "codereview.grounding_failed", "repo": diff.repo},
+                )
+                yield None
+                return
+
+            yield Grounding(impact_source=grounder, verifiers=[verifier])
+
+
+__all__ = ["ENABLE_ENV", "Grounding", "PRCheckoutGrounding", "checkout_enabled"]

--- a/src/orchestrator/codereview/reviewer.py
+++ b/src/orchestrator/codereview/reviewer.py
@@ -259,12 +259,18 @@ class ReviewService:
         llm_reviewer: LLMReviewer,
         verifiers: list[CodeVerifier] | None = None,
         impact_source: ImpactFindingSource | None = None,
+        grounding: Any | None = None,
         audit: AuditFn | None = None,
     ) -> None:
         self._github = github
         self._reviewer = llm_reviewer
         self._verifiers = verifiers if verifiers is not None else default_code_verifiers()
         self._impact_source = impact_source
+        #: Optional per-review PKG grounding (`codereview.checkout.PRCheckoutGrounding`).
+        #: Per *review* rather than per service, because the pieces need a checkout of the
+        #: PR's head and the head is not known until the diff has been fetched — which is why
+        #: `impact_source` and the grounded verifiers were never wired here before.
+        self._grounding = grounding
         self._audit = audit
 
     async def _compute(
@@ -275,11 +281,49 @@ class ReviewService:
             installation_id=installation_id, repo=repo, pr_number=pr_number
         )
         summary, llm_findings = await self._reviewer.review(diff)
+
+        grounded_verifiers: list[CodeVerifier] = []
+        impact_source = self._impact_source
+        degraded = False
+        if self._grounding is not None:
+            async with self._grounding.for_diff(diff) as grounding:
+                if grounding is None:
+                    degraded = True
+                else:
+                    grounded_verifiers = list(grounding.verifiers)
+                    impact_source = grounding.impact_source or impact_source
+                return self._assemble(
+                    diff, summary, llm_findings, grounded_verifiers, impact_source, degraded
+                )
+        return self._assemble(diff, summary, llm_findings, [], impact_source, False)
+
+    def _assemble(
+        self,
+        diff: PRDiff,
+        summary: str,
+        llm_findings: list[Finding],
+        grounded_verifiers: list[CodeVerifier],
+        impact_source: ImpactFindingSource | None,
+        degraded: bool,
+    ) -> tuple[PRDiff, ReviewSubmission, list[Finding]]:
+        """Run the verifier chain and build the submission.
+
+        Split out so the grounded path can hold its checkout open across the scan — the
+        verifiers read files from it — and release it before anything is posted.
+        """
         verifier_findings: list[Finding] = []
-        for v in self._verifiers:
+        for v in [*self._verifiers, *grounded_verifiers]:
             verifier_findings.extend(v.scan(diff))
-        impact_findings = self._impact_source.findings_for_diff(diff) if self._impact_source else []
+        impact_findings = impact_source.findings_for_diff(diff) if impact_source else []
         all_findings = [*impact_findings, *verifier_findings, *llm_findings]
+        if degraded:
+            # Said in the body, not just the log. A degraded review that reads identically to
+            # a clean one is the failure this codebase keeps finding: silence taken as success.
+            summary = (
+                f"{summary}\n\n_Graph-grounded checks did not run for this review: the "
+                "repository could not be checked out. Impact, fact-freshness and doc-drift "
+                "findings are absent — not clean._"
+            )
         return diff, build_review_submission(diff, all_findings, summary), all_findings
 
     async def preview_pull_request(

--- a/src/orchestrator/codereview/webhook.py
+++ b/src/orchestrator/codereview/webhook.py
@@ -208,4 +208,22 @@ def _build_review_service(request: Request, *, trace_id: str | None) -> Any:
             )
             await session.commit()
 
-    return ReviewService(github=github, llm_reviewer=reviewer, audit=_audit)
+    # PKG-grounded review needs a checkout of the PR's head, which this path does not
+    # otherwise have — which is why `impact_source` and the grounded verifiers were never
+    # wired here (STATE-OF-SPINE §8). Opt-in, because cloning per review is an operator's
+    # cost to accept: ORCHESTRATOR_REVIEW_CHECKOUT=1.
+    from orchestrator.codereview.checkout import PRCheckoutGrounding, checkout_enabled
+
+    grounding = None
+    if checkout_enabled():
+        from orchestrator.sdlc.gitauth import authenticate_repo_url
+
+        async def _clone_url_for(repo: str) -> str | None:
+            # A token is embedded when the deployment has one; `authenticate_repo_url` is
+            # best-effort and degrades to the bare URL, which is right for a public repo and
+            # fails cleanly for a private one — a failure the review reports rather than dies on.
+            return await authenticate_repo_url(f"https://github.com/{repo}.git")
+
+        grounding = PRCheckoutGrounding(clone_url_for=_clone_url_for, enabled=True)
+
+    return ReviewService(github=github, llm_reviewer=reviewer, grounding=grounding, audit=_audit)

--- a/src/orchestrator/core/pinned_checkout.py
+++ b/src/orchestrator/core/pinned_checkout.py
@@ -1,0 +1,111 @@
+"""Materialise a git repository at an exact commit — verified, or not at all.
+
+Two callers need the same thing for different reasons: ``evals.corpus_fetch`` puts the pinned
+G6 corpus on disk, and ``codereview.checkout`` puts a pull request's head on disk so the
+PKG-grounded verifiers have a tree to read. Both consume the result as *evidence*, so both have
+the same failure mode — **a partial checkout is worse than none**, because the metrics and
+findings computed from it are well-formed and false.
+
+So the discipline lives here once rather than in two copies that drift:
+
+**The marker is written last.** ``WorkspaceManager`` established the ordering — fetch, verify,
+*then* mark — so a process that dies mid-fetch leaves a directory that does not read as
+complete, and the next attempt tears it down instead of measuring a truncated tree.
+
+**Reuse re-asks the repository.** The marker records intent; ``git rev-parse HEAD`` records
+fact. Trusting the marker alone would reuse a checkout someone had since modified, which is
+invariant 8's "commit-keyed, and only trusted on a clean tree" in another setting.
+
+**The commit is fetched directly**, never a branch. ``git fetch --depth 1 origin <sha>`` asks
+for the object we named; a branch can move between the fetch and the read.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+#: A pin is a full 40-character object name. Abbreviations read as SHAs, resolve for a human,
+#: and cannot be handed to `git fetch` — so they are refused where they are introduced rather
+#: than failing later on a machine with a network.
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+_MARKER = ".spine-pin"
+
+
+class CheckoutError(RuntimeError):
+    """A repository could not be materialised at the commit that was asked for."""
+
+
+def _git(*args: str, cwd: Path | None = None) -> str:
+    proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        ["git", *args],
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise CheckoutError(f"git {' '.join(args)}: {proc.stderr.strip()[:300]}")
+    return proc.stdout.strip()
+
+
+def _pin(url: str, sha: str) -> str:
+    """The identity a checkout must match — URL *and* commit.
+
+    Both: the same commit id in a different repository is a different tree, and a marker
+    recording only the SHA would let a renamed entry reuse the wrong checkout.
+    """
+    return f"{url}@{sha}"
+
+
+def verified(dest: Path, url: str, sha: str) -> bool:
+    """Is ``dest`` a complete, unmodified checkout of exactly this commit?"""
+    marker = dest / _MARKER
+    if not (dest / ".git").exists() or not marker.exists():
+        return False
+    try:
+        if marker.read_text(encoding="utf-8").strip() != _pin(url, sha):
+            return False
+        if _git("rev-parse", "HEAD", cwd=dest) != sha:
+            return False
+        return _git("status", "--porcelain", cwd=dest) == ""
+    except (CheckoutError, OSError):
+        return False  # unreadable, or not a repo → not verified, so rebuild
+
+
+def materialize_at(url: str, sha: str, dest: Path | str) -> Path:
+    """Put ``url`` at commit ``sha`` in ``dest``, verified, and return the path.
+
+    Idempotent: a checkout that verifies is reused, anything else is torn down and refetched.
+    Never reconciles a partial state — after a failure there is nothing to reconcile, because
+    the marker that would have claimed completeness was never written.
+    """
+    if not FULL_SHA.match(sha):
+        raise CheckoutError(f"{sha!r} is not a full 40-character commit id")
+    path = Path(dest)
+    if verified(path, url, sha):
+        return path
+
+    shutil.rmtree(path, ignore_errors=True)
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", "--quiet", str(path))
+    _git("remote", "add", "origin", url, cwd=path)
+    # Depth 1 on the commit itself: a tree is all any caller here reads, and asking for the
+    # object removes any question of which branch it sits on.
+    _git("fetch", "--depth", "1", "--quiet", "origin", sha, cwd=path)
+    _git("checkout", "--quiet", "FETCH_HEAD", cwd=path)
+
+    head = _git("rev-parse", "HEAD", cwd=path)
+    if head != sha:
+        shutil.rmtree(path, ignore_errors=True)
+        raise CheckoutError(f"fetched {head}, asked for {sha}")
+
+    # Last. Everything above must have succeeded for this file to exist.
+    (path / _MARKER).write_text(_pin(url, sha) + "\n", encoding="utf-8")
+    return path
+
+
+__all__ = ["FULL_SHA", "CheckoutError", "materialize_at", "verified"]

--- a/src/orchestrator/evals/corpus_fetch.py
+++ b/src/orchestrator/evals/corpus_fetch.py
@@ -12,44 +12,32 @@ tree.
 run, so nothing survives to be half-trusted by the next one. Within a run the corpus is fetched
 once and reused by every metric.
 
-**The marker is written last**, and that ordering is the whole design. ``WorkspaceManager``
-established it — clone, *then* mark — so a process that dies mid-fetch leaves a directory that
-does not read as complete, and the next attempt tears it down instead of measuring a truncated
-tree. Reuse additionally re-verifies ``git rev-parse HEAD`` against the pin rather than trusting
-the marker alone, which is the same discipline as invariant 8: caches are commit-keyed and
-trusted only on a clean tree.
-
-**The commit is fetched directly**, not a branch. ``git fetch --depth 1 origin <sha>`` asks for
-the object we pinned; cloning a branch and hoping it still points there is how a corpus drifts
-under a published number.
+The materialisation itself — fetch the commit directly, verify ``rev-parse``, write the marker
+last — lives in :mod:`orchestrator.core.pinned_checkout`, shared with the code-review checkout.
+One copy, because two would drift and the failure mode is a well-formed false number.
 """
 
 from __future__ import annotations
 
-import re
-import shutil
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import yaml
 
+from orchestrator.core.pinned_checkout import FULL_SHA, CheckoutError, materialize_at
+
 #: The pinned corpus ships inside the package, for the reason `scoreboard.json` does: a
 #: pip-installed Spine must be able to read the manifest it measures against.
 MANIFEST = Path(__file__).with_name("comprehension_corpus.yaml")
 
-#: A pin is a full 40-character object name. Abbreviations are refused at load — they read as
-#: SHAs, resolve for a human, and cannot be handed to `git fetch`. (Written after padding four
-#: abbreviations into plausible-looking 40-character strings while building this file: they
-#: were well-formed, wrong, and nothing would have noticed until a fetch failed.)
-_FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
 
-_MARKER = ".spine-corpus-pin"
+class CorpusFetchError(CheckoutError):
+    """A pinned repository could not be materialised at the commit the manifest names.
 
-
-class CorpusFetchError(RuntimeError):
-    """A pinned repository could not be materialised at the commit the manifest names."""
+    A :class:`CheckoutError`, so a caller that only cares "the corpus is not usable" can catch
+    the base and a caller that wants to say *which manifest entry* can catch this.
+    """
 
 
 @dataclass(frozen=True)
@@ -91,7 +79,7 @@ def load_manifest(path: Path | str = MANIFEST) -> list[PinnedRepo]:
         if missing:
             raise CorpusFetchError(f"{path}: entry {entry.get('name', '?')!r} is missing {missing}")
         sha = str(entry["sha"])
-        if not _FULL_SHA.match(sha):
+        if not FULL_SHA.match(sha):
             raise CorpusFetchError(
                 f"{path}: {entry['name']!r} pins {sha!r} — a pin must be a full 40-character "
                 "commit id, not an abbreviation or a branch"
@@ -114,66 +102,16 @@ def load_manifest(path: Path | str = MANIFEST) -> list[PinnedRepo]:
     return out
 
 
-def _git(*args: str, cwd: Path | None = None) -> str:
-    proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
-        ["git", *args],
-        cwd=str(cwd) if cwd else None,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        raise CorpusFetchError(f"git {' '.join(args)}: {proc.stderr.strip()[:300]}")
-    return proc.stdout.strip()
-
-
-def _verified(dest: Path, repo: PinnedRepo) -> bool:
-    """Is ``dest`` a complete checkout of exactly this pin?
-
-    Marker present *and* matching, HEAD at the pinned commit, working tree clean. The marker
-    alone is not enough — it records intent, and this asks the repository itself.
-    """
-    marker = dest / _MARKER
-    if not (dest / ".git").exists() or not marker.exists():
-        return False
-    try:
-        if marker.read_text(encoding="utf-8").strip() != repo.pin:
-            return False
-        if _git("rev-parse", "HEAD", cwd=dest) != repo.sha:
-            return False
-        return _git("status", "--porcelain", cwd=dest) == ""
-    except (CorpusFetchError, OSError):
-        return False  # unreadable or not a repo → not verified, so rebuild
-
-
 def materialize(repo: PinnedRepo, root: Path | str) -> Path:
     """Put ``repo`` on disk at its pinned commit under ``root``, and return the path.
 
-    Idempotent within a task: a checkout that verifies is reused, anything else is torn down
-    and refetched. Never reconciles a partial state — after a failure there is nothing to
-    reconcile, because the marker that would have claimed completeness was never written.
+    Naming which entry failed, because "fetched X, asked for Y" is unactionable when five
+    repositories are being materialised in a loop.
     """
-    dest = Path(root) / repo.name
-    if _verified(dest, repo):
-        return dest
-
-    shutil.rmtree(dest, ignore_errors=True)
-    dest.mkdir(parents=True, exist_ok=True)
-    _git("init", "--quiet", str(dest))
-    _git("remote", "add", "origin", repo.url, cwd=dest)
-    # Depth 1 on the commit itself: the whole history is not needed to extract a tree, and
-    # asking for the object removes any question of which branch it sits on.
-    _git("fetch", "--depth", "1", "--quiet", "origin", repo.sha, cwd=dest)
-    _git("checkout", "--quiet", "FETCH_HEAD", cwd=dest)
-
-    head = _git("rev-parse", "HEAD", cwd=dest)
-    if head != repo.sha:
-        shutil.rmtree(dest, ignore_errors=True)
-        raise CorpusFetchError(f"{repo.name}: fetched {head}, manifest pins {repo.sha}")
-
-    # Last. Everything above must have succeeded for this file to exist.
-    (dest / _MARKER).write_text(repo.pin + "\n", encoding="utf-8")
-    return dest
+    try:
+        return materialize_at(repo.url, repo.sha, Path(root) / repo.name)
+    except CheckoutError as exc:
+        raise CorpusFetchError(f"{repo.name}: {exc}") from exc
 
 
 def materialize_all(root: Path | str, repos: list[PinnedRepo] | None = None) -> dict[str, Path]:

--- a/tests/codereview/test_checkout_grounding.py
+++ b/tests/codereview/test_checkout_grounding.py
@@ -1,0 +1,167 @@
+"""The PKG-grounded review layer reaches a pull request — or says it did not.
+
+Until 2026-08-31 it reached neither. `webhook.py` built `ReviewService` without `verifiers` or
+`impact_source`, so the impact brief, the fact-freshness check and the doc-drift finding never
+ran on a PR — all of them need a checkout, and that path has none. These tests are the wiring,
+and the honesty when the wiring cannot be used.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.codereview.checkout import ENABLE_ENV, Grounding, PRCheckoutGrounding, checkout_enabled
+from orchestrator.codereview.github_client import ChangedFile, PRDiff
+from orchestrator.codereview.reviewer import LLMReviewer, ReviewService
+from orchestrator.codereview.verifiers import Finding, Severity
+from orchestrator.core.llm import CompletionResult, Message
+
+PATCH = "@@ -1,2 +1,2 @@\n def f():\n-    return 1\n+    return 2\n"
+
+
+def _diff() -> PRDiff:
+    cf = ChangedFile(filename="m.py", status="modified", additions=1, deletions=1, patch=PATCH)
+    return PRDiff(repo="acme/app", pr_number=7, head_sha="d" * 40, files=(cf,))
+
+
+class _FakeLLM:
+    async def complete(self, messages: list[Message], **_: Any) -> CompletionResult:
+        return CompletionResult('{"summary": "looks fine", "findings": []}', "fake", 1, 1, 0.0, 1.0)
+
+
+class _FakeGitHub:
+    def __init__(self) -> None:
+        self.submitted: list[Any] = []
+
+    async def fetch_pr_diff(self, **_: Any) -> PRDiff:
+        return _diff()
+
+    async def submit_review(self, *, submission: Any, **_: Any) -> dict[str, object]:
+        self.submitted.append(submission)
+        return {}
+
+
+class _MarkerVerifier:
+    """Stands in for the PKG verifier: proves the grounded chain actually ran."""
+
+    verifier_id = "pkg.grounding"
+
+    def scan(self, diff: PRDiff) -> list[Finding]:
+        return [
+            Finding(
+                verifier_id=self.verifier_id,
+                rule="stale_fact",
+                severity=Severity.WARNING,
+                path="m.py",
+                line=1,
+                message="grounded finding",
+            )
+        ]
+
+
+class _FakeGrounding:
+    """A grounding provider that yields, or declines to."""
+
+    def __init__(self, *, available: bool) -> None:
+        self._available = available
+
+    @contextlib.asynccontextmanager
+    async def for_diff(self, diff: PRDiff) -> AsyncIterator[Grounding | None]:
+        yield Grounding(impact_source=None, verifiers=[_MarkerVerifier()]) if self._available else None
+
+
+def _service(grounding: Any) -> tuple[ReviewService, _FakeGitHub]:
+    github = _FakeGitHub()
+    service = ReviewService(
+        github=github,  # type: ignore[arg-type]
+        llm_reviewer=LLMReviewer(_FakeLLM()),
+        grounding=grounding,
+    )
+    return service, github
+
+
+# ---- the wiring -------------------------------------------------------------
+
+
+async def test_grounded_findings_reach_the_review() -> None:
+    service, _ = _service(_FakeGrounding(available=True))
+    _diff_out, submission, findings = await service._compute(installation_id=1, repo="acme/app", pr_number=7)
+    assert any(f.verifier_id == "pkg.grounding" for f in findings)
+    assert "did not run" not in submission.summary
+
+
+async def test_a_failed_checkout_still_produces_a_review() -> None:
+    """A network blip must not block a review three verifiers and a model could produce."""
+    service, _ = _service(_FakeGrounding(available=False))
+    _diff_out, submission, findings = await service._compute(installation_id=1, repo="acme/app", pr_number=7)
+    assert submission is not None
+    assert not any(f.verifier_id == "pkg.grounding" for f in findings)
+
+
+async def test_a_degraded_review_says_so_in_its_body() -> None:
+    """Absent is not clean. A degraded review that reads like a clean one is the whole trap."""
+    service, _ = _service(_FakeGrounding(available=False))
+    _diff_out, submission, _f = await service._compute(installation_id=1, repo="acme/app", pr_number=7)
+    assert "did not run" in submission.summary
+    assert "not clean" in submission.summary
+
+
+async def test_no_grounding_configured_is_not_reported_as_degraded() -> None:
+    """Opt-in: a deployment that never asked for it has nothing to apologise for."""
+    service, _ = _service(None)
+    _diff_out, submission, _f = await service._compute(installation_id=1, repo="acme/app", pr_number=7)
+    assert "did not run" not in submission.summary
+
+
+# ---- the opt-in -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected", [("1", True), ("true", True), ("on", True), ("", False), ("0", False)]
+)
+def test_the_checkout_is_opt_in(monkeypatch: pytest.MonkeyPatch, value: str, expected: bool) -> None:
+    monkeypatch.setenv(ENABLE_ENV, value)
+    assert checkout_enabled() is expected
+
+
+def test_it_is_off_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENABLE_ENV, raising=False)
+    assert checkout_enabled() is False
+
+
+async def test_a_disabled_provider_yields_nothing_and_fetches_nothing() -> None:
+    calls: list[str] = []
+
+    async def _url(repo: str) -> str | None:
+        calls.append(repo)
+        return "https://example.invalid/x.git"
+
+    provider = PRCheckoutGrounding(clone_url_for=_url, enabled=False)
+    async with provider.for_diff(_diff()) as grounding:
+        assert grounding is None
+    assert calls == []  # disabled means no network, not a fetch whose result is discarded
+
+
+async def test_a_missing_clone_url_degrades_rather_than_raising() -> None:
+    async def _url(repo: str) -> str | None:
+        return None
+
+    provider = PRCheckoutGrounding(clone_url_for=_url, enabled=True)
+    async with provider.for_diff(_diff()) as grounding:
+        assert grounding is None
+
+
+async def test_an_unfetchable_repo_degrades_rather_than_raising(tmp_path: Path) -> None:
+    """The head SHA here exists nowhere; materialisation must fail into a None, not an exception."""
+
+    async def _url(repo: str) -> str | None:
+        return str(tmp_path / "not-a-repo")
+
+    provider = PRCheckoutGrounding(clone_url_for=_url, enabled=True)
+    async with provider.for_diff(_diff()) as grounding:
+        assert grounding is None


### PR DESCRIPTION
Step 2 of the finding recorded in [#260](https://github.com/synaptixs/spine/pull/260). **Merge #260 first** — it adds the §8 row this closes, so the doc update comes in a follow-up rather than conflicting.

## What was wrong

The impact brief, the fact-freshness check and the doc-drift finding all need a checkout (`from_repo(root)`), and the webhook path has none — it works from the GitHub API's diff alone. So `webhook.py` built `ReviewService` without `verifiers` or `impact_source`, nothing outside tests ever constructed `PKGGroundingVerifier`, and **none of it ran on a pull request.** [#256](https://github.com/synaptixs/spine/pull/256)'s freshness fix and [#257](https://github.com/synaptixs/spine/pull/257)'s drift finding were both correct and inert.

## Where the wiring had to go

**Per review, inside `_compute` — not per service at construction time.** The head SHA isn't known until the diff has been fetched, so a checkout cannot exist when `ReviewService` is built. That timing is *why* the wiring was never there, and `default_code_verifiers()` taking no arguments is the same constraint showing up one level down.

## The three decisions

| | Decision | Why |
|---|---|---|
| **Opt-in** (`ORCHESTRATOR_REVIEW_CHECKOUT=1`, off by default) | Cloning per review is real cost, a real failure surface, and needs the App's token for a private repo — an operator's deliberate choice, not a behaviour change arriving with an upgrade |
| **Degrade, don't block** | The model and three diff-only verifiers still have what they need. **And the review says so in its body** — a degraded review that reads identically to a clean one is the failure this codebase keeps finding, so *absent* is stated rather than left looking like *clean*. A deployment that never opted in says nothing; it has nothing to apologise for |
| **Depth 1 at `head_sha`** | Extraction reads a tree, not a history. Taking the commit rather than a branch means the graph is built from exactly what the review is about |

## One refactor, deliberately

The materialisation discipline moves to `core/pinned_checkout` and is now **shared** with `evals/corpus_fetch` rather than copied: fetch the commit directly, verify `rev-parse`, write the marker **last** so a process that dies mid-fetch leaves a directory that does not read as complete, and re-ask the repository on reuse instead of trusting the marker. Two copies of that would drift, and the failure mode is a well-formed false result.

## Tests — thirteen, three behaviours verified by reverting them

Dropping the degradation note, ignoring the grounded verifiers, and fetching while disabled each fail exactly one test.

| Gate | Result |
|---|---|
| `mypy src tests` | 658 files, no issues |
| `ruff format --check .` | 686 files |
| `tests/codereview` + `evals` + `pkg` | 828 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)