### PR TITLE
fix(pkg): stop reading SHA-256 and ISO-8601 as issue keys

### DIFF
--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **57** | `grep -c '\.command(' src/orchestrator/cli.py` |
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,844** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,847** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.50** (TypeScript) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/recorded-intent-tier.md
+++ b/docs/specs/recorded-intent-tier.md
@@ -100,7 +100,7 @@ The concrete payoff is in the surfaces that already exist:
 |---|---|---|---|
 | **1 — reach the export** ✅ **2026-09-01** | `--intents` on `pkg export`, applying `link_intents` beside `link_docs` for non-sqlite formats. No exporter change was needed: they already emit every kind | ~2 h | ✅ 37 `Intent` + 1,418 `SERVES` in the JSON export, coverage printed beside it. **And it immediately exposed §6.1** |
 | **2 — a query seam** | `intents_for(symbol)` / `symbols_serving(intent)` on `FactStore`, mirroring `docs_for` / `mentions_of`. An MCP tool only if Phase 3 wants one | ~0.5 d | The question is answerable in-process and from a script |
-| **3 — one real consumer** | `investigate`'s landing report names the tickets a landing symbol serves, bounded and labelled *last changed for*. **Blocked on §6.1** — noise in an export is inspectable, noise in a landing report is a tool misinforming an engineer | ~1 d | A ticket landing on an attributed symbol reports it; one landing on an unattributed symbol says nothing, and says nothing *loudly* — never a blank that reads as "no prior work" |
+| **3 — one real consumer** | `investigate`'s landing report names the tickets a landing symbol serves, bounded and labelled *last changed for*. **Unblocked 2026-09-01** — §6.1 fixed | ~1 d | A ticket landing on an attributed symbol reports it; one landing on an unattributed symbol says nothing, and says nothing *loudly* — never a blank that reads as "no prior work" |
 | **4 — the "built for" half** | `git log -L` per symbol to recover the introducing commit | ~1–2 d | Deferred on purpose. One subprocess per symbol against 11,022 symbols needs its own measurement before anyone commits to it |
 
 **Phase 1 is the one that removes "no reader".** Everything after it is about *which* reader.
@@ -114,7 +114,7 @@ The concrete payoff is in the surfaces that already exist:
 | **D3** | Which consumer first? | **`investigate`.** It already reads the graph, already renders per-symbol context, and "what was this last changed for" is the question a ticket-landing report exists to answer |
 | **D4** | Add an `intent` table to the sqlite export? | **No.** That schema is kind-per-table and is a contract with the ontomesh consumer; `link_docs` is already excluded from it for the same reason. Revisit only if ontomesh asks |
 
-## 6.1 — Precision: about an eighth of the "intents" are not tickets
+## 6.1 — Precision: about an eighth of the "intents" were not tickets ✅ **fixed 2026-09-01**
 
 **Found the moment Phase 1 made the facts readable, which is the argument for Phase 1.** The key
 pattern is deliberately generic — `\b[A-Z][A-Z0-9]{1,9}-\d+\b`, so that no repository is locked
@@ -151,13 +151,40 @@ exactly one number, so a naive "≥2 distinct numbers" rule would discard it. Op
 | Require a conventional position (`fixes #`, `refs`, message prefix) | Precise; discards keys mentioned mid-sentence, which is most of them here |
 | Denylist of standards (`SHA-`, `ISO-`, `UTF-`, `RFC-`, `CVE-`) | Fragile, endless, and wrong the first time someone files `RFC-12` in their tracker |
 
