### PR TITLE
feat(pkg): let the recorded-intent tier reach the export

### DIFF
--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **57** | `grep -c '\.command(' src/orchestrator/cli.py` |
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,841** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,844** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.50** (TypeScript) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/recorded-intent-tier.md
+++ b/docs/specs/recorded-intent-tier.md
@@ -98,9 +98,9 @@ The concrete payoff is in the surfaces that already exist:
 
 | Phase | Work | Effort | Exit |
 |---|---|---|---|
-| **1 — reach the export** | `--intents` on `pkg export`, applying `link_intents` beside `link_docs` for non-sqlite formats. No exporter change: they already emit every kind | ~2 h | `pkg export . --format json --intents` yields non-zero `Intent`/`SERVES`; a test asserts it |
+| **1 — reach the export** ✅ **2026-09-01** | `--intents` on `pkg export`, applying `link_intents` beside `link_docs` for non-sqlite formats. No exporter change was needed: they already emit every kind | ~2 h | ✅ 37 `Intent` + 1,418 `SERVES` in the JSON export, coverage printed beside it. **And it immediately exposed §6.1** |
 | **2 — a query seam** | `intents_for(symbol)` / `symbols_serving(intent)` on `FactStore`, mirroring `docs_for` / `mentions_of`. An MCP tool only if Phase 3 wants one | ~0.5 d | The question is answerable in-process and from a script |
-| **3 — one real consumer** | `investigate`'s landing report names the tickets a landing symbol serves, bounded and labelled *last changed for* | ~1 d | A ticket landing on an attributed symbol reports it; one landing on an unattributed symbol says nothing, and says nothing *loudly* — never a blank that reads as "no prior work" |
+| **3 — one real consumer** | `investigate`'s landing report names the tickets a landing symbol serves, bounded and labelled *last changed for*. **Blocked on §6.1** — noise in an export is inspectable, noise in a landing report is a tool misinforming an engineer | ~1 d | A ticket landing on an attributed symbol reports it; one landing on an unattributed symbol says nothing, and says nothing *loudly* — never a blank that reads as "no prior work" |
 | **4 — the "built for" half** | `git log -L` per symbol to recover the introducing commit | ~1–2 d | Deferred on purpose. One subprocess per symbol against 11,022 symbols needs its own measurement before anyone commits to it |
 
 **Phase 1 is the one that removes "no reader".** Everything after it is about *which* reader.
@@ -113,6 +113,51 @@ The concrete payoff is in the surfaces that already exist:
 | **D2** | Opt-in, or on by default? | **Stays opt-in.** It costs 3.0s here against 2.8s for the whole extraction — it roughly *doubles* comprehension time, and on a repository with no issue keys it buys nothing. A default that doubles the cost of the cheap path for a repo-dependent payoff is the wrong default |
 | **D3** | Which consumer first? | **`investigate`.** It already reads the graph, already renders per-symbol context, and "what was this last changed for" is the question a ticket-landing report exists to answer |
 | **D4** | Add an `intent` table to the sqlite export? | **No.** That schema is kind-per-table and is a contract with the ontomesh consumer; `link_docs` is already excluded from it for the same reason. Revisit only if ontomesh asks |
+
+## 6.1 — Precision: about an eighth of the "intents" are not tickets
+
+**Found the moment Phase 1 made the facts readable, which is the argument for Phase 1.** The key
+pattern is deliberately generic — `\b[A-Z][A-Z0-9]{1,9}-\d+\b`, so that no repository is locked
+out by a hard-coded prefix — and it matches things that are not issue keys at all:
+
+| Claimed intent | Symbols | What it actually is |
+|---|---|---|
+| `SHA-256` | 31 | a hash algorithm named in a commit message |
+| `ISO-8601` | 27 | a date standard |
+| `CHANGE-2046` | 19 | not an issue key |
+| `UTF-16` | 8 | a text encoding |
+| `CB-676` | 7 | ambiguous |
+
+**5 of 37 intents (13.5%) and 92 of 1,418 `SERVES` edges (6.5%).** The join itself is correct —
+those commit messages really do contain those strings — but reading them as tickets is wrong, and
+a `SERVES` edge to `intent:SHA-256` asserts a symbol was changed for a ticket nobody ever filed.
+
+**This was invisible while the tier rendered only a count.** `34 intents` in a size line is as
+true of a good tier as a noisy one. Phase 1's whole value is that the facts became legible enough
+to be wrong out loud.
+
+**A deterministic discriminator exists, and it is the shape of the data.** A real tracker prefix
+appears with *many distinct numbers* — `SSPN-2`, `SSPN-3`, … `SSPN-49`. A standard appears with
+*one*: `SHA` only ever `256`, `ISO` only ever `8601`, `UTF` only ever `16`. Counting distinct
+numbers per prefix separates them without a list of standards to maintain.
+
+**It is not sufficient alone.** `WI-2` is a legitimate intent from the watch-items work and has
+exactly one number, so a naive "≥2 distinct numbers" rule would discard it. Options, none free:
+
+| Approach | Cost |
+|---|---|
+| Distinct-number threshold | Drops legitimate low-volume prefixes like `WI-2` |
+| Configurable prefix allow-list (`--intent-prefix SSPN`) | Correct and explicit; requires the operator to know their own prefix |
+| Require a conventional position (`fixes #`, `refs`, message prefix) | Precise; discards keys mentioned mid-sentence, which is most of them here |
+| Denylist of standards (`SHA-`, `ISO-`, `UTF-`, `RFC-`, `CVE-`) | Fragile, endless, and wrong the first time someone files `RFC-12` in their tracker |
+
+**Recommendation: the allow-list, defaulting to the distinct-number heuristic**, with the derived
+prefixes reported so an operator can see what was inferred and override it. That keeps a
+zero-config repository working and gives a precise answer to anyone who wants one.
+
+**This blocks Phase 3, not Phase 1.** Noise in an export is inspectable; noise in `investigate`'s
+landing report is a tool telling an engineer their change relates to `SHA-256`. **Fix precision
+before the tier faces a user.**
 
 ## 6. The risk, stated plainly
 

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -3928,6 +3928,14 @@ def pkg_export(
         Path | None,
         typer.Option("--out", "-o", help="Output file. Defaults to pkg-facts.<ext> for the format."),
     ] = None,
