### PR TITLE
feat(scripts): re-derive STATE-OF-SPINE's numbers, and fail when prose disagrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,14 @@ jobs:
       - name: Capability matrix counts match the table
         run: uv run python scripts/matrix-count.py --check
 
+      # STATE-OF-SPINE ends with "a number here without a 'how it is known' is a number that
+      # should not be here". The derivations were written down and nothing ran them, so they
+      # rotted: on 2026-09-01 the spec-file count, the CLI command count and the version string
+      # were all stale at once, and two were caught only because an unrelated gate happened to
+      # fail. This runs them.
+      - name: STATE-OF-SPINE's numbers match the source
+        run: uv run python scripts/state-numbers.py --check
+
       # Spine's own episteme has to describe Spine's own HEAD — but it is regenerated
       # *after* merge (.github/workflows/episteme.yml), not carried on branches. A PR
       # cannot keep it current: CI checks the merge ref, so the moment anything lands on

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **57** | `grep -c '\.command(' src/orchestrator/cli.py` |
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,832** across 296 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,837** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.50** (TypeScript) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |
@@ -358,7 +358,7 @@ and never promoted. A list that claims to be the authority has to actually absor
 |---|---|
 | Upgrade local `uv` past 0.8.0 | user's machine |
 | RBAC role-gating beyond the approval decision + secrets vault | parked |
-| CI gate on spec-status drift | not started |
+| CI gate on spec-status drift | 🟡 **the numbers half shipped 2026-09-01** — `scripts/state-numbers.py --check`, in CI, re-derives the eight figures this page and `SPEC-INDEX` state and fails when prose and source disagree. It caught a stale test count on its first run, and again when adding its own tests moved the number. **The judgement half is still open:** whether a spec's *status line* matches shipped reality is not mechanically checkable, and that is the class that produced the multi-repo row reading "not started" while the code was in `src/` |
 | Decide `--intents` — shipped with no reader, no export | undecided |
 | Rust front-end | not started |
 | Express endpoint extraction (TypeScript) | unscheduled |
@@ -415,4 +415,8 @@ Do not read these to answer "where do we stand" — read them to act on a specif
 | Every spec and its status | [SPEC-INDEX.md](SPEC-INDEX.md) |
 
 **Maintenance rule.** This page is refreshed at each release, from source, in one pass. A number
-here without a "how it is known" is a number that should not be here.
+here without a "how it is known" is a number that should not be here — and since 2026-09-01 that
+rule is enforced rather than trusted: `scripts/state-numbers.py --check` runs in CI and fails when
+any stated figure disagrees with the source it claims to come from. It was written because the
+rule had been true and unpoliced, and three of these numbers were stale simultaneously during one
+release cut.

