### PR TITLE
fix(docs): stop the drift list calling 58 filenames missing code

### DIFF
--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **57** | `grep -c '\.command(' src/orchestrator/cli.py` |
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,862** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,864** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/doc-binding-walkthrough.md
+++ b/docs/specs/doc-binding-walkthrough.md
@@ -88,7 +88,7 @@ Each reader converts its format into **markdown-shaped text**: HTML's `<h1>`, Wo
 style and a spreadsheet's sheet name all become an ATX `#` heading. Everything downstream reads
 that one shape and never learns which format it came from.
 
-The splitter then cuts on headings. **Measured here: 1,572 `Doc` nodes** across the repository —
+The splitter then cuts on headings. **Measured here: 1,583 `Doc` nodes** across the repository —
 sections, not files.
 
 Our subject becomes:
@@ -118,7 +118,7 @@ precedence:
 | `CAMEL` | `DocReconciler` |
 | `FILE` | `src/orchestrator/pkg/store.py` |
 
-Our section yields **12 mentions**. Repository-wide: **9,109**.
+Our section yields **12 mentions**. Repository-wide: **9,167**.
 
 One rule worth knowing: a bare CamelCase word — "GitHub", "Python" — binds if it happens to
 resolve, but **never counts as drift**. Prose capitalisation is not a code claim.
@@ -166,13 +166,13 @@ Repository-wide, every mention lands in exactly one of four buckets:
 
 | | count | share |
 |---|---|---|
-| **one symbol anchor → `MENTIONS` edge** | **2,475** | 27% |
-| more than one symbol anchor → skipped | 1,937 | 21% |
-| resolved to a **file**, no symbol | 1,372 | 15% |
-| nothing at all | 3,325 | 37% |
-| **total mentions** | **9,109** | |
+| **one symbol anchor → `MENTIONS` edge** | **2,479** | 27% |
+| more than one symbol anchor → skipped | 1,962 | 21% |
+| resolved to a **file**, no symbol | 1,376 | 15% |
+| nothing at all | 3,350 | 37% |
+| **total mentions** | **9,167** | |
 
-2,450 edges are drawn from those 2,475 — the 25 difference is de-duplication, where one section
+2,453 edges are drawn from those 2,479 — the 26 difference is de-duplication, where one section
 names the same symbol twice.
 
 > **These seven figures are derived, and reported rather than gated.**
@@ -199,22 +199,22 @@ names the same symbol twice.
 > summary used the wrong one.
 >
 > The conclusion followed the bad number. It read *"ambiguity, not absence, is the larger
-> loss"*, and that is **false**: absence is 3,325 against ambiguity's 1,937.
+> loss"*, and that is **false**: absence is 3,343 against ambiguity's 1,959.
 
-**What is true, and still worth saying:** ambiguity is not a rounding error. **1,937 mentions
+**What is true, and still worth saying:** ambiguity is not a rounding error. **1,962 mentions
 found real code and were deliberately dropped** for naming more than one thing — 29% of
-everything that fails to become an edge. That is qualitatively different from the 3,325 that
+everything that fails to become an edge. That is qualitatively different from the 3,350 that
 found nothing, and it matters for how the gap gets closed: reducing it means answering *which*
 symbol was meant, not *whether* one exists. Doing that by proximity, or by "the most likely", is
 precisely the guess this tier does not make.
 
-The 1,370 file-only mentions are a third category and mostly correct behaviour: prose citing
+The 1,376 file-only mentions are a third category and mostly correct behaviour: prose citing
 `src/orchestrator/pkg/store.py` is naming a path, not a symbol, and there is no symbol edge to
 draw.
 
 ## Step 6 — drift, in detail
 
-Of the 3,325 mentions that matched nothing, most are prose: ordinary words in backticks, URLs,
+Of the 3,350 mentions that matched nothing, most are prose: ordinary words in backticks, URLs,
 filenames. `symbolish_drift` narrows to identifier-shaped claims, leaving **about 900** on this
 repository. Examples, all real:
 
@@ -231,6 +231,33 @@ un-gated one pull request later, after failing a documentation change: about a t
 population cannot bind by construction — parameters, module constants, string literals, log
 event names and builtins have no node kind. The number stands as an **upper bound** on drift,
 never as a defect count.
