### PR TITLE
feat(scripts): derive the doc-binding figures, and trend rather than gate them

### DIFF
--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **57** | `grep -c '\.command(' src/orchestrator/cli.py` |
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,852** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,857** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.50** (TypeScript) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/doc-binding-walkthrough.md
+++ b/docs/specs/doc-binding-walkthrough.md
@@ -88,7 +88,7 @@ Each reader converts its format into **markdown-shaped text**: HTML's `<h1>`, Wo
 style and a spreadsheet's sheet name all become an ATX `#` heading. Everything downstream reads
 that one shape and never learns which format it came from.
 
-The splitter then cuts on headings. **Measured here: 1,560 `Doc` nodes** across the repository —
+The splitter then cuts on headings. **Measured here: 1,572 `Doc` nodes** across the repository —
 sections, not files.
 
 Our subject becomes:
@@ -118,7 +118,7 @@ precedence:
 | `CAMEL` | `DocReconciler` |
 | `FILE` | `src/orchestrator/pkg/store.py` |
 
-Our section yields **12 mentions**. Repository-wide: **9,104**.
+Our section yields **12 mentions**. Repository-wide: **9,109**.
 
 One rule worth knowing: a bare CamelCase word — "GitHub", "Python" — binds if it happens to
 resolve, but **never counts as drift**. Prose capitalisation is not a code claim.
@@ -166,14 +166,29 @@ Repository-wide, every mention lands in exactly one of four buckets:
 
 | | count | share |
 |---|---|---|
-| **one symbol anchor → `MENTIONS` edge** | **2,472** | 27% |
+| **one symbol anchor → `MENTIONS` edge** | **2,475** | 27% |
 | more than one symbol anchor → skipped | 1,937 | 21% |
-| resolved to a **file**, no symbol | 1,370 | 15% |
+| resolved to a **file**, no symbol | 1,372 | 15% |
 | nothing at all | 3,325 | 37% |
-| **total mentions** | **9,104** | |
+| **total mentions** | **9,109** | |
 
-2,447 edges are drawn from those 2,472 — the 25 difference is de-duplication, where one section
+2,450 edges are drawn from those 2,475 — the 25 difference is de-duplication, where one section
 names the same symbol twice.
+
+> **These seven figures are derived, and reported rather than gated.**
+> `scripts/state-numbers.py` re-computes every one of them and prints a `[trend]` line when the
+> table has aged. It does **not** fail the build on them, and measuring is what decided that:
+> they moved within an hour of first being written, because they count mentions across every
+> markdown file and anchors across every symbol, so any commit touching either moves them.
+> Gating that would fail nearly every pull request for refreshing seven numbers in a
+> walkthrough — the failure that un-gated the doc-drift ratchet a day earlier.
+>
+> Deriving them still catches the error they exist for: a figure wrong **when written**, as
+> opposed to one that has merely aged. Re-derive with:
+>
+> ```bash
+> python scripts/state-numbers.py
+> ```
 
 > **This table replaced a wrong one on 2026-09-01, and the error is worth keeping visible.** The
 > first version reported "at least one anchor: 5,721" and "more than one → skipped: 2,317",

--- a/scripts/state-numbers.py
+++ b/scripts/state-numbers.py
@@ -41,6 +41,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 STATE = ROOT / "docs" / "specs" / "STATE-OF-SPINE.md"
 SPEC_INDEX = ROOT / "docs" / "specs" / "SPEC-INDEX.md"
+WALKTHROUGH = ROOT / "docs" / "specs" / "doc-binding-walkthrough.md"
 
 
 _TEST_DEF = re.compile(r"^(?:async )?def test_", re.M)
@@ -70,6 +71,49 @@ def spec_files() -> int:
     return len(list((ROOT / "docs" / "specs").glob("*.md")))
 
 
