### PR TITLE
feat(corpus): widen the TypeScript fixtures, and let the number fall

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ about it.
 **1 · The graph is built by parsers, not by a model — and its accuracy is published.**
 Eight language front-ends, every fact carrying `file:line`. Scored against a hand-labelled
 corpus in CI: **precision 1.00 on every node and edge kind**. Where it's weaker, that's
-published too — `CALLS` recall runs 1.00 on C and SQL down to 0.57 on TypeScript, reported
+published too — `CALLS` recall runs 1.00 on C and SQL down to 0.36 on TypeScript, reported
 separately rather than averaged into something flattering.
 
 **2 · The failure mode is silence, not fiction.** Everything the graph asserts exists;

--- a/corpus/typescript/receiver_shapes/.repo/app/callers.ts
+++ b/corpus/typescript/receiver_shapes/.repo/app/callers.ts
@@ -1,0 +1,15 @@
+import { Handler } from "./handler";
+
+export function viaChain(): string {
+  return new Handler().run();
+}
+
+export function viaLet(): string {
+  let h: Handler = new Handler();
+  return h.run();
+}
+
+export function viaField(): string {
+  const box = { h: new Handler() };
+  return box.h.run();
+}

--- a/corpus/typescript/receiver_shapes/.repo/app/handler.ts
+++ b/corpus/typescript/receiver_shapes/.repo/app/handler.ts
@@ -1,0 +1,5 @@
+export class Handler {
+  run(): string {
+    return "x";
+  }
+}

--- a/corpus/typescript/receiver_shapes/expected.json
+++ b/corpus/typescript/receiver_shapes/expected.json
@@ -1,0 +1,33 @@
+{
+  "language": "typescript",
+  "case": "receiver_shapes",
+  "why": "The variable-receiver family, measured. `instance_calls` records two shapes; probing on 2026-09-01 found the miss is wider and not really about types — `new Handler().run()` has no variable and no inference to do, and misses anyway. Ground truth here is what a reader would expect the graph to say; the recall this scores is the honest cost of the resolver handling only a bare identifier and `this`. Following `instance_calls`, a `new T()` is recorded as CALLS to the Type, there being no constructor node.",
+  "root": ".repo",
+  "nodes": [
+    {"id": "ts:app/handler", "kind": "Module"},
+    {"id": "ts:app/callers", "kind": "Module"},
+
+    {"id": "ts:app/handler.Handler", "kind": "Type"},
+
+    {"id": "ts:app/handler.Handler.run", "kind": "Function"},
+    {"id": "ts:app/callers.viaChain", "kind": "Function"},
+    {"id": "ts:app/callers.viaLet", "kind": "Function"},
+    {"id": "ts:app/callers.viaField", "kind": "Function"}
+  ],
+  "edges": [
+    {"src": "ts:app/callers", "dst": "ts:app/handler", "kind": "IMPORTS"},
+
+    {"src": "ts:app/handler", "dst": "ts:app/handler.Handler", "kind": "CONTAINS"},
+    {"src": "ts:app/handler.Handler", "dst": "ts:app/handler.Handler.run", "kind": "CONTAINS"},
+    {"src": "ts:app/callers", "dst": "ts:app/callers.viaChain", "kind": "CONTAINS"},
+    {"src": "ts:app/callers", "dst": "ts:app/callers.viaLet", "kind": "CONTAINS"},
+    {"src": "ts:app/callers", "dst": "ts:app/callers.viaField", "kind": "CONTAINS"},
+
+    {"src": "ts:app/callers.viaChain", "dst": "ts:app/handler.Handler", "kind": "CALLS"},
+    {"src": "ts:app/callers.viaChain", "dst": "ts:app/handler.Handler.run", "kind": "CALLS"},
+    {"src": "ts:app/callers.viaLet", "dst": "ts:app/handler.Handler", "kind": "CALLS"},
+    {"src": "ts:app/callers.viaLet", "dst": "ts:app/handler.Handler.run", "kind": "CALLS"},
+    {"src": "ts:app/callers.viaField", "dst": "ts:app/handler.Handler", "kind": "CALLS"},
+    {"src": "ts:app/callers.viaField", "dst": "ts:app/handler.Handler.run", "kind": "CALLS"}
+  ]
+}

