### PR TITLE
feat(pkg): resolve TypeScript calls through a typed receiver, locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ about it.
 **1 · The graph is built by parsers, not by a model — and its accuracy is published.**
 Eight language front-ends, every fact carrying `file:line`. Scored against a hand-labelled
 corpus in CI: **precision 1.00 on every node and edge kind**. Where it's weaker, that's
-published too — `CALLS` recall runs 1.00 on C and SQL down to 0.36 on TypeScript, reported
+published too — `CALLS` recall runs 1.00 on C and SQL down to 0.86 on TypeScript, reported
 separately rather than averaged into something flattering.
 
 **2 · The failure mode is silence, not fiction.** Everything the graph asserts exists;

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,9 +28,9 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **57** | `grep -c '\.command(' src/orchestrator/cli.py` |
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,857** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,862** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
-| `CALLS` recall | **1.00** (C, SQL) → **0.36** (TypeScript, on 14 labelled edges) | same |
+| `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |
 | Same, across two codebases | **47/68 vs 3/68** | replicated on an unrelated external repo |
 | Control (`edit` tickets, target file named) | **122/124 either arm** | rules out a generic more-context effect |
@@ -98,7 +98,7 @@ Measured against a hand-labelled corpus, all 8 languages
 |---|---|
 | **Precision** | **1.00** on every node kind and every edge kind, all 8 languages — *on the corpus*, and see the caveat below |
 | **Recall** | 1.00 on every kind **except `CALLS`** |
-| `CALLS` recall | 1.00 (c, sql) · 0.73 (python) · 0.67 (cpp, csharp, go, java) · **0.36 (typescript)** — every one of the four denominators is small; TypeScript's is 14 labelled edges, doubled on 2026-09-01 |
+| `CALLS` recall | 1.00 (c, sql) · 0.73 (python) · 0.67 (cpp, csharp, go, java) · **0.86 (typescript)** — every one of the four denominators is small; TypeScript's is 14 labelled edges, doubled on 2026-09-01 |
 | Invention | **0** on this repo and on 11 pinned public repos across 6 front-ends, gated `strict` at zero per language (2026-08-24) |
 
 **That precision row was a corpus score over a corpus missing a shape, and both have been
@@ -135,7 +135,7 @@ for this section:
 
 The fix was one line, shipped in 3.18.0: return `None` instead of a guess. That is why the
 invention oracle exists as a standing measurement rather than a one-off, and why `CALLS` recall
-is allowed to sit at 0.36 on TypeScript instead of being padded.
+is allowed to sit below 1.00 on TypeScript instead of being padded.
 
 ### Why this matters
 
@@ -170,11 +170,12 @@ that. Nothing in the pipeline has to ration it.
 
 ### Where it is honestly weak
 
-- **`CALLS` recall on TypeScript is 0.36**, on 14 labelled edges — and the loss is one family,
-  not a spread. `this.method()` resolves; every call through a *variable* is missed, including
-  `new Handler().run()`, which needs no type inference at all. Measured 2026-09-01 and scoped in
+- **`CALLS` recall on TypeScript is 0.86**, on 14 labelled edges — up from 0.36 on 2026-09-01, and the remaining loss is one shape,
+  not a family: a receiver typed only by an object-literal field (`{ h: new Handler() }`). Every
+  other probed shape — annotated parameter, `const`/`let` with `new`, and `new Handler().run()` —
+  resolves, through a local pass over the same tree-sitter CST with no new dependency. Scoped in
   [`typescript-call-resolution.md`](typescript-call-resolution.md), which argues against the
-  compiler API on determinism grounds.
+  compiler API on determinism grounds and did not need it.
 - **`runtime` is still Python-only** (PEP 669) — the last of the four oracles with that
   limit. On a non-Python repo it reports nothing, and that is *not measured*, not clean.
   `invention` was the same until 2026-08-24 and now walks six front-ends, naming Java and SQL

--- a/docs/specs/typescript-call-resolution.md
+++ b/docs/specs/typescript-call-resolution.md
@@ -1,7 +1,8 @@
 # TypeScript call resolution — what the number actually is
 
-**Status:** **Written 2026-09-01 against 3.26.1.** Not started, and this spec argues the obvious
-approach is the wrong one to start with.
+**Status:** **Written and delivered 2026-09-01 against 3.26.1.** Steps 1 and 2 shipped the same
+day; the compiler API (Option B) was argued against and not built. TypeScript `CALLS` recall
+went **0.36 → 0.86** without a new dependency.
 **Owner:** _unassigned_
 
 `STATE-OF-SPINE` §8 has carried *"TypeScript resolution via the TS compiler API"* as an idea
@@ -143,7 +144,29 @@ unknowable.**
    **Still unprobed, and deliberately not invented:** generics, union-typed variables and
    destructured bindings. Each needs a judgement about what the *correct* edge is before it can
    be labelled, and a fixture asserting a contested truth is worse than no fixture.
-2. **Then Option A**, sized against what the widened corpus actually shows.
+2. ~~**Then Option A**~~ ✅ **done 2026-09-01.** `_typed_locals` reads the receiver's type from
+   the annotation or the `new` in the same tree, and `finalize` emits the call **only where the
+   target node exists in the merged graph**. Recall went **0.36 → 0.86** (12 of 14), precision
+   held at **1.00** on every case, and the invention oracle stayed at zero.
+
+   Of the six originally probed shapes, five now resolve. The one that does not is the receiver
+   typed by an object-literal field — the case §3 called the rarest and left open.
+
+   **Two things the corpus caught within a minute of it working**, both precision, both now
+   pinned by tests:
+
+   - **Receiving an instance is not calling its constructor.** `new Handler().run()` reaches
+     the constructor and the method; `h.run()` on an annotated parameter reaches only the
+     method. Emitting the type edge for both cost 0.20 precision immediately.
+   - **A method the type does not have must not be minted.** One file can resolve `h: Handler`
+     and cannot know whether `Handler` has a `missing`. That is why resolution defers to
+     `finalize`: the check is existence in the merged graph, and absence means no edge.
+
+   And one the corpus caught that was not precision at all: a `ValueError` from a half-finished
+   refactor was swallowed by `RepoCodeExtractor`'s `(SyntaxError, UnicodeDecodeError, ValueError)`
+   handler and reported as an unparseable file, so a whole module silently vanished from the
+   `generics` case. **A bug in extractor logic is indistinguishable from malformed source**, and
+   only the corpus said so.
 3. **Option B only if** the widened corpus shows the loss is dominated by shapes no local pass
    can reach — and even then, only confined to first-party source, for the determinism reason
    in §3.
@@ -155,7 +178,7 @@ Skipping step 1 means building a fix for the one shape we happen to have written
 | | Decision | Recommendation |
 |---|---|---|
 | **D1** | Chase the compiler API now? | **No.** Every measured miss is reachable without it, and its determinism cost is disqualifying as normally implemented |
-| **D2** | Build Option A now? | **Not yet.** It would take the corpus to 7/7 and teach us nothing about real TypeScript. Widen the corpus first |
+| **D2** | ~~Build Option A now?~~ | ✅ **Built 2026-09-01, after step 1.** The order mattered: against the original 7 edges it would have scored 7/7 and proved nothing. Against 14 it scores 12, and the two it misses are one named, understood shape |
 | **D3** | ~~What is step 1 worth?~~ | ✅ **Done 2026-09-01.** It cost an afternoon and moved the published figure from 0.57 to 0.36 — measurement, not regression. **What it bought:** the family now has a number and a regression guard, and `this.method()` can no longer break silently |
 | **D4** | Extend the `runtime` oracle to TypeScript? | Out of scope here, and the only thing that would make TS recall properly measurable. Worth its own row: it is currently the last Python-only oracle |
 

--- a/scripts/state-numbers.py
+++ b/scripts/state-numbers.py
@@ -114,6 +114,25 @@ def _binding() -> dict[str, int]:
     return _BINDING
 
 
+def ts_calls_recall() -> str:
+    """TypeScript `CALLS` recall, to two places, read from the committed scoreboard.
+
+    Chained deliberately: source → scoreboard (gated by `pkg accuracy --check`) → prose (gated
+    here). The scoreboard cannot go stale against the code, so a claim that matches it is a
+    claim that matches the code.
+
+    This figure moved three times on 2026-09-01 — a stale 0.50 corrected to 0.571, then 0.357
+    when the corpus doubled — while being quoted in the README and in three places on
+    `STATE-OF-SPINE`. It is the clearest case in the repository for deriving a number instead
+    of carrying it.
+    """
+    import json
+
+    board = json.loads((ROOT / "src" / "orchestrator" / "pkg" / "scoreboard.json").read_text())
+    calls = board["metrics"]["corpus"]["languages"]["typescript"]["edges"]["CALLS"]
+    return f"{calls['matched'] / calls['expected']:.2f}"
+
+
 def package_version() -> str:
     import tomllib
 
@@ -180,6 +199,27 @@ CLAIMS: tuple[Claim, ...] = (
         STATE,
         re.compile(r"\| Version \| \*\*([\d.]+)\*\*"),
         package_version,
+        numeric=False,
+    ),
+    Claim(
+        "TypeScript CALLS recall (STATE §2)",
+        STATE,
+        re.compile(r"\| `CALLS` recall \| \*\*1\.00\*\* \(C, SQL\) → \*\*([\d.]+)\*\*"),
+        ts_calls_recall,
+        numeric=False,
+    ),
+    Claim(
+        "TypeScript CALLS recall (STATE §3)",
+        STATE,
+        re.compile(r"· \*\*([\d.]+) \(typescript\)\*\*"),
+        ts_calls_recall,
+        numeric=False,
+    ),
+    Claim(
+        "TypeScript CALLS recall (README)",
+        ROOT / "README.md",
+        re.compile(r"down to ([\d.]+) on TypeScript"),
+        ts_calls_recall,
         numeric=False,
     ),
     # The doc-binding walkthrough. Every figure below is a partition of the same population, so

--- a/src/orchestrator/pkg/scoreboard.json
+++ b/src/orchestrator/pkg/scoreboard.json
@@ -8,9 +8,9 @@
       },
       "note": "provenance measured on this repo, offline; the pinned corpus is run explicitly",
       "provenance": {
-        "anchored": 10981,
+        "anchored": 10994,
         "excluded": 769,
-        "resolved": 10981,
+        "resolved": 10994,
         "unreadable": 0
       }
     },
@@ -388,9 +388,9 @@
         "typescript": {
           "edges": {
             "CALLS": {
-              "emitted": 5,
+              "emitted": 12,
               "expected": 14,
-              "matched": 5
+              "matched": 12
             },
             "CONTAINS": {
               "emitted": 33,
@@ -438,7 +438,7 @@
       "count": 913,
       "docs": 1583,
       "gated": false,
-      "mentions": 9148,
+      "mentions": 9151,
       "note": "recorded, never gated \u2014 an upper bound: a tenth of the population cannot bind by construction. See GATES"
     },
     "invention": {
@@ -450,12 +450,12 @@
           "invented": 0,
           "shadowable": 0,
           "status": "measured",
-          "total_calls": 17217,
+          "total_calls": 17232,
           "unexamined": 0
         }
       },
       "note": "gated at zero per language, not against this baseline \u2014 see GATES",
-      "total_calls": 17217
+      "total_calls": 17232
     },
     "parity": {
       "declared": 75,

--- a/src/orchestrator/pkg/typescript_extractor.py
+++ b/src/orchestrator/pkg/typescript_extractor.py
@@ -22,6 +22,7 @@ skipped — they'd need type inference, and a guessed edge poisons grounding.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -48,6 +49,39 @@ class TypeScriptExtractor:
 
     language: str = "typescript"
     suffixes: tuple[str, ...] = (".ts", ".tsx")
+
+    def __init__(self) -> None:
+        #: Member calls whose receiver type is known but whose target is unproven until the
+        #: whole repository is in hand. Drained by `finalize`.
+        self._pending_calls: list[_PendingCall] = []
+
+    def finalize(self, batch: FactBatch) -> FactBatch:
+        """Emit the deferred member calls whose target actually exists in the merged graph.
+
+        A single file can resolve `h: Handler` to `ts:app/handler.Handler`, and cannot know
+        whether that type has a `run`. Minting the id anyway is the fabrication that cost 497
+        edges in Python and 47 across four front-ends. So the check is existence, here, once
+        every file has been read: **if the node is not in the graph, no edge is drawn** — the
+        same skip-rather-than-guess rule, moved to the only place with enough information to
+        apply it.
+
+        Clears the queue so a later extraction starts clean, as Go's finalize does.
+        """
+        pending = self._pending_calls
+        self._pending_calls = []
+        if not pending:
+            return batch
+        known = {n.id for n in batch.nodes}
+        for call in pending:
+            target = f"{call.type_id}.{call.method}"
+            if target in known:
+                batch.add_edge(Edge(call.caller, target, EdgeKind.CALLS, Provenance(call.rel, call.line)))
+            # The receiver's own type is a call only when it was *constructed* here.
+            if call.constructed and call.type_id in known:
+                batch.add_edge(
+                    Edge(call.caller, call.type_id, EdgeKind.CALLS, Provenance(call.rel, call.line))
+                )
+        return batch
 
     def module_name(self, path: Path, root: Path) -> str:
         # TS modules are path-addressed (no package decl): repo-relative path
@@ -94,7 +128,21 @@ class TypeScriptExtractor:
             elif node.type in _FUNC_CONST_DECLS:
                 self._emit_const_functions(node, module_id, source, rel, batch, funcs, local_funcs)
         for fid, type_id, body in funcs:
-            _calls(fid, type_id, body, type_methods, local_funcs, imports, namespaces, source, rel, batch)
+            _calls(
+                fid,
+                type_id,
+                body,
+                type_methods,
+                local_funcs,
+                imports,
+                namespaces,
+                source,
+                rel,
+                batch,
+                local_types,
+                module_id,
+                self._pending_calls,
+            )
         return batch
 
     def _imports(
@@ -320,10 +368,14 @@ def _calls(
     source: bytes,
     rel: str,
     batch: FactBatch,
+    local_types: set[str],
+    module_id: str,
+    pending: list[_PendingCall],
 ) -> None:
     """Emit CALLS for precisely-resolvable ``call_expression`` sites in a body."""
     siblings = type_methods.get(type_id or "", set())
     bound = _bound_names(body, source)
+    typed, constructors = _typed_locals(body, source)
     stack = list(body.named_children)
     while stack:
         n = stack.pop()
@@ -343,7 +395,119 @@ def _calls(
             if target is not None:
                 _ensure_external(batch, target)
                 batch.add_edge(Edge(caller, target, EdgeKind.CALLS, Provenance(rel, n.start_point[0] + 1)))
+            elif fn is not None and fn.type == "member_expression":
+                _defer_member_call(
+                    caller, fn, typed, constructors, imports, local_types, module_id, rel, source, pending
+                )
         stack.extend(n.named_children)
+
+
+@dataclass(frozen=True)
+class _PendingCall:
+    """A ``receiver.method()`` whose receiver type is known but whose target is not yet proven."""
+
+    caller: str
+    type_id: str
+    method: str
+    rel: str
+    line: int
+    #: Whether the receiver was *constructed* at the call site. `new Handler().run()` reaches
+    #: the constructor and the method; `h.run()` on an annotated parameter reaches only the
+    #: method — the caller received the instance, it did not build one. Emitting the type edge
+    #: for both cost 0.20 precision the moment it was measured.
+    constructed: bool
+
+
+def _typed_locals(body: TSNode, src: bytes) -> tuple[dict[str, str], dict[str, bool]]:
+    """``{identifier: type name}`` for the receivers a function body states the type of.
+
+    Three forms, all of them **in the same tree as the call** — no inference, no symbol table:
+
+    ===========================  ===========================================
+    `function f(h: Handler)`     the parameter's `type_annotation`
+    `let h: Handler`             the declarator's `type_annotation`
+    `const h = new Handler()`    the `new_expression`'s constructor name
+    ===========================  ===========================================
+
+    Everything else — a call's return value, a destructured binding, a field of an object
+    literal — is left out on purpose. Each needs an answer this pass does not have, and a
+    receiver typed by guess is the fabricated edge that `_resolve_call` exists to refuse.
+    """
+    found: dict[str, str] = {}
+    constructed: dict[str, bool] = {}
+    # Parameters are siblings of the body, not inside it — walking only the body finds every
+    # local and no annotated parameter, which is the single most common typed receiver there is.
+    params = body.parent.child_by_field_name("parameters") if body.parent is not None else None
+    stack = list(body.named_children) + (list(params.named_children) if params is not None else [])
+    # The whole body, function scopes included: a nested arrow sees the outer `const`, and
+    # stopping at the boundary would drop the receivers most likely to appear in a callback.
+    while stack:
+        n = stack.pop()
+        if n.type in ("required_parameter", "optional_parameter", "variable_declarator"):
+            name_node = n.child_by_field_name("pattern") or n.child_by_field_name("name")
+            name = _text(name_node, src) if name_node is not None and name_node.type == "identifier" else ""
+            if name:
+                annotated = n.child_by_field_name("type")
+                value = n.child_by_field_name("value")
+                built = value is not None and value.type == "new_expression"
+                if annotated is not None:
+                    # `: Handler` — the annotation node keeps its colon.
+                    found.setdefault(name, _text(annotated, src).lstrip(":").strip())
+                    constructed.setdefault(name, built)
+                elif built and value is not None:
+                    ctor = value.child_by_field_name("constructor")
+                    if ctor is not None:
+                        found.setdefault(name, _text(ctor, src))
+                        constructed.setdefault(name, True)
+        stack.extend(n.named_children)
+    return found, constructed
+
+
+def _defer_member_call(
+    caller: str,
+    fn: TSNode,
+    typed: dict[str, str],
+    constructors: dict[str, bool],
+    imports: dict[str, str],
+    local_types: set[str],
+    module_id: str,
+    rel: str,
+    source: bytes,
+    pending: list[_PendingCall],
+) -> None:
+    """Record ``receiver.method()`` for the whole-repo pass, when the receiver's type is stated.
+
+    **Deferred rather than emitted**, and that is the point. The type resolves here — `Handler`
+    is an import or a sibling — but whether `Handler` *has* a `run` cannot be known from one
+    file, and minting `ts:app/handler.Handler.run` unchecked is precisely the invented edge that
+    cost 497 fabrications in Python. `finalize` sees the merged graph and emits only where the
+    target node actually exists.
+    """
+    obj = fn.child_by_field_name("object")
+    prop = fn.child_by_field_name("property")
+    pname = _text(prop, source) if prop is not None else ""
+    if obj is None or not pname:
+        return
+
+    constructed = False
+    if obj.type == "new_expression":  # `new Handler().run()` — the receiver IS the constructor
+        ctor = obj.child_by_field_name("constructor")
+        base = _text(ctor, source) if ctor is not None else ""
+        constructed = True
+    elif obj.type == "identifier":
+        name = _text(obj, source)
+        base = typed.get(name, "")
+        # A local whose type came from `new T()` was constructed in this body; one whose type
+        # came from an annotation was handed in.
+        constructed = bool(base) and constructors.get(name, False)
+    else:
+        return
+    if not base:
+        return
+
+    type_id = _resolve_type(base, imports, local_types, module_id, rel)
+    if type_id is not None:
+        pending.append(_PendingCall(caller, type_id, pname, rel, fn.start_point[0] + 1, constructed))
 
 
 def _pattern_names(node: TSNode | None, src: bytes) -> list[str]:

--- a/tests/pkg/test_graph_export.py
+++ b/tests/pkg/test_graph_export.py
@@ -352,3 +352,73 @@ def test_an_explicit_prefix_overrides_the_inference(tmp_path: Path) -> None:
 
     assert coverage.prefixes_used == ("OPS",)
     assert coverage.intents == 1
+
+
+# ---- TypeScript receiver typing (call-resolution spec, Option A) --------------
+
+
+def _ts_repo(tmp_path: Path, callers: str) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "app").mkdir(parents=True)
+    (repo / "app" / "handler.ts").write_text(
+        'export class Handler {\n  run(): string { return "x"; }\n}\n', encoding="utf-8"
+    )
+    (repo / "app" / "callers.ts").write_text(
+        'import { Handler } from "./handler";\n\n' + callers, encoding="utf-8"
+    )
+    return repo
+
+
+def _ts_calls(repo: Path) -> set[tuple[str, str]]:
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+    from orchestrator.pkg.facts import EdgeKind
+
+    batch = RepoCodeExtractor().extract(repo)
+    return {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.CALLS}
+
+
+def test_a_method_on_an_annotated_parameter_resolves(tmp_path: Path) -> None:
+    pytest.importorskip("tree_sitter_typescript", reason="install the 'typescript' extra")
+    repo = _ts_repo(tmp_path, "export function f(h: Handler): string { return h.run(); }\n")
+    assert ("ts:app/callers.f", "ts:app/handler.Handler.run") in _ts_calls(repo)
+
+
+def test_receiving_an_instance_is_not_calling_its_constructor(tmp_path: Path) -> None:
+    """The precision bug the corpus caught within a minute of the feature working.
+
+    `new Handler().run()` reaches the constructor *and* the method. `h.run()` on an annotated
+    parameter reaches only the method — the caller was handed the instance. Emitting the type
+    edge for both read as a call to `Handler` that never happens, and cost 0.20 precision.
+    """
+    pytest.importorskip("tree_sitter_typescript", reason="install the 'typescript' extra")
+    repo = _ts_repo(tmp_path, "export function f(h: Handler): string { return h.run(); }\n")
+    assert ("ts:app/callers.f", "ts:app/handler.Handler") not in _ts_calls(repo)
+
+
+def test_constructing_then_calling_reaches_both(tmp_path: Path) -> None:
+    pytest.importorskip("tree_sitter_typescript", reason="install the 'typescript' extra")
+    repo = _ts_repo(tmp_path, "export function f(): string { return new Handler().run(); }\n")
+    calls = _ts_calls(repo)
+    assert ("ts:app/callers.f", "ts:app/handler.Handler.run") in calls
+    assert ("ts:app/callers.f", "ts:app/handler.Handler") in calls
+
+
+def test_a_method_the_type_does_not_have_is_not_invented(tmp_path: Path) -> None:
+    """The whole reason resolution is deferred to `finalize`.
+
+    One file can resolve `h: Handler` and cannot know whether `Handler` has a `missing`.
+    Minting the id anyway is the fabrication that cost 497 edges in Python — so the check is
+    existence in the merged graph, and absence means no edge.
+    """
+    pytest.importorskip("tree_sitter_typescript", reason="install the 'typescript' extra")
+    repo = _ts_repo(tmp_path, "export function f(h: Handler): string { return h.missing(); }\n")
+    calls = _ts_calls(repo)
+    assert not any(dst.endswith(".missing") for _src, dst in calls)
+    assert not any("missing" in dst for _src, dst in calls)
+
+
+def test_an_unknown_receiver_type_resolves_to_nothing(tmp_path: Path) -> None:
+    """Skip rather than guess: a receiver whose type is not stated stays unresolved."""
+    pytest.importorskip("tree_sitter_typescript", reason="install the 'typescript' extra")
+    repo = _ts_repo(tmp_path, "export function f(h): string { return h.run(); }\n")
+    assert ("ts:app/callers.f", "ts:app/handler.Handler.run") not in _ts_calls(repo)


### PR DESCRIPTION
**Steps 2 and 3** of [`typescript-call-resolution.md`](docs/specs/typescript-call-resolution.md).

**TypeScript `CALLS` recall: 0.36 → 0.86** (12 of 14 labelled edges), precision held at **1.00 on every case**, invention oracle still zero. **No new dependency, no new runtime, no determinism risk** — the compiler API was argued against and not built.

Of the six shapes probed when the spec was written, **five now resolve**:

| Shape | before | after |
|---|---|---|
| `this.helper()` | resolves | resolves |
| `h.run()`, `h: Handler` parameter | missed | **resolves** |
| `h.run()` after `const h = new Handler()` | missed | **resolves** |
| `h.run()` after `let h: Handler` | missed | **resolves** |
| `new Handler().run()` | missed | **resolves** |
| `o.h.run()` from an object literal | missed | missed — named and left open |

## The safety argument is the deferral

`_typed_locals` reads the receiver's type from the same tree as the call. **Resolution then defers to `finalize`**, because one file can resolve `h: Handler` to `ts:app/handler.Handler` and *cannot know whether that type has a `run`*. Minting the id anyway is the fabrication that cost 497 edges in Python and 47 across four front-ends.

So the check is **existence in the merged graph** — if the node isn't there, no edge. Skip-rather-than-guess, moved to the only place with enough information to apply it. Go's `finalize` set the precedent.

## Three things the corpus caught, within minutes

**Receiving an instance is not calling its constructor.** `new Handler().run()` reaches the constructor *and* the method; `h.run()` on an annotated parameter reaches only the method. Emitting the type edge for both **dropped precision to 0.80 the instant recall hit 1.00** on that case.

**A method the type does not have must not be minted** — the existence check above, now pinned by a test that fails without it.

**And one that wasn't precision at all:** a `ValueError` from a half-finished refactor was swallowed by `RepoCodeExtractor`'s `(SyntaxError, UnicodeDecodeError, ValueError)` handler, reported as an unparseable file, and **silently removed a whole module** from the `generics` case. A bug in extractor logic is indistinguishable from malformed source — only the corpus said so.

## Also: the figure is now gated

`CALLS` recall moved **four times in one day** — stale 0.50, actual 0.571, 0.357 when the corpus doubled, 0.857 now — while quoted in the README and three places on `STATE-OF-SPINE`. `state-numbers.py` now derives it from the committed scoreboard, chaining source → scoreboard (gated by `pkg accuracy --check`) → prose.

| Gate | Result |
|---|---|
| Full suite | 3,280 passed, 3 skipped |
| `pkg accuracy --check` | OK |
| `state-numbers.py --check` | **11 gated match**, 7 trended |
| `--oracle invention` | 0 invented edges |
| Both precision guards | verified by reverting |

🤖 Generated with [Claude Code](https://claude.com/claude-code)