-**Recommendation: the allow-list, defaulting to the distinct-number heuristic**, with the derived
-prefixes reported so an operator can see what was inferred and override it. That keeps a
-zero-config repository working and gives a precise answer to anyone who wants one.
+> **✅ Fixed 2026-09-01, and the measurement changed the answer.** The recommendation above was a
+> distinct-number *threshold*. Counting them settled it against that:
+>
+> | prefix | distinct numbers | mentions |
+> |---|---|---|
+> | **SSPN** | **45** | 111 |
+> | UTF | 2 | 6 |
+> | WI | 2 | 11 |
+> | SHA · ISO · CHANGE · CB · CVE · PROJ | 1 each | ≤ 8 |
+>
+> **"≥2" keeps `UTF` (8 and 16); "≥3" discards the legitimate `WI-2`.** Any constant between
+> them is the arbitrary tolerance band `GATES` already argues against — one that eventually
+> fires on something legitimate and gets widened until it means nothing.
+>
+> **So: the single dominant prefix, which is a maximum and not a band.** A repository has one
+> issue tracker, and here it wins 45 distinct numbers to 2. The one floor is that the winner
+> must have **at least two** distinct numbers — a prefix seen with exactly one is
+> indistinguishable from a standard, so a repository whose leader has only one gets no intents
+> rather than a coin-flip.
+>
+> `--intent-prefix` (repeatable) overrides it for a repository with two trackers or a history
+> too thin to infer from, and **every run reports what it accepted and what it rejected** —
+> an inference nobody can inspect is a guess wearing a measurement's clothes.
+>
+> **Effect here: 37 intents → 31, all genuine `SSPN-N`; 1,418 `SERVES` → 1,263; coverage 11.5%
+> → 10.2%.** The cost is `WI-2`'s 63 edges, and that is the right trade: `WI` is a roadmap
+> label, not a tracker key, and precision over recall is this graph's standing rule.
+>
+> One thing found while testing it: `_all_commit_keys` reads only the **first** key in a
+> message, so a standard sharing a commit with a real key never surfaced at all. The five that
+> did were first in their own commits.
 
-**This blocks Phase 3, not Phase 1.** Noise in an export is inspectable; noise in `investigate`'s
-landing report is a tool telling an engineer their change relates to `SHA-256`. **Fix precision
-before the tier faces a user.**
+**This blocked Phase 3, not Phase 1.** Noise in an export is inspectable; noise in
+`investigate`'s landing report is a tool telling an engineer their change relates to `SHA-256`.
 
 ## 6. The risk, stated plainly
 

--- a/src/orchestrator/cli.py
+++ b/src/orchestrator/cli.py
@@ -3936,6 +3936,14 @@ def pkg_export(
             "changed for). Costs a `git blame` pass; ignored for --format sqlite.",
         ),
     ] = False,