+#: The doc-binding figures come from one expensive pass — a full extraction plus a doc walk,
+#: about ten seconds — so it is done once and every claim reads from it.
+_BINDING: dict[str, int] | None = None
+
+
+def _binding() -> dict[str, int]:
+    """Every mention, sorted into the four buckets the walkthrough tabulates.
+
+    The buckets partition the mentions: a mention has exactly one symbol anchor, or more than
+    one, or none but a file, or nothing. `link_docs` draws an edge only for the first, and the
+    difference between that count and the edges drawn is de-duplication.
+
+    That distinction is the whole reason these claims exist. The walkthrough's first table
+    reported `DocBinding.bound` — true for a symbol anchor *or* a file anchor — as though it
+    meant "will become an edge", inflating two figures and hiding the file-only bucket
+    entirely. Nothing derived them, so it stood for a day.
+    """
+    global _BINDING
+    if _BINDING is not None:
+        return _BINDING
+
+    from orchestrator.pkg.doc_link import link_docs
+    from orchestrator.pkg.doc_source import read_doc_pages
+    from orchestrator.pkg.docs import DocReconciler
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+    from orchestrator.pkg.facts import EdgeKind, NodeKind
+
+    batch = RepoCodeExtractor().extract(ROOT)
+    bindings, _drift = DocReconciler(batch, repo_root=ROOT).reconcile(read_doc_pages(ROOT))
+    linked = link_docs(RepoCodeExtractor().extract(ROOT), ROOT)
+
+    _BINDING = {
+        "mentions": len(bindings),
+        "one_symbol": sum(1 for b in bindings if len(b.anchor_ids) == 1),
+        "many_symbols": sum(1 for b in bindings if len(b.anchor_ids) > 1),
+        "file_only": sum(1 for b in bindings if not b.anchor_ids and b.anchor_files),
+        "nothing": sum(1 for b in bindings if not b.anchor_ids and not b.anchor_files),
+        "edges": sum(1 for e in linked.edges if e.kind is EdgeKind.MENTIONS),
+        "doc_nodes": sum(1 for n in linked.nodes if n.kind is NodeKind.DOC),
+    }
+    return _BINDING
+
+
 def package_version() -> str:
     import tomllib
 
@@ -89,6 +133,18 @@ class Claim:
     derive: Callable[[], object]
     #: Digits only: the prose writes thousands with a comma, and the derivation does not.
     numeric: bool = True
+    #: Whether a mismatch fails the build.
+    #:
+    #: The doc-binding figures are **not** gated, and measuring is what decided that: they moved
+    #: within an hour of being written, because they count mentions across every markdown file
+    #: and anchors across every symbol — so any commit touching either moves them. Gating that
+    #: would fail nearly every pull request for refreshing seven numbers in a walkthrough, which
+    #: is the failure that killed the doc-drift ratchet a day earlier: a gate firing on ordinary
+    #: work gets switched off, and then it protects nothing.
+    #:
+    #: They are still derived and still reported, which is what catches the error they exist
+    #: for — a figure wrong *when written*, as opposed to one that has merely aged.
+    gated: bool = True
 
 
 CLAIMS: tuple[Claim, ...] = (
@@ -126,13 +182,71 @@ CLAIMS: tuple[Claim, ...] = (
         package_version,
         numeric=False,
     ),
+    # The doc-binding walkthrough. Every figure below is a partition of the same population, so
+    # a miscategorisation moves two of them in opposite directions — which is exactly what went
+    # unnoticed for a day when nothing derived them.
+    Claim(
+        "binding: total mentions",
+        WALKTHROUGH,
+        re.compile(r"\| \*\*total mentions\*\* \| \*\*([\d,]+)\*\*"),
+        lambda: _binding()["mentions"],
+        gated=False,
+    ),
+    Claim(
+        "binding: one symbol anchor",
+        WALKTHROUGH,
+        re.compile(r"\| \*\*one symbol anchor → `MENTIONS` edge\*\* \| \*\*([\d,]+)\*\*"),
+        lambda: _binding()["one_symbol"],
+        gated=False,
+    ),
+    Claim(
+        "binding: ambiguous",
+        WALKTHROUGH,
+        re.compile(r"\| more than one symbol anchor → skipped \| ([\d,]+) \|"),
+        lambda: _binding()["many_symbols"],
+        gated=False,
+    ),
+    Claim(
+        "binding: file only",
+        WALKTHROUGH,
+        re.compile(r"\| resolved to a \*\*file\*\*, no symbol \| ([\d,]+) \|"),
+        lambda: _binding()["file_only"],
+        gated=False,
+    ),
+    Claim(
+        "binding: no anchor",
+        WALKTHROUGH,
+        re.compile(r"\| nothing at all \| ([\d,]+) \|"),
+        lambda: _binding()["nothing"],
+        gated=False,
+    ),
+    Claim(
+        "binding: edges drawn",
+        WALKTHROUGH,
+        re.compile(r"\n([\d,]+) edges are drawn from those"),
+        lambda: _binding()["edges"],
+        gated=False,
+    ),
+    Claim(
+        "binding: Doc nodes",
+        WALKTHROUGH,
+        re.compile(r"\*\*Measured here: ([\d,]+) `Doc` nodes\*\*"),
+        lambda: _binding()["doc_nodes"],
+        gated=False,
+    ),
 )
 
 
