### PR TITLE
docs(specs): update the binding walkthrough for 3.27.0, and derive its last loose number

### DIFF
--- a/docs/specs/doc-binding-walkthrough.md
+++ b/docs/specs/doc-binding-walkthrough.md
@@ -1,7 +1,8 @@
 # How a document binds to the graph — a walkthrough
 
-**Written 2026-09-01 against 3.26.1.** Every number here was measured on this repository the day
-it was written.
+**Written 2026-09-01 against 3.26.1; the fix it describes shipped in 3.27.0.** Every number here
+is measured on this repository, and `scripts/state-numbers.py` re-derives nine of them — it prints
+a `[trend]` line when this page has aged rather than failing the build.
 
 Two sections. **The first is the whole mechanism in six steps** — read that if you want to know
 what happens and when. **The second walks one real page through every one of those steps**, with
@@ -118,7 +119,7 @@ precedence:
 | `CAMEL` | `DocReconciler` |
 | `FILE` | `src/orchestrator/pkg/store.py` |
 
-Our section yields **12 mentions**. Repository-wide: **9,190**.
+Our section yields **12 mentions**. Repository-wide: **9,192**.
 
 One rule worth knowing: a bare CamelCase word — "GitHub", "Python" — binds if it happens to
 resolve, but **never counts as drift**. Prose capitalisation is not a code claim.
@@ -167,10 +168,10 @@ Repository-wide, every mention lands in exactly one of four buckets:
 | | count | share |
 |---|---|---|
 | **one symbol anchor → `MENTIONS` edge** | **2,481** | 27% |
-| more than one symbol anchor → skipped | 1,965 | 21% |
-| resolved to a **file**, no symbol | 1,377 | 15% |
+| more than one symbol anchor → skipped | 1,966 | 21% |
+| resolved to a **file**, no symbol | 1,378 | 15% |
 | nothing at all | 3,367 | 37% |
-| **total mentions** | **9,190** | |
+| **total mentions** | **9,192** | |
 
 2,453 edges are drawn from those 2,481 — the 28 difference is de-duplication, where one section
 names the same symbol twice.
@@ -201,14 +202,14 @@ names the same symbol twice.
 > The conclusion followed the bad number. It read *"ambiguity, not absence, is the larger
 > loss"*, and that is **false**: absence is 3,343 against ambiguity's 1,959.
 
-**What is true, and still worth saying:** ambiguity is not a rounding error. **1,965 mentions
+**What is true, and still worth saying:** ambiguity is not a rounding error. **1,966 mentions
 found real code and were deliberately dropped** for naming more than one thing — 29% of
 everything that fails to become an edge. That is qualitatively different from the 3,367 that
 found nothing, and it matters for how the gap gets closed: reducing it means answering *which*
 symbol was meant, not *whether* one exists. Doing that by proximity, or by "the most likely", is
 precisely the guess this tier does not make.
 
-The 1,377 file-only mentions are a third category and mostly correct behaviour: prose citing
+The 1,378 file-only mentions are a third category and mostly correct behaviour: prose citing
 `src/orchestrator/pkg/store.py` is naming a path, not a symbol, and there is no symbol edge to
 draw.
 
@@ -232,7 +233,8 @@ population cannot bind by construction — parameters, module constants, string 
 event names and builtins have no node kind. The number stands as an **upper bound** on drift,
 never as a defect count.
 
-> **The leaf-only fallback was audited on 2026-09-01 and cleared.** `bind`'s last resort, when a
+> **The leaf-only fallback was audited on 2026-09-01, cleared, and the real defect fixed in
+> 3.27.0.** `bind`'s last resort, when a
 > dotted mention matches no id tail, is to match its **final segment alone** — throwing the
 > qualifier away. That looks like a fabrication waiting to happen: with exactly one symbol named
 > `json` in this repository, every `.json` filename could bind to `DummyResponse.json`, a test
@@ -254,7 +256,8 @@ never as a defect count.
 > `graph.html` and `compose.dev.yml` are dotted, lowercase and multi-segment, so they are shaped
 > exactly like symbol paths; the FILE pattern does not recognise their extensions, so they arrived
 > as symbol claims and the drift list reported **58 filenames as prose naming code that does not
-> exist**. Extensions were added to `_URL_TAILS` and checked in `_can_drift`. Drift went
+> exist**. Extensions were added to `_URL_TAILS` and checked in `_can_drift` — shipped in
+> **3.27.0**. Drift went
 > **1,661 → 1,603** and **not one `MENTIONS` edge changed** — the same 2,453 (source, target)
 > pairs before and after, and the only binding bucket that moves is *nothing at all*, by the 12
 > filenames that stop being mentions at all. A naming asymmetry, not a coverage gap.
@@ -292,13 +295,32 @@ inference over the graph changing, not the graph being rewritten.
 
 ## The open gap
 