+
+> **The leaf-only fallback was audited on 2026-09-01 and cleared.** `bind`'s last resort, when a
+> dotted mention matches no id tail, is to match its **final segment alone** — throwing the
+> qualifier away. That looks like a fabrication waiting to happen: with exactly one symbol named
+> `json` in this repository, every `.json` filename could bind to `DummyResponse.json`, a test
+> double's method.
+>
+> **It does not happen, and the suspicion was quantified before it was acted on.** The fallback
+> rescues **76 mentions** into a single correct anchor — `store.find` onto `FactStore.find`,
+> `Budget.max_replan_count`, `CapabilityResult.content_type` — turns 166 into ambiguous
+> bindings that are skipped, and mis-binds **no filename at all**. Filenames never reach it:
+> a recognised extension makes the mention `FILE`-kind, which resolves against the filesystem
+> instead.
+>
+> Two `MENTIONS` edges *do* point at that method, and neither comes from the fallback. They come
+> from the bare word `` `json` `` in prose, which resolves exactly and binds — the documented
+> behaviour that single plain lowercase words bind when they resolve. That is a separate and much
+> smaller question than the one investigated.
+>
+> **What the audit did find was a drift-precision defect, in a different place.** `md.js`,
+> `graph.html` and `compose.dev.yml` are dotted, lowercase and multi-segment, so they are shaped
+> exactly like symbol paths; the FILE pattern does not recognise their extensions, so they arrived
+> as symbol claims and the drift list reported **55 filenames as prose naming code that does not
+> exist**. Extensions were added to `_URL_TAILS` and checked in `_can_drift`. Drift went
+> **1,651 → 1,596** and **not one `MENTIONS` edge changed** — a naming asymmetry, not a coverage
+> gap. `README.md` and `src/a/b.py` keep their disk check, because a document linking a file that
+> is not there is a real finding.
 
 ## What is added, and what is not
 
@@ -256,8 +283,8 @@ inference over the graph changing, not the graph being rewritten.
 
 **56% of `Doc` sections bind to nothing at all.** Section 2 shows why in miniature: prose that
 explains *why* something exists often names no identifier, and prose that does name one often
-names an ambiguous one. Both causes are real, and **absence is the larger of the two** — 3,325
-mentions against 1,937 — though the smaller one is the more interesting, because those 1,937
+names an ambiguous one. Both causes are real, and **absence is the larger of the two** — 3,350
+mentions against 1,962 — though the smaller one is the more interesting, because those 1,962
 found the code and were refused.
 
 Closing it needs semantic matching — meaning rather than string equality — which means a model,

--- a/src/orchestrator/pkg/docs.py
+++ b/src/orchestrator/pkg/docs.py
@@ -30,8 +30,68 @@ from orchestrator.pkg.facts import FactBatch, Node
 
 _BACKTICK_RE = re.compile(r"`([^`\n]{2,120})`")
 _DOTTED_RE = re.compile(r"\b[a-z_]\w*(?:\.[A-Za-z_]\w*){2,}\b")  # a.b.C at least
-# Last segments that mark a URL/domain rather than a code path.
-_URL_TAILS = frozenset({"com", "net", "org", "io", "dev", "ai", "html", "www"})
+# Tails that make a dotted token something other than a symbol path. Domains were the original
+# reason; file extensions were the omission. `compose.dev.yml`, `docs.astral.sh` and
+# `orchestrator.pkg.persistence.md` are dotted, lowercase and multi-segment, so they read as
+# symbol paths, match nothing, and land in the drift list as claims the code failed to support.
+# They are filenames. This list drops 12 of them at extraction; `_can_drift` drops a further 43
+# that arrive backticked. Measured 2026-09-01: **55 fewer drift findings, 1,651 -> 1,596, and
+# zero change to MENTIONS edges** — this is drift precision, not binding coverage.
+#
+# It was investigated as a *binding* defect and is not one. See `test_docs.py` for what the
+# leaf-only fallback in `bind` actually does: on this repository it rescues 76 mentions like
+# `store.find` onto `FactStore.find` and mis-binds no filename at all.
+_URL_TAILS = frozenset(
+    {
+        # domains
+        "com",
+        "net",
+        "org",
+        "io",
+        "dev",
+        "ai",
+        "www",
+        # file extensions — a dotted token ending in one names a FILE, never a symbol
+        "html",
+        "json",
+        "yaml",
+        "yml",
+        "toml",
+        "md",
+        "rst",
+        "txt",
+        "cfg",
+        "ini",
+        "lock",
+        "png",
+        "svg",
+        "jpg",
+        "jpeg",
+        "gif",
+        "pdf",
+        "csv",
+        "tsv",
+        "sh",
+        "bat",
+        "sql",
+        # Source extensions. Measured zero edges either way on this repository; listed
+        # because the rule is identical — `handler.py` names a file. A genuine path
+        # mention takes the FILE branch and resolves against real paths.
+        "py",
+        "ts",
+        "tsx",
+        "js",
+        "jsx",
+        "go",
+        "java",
+        "cs",
+        "c",
+        "h",
+        "cc",
+        "cpp",
+        "rs",
+    }
+)
 _SNAKE_RE = re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b")
 _CAMEL_RE = re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)+\b")
 _IDENT_RE = re.compile(r"[A-Za-z_][\w.]*")