+    intents: Annotated[
+        bool,
+        typer.Option(
+            "--intents",
+            help="Also emit Intent nodes + SERVES edges (which ticket a symbol was last "
+            "changed for). Costs a `git blame` pass; ignored for --format sqlite.",
+        ),
+    ] = False,
     db: Annotated[
         Path | None,
         typer.Option("--db", help="DEPRECATED alias for --out (sqlite only). Use --out."),
@@ -3977,6 +3985,14 @@ def pkg_export(
     # --db predates --format and is published surface, so it keeps working rather than being
     # silently ignored — that would break a script without saying so. It only ever meant sqlite.
     if db is not None:
+        if intents and fmt == "sqlite":
+            # Said, not silently ignored. That schema is kind-per-table and is a contract with
+            # the ontomesh consumer; `link_docs` is excluded from it for the same reason.
+            typer.echo(
+                "  note: --intents does not apply to --format sqlite (kind-per-table schema, "
+                "no intent table)",
+                err=True,
+            )
         if fmt != "sqlite":
             typer.echo(f"--db only applies to --format sqlite (got {fmt!r}). Use --out instead.")
             raise typer.Exit(code=2)
@@ -4000,6 +4016,29 @@ def pkg_export(
             from orchestrator.pkg import link_docs
 
             batch = link_docs(batch, repo)
+
+            # Same post-pass argument, same modality problem: Intent nodes and SERVES edges
+            # come from `link_intents`, so without this the recorded-intent tier is invisible
+            # in the export exactly as docs would be. The exporters do not filter by kind —
+            # `export_json` emits every node — so the facts were absent because nothing added
+            # them, not because anything rejected them.
+            #
+            # Opt-in rather than unconditional, unlike docs: blame roughly doubles the cost of
+            # an extraction, and on a repository whose commits carry no issue keys it buys
+            # nothing at all.
+            if intents:
+                from orchestrator.pkg.intent_link import link_intents
+
+                coverage = link_intents(batch, repo)
+                rate = f"{coverage.rate:.1%}" if coverage.rate is not None else "n/a"
+                # The denominator travels with the facts. A tier that attributes 12 of 4,000
+                # symbols is working as designed and says almost nothing, and only the ratio
+                # makes that visible to whoever reads the export.
+                typer.echo(
+                    f"  intents: {coverage.intents} from {coverage.commits_keyed} keyed commit(s); "
+                    f"{coverage.symbols_attributed}/{coverage.symbols_total} symbols attributed ({rate})",
+                    err=True,
+                )
     counts = export_sqlite(batch, target) if fmt == "sqlite" else WRITERS[fmt](batch, target)
     typer.echo(f"Exported {path} → {target} ({fmt})")
     for label, n in counts.items():

--- a/tests/pkg/test_graph_export.py
+++ b/tests/pkg/test_graph_export.py
@@ -166,3 +166,81 @@ def test_empty_graph_still_writes_a_valid_file(tmp_path: Path) -> None:
         assert path.read_text(encoding="utf-8").strip()
     ET.parse(tmp_path / "empty.graphml")  # noqa: S314 — self-written file
     assert json.loads((tmp_path / "empty.json").read_text(encoding="utf-8"))["nodes"] == []
+
+
+# ---- the recorded-intent tier reaches the export (spec phase 1) ---------------
+#
+# `pkg export` applied `link_docs` as a post-pass and not `link_intents`, so Intent nodes and
+# SERVES edges were absent from every export. The comprehension test plan recorded that as
+# "Intent nodes: 0 / SERVES edges: 0" and concluded the facts were unreachable. They were only
+# never added: nothing here filters by kind.
+
+
+def _repo_with_history(tmp_path: Path) -> Path:
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "m.py").write_text("def handler():\n    return 1\n", encoding="utf-8")
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, capture_output=True, check=True)
+
+    git("init", "--quiet")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "T")
+    git("add", "-A")
+    git("commit", "--quiet", "-m", "PROJ-7 add the handler")
+    return repo
+
+
+def test_the_exporters_do_not_filter_by_kind(tmp_path: Path) -> None:
+    """The reason the facts were missing was that nothing added them, not that anything
+    rejected them. If a kind filter ever appears here, this is the test that says so."""
+    from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind
+
+    batch = FactBatch()
+    batch.add_node(Node("py:m.f", NodeKind.FUNCTION, "f", "python", Provenance("m.py", 1)))
+    batch.add_node(Node("intent:PROJ-7", NodeKind.INTENT, "PROJ-7", "", None))
+    batch.add_edge(Edge("py:m.f", "intent:PROJ-7", EdgeKind.SERVES, Provenance("m.py", 1)))
+
+    out = tmp_path / "g.json"
+    export_json(batch, out)
+    data = json.loads(out.read_text(encoding="utf-8"))
+
+    assert any(n["kind"] == "Intent" for n in data["nodes"])
+    assert any(e["kind"] == "SERVES" for e in data["edges"])
+
+
+def test_an_intent_node_survives_carrying_no_provenance(tmp_path: Path) -> None:
+    """An Intent is not a place in a file, so it is ungrounded by construction.
+
+    Any consumer assuming every node has a `file:line` breaks on this kind — the exporter
+    included, which is why it is asserted rather than assumed.
+    """
+    from orchestrator.pkg.facts import FactBatch, Node, NodeKind
+
+    batch = FactBatch()
+    batch.add_node(Node("intent:PROJ-7", NodeKind.INTENT, "PROJ-7", "", None))
+
+    out = tmp_path / "g.json"
+    export_json(batch, out)
+    node = json.loads(out.read_text(encoding="utf-8"))["nodes"][0]
+
+    assert node["kind"] == "Intent"
+    assert not node.get("file")
+    assert node.get("grounded") is False
+
+
+def test_link_intents_attributes_a_symbol_to_its_commits_key(tmp_path: Path) -> None:
+    """End to end on a real repository: blame → commit message → key → SERVES."""
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+    from orchestrator.pkg.intent_link import link_intents
+
+    repo = _repo_with_history(tmp_path)
+    batch = RepoCodeExtractor().extract(repo)
+    coverage = link_intents(batch, repo)
+
+    assert coverage.intents == 1
+    assert coverage.symbols_attributed >= 1
+    assert any(n.id == "intent:PROJ-7" for n in batch.nodes)


