### PR TITLE
fix(pkg): stop printing the target repository's compile warnings

### DIFF
--- a/src/orchestrator/pkg/extractor.py
+++ b/src/orchestrator/pkg/extractor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import ast
 import os
+import warnings
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Protocol
@@ -173,7 +174,18 @@ class PythonExtractor:
         return module_qualname(path, root)
 
     def extract(self, *, path: Path, module: str, rel: str) -> FactBatch:
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
+        # `ast.parse` compiles, and compiling emits `SyntaxWarning` for things like an invalid
+        # escape sequence in the *target's* source. Spine is reading that code, not running it,
+        # and the author of the repository being extracted is not the person at this terminal —
+        # so the warning is noise they cannot act on. Extracting the five pinned benchmark
+        # repositories printed ~60 lines of it before any result, which is what a reader
+        # following BENCHMARK.md would have seen and reasonably read as "something is broken".
+        #
+        # Scoped to this one call, and to `SyntaxWarning` only: a genuine `SyntaxError` still
+        # raises and still reaches the caller, which is what marks a file unparseable.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", SyntaxWarning)
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
         batch = FactBatch()
         module_id = f"py:{module}" if module else "py:<root>"
         batch.add_node(Node(module_id, NodeKind.MODULE, module or rel, "python", Provenance(rel, 1)))

--- a/tests/pkg/test_verifier.py
+++ b/tests/pkg/test_verifier.py
@@ -249,3 +249,26 @@ def test_doc_findings_flag_stale_symbol_claims(tmp_path: Path) -> None:
 def test_doc_findings_empty_without_docs(tmp_path: Path) -> None:
     repo, batch = _extracted_repo(tmp_path)
     assert GroundingVerifier(batch).doc_findings(repo) == []
+
+
+def test_extracting_a_file_with_a_bad_escape_prints_nothing(tmp_path: Path, capsys: object) -> None:
+    """Spine reads the target's code; it does not run it, and it is not their linter.
+
+    `ast.parse` compiles, and compiling emits `SyntaxWarning` for an invalid escape sequence in
+    the source being read. Extracting the five pinned benchmark repositories printed ~60 lines of
+    it before any result — which is what a reader following BENCHMARK.md would have seen, and
+    would reasonably have read as "something is broken".
+    """
+    import warnings as _warnings
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # A regex-ish string with a bare backslash: valid Python, warns on compile.
+    (repo / "m.py").write_text('PATTERN = "\\d+"\n\n\ndef f():\n    return PATTERN\n', encoding="utf-8")
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        batch = RepoCodeExtractor().extract(repo)
+
+    assert [w for w in caught if issubclass(w.category, SyntaxWarning)] == []
+    assert any(n.name == "f" for n in batch.nodes), "and it still extracted the file"


### PR DESCRIPTION
Running the command [BENCHMARK.md](BENCHMARK.md) publishes printed **roughly sixty lines of `SyntaxWarning: invalid escape sequence`** before any result.

They come from the *corpus repositories'* own Python — libuv's `support/docopt.py`, the docs tooling in the others — because `ast.parse` compiles, and compiling warns.

Spine is **reading** that code, not running it, and the author of the repository being extracted is not the person at this terminal. The warning is noise they cannot act on. A reader following the published reproduce step saw a wall of warnings and would reasonably have concluded something was broken — on the one command a benchmark page exists to invite people to run.

## Before

```
  fetching libuv @ 8fc70344df78 ...
support/docopt.py:160: SyntaxWarning: invalid escape sequence '\S'
support/docopt.py:161: SyntaxWarning: invalid escape sequence '\['
...  (~60 more lines)
provenance validity on the pinned corpus
```

## After

```
  fetching libuv @ 8fc70344df78 ...
  fetching flask @ ad68a12645d9 ...

provenance validity on the pinned corpus
  vue-core   typescript    3928/3928   1.0000
```

## Scope

The filter wraps the single `ast.parse` call and suppresses `SyntaxWarning` only. **A genuine `SyntaxError` still raises**, still reaches the caller, and still lands the file in `skipped` — verified alongside the test, which fails when the filter is removed.

Found by running the published command as an outsider would. This class of defect doesn't turn up any other way.

| Gate | Result |
|---|---|
| Full suite | 3,248 passed, 3 skipped |
| `mypy src tests` | 661 files, no issues |
| `ruff format --check .` | 689 files |

🤖 Generated with [Claude Code](https://claude.com/claude-code)