@@ -195,8 +255,14 @@ class DocReconciler:
             # partial dotted tail: "pkg.persistence" ⊂ "orchestrator.pkg.persistence"
             binding.anchor_ids = [ids[0] for tail, ids in self._suffixes.items() if tail.endswith(f".{text}")]
         if not binding.anchor_ids and "." in text:
+            # Last resort: the leaf alone, which throws the qualifier away — this is what
+            # binds `store.find` onto `FactStore.find`, 76 times here. The guard is repeated
+            # rather than left to `extract_mentions` because a BACKTICK mention never passes
+            # through the dotted-token filter, so `` `a.b.json` `` arrives intact. Nothing in
+            # this repository currently reaches it; the asymmetry is the trap, not a live bug.
             leaf = text.rsplit(".", 1)[-1]
-            binding.anchor_ids = list(self._names.get(leaf, []))
+            if leaf.lower() not in _URL_TAILS:
+                binding.anchor_ids = list(self._names.get(leaf, []))
         return binding
 
     def _can_drift(self, mention: DocMention) -> bool:
@@ -205,8 +271,21 @@ class DocReconciler:
         CamelCase prose, ALL-CAPS tokens (env vars/config keys), and single
         plain lowercase words (tool, branch, command names) bind when they
         resolve but never count against the docs.
