### PR TITLE
feat(cli): add `--version`, and stop `__version__` being a literal

### DIFF
--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **57** | `grep -c '\.command(' src/orchestrator/cli.py` |
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,837** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,841** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.50** (TypeScript) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |
@@ -357,6 +357,7 @@ and never promoted. A list that claims to be the authority has to actually absor
 | Item | State |
 |---|---|
 | Upgrade local `uv` past 0.8.0 | user's machine |
+| `orchestrator --version` | ✅ **added 2026-09-01.** It errored with *"No such option"* — the first thing anyone runs after installing, and the path [`BENCHMARK.md`](../../BENCHMARK.md) now sends strangers down. It prints the installed version **and where it is running from**, because CONTRIBUTING's own warning is that a bare command resolves to whatever is on `PATH`. Found alongside it: `orchestrator.__version__` was the literal `"0.0.0"` and no release step ever touched it, so every version ever shipped reported 0.0.0 to anything that imported it — now derived from the installed distribution |
 | RBAC role-gating beyond the approval decision + secrets vault | parked |
 | CI gate on spec-status drift | 🟡 **the numbers half shipped 2026-09-01** — `scripts/state-numbers.py --check`, in CI, re-derives the eight figures this page and `SPEC-INDEX` state and fails when prose and source disagree. It caught a stale test count on its first run, and again when adding its own tests moved the number. **The judgement half is still open:** whether a spec's *status line* matches shipped reality is not mechanically checkable, and that is the class that produced the multi-repo row reading "not started" while the code was in `src/` |
 | Decide `--intents` — shipped with no reader, no export | undecided |