--- a/corpus/typescript/this_calls/.repo/app/service.ts
+++ b/corpus/typescript/this_calls/.repo/app/service.ts
@@ -1,0 +1,9 @@
+export class Service {
+  helper(): string {
+    return "s";
+  }
+
+  run(): string {
+    return this.helper();
+  }
+}

--- a/corpus/typescript/this_calls/expected.json
+++ b/corpus/typescript/this_calls/expected.json
@@ -1,0 +1,19 @@
+{
+  "language": "typescript",
+  "case": "this_calls",
+  "why": "A shape that WORKS and was tested nowhere. `this.method()` is the most common call in class-heavy TypeScript, and on 2026-09-01 a probe found it resolves correctly while every other receiver shape misses (see `typescript-call-resolution.md`). A shape that works and is untested is one refactor away from silently not working — this is the fixture that would say so.",
+  "root": ".repo",
+  "nodes": [
+    {"id": "ts:app/service", "kind": "Module"},
+    {"id": "ts:app/service.Service", "kind": "Type"},
+    {"id": "ts:app/service.Service.helper", "kind": "Function"},
+    {"id": "ts:app/service.Service.run", "kind": "Function"}
+  ],
+  "edges": [
+    {"src": "ts:app/service", "dst": "ts:app/service.Service", "kind": "CONTAINS"},
+    {"src": "ts:app/service.Service", "dst": "ts:app/service.Service.helper", "kind": "CONTAINS"},
+    {"src": "ts:app/service.Service", "dst": "ts:app/service.Service.run", "kind": "CONTAINS"},
+
+    {"src": "ts:app/service.Service.run", "dst": "ts:app/service.Service.helper", "kind": "CALLS"}
+  ]
+}

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -30,7 +30,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
 | Test functions | **2,857** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
-| `CALLS` recall | **1.00** (C, SQL) → **0.57** (TypeScript, on 7 labelled edges) | same |
+| `CALLS` recall | **1.00** (C, SQL) → **0.36** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |
 | Same, across two codebases | **47/68 vs 3/68** | replicated on an unrelated external repo |
 | Control (`edit` tickets, target file named) | **122/124 either arm** | rules out a generic more-context effect |
@@ -98,7 +98,7 @@ Measured against a hand-labelled corpus, all 8 languages
 |---|---|
 | **Precision** | **1.00** on every node kind and every edge kind, all 8 languages — *on the corpus*, and see the caveat below |
 | **Recall** | 1.00 on every kind **except `CALLS`** |
-| `CALLS` recall | 1.00 (c, sql) · 0.73 (python) · 0.67 (cpp, csharp, go, java) · **0.57 (typescript)** — every one of the four denominators is small; TypeScript's is 7 labelled edges |
+| `CALLS` recall | 1.00 (c, sql) · 0.73 (python) · 0.67 (cpp, csharp, go, java) · **0.36 (typescript)** — every one of the four denominators is small; TypeScript's is 14 labelled edges, doubled on 2026-09-01 |
 | Invention | **0** on this repo and on 11 pinned public repos across 6 front-ends, gated `strict` at zero per language (2026-08-24) |
 
 **That precision row was a corpus score over a corpus missing a shape, and both have been
@@ -135,7 +135,7 @@ for this section:
 
 The fix was one line, shipped in 3.18.0: return `None` instead of a guess. That is why the
 invention oracle exists as a standing measurement rather than a one-off, and why `CALLS` recall
-is allowed to sit at 0.57 on TypeScript instead of being padded.
+is allowed to sit at 0.36 on TypeScript instead of being padded.
 
 ### Why this matters
 
@@ -170,7 +170,7 @@ that. Nothing in the pipeline has to ration it.
 
 ### Where it is honestly weak
 
-- **`CALLS` recall on TypeScript is 0.57**, on 7 labelled edges — and the loss is one family,
+- **`CALLS` recall on TypeScript is 0.36**, on 14 labelled edges — and the loss is one family,
   not a spread. `this.method()` resolves; every call through a *variable* is missed, including
   `new Handler().run()`, which needs no type inference at all. Measured 2026-09-01 and scoped in
   [`typescript-call-resolution.md`](typescript-call-resolution.md), which argues against the