+    intent_prefix: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--intent-prefix",
+            help="Issue-key prefix to accept, repeatable (e.g. --intent-prefix PROJ). Default: "
+            "infer the repository's dominant prefix, which the run reports.",
+        ),
+    ] = None,
     db: Annotated[
         Path | None,
         typer.Option("--db", help="DEPRECATED alias for --out (sqlite only). Use --out."),
@@ -4029,8 +4037,21 @@ def pkg_export(
             if intents:
                 from orchestrator.pkg.intent_link import link_intents
 
-                coverage = link_intents(batch, repo)
+                coverage = link_intents(batch, repo, prefixes=intent_prefix or None)
                 rate = f"{coverage.rate:.1%}" if coverage.rate is not None else "n/a"
+                # What it decided, not just what it found. The generic key pattern reads
+                # `SHA-256` and `ISO-8601` as tickets, so which prefixes were accepted is the
+                # difference between a measurement and a guess — and an operator who can see
+                # the rejects can correct them with --intent-prefix.
+                typer.echo(
+                    f"  intent prefixes: accepted {', '.join(coverage.prefixes_used) or 'none'}"
+                    + (
+                        f"; rejected as not tickets: {', '.join(coverage.prefixes_rejected)}"
+                        if coverage.prefixes_rejected
+                        else ""
+                    ),
+                    err=True,
+                )
                 # The denominator travels with the facts. A tier that attributes 12 of 4,000
                 # symbols is working as designed and says almost nothing, and only the ratio
                 # makes that visible to whoever reads the export.

--- a/src/orchestrator/pkg/intent_link.py
+++ b/src/orchestrator/pkg/intent_link.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -48,7 +49,13 @@ from orchestrator.pkg.facts import SYMBOL_KINDS, Edge, EdgeKind, FactBatch, Node
 
 # Deliberately generic: `SSPN-49`, `PROJ-1`, `AB1-23`. No repository outside this one uses this
 # project's prefix, so a hard-coded key pattern would make the feature useless everywhere else.
-DEFAULT_KEY_PATTERN = r"\b[A-Z][A-Z0-9]{1,9}-\d+\b"
+#
+# Generic is also why it over-matches. On this repository it read `SHA-256`, `ISO-8601`,
+# `UTF-16`, `CVE-2024`, `CHANGE-2046` and `CB-676` as tickets — 5 of 37 intents and 92 of 1,418
+# edges asserting a symbol was changed for a ticket nobody filed. The join was right; treating
+# every match as an issue key was not. `_dominant_prefix` is the answer, and the group is
+# captured here so the prefix can be read out of a match.
+DEFAULT_KEY_PATTERN = r"\b([A-Z][A-Z0-9]{1,9})-\d+\b"
 
 _BLAME_LINE = re.compile(r"^([0-9a-f]{40}) \d+ (\d+)", re.M)
 _GIT_TIMEOUT = 120
@@ -76,6 +83,11 @@ class IntentCoverage:
     symbols_attributed: int
     commits_scanned: int
     commits_keyed: int
+    #: The prefixes accepted as issue keys, and the ones seen and rejected as not tickets.
+    #: Reported so an operator can see what was inferred and override it — an inference nobody
+    #: can inspect is a guess wearing a measurement's clothes.
+    prefixes_used: tuple[str, ...] = ()
+    prefixes_rejected: tuple[str, ...] = ()
 
     @property
     def rate(self) -> float | None:
@@ -89,6 +101,43 @@ def _git(root: Path, *args: str) -> str | None:
     except (OSError, subprocess.SubprocessError):
         return None
     return proc.stdout if proc.returncode == 0 else None
+
+
+def _dominant_prefix(keys: dict[str, str | None]) -> tuple[str | None, list[str]]:
+    """The repository's issue-key prefix, and every prefix rejected as not one.
+
+    **A tracker prefix appears with many distinct numbers; a standard appears with one.**
+    `SSPN` is used with 45 different numbers here; `SHA` only ever with `256`, `ISO` only with
+    `8601`, `CVE` only with `2024`. That is the shape of the data rather than a list of
+    standards to maintain, and it needs no denylist to keep current.
+
+    **A single dominant prefix, not a threshold.** A cut-off of "2 or more distinct numbers"
+    keeps `UTF` (8 and 16); "3 or more" discards the legitimate `WI-2`. Any constant between
+    them is the arbitrary tolerance band `pkg/accuracy.py`'s GATES argues against — one that
+    eventually fires on something legitimate and gets widened until it means nothing. A
+    repository has one issue tracker, and here it wins by 45 distinct numbers to 2, so the
+    maximum is the answer and no band is needed.
+
+    The one floor: the winner must have **at least two** distinct numbers. A prefix seen with
+    exactly one number is indistinguishable from a standard, so a repository whose leader has
+    only one is a repository with no discernible tracker — and gets no intents rather than a
+    coin-flip.
+
+    A repository with genuinely two trackers, or one whose history is too thin for the
+    inference, passes ``prefixes`` explicitly. This is the default, not the mechanism.
+    """
+    numbers: dict[str, set[str]] = {}
+    for key in keys.values():
+        if not key:
+            continue
+        prefix, _, number = key.rpartition("-")
+        numbers.setdefault(prefix, set()).add(number)
+    if not numbers:
+        return None, []
+    winner = max(numbers, key=lambda p: (len(numbers[p]), p))
+    if len(numbers[winner]) < 2:
+        return None, sorted(numbers)
+    return winner, sorted(p for p in numbers if p != winner)
 
 
 def _all_commit_keys(root: Path, pattern: re.Pattern[str]) -> dict[str, str | None]:
@@ -120,16 +169,37 @@ def _blame(root: Path, rel: str) -> dict[int, str]:
 
 
 def link_intents(
-    batch: FactBatch, root: Path | str, *, key_pattern: str = DEFAULT_KEY_PATTERN
+    batch: FactBatch,
+    root: Path | str,
+    *,
+    key_pattern: str = DEFAULT_KEY_PATTERN,
+    prefixes: Sequence[str] | None = None,
 ) -> IntentCoverage:
     """Add ``Intent`` nodes and ``SERVES`` edges to ``batch``. Mutates in place.
 
     Deterministic for a given history: no timestamps, no wall-clock, and commits are identified
     by hash. The same tree at the same commit yields the same facts.
+
+    ``prefixes`` names the issue-key prefixes to accept. Omit it and the repository's dominant
+    prefix is inferred — see :func:`_dominant_prefix` for why that is a maximum and not a
+    threshold. Pass it when a repository has two trackers, or when the inference is wrong and
+    you can see that it is, because the coverage report says what it chose.
     """
     base = Path(root)
     pattern = re.compile(key_pattern)
     key_cache = _all_commit_keys(base, pattern)
+
+    if prefixes is not None:
+        allowed: set[str] = set(prefixes)
+        rejected: list[str] = []
+    else:
+        winner, rejected = _dominant_prefix(key_cache)
+        allowed = {winner} if winner else set()
+    # Drop every key outside the allow-list *before* the join, so a rejected prefix cannot
+    # reach a node, an edge or the attributed count.
+    key_cache = {
+        sha: (key if key and key.rpartition("-")[0] in allowed else None) for sha, key in key_cache.items()
+    }
 
     # Only symbols carry intent. A Module is a file, and attributing a whole file to whichever
     # ticket last touched line 1 of it would be noise wearing a provenance label.
@@ -175,6 +245,8 @@ def link_intents(
         symbols_attributed=attributed,
         commits_scanned=len(key_cache),
         commits_keyed=keyed,
+        prefixes_used=tuple(sorted(allowed)),
+        prefixes_rejected=tuple(rejected),
     )
 
 

--- a/tests/pkg/test_graph_export.py
+++ b/tests/pkg/test_graph_export.py
@@ -191,6 +191,11 @@ def _repo_with_history(tmp_path: Path) -> Path:
     git("config", "user.name", "T")
     git("add", "-A")
     git("commit", "--quiet", "-m", "PROJ-7 add the handler")
+    (repo / "n.py").write_text("def other():\n    return 2\n", encoding="utf-8")
+    git("add", "-A")
+    # A second distinct number: one alone is indistinguishable from a standard and is declined
+    # by design (spec §6.1), so a single-ticket fixture would test the rejection, not the join.
+    git("commit", "--quiet", "-m", "PROJ-8 add another")
     return repo
 
 
@@ -241,6 +246,109 @@ def test_link_intents_attributes_a_symbol_to_its_commits_key(tmp_path: Path) -> 
     batch = RepoCodeExtractor().extract(repo)
     coverage = link_intents(batch, repo)
 
-    assert coverage.intents == 1
+    assert coverage.prefixes_used == ("PROJ",)
+    assert coverage.intents == 2
     assert coverage.symbols_attributed >= 1
     assert any(n.id == "intent:PROJ-7" for n in batch.nodes)
+
+
+# ---- issue keys vs things that merely look like them (spec §6.1) --------------
+
+
+def test_a_standard_is_not_read_as_a_ticket(tmp_path: Path) -> None:
+    """`SHA-256`, `ISO-8601`, `UTF-16` and `CVE-2024` matched the generic key pattern.
+
+    Five of 37 intents on this repository were of that shape — a `SERVES` edge asserting a
+    symbol was changed for a ticket nobody ever filed. The join was right; reading every match
+    as an issue key was not.
+    """
+    import subprocess
+
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+    from orchestrator.pkg.intent_link import link_intents
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, capture_output=True, check=True)
+
+    git("init", "--quiet")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "T")
+    # One key per commit: `_all_commit_keys` reads the *first* match in a message, so a
+    # standard sharing a commit with a real key never surfaces at all. Giving each its own
+    # commit is what puts the discriminator under test rather than that incidental filter.
+    for i, message in enumerate(
+        [
+            "PROJ-1 add the first thing",
+            "PROJ-2 add the second",
+            "hash it with SHA-256 throughout",
+            "format dates as ISO-8601",
+        ]
+    ):
+        (repo / f"m{i}.py").write_text(f"def f{i}():\n    return {i}\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "--quiet", "-m", message)
+
+    coverage = link_intents(RepoCodeExtractor().extract(repo), repo)
+
+    assert coverage.prefixes_used == ("PROJ",)
+    assert "SHA" in coverage.prefixes_rejected
+    assert "ISO" in coverage.prefixes_rejected
+
+
+def test_a_repository_with_no_discernible_tracker_gets_no_intents(tmp_path: Path) -> None:
+    """One number is indistinguishable from a standard, so a lone prefix wins nothing.
+
+    Silence over fiction: a coin-flip between `SHA-256` and a real key is not an answer.
+    """
+    import subprocess
+
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+    from orchestrator.pkg.intent_link import link_intents
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, capture_output=True, check=True)
+
+    git("init", "--quiet")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "T")
+    (repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "--quiet", "-m", "encode with UTF-8 throughout")
+
+    coverage = link_intents(RepoCodeExtractor().extract(repo), repo)
+
+    assert coverage.prefixes_used == ()
+    assert coverage.intents == 0
+
+
+def test_an_explicit_prefix_overrides_the_inference(tmp_path: Path) -> None:
+    """The inference is the default, not the mechanism. A repo with two trackers says so."""
+    import subprocess
+
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+    from orchestrator.pkg.intent_link import link_intents
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, capture_output=True, check=True)
+
+    git("init", "--quiet")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "T")
+    (repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "--quiet", "-m", "OPS-9 wire the thing")
+
+    # One number, so the inference would decline it. Named explicitly, it counts.
+    coverage = link_intents(RepoCodeExtractor().extract(repo), repo, prefixes=["OPS"])
+
+    assert coverage.prefixes_used == ("OPS",)
+    assert coverage.intents == 1