--- a/src/orchestrator/__init__.py
+++ b/src/orchestrator/__init__.py
@@ -1,1 +1,17 @@
-__version__ = "0.0.0"
+"""Spine — the package is ``synaptixs-spine``; the import and CLI stay ``orchestrator``."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _installed_version
+
+try:
+    #: Read from the installed distribution rather than hardcoded. It was `"0.0.0"` until
+    #: 2026-09-01 — a literal that no release step touched, so `orchestrator.__version__`
+    #: reported 0.0.0 for every version ever shipped. A version string nothing derives is a
+    #: version string nobody can trust, which is the same failure as a count nobody re-runs.
+    __version__ = _installed_version("synaptixs-spine")
+except PackageNotFoundError:  # pragma: no cover - only when running from a source tree uninstalled
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -31,6 +31,36 @@ import httpx
 import typer
 
 app = typer.Typer(help="Orchestrator registry client.", no_args_is_help=True)
+
+
+def _version(show: bool) -> None:
+    """`--version`: what is installed, and *where it came from*.
+
+    The path is not decoration. CONTRIBUTING warns that "a bare command resolves to whichever
+    install is on your PATH, which may be an older release that has no `pkg accuracy` at all" —
+    and the first thing anyone does after installing is check the version. Printing only a
+    number answers "which version exists"; printing the location answers "which one am I
+    actually running", which is the question behind it.
+    """
+    if not show:
+        return
+    from orchestrator import __version__
+
+    typer.echo(f"Spine {__version__}  (synaptixs-spine)")
+    typer.echo(f"  running from {Path(__file__).resolve().parent}")
+    raise typer.Exit()
+
+
+@app.callback()
+def _root(
+    version: Annotated[
+        bool,
+        typer.Option("--version", callback=_version, is_eager=True, help="Show the version and exit."),
+    ] = False,
+) -> None:
+    """Spine — requirement in, reviewed pull request out, grounded in a graph of your code."""
+
+
 template_app = typer.Typer(help="Manage agent templates.", no_args_is_help=True)
 contract_app = typer.Typer(help="Manage tool contracts.", no_args_is_help=True)
 task_app = typer.Typer(help="Submit tasks for execution.", no_args_is_help=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -364,3 +364,64 @@ def test_understand_leads_with_what_it_learned_not_a_file_listing(tmp_path: Path
     # it printed `['python']` at a stranger on their first run.
     assert "['python']" not in rendered
     assert "f0.md" not in rendered, "the file listing belongs behind --json"
+
+
+# ---- `--version`, and the version that was a literal --------------------------
+
+
+def test_version_reports_the_installed_distribution() -> None:
+    """`orchestrator --version` errored with "No such option" until 2026-09-01.
+
+    It is the first thing anyone runs after installing, and BENCHMARK.md now sends strangers
+    down exactly that path.
+    """
+    from importlib.metadata import version as installed
+
+    from typer.testing import CliRunner
+
+    from orchestrator.cli import app
+
+    result = CliRunner().invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert installed("synaptixs-spine") in result.stdout
+    assert "synaptixs-spine" in result.stdout
+
+
+def test_version_says_where_it_is_running_from() -> None:
+    """CONTRIBUTING warns a bare command resolves to whatever is on PATH.
+
+    A number alone answers "which version exists"; the path answers "which one am I actually
+    running", which is the question behind it.
+    """
+    from typer.testing import CliRunner
+
+    from orchestrator.cli import app
+
+    result = CliRunner().invoke(app, ["--version"])
+    assert "running from" in result.stdout
+    assert "orchestrator" in result.stdout
+
+
+def test_the_package_version_is_derived_not_a_literal() -> None:
+    """`__version__` was hardcoded `"0.0.0"` and no release step touched it.
+
+    Every version ever shipped reported 0.0.0 to anything that imported it. A version string
+    nothing derives is a version string nobody can trust.
+    """
+    from importlib.metadata import version as installed
+
+    import orchestrator
+
+    assert orchestrator.__version__ == installed("synaptixs-spine")
+    assert orchestrator.__version__ != "0.0.0"
+
+
+def test_the_root_callback_did_not_break_subcommands() -> None:
+    """Adding a callback to a Typer app is where subcommand dispatch quietly stops working."""
+    from typer.testing import CliRunner
+
+    from orchestrator.cli import app
+
+    result = CliRunner().invoke(app, ["pkg", "--help"])
+    assert result.exit_code == 0
+    assert "accuracy" in result.stdout


### PR DESCRIPTION
`orchestrator --version` errored with **"No such option"**. It's the first thing anyone runs after installing, and [BENCHMARK.md](BENCHMARK.md) now sends strangers down exactly that path.

```
$ orchestrator --version
Spine 3.26.1  (synaptixs-spine)
  running from /Users/falcon/projects/ai/spine/src/orchestrator
```

**The path is not decoration.** CONTRIBUTING's own warning is that *"a bare command resolves to whichever install is on your PATH, which may be an older release that has no `pkg accuracy` at all"*. A number alone answers *which version exists*; the location answers *which one am I actually running* — the question behind it.

## The quieter bug it uncovered

`orchestrator.__version__` was the literal `"0.0.0"`, and no release step ever touched it. **Every version ever shipped reported 0.0.0** to anything that imported it — including any user code keying a compatibility check off it. Now read from the installed distribution.

A version string nothing derives is a version string nobody can trust — the same failure as a count nobody re-runs.

## Tests

Four, including one asserting the **root callback didn't break subcommand dispatch** — adding a callback to a Typer app is where that quietly stops working. Verified by reverting: restoring the `"0.0.0"` literal fails two of them.

## The numbers gate earned its keep again

[#276](https://github.com/synaptixs/spine/pull/276) merged an hour ago and caught its **third real drift** while this landed: adding these tests moved the count `STATE-OF-SPINE` states, and `--check` refused to pass until the page was refreshed.

| Gate | Result |
|---|---|
| Full suite | 3,259 passed, 3 skipped |
| `mypy src tests` | 662 files, no issues |
| `ruff format --check .` | 691 files |
| `state-numbers.py --check` | OK — 8 claims match |
| `render_architecture_svg.py --check` | current |

🤖 Generated with [Claude Code](https://claude.com/claude-code)