@@ -380,7 +380,7 @@ and never promoted. A list that claims to be the authority has to actually absor
 | PDF, `.rst`/`.txt` and media collapse to one `Doc` node per file | unscheduled. Media is the one fixable without a new dependency — its segments already carry `start_ms`/`end_ms` and could become timestamped sections. **Unmeasured** |
 | Diagram arrows never become graph edges | **idea, no spec.** A mermaid flowchart is read as text; its labels bind to nothing and `intake --> design` produces no relationship. The more promising framing is the inverse — a diagram as a set of assertions to *check* against the graph rather than facts to add to it |
 | Shadowed-name `CALLS` invention in TypeScript, Go, C++, C# | ✅ **closed 2026-08-24** — oracle widened to 6 front-ends, all four fixed, 4 corpus cases added, `invention` gated `strict` at zero per language. 47 fabricated edges removed with no true edge lost. [Record](invention-oracle-cross-language.md) |
-| TypeScript resolution via the TS compiler API | 🟡 **scoped 2026-09-01, and the spec argues against it** — [`typescript-call-resolution.md`](typescript-call-resolution.md). The number was **0.50 in three places and is 0.57** (4 of 7 labelled edges). Probing six call shapes showed the loss is one family: `this.method()` resolves, every call through a *variable* misses — including `new Handler().run()`, which needs no type inference at all. Four of five missed shapes are reachable with a **local** pass over the same tree-sitter CST, no new dependency and no determinism risk, so the compiler API is not the first move. Its third cost is disqualifying as normally implemented: resolution that reads `node_modules` gives a different graph for the same commit, which invariant 2 forbids. **The scheduled piece is widening the corpus first** — 7 labelled edges cannot tell you whether a fix works |
+| TypeScript resolution via the TS compiler API | 🟡 **scoped 2026-09-01, and the spec argues against it** — [`typescript-call-resolution.md`](typescript-call-resolution.md). The number was **0.50 in three places, is 0.36**, and moved twice on the way: 0.50 was stale (the scoreboard said 0.571), and widening the corpus on 2026-09-01 took it to **5 of 14**. **The drop is measurement, not regression** — the code did not change; two fixtures were added for shapes nothing was testing. Probing six call shapes showed the loss is one family: `this.method()` resolves, every call through a *variable* misses — including `new Handler().run()`, which needs no type inference at all. Four of five missed shapes are reachable with a **local** pass over the same tree-sitter CST, no new dependency and no determinism risk, so the compiler API is not the first move. Its third cost is disqualifying as normally implemented: resolution that reads `node_modules` gives a different graph for the same commit, which invariant 2 forbids. **The scheduled piece is widening the corpus first** — 7 labelled edges cannot tell you whether a fix works |
 | G4 adoption — friction audit | ✅ **Phase 1 done 2026-08-19** — ≈28s cold start, no key; channels/proof/measurement outstanding |
 | `episteme.yml` main-branch path produces orphan branches | ✅ **fixed 2026-08-19** — regeneration is `develop`-only; `main` inherits the bank verbatim |
 

--- a/docs/specs/typescript-call-resolution.md
+++ b/docs/specs/typescript-call-resolution.md
@@ -1,4 +1,4 @@
-# TypeScript call resolution — what the 0.57 actually is
+# TypeScript call resolution — what the number actually is
 
 **Status:** **Written 2026-09-01 against 3.26.1.** Not started, and this spec argues the obvious
 approach is the wrong one to start with.
@@ -11,15 +11,20 @@ of the premise.
 
 ---
 
-## 1. The number is 0.57, and it was 0.50 in three places
+## 1. The number moved twice, and neither move was the code changing
 
-| | |
-|---|---|
-| Scoreboard, today | **4 matched of 7 expected — 0.571** |
-| `STATE-OF-SPINE` §2 and §3 | 0.50 |
-| `README.md` | 0.50 |
+| | recall | why |
+|---|---|---|
+| Published in three places | 0.50 | stale — nothing derives it |
+| Scoreboard, 2026-09-01 | **0.571** (4 of 7) | what it had actually been |
+| Scoreboard, after step 1 | **0.357** (5 of 14) | the corpus doubled |
 
