### PR TITLE
fix(evals): re-pin the G6 corpus to commits that have fixes after them

### DIFF
--- a/docs/specs/gap6-benchmarks-roadmap.md
+++ b/docs/specs/gap6-benchmarks-roadmap.md
@@ -114,11 +114,46 @@ so the corpus arrives pinned and already known to extract.
 
 | Repo | Language | Pin | Why this one earns a slot |
 |---|---|---|---|
-| **vuejs/core** | TypeScript | `e2bede96134f` | TS has the weakest `CALLS` recall we ship — **0.50**. Measure it or it hides |
-| **gin-gonic/gin** | Go | `dcaa4296d111` | Mid-size, dense HTTP routing — exercises `Endpoint`/`EXPOSES` alongside localization |
-| **fmtlib/fmt** | C++ | `e27cc20bd93a` | The hardest extraction shape we ship, and it carried 43 of the 47 fabricated edges the invention widening found |
-| **libuv/libuv** | C | `f87c8e4f70f2` | C is where `invention` originally could not see; it is also the front-end with `CALLS` recall 1.00, so a poor localization score here is *not* a recall artefact |
-| **pallets/flask** | Python | **to be pinned in Phase 1** | The largest front-end and the language most users point Spine at. The one slot with no recorded SHA — pinning it is Phase 1's first act, not an assumption |
+| **vuejs/core** | TypeScript | `25ebe3a42cd8` | TS has the weakest `CALLS` recall we ship — **0.50**. Measure it or it hides |
+| **gin-gonic/gin** | Go | `f416d1e594a0` | Mid-size, dense HTTP routing — exercises `Endpoint`/`EXPOSES` alongside localization |
+| **fmtlib/fmt** | C++ | `2d839bbc6165` | The hardest extraction shape we ship, and it carried 43 of the 47 fabricated edges the invention widening found |
+| **libuv/libuv** | C | `8fc70344df78` | C is where `invention` originally could not see; it is also the front-end with `CALLS` recall 1.00, so a poor localization score here is *not* a recall artefact |
+| **pallets/flask** | Python | `ad68a12645d9` | The largest front-end and the language most users point Spine at |
+
+> **These are late-November-2025 commits, and the date is the point.** The pins were inherited
+> from the invention oracle, where a *recent* tree is exactly right — that oracle counts
+> fabricated edges in whatever the code is now. **Localization needs the opposite:** the tree
+> must be the **pre-fix** state, so every labelled issue has to have been fixed *after* the pin.
+>
+> Measured against the inherited pins on the day labelling started, that window was empty:
+>
+> | | merged PRs after the pin |
+> |---|---|
+> | vuejs/core | 35 |
+> | fmtlib/fmt | 7 |
+> | libuv/libuv | 2 |
+> | gin-gonic/gin | **0** |
+> | pallets/flask | **0** |
+>
+> A 30–50 issue gold set was unreachable, and four fifths of what existed sat in one repository
+> — exactly the Python-heavy-by-accident failure D3 chose this corpus to avoid, with the
+> imbalance pointing at TypeScript instead. At the current pins the windows are 200+ / 93 / 147 /
+> 71 / 17: every front-end can be labelled. **Found by trying to label, not by review** — the
+> corpus looked fine until someone asked it for an issue.
+>
+> The invention record is untouched; that is a separate eleven-repository corpus these five only
+> borrowed SHAs from.
+
+**Provenance validity at these pins**, measured 2026-08-31 — the spread is why measuring on code
+we do not control is worth the fetch:
+
+| | | |
+|---|---|---|
+| vue-core | TypeScript | **1.0000** |
+| gin | Go | **1.0000** |
+| flask | Python | 0.9955 |
+| fmt | C++ | 0.9857 |
+| libuv | C | 0.9850 |
 
 **Excluded, and why — required by "bound honestly".**
 

--- a/src/orchestrator/evals/comprehension_corpus.yaml
+++ b/src/orchestrator/evals/comprehension_corpus.yaml
@@ -9,6 +9,29 @@
 # the invention oracle: 30-50 labelled issues spread over eleven repositories is too thin per
 # repository to say anything about any of them.
 #