--- a/scripts/state-numbers.py
+++ b/scripts/state-numbers.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Re-derive the numbers `STATE-OF-SPINE.md` states, and fail if the prose disagrees.
+
+That page ends with a maintenance rule: *"A number here without a 'how it is known' is a number
+that should not be here."* Every row in §2 carries its derivation in a column beside it. So the
+derivations exist, they are written down — and until now nothing ran them.
+
+**They rot, and they rot silently.** On 2026-09-01 alone, three derived figures were stale in
+prose at the same time: the spec-file count, the CLI command count, and the version string in
+four places. Two were caught only because an *unrelated* gate happened to fail — the capability
+matrix count, and the architecture SVG that happens to render the version. Nothing was checking
+the numbers themselves.
+
+This closes that. It is deliberately narrow: it checks the claims whose derivation is a command,
+not whether a spec's *status line* matches shipped reality. That second thing needs judgement and
+is still open (`STATE-OF-SPINE` §8).
+
+    python scripts/state-numbers.py            # print each claim, derived and stated
+    python scripts/state-numbers.py --check    # non-zero if any disagree
+
+**Why not parse the "how it is known" column and run it?** Because that column is prose written
+for a human — it abbreviates, and one row's derivation spans two commands joined by a semicolon.
+Executing prose from a document is also how a documentation change becomes arbitrary code
+execution in CI. The derivations are re-implemented here instead, and the doc's column stays the
+human-readable statement of the same thing.
+
+**And re-implemented in Python rather than shelled out.** The first version ran the documented
+`grep` through `sh` and got 307 test files where the same command in a terminal gave 296 — a
+gate whose answer depends on the shell it is invoked from is not a gate. Reading the files
+directly is deterministic, which is the property the rest of this pipeline is built on.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+STATE = ROOT / "docs" / "specs" / "STATE-OF-SPINE.md"
+SPEC_INDEX = ROOT / "docs" / "specs" / "SPEC-INDEX.md"
+
+
+_TEST_DEF = re.compile(r"^(?:async )?def test_", re.M)
+
+
+def _test_files() -> list[Path]:
+    return sorted((ROOT / "tests").rglob("*.py"))
+
+
+def cli_commands() -> int:
+    return len(re.findall(r"\.command\(", (ROOT / "src" / "orchestrator" / "cli.py").read_text()))
+
+
+def source_modules() -> int:
+    return len(list((ROOT / "src" / "orchestrator").rglob("*.py")))
+
+
+def test_functions() -> int:
+    return sum(len(_TEST_DEF.findall(p.read_text(encoding="utf-8", errors="replace"))) for p in _test_files())
+
+
+def test_files() -> int:
+    return sum(1 for p in _test_files() if _TEST_DEF.search(p.read_text(encoding="utf-8", errors="replace")))
+
+
+def spec_files() -> int:
+    return len(list((ROOT / "docs" / "specs").glob("*.md")))
+
+
+def package_version() -> str:
+    import tomllib
+
+    return str(tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"])
+
+
+@dataclass(frozen=True)
+class Claim:
+    """One number a document states, and the way to derive it independently."""
+
+    label: str
+    path: Path
+    #: Captures the stated value in group 1. Written to match the row, not the whole table, so a
+    #: reworded sentence around it does not silently stop the check from finding anything —
+    #: a pattern that matches nothing is reported as a failure, never as a pass.
+    pattern: re.Pattern[str]
+    derive: Callable[[], object]
+    #: Digits only: the prose writes thousands with a comma, and the derivation does not.
+    numeric: bool = True
+
+
+CLAIMS: tuple[Claim, ...] = (
+    Claim("CLI commands", STATE, re.compile(r"\| CLI commands \| \*\*([\d,]+)\*\*"), cli_commands),
+    Claim("source modules", STATE, re.compile(r"\| Source modules \| \*\*([\d,]+)\*\*"), source_modules),
+    Claim(
+        "test functions",
+        STATE,
+        re.compile(r"\| Test functions \| \*\*([\d,]+)\*\* across"),
+        test_functions,
+    ),
+    Claim(
+        "test files",
+        STATE,
+        re.compile(r"\| Test functions \| \*\*[\d,]+\*\* across ([\d,]+) files"),
+        test_files,
+    ),
+    Claim("spec files (STATE)", STATE, re.compile(r"holds \*\*([\d,]+)\*\* markdown files"), spec_files),
+    Claim(
+        "spec files (SPEC-INDEX prose)",
+        SPEC_INDEX,
+        re.compile(r"holds \*\*([\d,]+)\*\* markdown files"),
+        spec_files,
+    ),
+    Claim(
+        "spec files (SPEC-INDEX command)",
+        SPEC_INDEX,
+        re.compile(r"ls docs/specs/\*\.md \| wc -l\s+# ([\d,]+)"),
+        spec_files,
+    ),
+    Claim(
+        "version",
+        STATE,
+        re.compile(r"\| Version \| \*\*([\d.]+)\*\*"),
+        package_version,
+        numeric=False,
+    ),
+)
+
+
+def check() -> list[str]:
+    """Every claim that disagrees with its derivation, or that could not be found at all."""
+    problems: list[str] = []
+    for claim in CLAIMS:
+        text = claim.path.read_text(encoding="utf-8")
+        found = claim.pattern.search(text)
+        if found is None:
+            # Not a pass. A pattern that stops matching is how a check quietly stops checking —
+            # the failure this whole page exists to catch, one level up.
+            problems.append(f"{claim.label}: no longer found in {claim.path.name} — has it been reworded?")
+            continue
+        stated = found.group(1).replace(",", "") if claim.numeric else found.group(1)
+        actual = str(claim.derive())
+        if stated != actual:
+            problems.append(f"{claim.label}: {claim.path.name} says {stated}, the source says {actual}")
+    return problems
+
+
+def main() -> int:
+    problems = check()
+    if "--check" not in sys.argv:
+        for claim in CLAIMS:
+            text = claim.path.read_text(encoding="utf-8")
+            found = claim.pattern.search(text)
+            stated = found.group(1) if found else "NOT FOUND"
+            print(f"  {claim.label:32s} stated {stated:>10s}   derived {claim.derive()!s:>10s}")
+        return 0
+    for problem in problems:
+        print(f"[STALE] {problem}")
+    if problems:
+        print(f"\nstate-numbers --check: FAILED — {len(problems)} claim(s) disagree with the source.")
+        print("Refresh them, or the page's own maintenance rule is a rule nothing enforces.")
+        return 1
+    print(f"state-numbers --check: OK — {len(CLAIMS)} claims match the source.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_state_numbers.py
+++ b/tests/test_state_numbers.py
@@ -1,0 +1,92 @@
+"""The gate that re-derives STATE-OF-SPINE's numbers must itself keep working.
+
+A checker that stops finding what it checks is worse than no checker: it reports success while
+measuring nothing. Every regex here is matched against a document that people edit, so the
+"pattern found nothing" case has to fail loudly rather than pass quietly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "state-numbers.py"
+
+
+def _module() -> Any:
+    """Load the script as a module.
+
+    Registered in `sys.modules` before exec: the script defines a `@dataclass` under
+    `from __future__ import annotations`, and dataclasses resolves those annotations through
+    `sys.modules[cls.__module__]`. Without the registration that lookup returns None and the
+    class body raises — a failure about the loader, not about anything under test.
+    """
+    import sys
+
+    spec = importlib.util.spec_from_file_location("state_numbers", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["state_numbers"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_every_stated_number_matches_the_source() -> None:
+    """The gate itself, run against this tree — the same thing CI runs."""
+    assert _module().check() == []
+
+
+def test_a_pattern_that_stops_matching_is_a_failure_not_a_pass(tmp_path: Path) -> None:
+    """The way a check quietly stops checking, refused here.
+
+    Every claim is found by a regex over a document people reword. If a rewrite moved a number
+    out from under its pattern and that counted as "nothing to compare", the gate would go green
+    for ever while measuring nothing — the exact failure STATE-OF-SPINE §9 catalogues.
+    """
+    mod = _module()
+    doc = tmp_path / "doc.md"
+    doc.write_text("nothing resembling the claim here\n", encoding="utf-8")
+
+    claim = mod.Claim(
+        label="invented", path=doc, pattern=mod.re.compile(r"\| Nope \| \*\*(\d+)\*\*"), derive=lambda: 1
+    )
+    original = mod.CLAIMS
+    mod.CLAIMS = (claim,)
+    try:
+        problems = mod.check()
+    finally:
+        mod.CLAIMS = original
+
+    assert len(problems) == 1
+    assert "no longer found" in problems[0]
+
+
+def test_a_disagreement_is_reported_with_both_numbers(tmp_path: Path) -> None:
+    """A gate that says only 'stale' makes the reader go looking for what changed."""
+    mod = _module()
+    doc = tmp_path / "doc.md"
+    doc.write_text("| Widgets | **41** |\n", encoding="utf-8")
+
+    claim = mod.Claim(
+        label="widgets",
+        path=doc,
+        pattern=mod.re.compile(r"\| Widgets \| \*\*([\d,]+)\*\*"),
+        derive=lambda: 42,
+    )
+    original = mod.CLAIMS
+    mod.CLAIMS = (claim,)
+    try:
+        problems = mod.check()
+    finally:
+        mod.CLAIMS = original
+
+    assert problems == ["widgets: doc.md says 41, the source says 42"]
+
+
+@pytest.mark.parametrize("label", ["CLI commands", "source modules", "test functions", "version"])
+def test_the_headline_claims_are_covered(label: str) -> None:
+    """These four went stale during one release cut; none may quietly leave the gate."""
+    assert any(c.label == label for c in _module().CLAIMS)


### PR DESCRIPTION
`STATE-OF-SPINE.md` ends with a maintenance rule — *"a number here without a 'how it is known' is a number that should not be here"* — and every row in §2 carries its derivation in a column beside it.

**The derivations were written down and nothing ran them.**

On 2026-09-01 three derived figures were stale at the same time: the spec-file count, the CLI command count, and the version string in four places. **Two were caught only because an unrelated gate happened to fail** — the capability matrix count, and the architecture SVG that happens to render the version. Nothing was checking the numbers themselves.

## What it does

`scripts/state-numbers.py --check`, wired into CI beside `matrix-count.py`, re-derives **eight claims** across `STATE-OF-SPINE` and `SPEC-INDEX`: CLI commands, source modules, test functions, test files, three spec-file counts, and the version.

It **caught a stale test count on its first run**, and caught itself on its second — adding its own tests moved the number it checks. That's the behaviour that makes it worth having.

## Three decisions in it

**Derivations are re-implemented, not executed from the document.** That column is prose written for a human — it abbreviates, and one row's derivation spans two commands joined by a semicolon. Running prose out of a markdown file is also how a documentation change becomes arbitrary code execution in CI.

**In Python, not shelled out.** The first version ran the documented `grep` through `sh` and got **307** test files where the same command in a terminal gave **296**. A gate whose answer depends on the shell it's invoked from is not a gate.

**A pattern that matches nothing is a FAILURE, never a pass.** Every claim is found by a regex over a document people reword. If a rewrite moved a number out from under its pattern and that counted as "nothing to compare", the gate would go green for ever while measuring nothing — §9's failure mode one level up. It has its own test.

## Scope

This is **half** of §8's *"CI gate on spec-status drift"*. The other half — whether a spec's *status line* matches shipped reality — needs judgement and isn't mechanically checkable; the row now says so. That's the class that let `multi-repo-roadmap` read "not started" while its code sat in `src/`.

| Gate | Result |
|---|---|
| Full suite | 3,255 passed, 3 skipped |
| `mypy src tests` | 662 files, no issues |
| `ruff format --check .` | 690 files |
| `state-numbers.py --check` | OK — 8 claims match |

🤖 Generated with [Claude Code](https://claude.com/claude-code)