-Corrected in all three by this change. Nothing derives that figure — `scripts/state-numbers.py`
+**The drop to 0.36 is measurement, not regression.** No extractor changed. Two fixtures were
+added for shapes nothing was testing — one that works, one family that does not — and the
+denominator went from 7 labelled edges to 14. A number that falls when you look harder was
+always that number.
+
+Corrected in all three places. Nothing derives that figure — `scripts/state-numbers.py`
 covers eight claims and `CALLS` recall is not among them — so it aged silently the way every
 hand-carried number in this repository has.
 
@@ -128,11 +133,16 @@ unknowable.**
 
 **So the honest sequence is not "build Option A".** It is:
 
-1. **Extend the corpus first** with the shapes probed above and the ones still unprobed — a
-   generic parameter, a union-typed variable, a destructured binding, an imported instance —
-   **including `this.method()`, which works today and is tested nowhere.** A shape that works
-   and is untested is one refactor from silently not working, and the fixtures are what would
-   say so.
+1. ~~**Extend the corpus first**~~ ✅ **done 2026-09-01.** Two cases added:
+   `typescript/this_calls` pins the shape that works and was tested nowhere, and
+   `typescript/receiver_shapes` puts a number on the family that does not — `new Handler().run()`,
+   a `let` with an annotation, and a call through an object-literal field. It scores **CALLS
+   recall 0.00 on 6 expected edges**, which is the honest cost of a resolver that handles only a
+   bare identifier and `this`.
+
+   **Still unprobed, and deliberately not invented:** generics, union-typed variables and
+   destructured bindings. Each needs a judgement about what the *correct* edge is before it can
+   be labelled, and a fixture asserting a contested truth is worse than no fixture.
 2. **Then Option A**, sized against what the widened corpus actually shows.
 3. **Option B only if** the widened corpus shows the loss is dominated by shapes no local pass
    can reach — and even then, only confined to first-party source, for the determinism reason
@@ -146,7 +156,7 @@ Skipping step 1 means building a fix for the one shape we happen to have written
 |---|---|---|
 | **D1** | Chase the compiler API now? | **No.** Every measured miss is reachable without it, and its determinism cost is disqualifying as normally implemented |
 | **D2** | Build Option A now? | **Not yet.** It would take the corpus to 7/7 and teach us nothing about real TypeScript. Widen the corpus first |
-| **D3** | What is step 1 worth? | ~half a day, no dependencies, and it converts an unmeasurable question into a measured one. **This is the piece to schedule** |
+| **D3** | ~~What is step 1 worth?~~ | ✅ **Done 2026-09-01.** It cost an afternoon and moved the published figure from 0.57 to 0.36 — measurement, not regression. **What it bought:** the family now has a number and a regression guard, and `this.method()` can no longer break silently |
 | **D4** | Extend the `runtime` oracle to TypeScript? | Out of scope here, and the only thing that would make TS recall properly measurable. Worth its own row: it is currently the last Python-only oracle |
 
 ## 6. Invariants

--- a/src/orchestrator/pkg/scoreboard.json
+++ b/src/orchestrator/pkg/scoreboard.json
@@ -3,22 +3,14 @@
     "comprehension": {
       "gated": "ratchet",
       "localization": {
-        "empty_results": 2,
-        "gold_digest": "0a6ecf8c7bd22fd8",
-        "labelled": 38,
-        "status": "measured",
-        "top_k": {
-          "1": 12,
-          "10": 27,
-          "3": 18,
-          "5": 22
-        }
+        "reason": "gold set of 38 \u2014 run `pkg accuracy --scoreboard --pinned-corpus`",
+        "status": "not_measured"
       },
       "note": "provenance measured on this repo, offline; the pinned corpus is run explicitly",
       "provenance": {
-        "anchored": 10916,
-        "excluded": 767,
-        "resolved": 10916,
+        "anchored": 10981,
+        "excluded": 769,
+        "resolved": 10981,
         "unreadable": 0
       }
     },