-**56% of `Doc` sections bind to nothing at all.** Section 2 shows why in miniature: prose that
-explains *why* something exists often names no identifier, and prose that does name one often
-names an ambiguous one. Both causes are real, and **absence is the larger of the two** — 3,367
-mentions against 1,965 — though the smaller one is the more interesting, because those 1,965
+**874 of 1,583 `Doc` sections — 55% — bind to nothing at all.** Section 2 shows why in miniature:
+prose that explains *why* something exists often names no identifier, and prose that does name one
+often names an ambiguous one. Both causes are real, and **absence is the larger of the two** —
+3,367 mentions against 1,966 — though the smaller one is the more interesting, because those 1,966
 found the code and were refused.
 
+**Nothing above closed any of it, and that is worth stating plainly.** The 2026-09-01 audit ran at
+this gap and came back with a *drift-precision* fix: 58 filenames that the drift list was calling
+missing code. Real, worth having, and **it moved this number by zero** — not one `MENTIONS` edge
+changed. The investigation that goes looking for coverage and returns with precision has not
+failed, but it has not made progress on the thing it set out to measure either.
+
 Closing it needs semantic matching — meaning rather than string equality — which means a model,
-which collides with the determinism that makes `understand --check` a gate at all. Any fix
-belongs in a clearly-labelled second tier, measured and declared the way GraphIR Phase 2b's
-design promotion was, and never smuggled into the deterministic path.
+which collides with the determinism that makes `understand --check` a gate at all. Any fix belongs
+in a clearly-labelled second tier, measured and declared the way GraphIR Phase 2b's design
+promotion was, and never smuggled into the deterministic path.
+
+**What would count as progress**, in the order the evidence supports:
+
+1. **Answer *which* symbol was meant for the 1,966 ambiguous mentions.** They found real code and
+   were refused; the anchor set is already computed. This is the tractable half, and it is the
+   half a deterministic rule might still reach — a mention in a document that already binds to
+   one module is likelier to mean that module's symbol.
+2. **Characterise the 3,367 that found nothing** before trying to bind them. About a tenth cannot
+   bind by construction — parameters, module constants, string literals, log event names,
+   builtins have no node kind — and that share should be a number, not an estimate, before any
+   model is pointed at the remainder.
+3. **Only then a second tier.** Measured against these figures, declared as non-deterministic, and
+   kept out of the path `understand --check` gates.

--- a/scripts/state-numbers.py
+++ b/scripts/state-numbers.py
@@ -114,6 +114,15 @@ def _binding() -> dict[str, int]:
         # the two figures beside it went stale within the hour they were written — the same
         # way every hand-carried number in this repository has.
         "drift": len(drift),
+        # The gap section's headline. It was written as "56%" and had drifted to 55.2% by the
+        # time anyone re-measured — a section-level count, so it moves whenever a heading is
+        # added, not only when binding changes.
+        "unbound_sections": sum(
+            1
+            for n in linked.nodes
+            if n.kind is NodeKind.DOC
+            and n.id not in {e.src for e in linked.edges if e.kind is EdgeKind.MENTIONS}
+        ),
     }
     return _BINDING
 
@@ -276,6 +285,13 @@ CLAIMS: tuple[Claim, ...] = (
         WALKTHROUGH,
         re.compile(r"\*\*[\d,]+ → ([\d,]+)\*\* and \*\*not one"),
         lambda: _binding()["drift"],
+        gated=False,
+    ),
+    Claim(
+        "binding: unbound sections",
+        WALKTHROUGH,
+        re.compile(r"\*\*([\d,]+) of [\d,]+ `Doc` sections"),
+        lambda: _binding()["unbound_sections"],
         gated=False,
     ),
     Claim(


### PR DESCRIPTION
## What changed

The walkthrough described a fix as though it were pending. **It shipped in 3.27.0**, and the header still said "against 3.26.1".

## The gap section's headline had drifted

It read **"56% of `Doc` sections bind to nothing"**. Re-measured: **874 of 1,583 — 55.2%**.

That is the last figure on this page nothing derived. It is a *section*-level count, so it moves whenever a heading is added anywhere in the repository, not only when binding changes — precisely the shape of number that ages silently. `binding: unbound sections` joins the trended claims. **Nine of this page's figures now re-derive**, and none fails the build.

## The gap section says something it did not say before

**The audit moved this number by zero.**

It went looking for coverage and came back with a drift-precision fix — 58 filenames the drift list was calling missing code. Real, worth having, and not one `MENTIONS` edge changed. An investigation that returns precision when it set out to measure coverage has not failed, but it has not made progress on the thing it set out to measure either, and the page should not read as though it had.

Added, in the order the evidence supports:

1. **Resolve the 1,966 ambiguous mentions first** — they found real code and were refused, and the anchor set is already computed. The tractable half, and the half a deterministic rule might still reach.
2. **Count what share of the 3,367 that found nothing *cannot* bind by construction** — parameters, module constants, string literals, log event names, builtins have no node kind. That should be a number before any model is pointed at the remainder, not the current estimate of "about a tenth".
3. **Only then a declared second tier**, measured against these figures and kept out of the path `understand --check` gates.

The gap stays the last section on the page.

## Gate

`state-numbers.py --check` (12 gated, 9 trended), `ruff format --check .`, `mypy src tests`, `test_state_numbers.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)