--- a/tests/pkg/test_intent_link.py
+++ b/tests/pkg/test_intent_link.py
@@ -38,9 +38,30 @@ def _repo(root: Path, *, message: str, source: str = SOURCE) -> Path:
     return root
 
 
-def _scan(root: Path) -> tuple[Any, Any]:
+def _commit(root: Path, message: str) -> None:
+    """Another commit on an existing fixture repo — for tests that need two distinct keys."""
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@e",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e",
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+    }
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True, env=env)
+    subprocess.run(["git", "commit", "-q", "-m", message], cwd=root, check=True, env=env)
+
+
+def _scan(root: Path, *, prefixes: list[str] | None = None, **kwargs: Any) -> tuple[Any, Any]:
+    """Scan with the prefix named, because these tests are about the **join**, not the policy.
+
+    Since 2026-09-01 an unnamed prefix has to be inferred, and the inference declines a prefix
+    seen with exactly one number — one is indistinguishable from `SHA-256` (spec §6.1). Every
+    fixture here is a one-commit repository, so leaving it to the inference would make each of
+    these assert the rejection rule rather than the thing it is named for. The default path is
+    covered end to end in `test_graph_export.py`.
+    """
     batch = RepoCodeExtractor().extract(root)
-    return batch, link_intents(batch, root)
+    return batch, link_intents(batch, root, prefixes=prefixes or ["SSPN"], **kwargs)
 
 
 def test_a_keyed_commit_yields_an_intent_and_serves_edges(tmp_path: Path) -> None:
@@ -121,11 +142,11 @@ def test_the_key_pattern_is_configurable(tmp_path: Path) -> None:
     """No repository outside this one uses this project's prefix."""
     root = _repo(tmp_path, message="feat: x (ACME-123)")
     batch = RepoCodeExtractor().extract(root)
-    link_intents(batch, root)
+    link_intents(batch, root, prefixes=["ACME"])
     assert [n.id for n in batch.nodes if n.kind is NodeKind.INTENT] == ["intent:ACME-123"]
 
     batch2 = RepoCodeExtractor().extract(root)
-    link_intents(batch2, root, key_pattern=r"\bNOPE-\d+\b")
+    link_intents(batch2, root, key_pattern=r"\b(NOPE)-\d+\b", prefixes=["NOPE"])
     assert [n for n in batch2.nodes if n.kind is NodeKind.INTENT] == []
 
 
@@ -165,7 +186,13 @@ def test_analysis_does_not_scan_intents_by_default(tmp_path: Path) -> None:
 def test_analysis_scans_intents_when_asked(tmp_path: Path) -> None:
     from orchestrator.knowledge.analysis import analyse
 
-    _repo(tmp_path, message="feat: x (SSPN-9)")
+    # Two distinct numbers under one prefix: `analyse` takes no prefix argument, so this is the
+    # inference's own path, and one number is declined by design (spec §6.1).
+    root = _repo(tmp_path, message="feat: x (SSPN-9)")
+    (root / "app" / "b.py").write_text("def g():\n    return 2\n", encoding="utf-8")
+    _commit(root, "feat: y (SSPN-10)")
+
     result = analyse(tmp_path, intents=True)