@@ -396,14 +388,14 @@
         "typescript": {
           "edges": {
             "CALLS": {
-              "emitted": 4,
-              "expected": 7,
-              "matched": 4
+              "emitted": 5,
+              "expected": 14,
+              "matched": 5
             },
             "CONTAINS": {
-              "emitted": 25,
-              "expected": 25,
-              "matched": 25
+              "emitted": 33,
+              "expected": 33,
+              "matched": 33
             },
             "IMPLEMENTS": {
               "emitted": 2,
@@ -411,9 +403,9 @@
               "matched": 2
             },
             "IMPORTS": {
-              "emitted": 2,
-              "expected": 2,
-              "matched": 2
+              "emitted": 3,
+              "expected": 3,
+              "matched": 3
             }
           },
           "nodes": {
@@ -423,19 +415,19 @@
               "matched": 4
             },
             "Function": {
-              "emitted": 15,
-              "expected": 15,
-              "matched": 15
+              "emitted": 21,
+              "expected": 21,
+              "matched": 21
             },
             "Module": {
-              "emitted": 6,
-              "expected": 6,
-              "matched": 6
+              "emitted": 9,
+              "expected": 9,
+              "matched": 9
             },
             "Type": {
-              "emitted": 6,
-              "expected": 6,
-              "matched": 6
+              "emitted": 8,
+              "expected": 8,
+              "matched": 8
             }
           }
         }
@@ -443,10 +435,10 @@
       "skipped_languages": []
     },
     "drift": {
-      "count": 895,
-      "docs": 1533,
+      "count": 913,
+      "docs": 1583,
       "gated": false,
-      "mentions": 8917,
+      "mentions": 9148,
       "note": "recorded, never gated \u2014 an upper bound: a tenth of the population cannot bind by construction. See GATES"
     },
     "invention": {
@@ -458,12 +450,12 @@
           "invented": 0,
           "shadowable": 0,
           "status": "measured",
-          "total_calls": 17100,
+          "total_calls": 17217,
           "unexamined": 0
         }
       },
       "note": "gated at zero per language, not against this baseline \u2014 see GATES",
-      "total_calls": 17100
+      "total_calls": 17217
     },
     "parity": {
       "declared": 75,


### PR DESCRIPTION
**Step 1** of [`typescript-call-resolution.md`](docs/specs/typescript-call-resolution.md). Two cases, and the published figure moves **0.57 → 0.36**.

**That drop is measurement, not regression.** No extractor changed. The denominator went from 7 labelled call edges to 14.

## `typescript/this_calls` — a shape that works and was tested nowhere

`this.method()` is the most common call in class-heavy TypeScript. Probing found it resolves correctly while every other receiver shape misses — and **nothing was testing it**. A shape that works and is untested is one refactor from silently not working.

Scores 1.00 across the board. It's a regression guard, not a finding.

## `typescript/receiver_shapes` — a number on the family that doesn't

```ts
export function viaChain(): string { return new Handler().run(); }
export function viaLet(): string   { let h: Handler = new Handler(); return h.run(); }
export function viaField(): string { const box = { h: new Handler() }; return box.h.run(); }
```

**CALLS recall 0.00 on 6 expected edges.**

The first line is the one worth staring at. `new Handler().run()` has **no variable and no inference to do** — the constructor is right there in the call expression — and it misses anyway. The gap is less about *types* than about a resolver that handles a bare identifier and `this` and gives up on everything else.

## The gate fired, correctly

```
[REGRESSION] corpus: typescript/edges/CALLS recall — was 0.5714, now 0.3571
```

Baseline regenerated. Figure corrected in README and `STATE-OF-SPINE` — where it had **already** been corrected once today, from a stale 0.50. Three moves in one day for a number nothing derives.

## What is deliberately not here

Generics, union-typed variables and destructured bindings. Each needs a judgement about what the *correct* edge is before it can be labelled, and **a fixture asserting a contested truth is worse than no fixture.** Recorded in the spec as still unprobed rather than quietly skipped.

| Gate | Result |
|---|---|
| Full suite | 3,275 passed, 3 skipped |
| `pkg accuracy --check` | OK |
| `state-numbers.py --check` | 8 gated match, 7 trended |
| `mypy src tests` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)