### PR TITLE
docs(specs): scope TypeScript call resolution — and argue against the compiler API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ about it.
 **1 · The graph is built by parsers, not by a model — and its accuracy is published.**
 Eight language front-ends, every fact carrying `file:line`. Scored against a hand-labelled
 corpus in CI: **precision 1.00 on every node and edge kind**. Where it's weaker, that's
-published too — `CALLS` recall runs 1.00 on C and SQL down to 0.50 on TypeScript, reported
+published too — `CALLS` recall runs 1.00 on C and SQL down to 0.57 on TypeScript, reported
 separately rather than averaged into something flattering.
 
 **2 · The failure mode is silence, not fiction.** Everything the graph asserts exists;

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -1,8 +1,8 @@
 # Spec index — every design record, and where it stands
 
 **Generated 2026-08-15 against 3.18.1; refreshed 2026-08-21 for the completed GraphIR
-programme; recounted 2026-09-01 at 3.26.1.** `docs/specs/` holds **80** markdown files —
-**77 specs** plus three navigation documents ([README](README.md), this index,
+programme; recounted 2026-09-01 at 3.26.1.** `docs/specs/` holds **81** markdown files —
+**78 specs** plus three navigation documents ([README](README.md), this index,
 [STATE-OF-SPINE](STATE-OF-SPINE.md)) — with 6 archived and 10 build documents. The count read
 *63* until 2026-08-21, and **five specs were not listed at all**, including this file's own
 companion matrix and both measurements it cites as evidence. An inventory that silently omits
@@ -10,7 +10,7 @@ things is the failure it was built to catch, so the count is now stated as a der
 can re-run:
 
 ```
-ls docs/specs/*.md | wc -l          # 80
+ls docs/specs/*.md | wc -l          # 81
 ```
 
 **It rotted anyway.** The line read *70* from 2026-08-21 until 2026-08-28 while the directory
@@ -103,6 +103,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [pkg-code-grounded-understanding](pkg-code-grounded-understanding.md) | Proposed, for review | |
 | [language-support-roadmap](language-support-roadmap.md) | Design/blueprint, not started | Three new front-ends |
 | [language-expansion-roadmap](language-expansion-roadmap.md) | Prioritization only | Go ✅ · Rust · Kotlin · Ruby |
+| [typescript-call-resolution](typescript-call-resolution.md) | **Written 2026-09-01** — scoped, and argues **against** the compiler API | The recall figure was 0.50 in three places and is 0.57; the loss is one call-shape family, four fifths of it reachable locally. Widen the corpus first | **✔** |
 | [tri-repo-integration](tri-repo-integration.md) | Design only | Spans ontomesh + infodrift |
 | [ontomesh-integration-analysis](ontomesh-integration-analysis.md) | Analysis for decision | Nothing built |
 
@@ -155,7 +156,7 @@ Analysis, comparisons, test plans and assets. No completion state applies.
 |---|---|
 | ✅ Complete | 17 |
 | 🟡 Partial | 13 |
-| 📋 Outstanding | 14 |
+| 📋 Outstanding | 15 |
 | ⚠️ Stale status | 2 |
 | 📖 Reference | 25 |
 

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -3,7 +3,7 @@
 **The one document to read.** Verified against source on **2026-09-01**, at the 3.26.1 release
 cut. Every number below was re-measured that day.
 
-> **Why this exists.** `docs/specs/` holds **80** markdown files — **77 specs** plus this
+> **Why this exists.** `docs/specs/` holds **81** markdown files — **78 specs** plus this
 > page, [`README`](README.md) and [`SPEC-INDEX`](SPEC-INDEX.md) — with 6 archived, 10 build
 > documents, and 17 root-level user documents.
 > Answering "where do we stand?" required opening five of them and reconciling three that
@@ -30,7 +30,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
 | Test functions | **2,857** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
-| `CALLS` recall | **1.00** (C, SQL) → **0.50** (TypeScript) | same |
+| `CALLS` recall | **1.00** (C, SQL) → **0.57** (TypeScript, on 7 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |
 | Same, across two codebases | **47/68 vs 3/68** | replicated on an unrelated external repo |
 | Control (`edit` tickets, target file named) | **122/124 either arm** | rules out a generic more-context effect |
@@ -98,7 +98,7 @@ Measured against a hand-labelled corpus, all 8 languages
 |---|---|
 | **Precision** | **1.00** on every node kind and every edge kind, all 8 languages — *on the corpus*, and see the caveat below |
 | **Recall** | 1.00 on every kind **except `CALLS`** |
-| `CALLS` recall | 1.00 (c, sql) · 0.73 (python) · 0.67 (cpp, csharp, go, java) · **0.50 (typescript)** |
+| `CALLS` recall | 1.00 (c, sql) · 0.73 (python) · 0.67 (cpp, csharp, go, java) · **0.57 (typescript)** — every one of the four denominators is small; TypeScript's is 7 labelled edges |
 | Invention | **0** on this repo and on 11 pinned public repos across 6 front-ends, gated `strict` at zero per language (2026-08-24) |
 
 **That precision row was a corpus score over a corpus missing a shape, and both have been
@@ -135,7 +135,7 @@ for this section:
 
 The fix was one line, shipped in 3.18.0: return `None` instead of a guess. That is why the
 invention oracle exists as a standing measurement rather than a one-off, and why `CALLS` recall
-is allowed to sit at 0.50 on TypeScript instead of being padded.
+is allowed to sit at 0.57 on TypeScript instead of being padded.
 
 ### Why this matters
 
@@ -170,8 +170,11 @@ that. Nothing in the pipeline has to ration it.
 
 ### Where it is honestly weak
 
-- **`CALLS` recall on TypeScript is 0.50** — half the call edges are missed. Structure is
-  complete; the call graph is not.
+- **`CALLS` recall on TypeScript is 0.57**, on 7 labelled edges — and the loss is one family,
+  not a spread. `this.method()` resolves; every call through a *variable* is missed, including
+  `new Handler().run()`, which needs no type inference at all. Measured 2026-09-01 and scoped in
+  [`typescript-call-resolution.md`](typescript-call-resolution.md), which argues against the
+  compiler API on determinism grounds.
 - **`runtime` is still Python-only** (PEP 669) — the last of the four oracles with that
   limit. On a non-Python repo it reports nothing, and that is *not measured*, not clean.
   `invention` was the same until 2026-08-24 and now walks six front-ends, naming Java and SQL
@@ -377,7 +380,7 @@ and never promoted. A list that claims to be the authority has to actually absor
 | PDF, `.rst`/`.txt` and media collapse to one `Doc` node per file | unscheduled. Media is the one fixable without a new dependency — its segments already carry `start_ms`/`end_ms` and could become timestamped sections. **Unmeasured** |
 | Diagram arrows never become graph edges | **idea, no spec.** A mermaid flowchart is read as text; its labels bind to nothing and `intake --> design` produces no relationship. The more promising framing is the inverse — a diagram as a set of assertions to *check* against the graph rather than facts to add to it |
 | Shadowed-name `CALLS` invention in TypeScript, Go, C++, C# | ✅ **closed 2026-08-24** — oracle widened to 6 front-ends, all four fixed, 4 corpus cases added, `invention` gated `strict` at zero per language. 47 fabricated edges removed with no true edge lost. [Record](invention-oracle-cross-language.md) |
-| TypeScript resolution via the TS compiler API | **idea, not scheduled** (2026-08-21). `CALLS` recall is **0.50** for TypeScript against 1.00 for C and SQL — tree-sitter parses the syntax correctly but has no symbol table, so a call site resolves to the wrong target or none. The language's own toolchain would fix that. Costs: a Node runtime dependency, loss of tree-sitter's error tolerance, and a determinism risk if resolution depends on installed packages — the same commit could then give different graphs on different machines |
+| TypeScript resolution via the TS compiler API | 🟡 **scoped 2026-09-01, and the spec argues against it** — [`typescript-call-resolution.md`](typescript-call-resolution.md). The number was **0.50 in three places and is 0.57** (4 of 7 labelled edges). Probing six call shapes showed the loss is one family: `this.method()` resolves, every call through a *variable* misses — including `new Handler().run()`, which needs no type inference at all. Four of five missed shapes are reachable with a **local** pass over the same tree-sitter CST, no new dependency and no determinism risk, so the compiler API is not the first move. Its third cost is disqualifying as normally implemented: resolution that reads `node_modules` gives a different graph for the same commit, which invariant 2 forbids. **The scheduled piece is widening the corpus first** — 7 labelled edges cannot tell you whether a fix works |
 | G4 adoption — friction audit | ✅ **Phase 1 done 2026-08-19** — ≈28s cold start, no key; channels/proof/measurement outstanding |
 | `episteme.yml` main-branch path produces orphan branches | ✅ **fixed 2026-08-19** — regeneration is `develop`-only; `main` inherits the bank verbatim |
 

--- a/docs/specs/typescript-call-resolution.md
+++ b/docs/specs/typescript-call-resolution.md
@@ -1,0 +1,179 @@
+# TypeScript call resolution — what the 0.57 actually is
+
+**Status:** **Written 2026-09-01 against 3.26.1.** Not started, and this spec argues the obvious
+approach is the wrong one to start with.
+**Owner:** _unassigned_
+
+`STATE-OF-SPINE` §8 has carried *"TypeScript resolution via the TS compiler API"* as an idea
+since 2026-08-21, on the strength of one number: `CALLS` recall **0.50** on TypeScript against
+1.00 on C and SQL. This spec was meant to scope that work. Measuring first changed both halves
+of the premise.
+
+---
+
+## 1. The number is 0.57, and it was 0.50 in three places
+
+| | |
+|---|---|
+| Scoreboard, today | **4 matched of 7 expected — 0.571** |
+| `STATE-OF-SPINE` §2 and §3 | 0.50 |
+| `README.md` | 0.50 |
+
+Corrected in all three by this change. Nothing derives that figure — `scripts/state-numbers.py`
+covers eight claims and `CALLS` recall is not among them — so it aged silently the way every
+hand-carried number in this repository has.
+
+**It is also a very small denominator.** Seven labelled call edges is a passing test, not a
+measurement, and anyone quoting TypeScript call accuracy should quote the denominator with it.
+The same caution already applies to SQL, whose 1.00 rests on exactly one labelled call edge.
+
+## 2. The loss is one family of call shapes, and it is not what the corpus alone suggests
+
+| Corpus case | `CALLS` expected | matched | recall |
+|---|---|---|---|
+| `typescript/plain` | 2 | 2 | **1.00** |
+| `typescript/shadowed_calls` | 1 | 1 | **1.00** |
+| `typescript/generics` | 0 | — | n/a |
+| **`typescript/instance_calls`** | **4** | **1** | **0.25** |
+
+Every corpus miss is in one fixture, and all three are the same thing:
+
+```ts
+import { Handler } from "./handler";
+
+export function viaParameter(h: Handler): string {
+  return h.run();          // missed
+}
+
+export function viaLocal(): string {
+  const h = new Handler();
+  return h.run();          // missed
+}
+```
+
+tree-sitter sees `h.run()` and knows exactly two facts: `h` is an identifier, `run` is a
+property. **It has no idea `h` is a `Handler`**, so the call cannot be resolved to
+`Handler.run` and — under this graph's standing rule — is skipped rather than guessed. That is
+`_resolve_call`'s *"return `None` instead of a guess"*, working as designed and costing recall.
+
+**The corpus is too small to stop here**, so six shapes were probed directly against the
+front-end rather than reasoned about:
+
+| Shape | |
+|---|---|
+| `this.helper()` | **resolves** |
+| `h.run()` where `h: Handler` is a parameter | missed |
+| `h.run()` after `const h = new Handler()` | missed |
+| `h.run()` after `let h: Handler; h = new Handler()` | missed |
+| `o.h.run()` where `o = { h: new Handler() }` | missed |
+| `new Handler().run()` | missed |
+
+**`this.method()` — the most common call shape in class-heavy TypeScript — already works.** What
+fails is one family: **the receiver is a variable, and its type is known only from a declaration
+elsewhere in the function.**
+
+The last row is the one to notice. `new Handler().run()` has no variable and needs no inference
+at all: the constructor is right there in the call expression. It is missed anyway, which says
+the gap is not really about *types* — it is that the resolver only handles a bare identifier and
+`this`, and gives up on every other receiver shape.
+
+## 3. That changes which fix to reach for
+
+### Option A — a bounded local-type pass, in the existing front-end
+
+Five of the six probed misses are **syntactically local**. The type is in the same tree-sitter
+CST as the call:
+
+| Shape | What resolves it |
+|---|---|
+| `new Handler().run()` | the `new_expression` *is* the receiver — no inference at all |
+| `h: Handler` parameter | the type annotation on the parameter |
+| `const h = new Handler()` | a `new_expression` on the right of a declarator |
+| `let h: Handler` | the declarator's annotation |
+| `o = { h: new Handler() }` then `o.h.run()` | harder — needs a shape for the object literal |
+
+Walk a function body, record `identifier → type name` for the annotation and `new` forms, and
+resolve a member call against it. **No new dependency, no new runtime, no determinism risk.** It
+covers every corpus miss and four of the five probed shapes; the object-literal case is the one
+that would stay open, and it is the rarest.
+
+### Option B — the TypeScript compiler API
+
+A real symbol table, resolving arbitrary expressions, imported types, generics and inference.
+Strictly more capable. It carries three costs, and the third is disqualifying as stated:
+
+| Cost | Weight |
+|---|---|
+| A **Node runtime dependency** for a Python package whose base install is stdlib-only | Contradicts the standing rule that every parser lives behind a lazy extra — but an extra could hold it |
+| **Loss of tree-sitter's error tolerance** — a file that does not compile currently still yields the parts that parse | Real. Half a repository's value during a refactor is reading code mid-edit |
+| **Resolution depends on installed packages** — `node_modules` present or absent changes what a type resolves to | **This breaks invariant 2.** Same commit, different graph on different machines. `understand --check` could not gate it, extraction could not be commit-keyed, and a run's evidence could not be replayed |
+
+The third is not a trade to weigh; it is the property everything else in this system is built
+on. **Option B is only viable if resolution is confined to first-party source** — no
+`node_modules`, no ambient types — and at that point it is doing a more expensive version of
+Option A's job over the same information.
+
+## 4. The blocking unknown: we cannot measure this
+
+Option A demonstrably fixes the corpus. **Whether it fixes TypeScript is unknown, and today
+unknowable.**
+
+- The corpus holds **7 labelled call edges**. Option A would take it to 7/7, and 7/7 on seven
+  edges is not evidence about vue-core.
+- The `runtime` oracle — which measures `CALLS` recall by *executing a repository's own tests*
+  and watching what actually gets called — is **Python-only**. It is the one instrument that
+  could answer this, and it does not point at TypeScript.
+- The `invention` oracle measures the opposite direction: fabricated edges, not missing ones. It
+  says nothing about recall.
+
+**So the honest sequence is not "build Option A".** It is:
+
+1. **Extend the corpus first** with the shapes probed above and the ones still unprobed — a
+   generic parameter, a union-typed variable, a destructured binding, an imported instance —
+   **including `this.method()`, which works today and is tested nowhere.** A shape that works
+   and is untested is one refactor from silently not working, and the fixtures are what would
+   say so.
+2. **Then Option A**, sized against what the widened corpus actually shows.
+3. **Option B only if** the widened corpus shows the loss is dominated by shapes no local pass
+   can reach — and even then, only confined to first-party source, for the determinism reason
+   in §3.
+
+Skipping step 1 means building a fix for the one shape we happen to have written a fixture for.
+
+## 5. Decisions
+
+| | Decision | Recommendation |
+|---|---|---|
+| **D1** | Chase the compiler API now? | **No.** Every measured miss is reachable without it, and its determinism cost is disqualifying as normally implemented |
+| **D2** | Build Option A now? | **Not yet.** It would take the corpus to 7/7 and teach us nothing about real TypeScript. Widen the corpus first |
+| **D3** | What is step 1 worth? | ~half a day, no dependencies, and it converts an unmeasurable question into a measured one. **This is the piece to schedule** |
+| **D4** | Extend the `runtime` oracle to TypeScript? | Out of scope here, and the only thing that would make TS recall properly measurable. Worth its own row: it is currently the last Python-only oracle |
+
+## 6. Invariants
+
+- **Determinism is not negotiable.** Any resolution whose answer depends on what is installed
+  produces a different graph for the same commit and disqualifies itself, whatever it buys.
+- **Skip rather than guess.** A call whose target cannot be resolved emits nothing. Recall may
+  be imperfect; precision is held at 1.00, because a fabricated edge sends an agent into a
+  function nobody wrote.
+- **Structure comes from a real parser.** Whatever resolves types reads the tree; it does not
+  pattern-match source text.
+
+## 7. Non-goals
+
+- **Type checking.** Spine records what calls what, not whether the program is well-typed.
+- **Raising the number by relaxing the guess rule.** Recall bought with fabricated edges is the
+  bug 3.18.0 fixed at a cost of 497 edges.
+- **Any change to the other seven front-ends.** They score their own recall and have their own
+  shapes.
+
+## 8. Open questions
+
+1. **How much of real TypeScript is the variable-receiver family?** Still unknown. The probe
+   shows *which* shapes fail, not how often they occur in vue-core. Counting member calls by
+   receiver shape across the pinned corpus repository would answer it, needs no ground truth,
+   and is the cheapest next measurement after step 1.
+2. ~~**Does `this.method()` resolve today?**~~ **Answered while writing this: yes.** It is absent
+   from the corpus, so the fixtures neither credit nor blame the front-end for the most common
+   call shape in class-heavy TypeScript. **That is a fixture gap of its own** — a shape that
+   works and is untested is one refactor away from silently not working.


### PR DESCRIPTION
`STATE-OF-SPINE` §8 has carried *"TypeScript resolution via the TS compiler API"* since 2026-08-21 on the strength of one number. This spec was meant to scope that work. **Measuring first changed both halves of the premise.**

## 1. The number was wrong

| | |
|---|---|
| Scoreboard, today | **4 of 7 labelled edges — 0.571** |
| `STATE-OF-SPINE` §2 and §3 | 0.50 |
| `README.md` | 0.50 |

Nothing derives it — `state-numbers.py` covers eight claims and `CALLS` recall isn't among them — so it aged silently the way every hand-carried figure here has. Corrected in all three, with the denominator now stated beside it: **seven labelled edges is a passing test, not a measurement.**

## 2. The gap is not what the corpus alone suggests

Six call shapes probed directly against the front-end rather than reasoned about:

| Shape | |
|---|---|
| `this.helper()` | **resolves** |
| `h.run()` where `h: Handler` is a parameter | missed |
| `h.run()` after `const h = new Handler()` | missed |
| `h.run()` after `let h: Handler` | missed |
| `o.h.run()` from an object literal | missed |
| `new Handler().run()` | missed |

**`this.method()` — the most common shape in class-heavy TypeScript — already works, and is tested nowhere.** That's a fixture gap of its own: a shape that works and is untested is one refactor from silently not working.

**The last row is the tell.** `new Handler().run()` needs no type inference at all — the constructor is right there in the call — and misses anyway. So this is less about *types* than about a resolver that gives up on every receiver shape other than a bare identifier and `this`.

## 3. Why the compiler API is not the first move

**Four of the five misses are reachable locally** — the annotation or the `new` expression is in the same tree-sitter CST as the call. No new dependency, no new runtime, no determinism risk.

And the compiler API's third cost is **disqualifying as normally implemented**: resolution that reads `node_modules` returns a different answer depending on what's installed, so **the same commit yields different graphs on different machines.** That's invariant 2 — the property `understand --check`, the commit-keyed cache and replayable evidence all rest on. Viable only if confined to first-party source, at which point it's an expensive version of the local pass over the same information.

## 4. And the piece to schedule is neither

**7 labelled edges cannot tell you whether a fix works.** The local pass would take the corpus to 7/7 and teach nothing about vue-core. The `runtime` oracle — which measures recall by executing a repository's own tests — is **Python-only**, and is the one instrument that could answer this.

So **step 1 is widening the corpus**: half a day, no dependencies, and it converts an unmeasurable question into a measured one. Building the fix first means fixing the shape we happen to have written a fixture for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)