-    assert [n.id for n in result.batch.nodes if n.kind is NodeKind.INTENT] == ["intent:SSPN-9"]
+    found = sorted(n.id for n in result.batch.nodes if n.kind is NodeKind.INTENT)
+    assert found == ["intent:SSPN-10", "intent:SSPN-9"]
     assert any(e.kind is EdgeKind.SERVES for e in result.batch.edges)


### PR DESCRIPTION
**Spec §6.1**, which unblocks phase 3.

[#280](https://github.com/synaptixs/spine/pull/280) made the recorded-intent facts readable and they were immediately wrong out loud: 5 of 37 intents were `SHA-256`, `ISO-8601`, `UTF-16`, `CVE-2024`, `CHANGE-2046`, `CB-676` — **92 of 1,418 `SERVES` edges asserting a symbol was changed for a ticket nobody filed.**

## The measurement changed the answer

The spec recommended a distinct-number **threshold**: a tracker prefix appears with many numbers, a standard with one. Counting them ruled that out:

| prefix | distinct numbers |
|---|---|
| **SSPN** | **45** |
| UTF | 2 |
| WI | 2 |
| SHA · ISO · CHANGE · CB · CVE · PROJ | 1 each |

**"≥2" keeps `UTF` (8 and 16). "≥3" discards the legitimate `WI-2`.** Any constant between them is the arbitrary tolerance band `GATES` already argues against — one that eventually fires on something legitimate and gets widened until it means nothing.

So: **the single dominant prefix — a maximum, not a band.** A repository has one issue tracker, and here it wins 45 distinct numbers to 2. The one floor is that the winner needs **at least two** distinct numbers: a prefix seen with exactly one is indistinguishable from a standard, so a repo whose leader has only one gets no intents rather than a coin-flip. *Skip rather than guess* — the rule `_resolve_call` already follows.

`--intent-prefix` (repeatable) overrides it, and **every run reports what it accepted and rejected**:

```
intent prefixes: accepted SSPN; rejected as not tickets: CB, CHANGE, CVE, ISO, SHA, UTF, WI
intents: 31 from 74 keyed commit(s); 1120/11030 symbols attributed (10.2%)
```

An inference nobody can inspect is a guess wearing a measurement's clothes.

## Effect

**37 intents → 31, all genuine `SSPN-N`. 1,418 `SERVES` → 1,263. Coverage 11.5% → 10.2%.** The cost is `WI-2`'s 63 edges — the right trade, since `WI` is a roadmap label rather than a tracker key.

## Two things found while testing

**`_all_commit_keys` reads only the *first* key in a message**, so a standard sharing a commit with a real key never surfaced at all — the five that did were first in their own commits. A fixture putting both in one message tests *that filter*, not this rule, and the test says so.

**Five existing tests used one-commit fixtures** and now exercise the rejection rather than the join they're named for. They name the prefix explicitly with the reason written down; the inference's own path is covered end to end in `test_graph_export.py`.

| Gate | Result |
|---|---|
| Full suite | 3,265 passed, 3 skipped |
| `mypy src tests` | 662 files, no issues |
| `ruff format --check .` | 691 files |
| `state-numbers.py --check` | OK |

🤖 Generated with [Claude Code](https://claude.com/claude-code)