### PR DESCRIPTION
**Spec phase 1**, per D1 (keep) and D3 (investigate first).

`pkg export` applied `link_docs` as a post-pass and **not** `link_intents`, so Intent nodes and SERVES edges were absent from every export. The comprehension test plan recorded that as `Intent nodes: 0 / SERVES edges: 0` and concluded the facts were unreachable — they were only never *added*. Nothing filters by kind, and a test now says so, so a kind filter appearing later fails rather than silently dropping a modality.

```
$ orchestrator pkg export . --format json --intents
  intents: 37 from 92 keyed commit(s); 1272/11022 symbols attributed (11.5%)
  nodes              13916
  edges              39911
```

**Opt-in**, unlike docs: blame roughly doubles extraction cost, and on a repo whose commits carry no issue keys it buys nothing. `--intents` with `--format sqlite` **says it doesn't apply** rather than ignoring it — that schema is a contract with the ontomesh consumer.

## Making the facts legible immediately exposed a defect

The key pattern is deliberately generic so no repository is locked out by a hard-coded prefix. It matches things that are not tickets:

| Claimed intent | Symbols | What it is |
|---|---|---|
| `SHA-256` | 31 | a hash algorithm |
| `ISO-8601` | 27 | a date standard |
| `CHANGE-2046` | 19 | not an issue key |
| `UTF-16` | 8 | an encoding |
| `CB-676` | 7 | ambiguous |

**5 of 37 intents and 92 of 1,418 edges** assert a symbol was changed for a ticket nobody filed. The join is correct — those commit messages really do contain those strings — reading them as issue keys is not.

**This was invisible while the tier rendered only `34 intents` in a size line**, which is as true of a noisy tier as a good one. That's the argument for phase 1 in one observation.

Recorded in the spec as **§6.1**, with a deterministic discriminator that's the shape of the data — a real tracker prefix appears with *many* distinct numbers, a standard with exactly one — its known insufficiency (`WI-2` is legitimate and has one number), four options and a recommendation.

**It blocks phase 3, not this one.** Noise in an export is inspectable; noise in `investigate`'s landing report is a tool telling an engineer their change relates to `SHA-256`.

| Gate | Result |
|---|---|
| Full suite | 3,262 passed, 3 skipped |
| `mypy src tests` | 662 files, no issues |
| `ruff format --check .` | 691 files |
| `state-numbers.py --check` | OK |

🤖 Generated with [Claude Code](https://claude.com/claude-code)