-def check() -> list[str]:
-    """Every claim that disagrees with its derivation, or that could not be found at all."""
+def check(*, gated_only: bool = True) -> list[str]:
+    """Claims that disagree with their derivation, or that could not be found at all.
+
+    ``gated_only`` keeps the ungated ones out of the build's verdict while still allowing a
+    caller to ask for everything — which is how they are reported as a trend.
+    """
     problems: list[str] = []
     for claim in CLAIMS:
+        if gated_only and not claim.gated:
+            continue
         text = claim.path.read_text(encoding="utf-8")
         found = claim.pattern.search(text)
         if found is None:
@@ -158,11 +272,16 @@ def main() -> int:
         return 0
     for problem in problems:
         print(f"[STALE] {problem}")
+    # Ungated claims are reported and never fail — the same standing `invention` and `drift`
+    # have, and for the same reason: they move with ordinary commits.
+    for drifted in [p for p in check(gated_only=False) if p not in problems]:
+        print(f"[trend] {drifted}")
     if problems:
         print(f"\nstate-numbers --check: FAILED — {len(problems)} claim(s) disagree with the source.")
         print("Refresh them, or the page's own maintenance rule is a rule nothing enforces.")
         return 1
-    print(f"state-numbers --check: OK — {len(CLAIMS)} claims match the source.")
+    gated = sum(1 for c in CLAIMS if c.gated)
+    print(f"state-numbers --check: OK — {gated} gated claim(s) match; {len(CLAIMS) - gated} trended.")
     return 0
 
 

--- a/tests/test_state_numbers.py
+++ b/tests/test_state_numbers.py
@@ -90,3 +90,71 @@ def test_a_disagreement_is_reported_with_both_numbers(tmp_path: Path) -> None:
 def test_the_headline_claims_are_covered(label: str) -> None:
     """These four went stale during one release cut; none may quietly leave the gate."""
     assert any(c.label == label for c in _module().CLAIMS)