+# ── Why these commits, and not the ones the invention oracle used ─────────────
+#
+# The pins moved to late November 2025 on 2026-08-31. They were inherited from
+# `invention-oracle-cross-language.md`, where a RECENT tree is exactly right: that oracle counts
+# fabricated edges in whatever the code is now.
+#
+# Localization needs the opposite. It asks "given this issue, does Spine find where the fix
+# WENT?", so the tree has to be the PRE-FIX state and every labelled issue must have been fixed
+# AFTER the pin. Measured against the inherited pins the day labelling started:
+#
+#     vuejs/core     35 merged PRs after the pin
+#     fmtlib/fmt      7
+#     libuv/libuv     2
+#     gin-gonic/gin   0      <- nothing to label
+#     pallets/flask   0      <- nothing to label
+#
+# A 30-50 issue gold set was not reachable, and four fifths of what existed was one repository,
+# which is exactly the language mix D3 chose the corpus to avoid. At these pins the windows are
+# 200+/93/147/71/17 — every front-end can be labelled, Python and Go included.
+#
+# The invention record is untouched: that is a separate eleven-repository corpus which these
+# five only borrowed SHAs from.
+#
 # C# has NO slot in this corpus, and anything published from it must say so rather than let
 # five repositories imply the whole matrix. Dapper (6d48ef664acc) and Newtonsoft.Json
 # (09bb545d7296) stay pinned in `invention-oracle-cross-language.md` and can join when the gold
@@ -18,25 +41,25 @@ repos:
   - name: vue-core
     language: typescript
     url: https://github.com/vuejs/core.git
-    sha: e2bede96134f757aad5c5b33ac9be055022dbfc8
+    sha: 25ebe3a42cd80ac0256355c2740a0258cdd7419d
     why: TypeScript has the weakest CALLS recall we ship (0.50) — measure it or it hides
   - name: gin
     language: go
     url: https://github.com/gin-gonic/gin.git
-    sha: dcaa4296d111981ffb31ac3eba90bb63e1eb5ab9
+    sha: f416d1e594a027063e73f66ac873a82113036fd8
     why: mid-size, dense HTTP routing — exercises Endpoint/EXPOSES alongside localization
   - name: fmt
     language: cpp
     url: https://github.com/fmtlib/fmt.git
-    sha: e27cc20bd93a4e280fb9268d41cd131069a9c73f
+    sha: 2d839bbc61659d8a464bdcd2717b577f03991d94
     why: the hardest extraction shape we ship; carried 43 of the 47 fabricated edges
   - name: libuv
     language: c
     url: https://github.com/libuv/libuv.git
-    sha: f87c8e4f70f234b952d9c47b15fb567f78e5f399
+    sha: 8fc70344df789d95c18f3c5282f11dcd85205545
     why: C recall is 1.00, so a poor localization score here is not a recall artefact
   - name: flask
     language: python
     url: https://github.com/pallets/flask.git
-    sha: d318b683471101618febed18996405ad26462110
+    sha: ad68a12645d96fe51558da13e18544ba458d7af0
     why: the largest front-end and the language most users point Spine at


### PR DESCRIPTION
**Unblocks the gold-set labelling.** Found by trying to label, not by review — the corpus looked fine until someone asked it for an issue.

## The problem

The pins were inherited from the invention oracle, where a **recent** tree is exactly right: that oracle counts fabricated edges in whatever the code is now.

**Localization needs the opposite.** It asks *"given this issue, does Spine find where the fix went?"*, so the tree must be the **pre-fix** state and every labelled issue must have been fixed *after* the pin. That window was empty:

| Repo | Pinned | Merged PRs since |
|---|---|---|
| vuejs/core | 2026-08-21 | 35 |
| fmtlib/fmt | 2026-08-23 | 7 |
| libuv/libuv | 2026-08-20 | 2 |
| gin-gonic/gin | 2026-08-15 | **0** |
| pallets/flask | 2026-08-16 | **0** |

A 30–50 issue gold set was unreachable, and four fifths of what existed sat in one repository — the Python-heavy-by-accident failure D3 chose this corpus to avoid, pointing at TypeScript instead. **Every flask candidate examined while writing the labelling guide merged before flask's pin**, so every one would have failed `pkg labels --paths`.

## The fix

Late-November-2025 commits. Windows are now **200+ / 93 / 147 / 71 / 17** — every front-end labellable, Python and Go included.

All five materialise and extract:

| Repo | Language | Provenance validity |
|---|---|---|
| vue-core | TypeScript | **1.0000** |
| gin | Go | **1.0000** |
| flask | Python | 0.9955 |
| fmt | C++ | 0.9857 |
| libuv | C | 0.9850 |

A real spread — which is the whole argument for measuring on code we don't control. This repository alone reads a flat 1.0000.

## Kept from being quietly undone

Both the manifest and the spec now state **why the date matters**, so the next person refreshing these pins doesn't reach for HEAD and re-break labelling.

The invention record is untouched — a separate eleven-repository corpus these five only borrowed SHAs from.

| Gate | Result |
|---|---|
| `mypy src tests` | 661 files, no issues |
| `ruff format --check .` | 689 files |
| `tests/evals` | 118 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)