+
+        So do **filenames the FILE pattern does not recognise**. `md.js`, `graph.html`
+        and `compose.dev.yml` are dotted, lowercase and multi-segment — indistinguishable
+        from a symbol path by shape — and arrived as BACKTICK claims, so the drift list
+        reported 55 of them as prose naming code that does not exist. A *recognised*
+        extension (`README.md`, `src/a/b.py`) is a FILE mention and keeps its disk check:
+        naming a file that is not there is a real finding, and must still drift.
         """
         if mention.kind is MentionKind.CAMEL:
+            return False
+        if (
+            mention.kind is not MentionKind.FILE
+            and "." in mention.text
+            and mention.text.rsplit(".", 1)[-1].lower() in _URL_TAILS
+        ):
             return False
         if _ALL_CAPS_RE.match(mention.text):
             return False

--- a/tests/pkg/test_docs.py
+++ b/tests/pkg/test_docs.py
@@ -140,3 +140,46 @@ def test_file_mentions_bind_against_repo_root(tmp_path: Path) -> None:
     drifted = {f.mention for f in drift}
     assert "README.md" not in drifted  # exists on disk → bound
     assert "MISSING.md" in drifted  # doc references a file that isn't there
+
+
+# ---- a dotted filename is not a symbol path (doc-binding audit, 2026-09-01) --------
+
+
+def test_a_filename_is_not_drift(tmp_path: Path) -> None:
+    """`md.js` is a file, and the drift list was calling it a missing symbol.
+
+    Dotted, lowercase, multi-segment tokens are shaped exactly like symbol paths, so
+    filenames match nothing and arrive as claims the prose made and the code failed to
+    support. Measured 2026-09-01: 55 of them, against zero `MENTIONS` edges either way —
+    drift precision, not binding coverage.
+    """
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "m.py").write_text("X = 1\n", encoding="utf-8")
+    rec = DocReconciler(RepoCodeExtractor().extract(repo), repo_root=repo)
+    page = DocPage(
+        title="x",
+        text="Rendered by `md.js` and `graph.html`, brought up with compose.dev.yml.",
+    )
+    _bindings, drift = rec.reconcile([page])
+    assert [d.mention for d in drift] == []
+
+
+def test_the_leaf_only_fallback_still_rescues_a_qualified_name(tmp_path: Path) -> None:
+    """Prose writes `store.find`; the symbol is `FactStore.find`. That binding is deliberate.
+
+    `bind`'s last resort matches the final segment alone, which looks reckless enough to
+    delete on sight. It was audited on 2026-09-01: it rescues 76 mentions on this repository
+    and mis-binds no filename. This pins it so the audit does not have to be repeated.
+    """
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "m.py").write_text("class FactStore:\n    def find(self):\n        return 1\n", encoding="utf-8")
+    rec = DocReconciler(RepoCodeExtractor().extract(repo), repo_root=repo)
+    page = DocPage(title="x", text="Call `store.find`.")
+    (mention,) = [m for m in extract_mentions(page) if m.text == "store.find"]
+    assert rec.bind(mention, base_dir="").anchor_ids == ["py:m.FactStore.find"]


### PR DESCRIPTION
## What this is

The doc-binding gap, investigated. **The number that started the investigation did not survive being measured properly**, and the defect turned out to be one layer over from where it was suspected.

## The suspicion, and why it was wrong

`DocReconciler.bind`'s last resort, when a dotted mention matches no id tail, matches its **final segment alone** — throwing the qualifier away. With exactly one symbol named `json` in this repository, that reads as every `.json` filename binding to `DummyResponse.json`, a test double's method.

Measured, the fallback:

- rescues **76 mentions** onto a single correct anchor — `store.find` → `FactStore.find`, `Budget.max_replan_count`, `CapabilityResult.content_type`
- makes 166 ambiguous, and therefore skipped
- mis-binds **no filename at all** — a recognised extension makes the mention `FILE`-kind, resolved against the filesystem instead

Two `MENTIONS` edges do point at that method. Neither comes from the fallback: they come from the bare word `` `json` `` in prose binding exactly, which is documented behaviour and a much smaller question.

## The defect that is real

`md.js`, `graph.html` and `compose.dev.yml` are dotted, lowercase and multi-segment — shaped exactly like symbol paths. The FILE pattern does not recognise their extensions, so they arrived as symbol claims and **the drift list reported 58 filenames as prose naming code that does not exist.**

Extensions added to `_URL_TAILS` (12 dropped at extraction) and checked in `_can_drift` (the rest, which arrive backticked and bypass the dotted-token filter).

| | before | after |
|---|---|---|
| drift findings | 1,658 | **1,600** |
| `symbolish_drift` (scoreboard) | 913 | **906** |
| `MENTIONS` edges | 2,453 | 2,453 — **the same (source, target) set** |
| binding buckets | — | three identical; *nothing at all* −12 |

A naming asymmetry, not a coverage gap. `README.md` and `src/a/b.py` keep their disk check — a document linking a file that is not there is a real finding, and an earlier, blunter version of this filter broke exactly that test.

## Cross-checked

Every claim above re-measured independently rather than asserted:

- **0 drift findings added** — nothing legitimate was lost
- edge **sets** compared, not counts: 0 lost, 0 gained
- **20 of the 58 removed tokens name a file that exists in this repo** (`md.js` ×11, `schema.sql`, `uv.lock`, `setup.cfg`, `main.go`), which settles what they are; most of the rest are illustrative filenames in examples

**Four are removed for the wrong reason and are named as such in the walkthrough:** `javax.ws.rs` and `jakarta.ws.rs` are Java *package* prefixes and `a.b.C` is a placeholder from a regex comment — they match because `rs` and `c` are also file extensions. The outcome is right (none is this project's code) but a package path colliding with an extension is a real limit of a shape-based rule.

## Tests

- `test_a_filename_is_not_drift` — **verified to fail against `HEAD~1`'s source**, not merely to pass now
- `test_the_leaf_only_fallback_still_rescues_a_qualified_name` — passes both ways by design: it is a characterization test pinning a rescue that looks reckless enough to delete on sight and is load-bearing 76 times

An earlier pair of tests written for this change passed both ways, which is what first exposed that the suspected defect did not exist. They were deleted rather than kept as decoration — the trap from #285.

## Numbers

The audit box quoted two figures that nothing derived. `binding: drift findings` joins the trended claims, so all eight binding numbers now re-derive and match. They moved three times while writing, because the document describing the measurement contains backticked symbols and so changes the measurement — which is why these are `[trend]` and not gated.

`scripts/state-numbers.py --check`, `mypy src tests`, `ruff format --check .`, `pkg accuracy --check` and the suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)