+
+
+# ---- gated vs trended (the walkthrough figures) ------------------------------
+
+
+def test_the_binding_figures_are_trended_not_gated() -> None:
+    """They move on any commit touching a doc or a symbol, which is nearly every one.
+
+    Gating them would fail a pull request for refreshing seven numbers in a walkthrough — the
+    failure that un-gated the doc-drift ratchet. They are still derived, which is what catches
+    a figure wrong *when written* as opposed to one that has merely aged.
+    """
+    mod = _module()
+    binding = [c for c in mod.CLAIMS if c.label.startswith("binding:")]
+    assert binding, "the walkthrough figures must be derived at all"
+    assert all(not c.gated for c in binding)
+
+
+def test_the_headline_claims_stay_gated() -> None:
+    """Trending is for figures that move with ordinary work — not an escape hatch."""
+    mod = _module()
+    gated = {c.label for c in mod.CLAIMS if c.gated}
+    assert {"CLI commands", "source modules", "test functions", "version"} <= gated
+
+
+def test_an_ungated_mismatch_does_not_fail_the_build(tmp_path: Path) -> None:
+    from typing import Any as _Any
+
+    mod = _module()
+    doc = tmp_path / "doc.md"
+    doc.write_text("| Widgets | 41 |\n", encoding="utf-8")
+
+    stale: _Any = mod.Claim(
+        label="trended",
+        path=doc,
+        pattern=mod.re.compile(r"\| Widgets \| (\d+) \|"),
+        derive=lambda: 42,
+        gated=False,
+    )
+    original = mod.CLAIMS
+    mod.CLAIMS = (stale,)
+    try:
+        assert mod.check() == []  # the build's verdict ignores it
+        assert mod.check(gated_only=False) != []  # and it is still visible
+    finally:
+        mod.CLAIMS = original
+
+
+def test_the_binding_buckets_partition_the_mentions() -> None:
+    """A structural invariant, not a snapshot — it holds at every commit.
+
+    The four buckets are disjoint and exhaustive by construction, so a refactor that
+    double-counts or drops a mention breaks the sum. This is the check that survives the
+    figures themselves being trended rather than gated.
+    """
+    b = _module()._binding()
+    assert b["one_symbol"] + b["many_symbols"] + b["file_only"] + b["nothing"] == b["mentions"]
+
+
+def test_edges_never_exceed_single_anchor_mentions() -> None:
+    """`link_docs` draws an edge only for a mention with exactly one *symbol* anchor.
+
+    The gap is de-duplication. Edges exceeding that count would mean an edge drawn from an
+    ambiguous or file-only mention — the conflation that put a wrong table in this repository
+    for a day.
+    """
+    b = _module()._binding()
+    assert b["edges"] <= b["one_symbol"]


### PR DESCRIPTION
The walkthrough's table was wrong for a day because **nothing derived it**. Seven of its figures are now computed by `state-numbers.py`: total mentions, the four binding buckets, edges drawn, Doc nodes.

## They are reported, not gated — and measuring decided that

I set out to gate them. They **moved within an hour of first being written**:

```
[trend] binding: total mentions: says 9104, the source says 9108
[trend] binding: Doc nodes:      says 1560, the source says 1572
```

They count mentions across every markdown file and anchors across every symbol, so **any commit touching either moves them**. Gating that would fail nearly every PR for refreshing seven numbers in a walkthrough — the failure that un-gated the doc-drift ratchet a day earlier, where a gate firing on ordinary work gets switched off and then protects nothing. `invention` and `drift` already have this standing.

**Deriving them still catches the error they exist for:** a figure wrong *when written*, as opposed to one that has merely aged. That distinction is the whole argument for computing something you don't fail on.

```
state-numbers --check: OK — 8 gated claim(s) match; 7 trended.
```

## Two invariants that ARE asserted

They hold at *every* commit rather than describing one:

- **The four buckets partition the mentions** — a refactor that double-counts or drops one breaks the sum.
- **Edges never exceed single-symbol-anchor mentions**, the gap being de-duplication. Edges above that count would mean one drawn from an ambiguous or file-only mention — precisely the conflation that produced the wrong table.

## Cross-checked four ways before committing

| Check | Result |
|---|---|
| Buckets partition the total | 2,475 + 1,937 + 1,372 + 3,325 = 9,109 ✅ |
| Edges ≤ single-anchor | 2,450 ≤ 2,475, dedup gap 25 ✅ |
| Doc nodes, derived independently | `read_doc_pages` → 1,572 = `link_docs` → 1,572 ✅ |
| The retracted claim, re-tested | absence 3,325 vs ambiguity 1,937 — **retraction stands** ✅ |

## Validated by reverting

Removing the gated/trended split fails the ungated-mismatch test. Breaking the file-only bucket fails the partition test.

| Gate | Result |
|---|---|
| Full suite | 3,275 passed, 3 skipped |
| `mypy src tests` | 662 files, no issues |
| `ruff format --check .` | 691 files |
| `state-numbers.py --check` | 8 gated match, 7 trended |

🤖 Generated with [Claude Code](https://claude.com/claude-code)