### PR TITLE
docs(specs): scope binding a document to the module it cites

### DIFF
--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -1,7 +1,7 @@
 # Spec index — every design record, and where it stands
 
 **Generated 2026-08-15 against 3.18.1; refreshed 2026-08-21 for the completed GraphIR
-programme; recounted 2026-09-01 at 3.27.0.** `docs/specs/` holds **81** markdown files —
+programme; recounted 2026-09-01 at 3.27.0.** `docs/specs/` holds **82** markdown files —
 **78 specs** plus three navigation documents ([README](README.md), this index,
 [STATE-OF-SPINE](STATE-OF-SPINE.md)) — with 6 archived and 10 build documents. The count read
 *63* until 2026-08-21, and **five specs were not listed at all**, including this file's own
@@ -10,7 +10,7 @@ things is the failure it was built to catch, so the count is now stated as a der
 can re-run:
 
 ```
-ls docs/specs/*.md | wc -l          # 81
+ls docs/specs/*.md | wc -l          # 82
 ```
 
 **It rotted anyway.** The line read *70* from 2026-08-21 until 2026-08-28 while the directory
@@ -129,6 +129,7 @@ Analysis, comparisons, test plans and assets. No completion state applies.
 | [codegen-model-comparison-results](codegen-model-comparison-results.md) · [external-repo-grounding-results](external-repo-grounding-results.md) | The two measurements behind the matrix's ⁴ rows — 200 and 60 ticket-runs (2026-08-16) |
 | [parsing-and-the-pkg](parsing-and-the-pkg.md) | How source becomes graph facts, front-end by front-end (2026-08-16) |
 | [document-ingestion-reference](document-ingestion-reference.md) | How *prose* becomes graph facts, format by format — the five stages, per-format behaviour, bounds, and the measured cost of losing headings (2026-08-29) |
+| [doc-file-binding](doc-file-binding.md) | The first deterministic move against the 55% of `Doc` sections that bind to nothing: a cited path owns exactly one `Module`, and the edge was being discarded. Measures what it reaches — 108 sections — and, more usefully, what nothing deterministic reaches (2026-09-01) |
 | [doc-binding-walkthrough](doc-binding-walkthrough.md) | How prose becomes a `MENTIONS` edge, in six steps and then traced through one real page with the actual anchor counts — the mechanism, not the format-by-format reference beside it (2026-09-01) |
 | [ticket-to-landing-sites](ticket-to-landing-sites.md) | How a ticket's words become `file:line` landing sites — tokenising, scoring, and what the result is bound to (2026-08-25) |
 | [competitive-landscape](competitive-landscape.md) | Competitive **narrative and strategy** (2026-08-21). Its duplicate scored matrix was removed — see `capability-matrix.md` |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -3,7 +3,7 @@
 **The one document to read.** Verified against source on **2026-09-01**, at the 3.27.0 release
 cut. Every number below was re-measured that day.
 
-> **Why this exists.** `docs/specs/` holds **81** markdown files — **78 specs** plus this
+> **Why this exists.** `docs/specs/` holds **82** markdown files — **79 specs** plus this
 > page, [`README`](README.md) and [`SPEC-INDEX`](SPEC-INDEX.md) — with 6 archived, 10 build
 > documents, and 17 root-level user documents.
 > Answering "where do we stand?" required opening five of them and reconciling three that

--- a/docs/specs/doc-binding-walkthrough.md
+++ b/docs/specs/doc-binding-walkthrough.md
@@ -89,7 +89,7 @@ Each reader converts its format into **markdown-shaped text**: HTML's `<h1>`, Wo
 style and a spreadsheet's sheet name all become an ATX `#` heading. Everything downstream reads
 that one shape and never learns which format it came from.
 
-The splitter then cuts on headings. **Measured here: 1,583 `Doc` nodes** across the repository —
+The splitter then cuts on headings. **Measured here: 1,592 `Doc` nodes** across the repository —
 sections, not files.
 
 Our subject becomes:
@@ -119,7 +119,7 @@ precedence:
 | `CAMEL` | `DocReconciler` |
 | `FILE` | `src/orchestrator/pkg/store.py` |
 
-Our section yields **12 mentions**. Repository-wide: **9,192**.
+Our section yields **12 mentions**. Repository-wide: **9,218**.
 
 One rule worth knowing: a bare CamelCase word — "GitHub", "Python" — binds if it happens to
 resolve, but **never counts as drift**. Prose capitalisation is not a code claim.
@@ -167,13 +167,13 @@ Repository-wide, every mention lands in exactly one of four buckets:
 
 | | count | share |
 |---|---|---|
-| **one symbol anchor → `MENTIONS` edge** | **2,481** | 27% |
-| more than one symbol anchor → skipped | 1,966 | 21% |
-| resolved to a **file**, no symbol | 1,378 | 15% |
-| nothing at all | 3,367 | 37% |
-| **total mentions** | **9,192** | |
+| **one symbol anchor → `MENTIONS` edge** | **2,493** | 27% |
+| more than one symbol anchor → skipped | 1,974 | 21% |
+| resolved to a **file**, no symbol | 1,382 | 15% |
+| nothing at all | 3,369 | 37% |
+| **total mentions** | **9,218** | |
 
-2,453 edges are drawn from those 2,481 — the 28 difference is de-duplication, where one section
+2,465 edges are drawn from those 2,493 — the 28 difference is de-duplication, where one section
 names the same symbol twice.
 
 > **These seven figures are derived, and reported rather than gated.**
@@ -202,20 +202,20 @@ names the same symbol twice.
 > The conclusion followed the bad number. It read *"ambiguity, not absence, is the larger
 > loss"*, and that is **false**: absence is 3,343 against ambiguity's 1,959.
 
-**What is true, and still worth saying:** ambiguity is not a rounding error. **1,966 mentions
+**What is true, and still worth saying:** ambiguity is not a rounding error. **1,974 mentions
 found real code and were deliberately dropped** for naming more than one thing — 29% of
-everything that fails to become an edge. That is qualitatively different from the 3,367 that
+everything that fails to become an edge. That is qualitatively different from the 3,369 that
 found nothing, and it matters for how the gap gets closed: reducing it means answering *which*
 symbol was meant, not *whether* one exists. Doing that by proximity, or by "the most likely", is
 precisely the guess this tier does not make.
 
-The 1,378 file-only mentions are a third category and mostly correct behaviour: prose citing
+The 1,382 file-only mentions are a third category and mostly correct behaviour: prose citing
 `src/orchestrator/pkg/store.py` is naming a path, not a symbol, and there is no symbol edge to
 draw.
 
 ## Step 6 — drift, in detail
 
-Of the 3,367 mentions that matched nothing, most are prose: ordinary words in backticks, URLs,
+Of the 3,369 mentions that matched nothing, most are prose: ordinary words in backticks, URLs,
 filenames. `symbolish_drift` narrows to identifier-shaped claims, leaving **about 900** on this
 repository. Examples, all real:
 
@@ -258,7 +258,7 @@ never as a defect count.
 > as symbol claims and the drift list reported **58 filenames as prose naming code that does not
 > exist**. Extensions were added to `_URL_TAILS` and checked in `_can_drift` — shipped in
 > **3.27.0**. Drift went
-> **1,661 → 1,603** and **not one `MENTIONS` edge changed** — the same 2,453 (source, target)
+> **1,662 → 1,604** and **not one `MENTIONS` edge changed** — the same 2,465 (source, target)
 > pairs before and after, and the only binding bucket that moves is *nothing at all*, by the 12
 > filenames that stop being mentions at all. A naming asymmetry, not a coverage gap.
 > `README.md` and `src/a/b.py` keep their disk check, because a document linking a file that is
@@ -295,10 +295,10 @@ inference over the graph changing, not the graph being rewritten.
 
 ## The open gap
 
-**874 of 1,583 `Doc` sections — 55% — bind to nothing at all.** Section 2 shows why in miniature:
+**876 of 1,592 `Doc` sections — 55% — bind to nothing at all.** Section 2 shows why in miniature:
 prose that explains *why* something exists often names no identifier, and prose that does name one
 often names an ambiguous one. Both causes are real, and **absence is the larger of the two** —
-3,367 mentions against 1,966 — though the smaller one is the more interesting, because those 1,966
+3,369 mentions against 1,974 — though the smaller one is the more interesting, because those 1,974
 found the code and were refused.
 
 **Nothing above closed any of it, and that is worth stating plainly.** The 2026-09-01 audit ran at
@@ -314,11 +314,11 @@ promotion was, and never smuggled into the deterministic path.
 
 **What would count as progress**, in the order the evidence supports:
 
-1. **Answer *which* symbol was meant for the 1,966 ambiguous mentions.** They found real code and
+1. **Answer *which* symbol was meant for the 1,974 ambiguous mentions.** They found real code and
    were refused; the anchor set is already computed. This is the tractable half, and it is the
    half a deterministic rule might still reach — a mention in a document that already binds to
    one module is likelier to mean that module's symbol.
-2. **Characterise the 3,367 that found nothing** before trying to bind them. About a tenth cannot
+2. **Characterise the 3,369 that found nothing** before trying to bind them. About a tenth cannot
    bind by construction — parameters, module constants, string literals, log event names,
    builtins have no node kind — and that share should be a number, not an estimate, before any
    model is pointed at the remainder.

--- a/docs/specs/doc-file-binding.md
+++ b/docs/specs/doc-file-binding.md
@@ -1,0 +1,129 @@
+# Binding a document to the module it cites
+
+**Status:** **Scoped 2026-09-01 against 3.27.0.** Not built. Approved to build as Option A
+(§4).
+**Owner:** _unassigned_
+
+`docs/specs/doc-binding-walkthrough.md` closes on a number: **55% of `Doc` sections bind to
+nothing at all.** This spec is the first deterministic move against it, and — measured — very
+nearly the only one.
+
+---
+
+## 1. The fact that is thrown away
+
+A section citing `src/orchestrator/pkg/store.py` resolves that path against the repository,
+finds it, and then draws **no edge**. `DocReconciler.bind` records the hit in `anchor_files`;
+`link_docs` emits an edge only for `anchor_ids`. The path is matched and then discarded.
+
+That path maps to exactly one `Module` node — `py:orchestrator.pkg.store`. **This is not a
+guess and not a heuristic**: it is the same provenance the extractor already wrote. The
+document names the module; the graph declines to say so.
+
+The walkthrough currently defends this:
+
+> The file-only mentions are a third category and mostly correct behaviour: prose citing
+> `src/orchestrator/pkg/store.py` is naming a path, not a symbol, and there is no symbol edge
+> to draw.
+
+**That reasoning is wrong.** A `Module` *is* a node. The premise — that a path names nothing in
+the graph — is false for every path the extractor produced a module from.
+
+## 2. Measured, on this repository at 3.27.0
+
+> Measured on `develop` **before this document existed**. Writing a spec about the binding
+> figures changes the binding figures — this page is itself ingested, and its own backticked
+> symbols become mentions. The live values are re-derived by `scripts/state-numbers.py` and
+> carried in the walkthrough; these are the ones the decision in §4 was actually made on.
+
+| File-only mentions | | |
+|---|---|---|
+| map to **exactly one** `Module` | **938** | become edges |
+| map to **more than one** | **0** | would be skipped, same rule as always |
+| map to **no** `Module` | 440 | assets, configs, `.md` — correctly stay unbound |
+| **total** | **1,378** | |
+
+938 mentions collapse to **~926 distinct `(section, module)` edges** after per-section
+de-duplication.
+
+### What it does to the gap
+
+| | before | after |
+|---|---|---|
+| `Doc` sections binding to nothing | **874** | **766** |
+| as a share of all 1,583 sections | 55% | **48%** |
+| `MENTIONS` edges | 2,453 | ~3,379 (**+38%**) |
+
+**The 55% is itself overstated, and this spec is the reason to say so.** Of the 874 unbound
+sections, **367 contain no symbol-shaped mention at all** — a heading, a table of links, a
+paragraph of prose. There is nothing to bind and no failure to fix. The real failure population
+is **507 sections**, and 108 of them are reached here.
+
+## 3. What is *not* reachable, which is the more important half
+
+The walkthrough's "what would count as progress" recommends resolving the 1,966 ambiguous
+mentions first, calling them *"the tractable half, and the half a deterministic rule might still
+reach"*. **Measured 2026-09-01, that is false**, and it is corrected as part of this work:
+
+| Of 507 failing sections | reached by |
+|---|---|
+| 108 | this spec — file → `Module` |
+| **5** | resolving ambiguity, taking every mention whose anchors share one owning module |
+| **0** | using this spec's module bindings as context to disambiguate the rest |
+| **394** | nothing deterministic |
+
+Only **48 of 1,966** ambiguous mentions (2%) have all their candidate anchors in a single owning
+module. The compounding idea — bind the file first, then use that module as context to pick
+among a mention's candidates — sounded right and rescues **nothing**.
+
+**So after this ships the gap is 48%, and no further deterministic rule is known to move it.**
+That is the honest end state, and it should be written down before anyone proposes a model.
+
+## 4. Decision
+
+| | Option | |
+|---|---|---|
+| **A** | **Bind every file-only mention whose path owns exactly one module** | **Chosen.** +926 edges |
+| B | Bind only in sections that would otherwise have no edge | +~150 edges, same 55%→48% |
+| C | Do not bind; redefine the metric | rejected — that is moving the goalposts |
+
+**A, because the fact does not depend on what else the section says.** Under B, whether the
+graph records "this section mentions `orchestrator.pkg.store`" would depend on whether some
+*other* sentence in the same section happened to name a symbol. Two documents making the same
+claim would be recorded differently. That is not a property a source of truth should have.
+
+**The cost is real and is accepted.** `PKGCodegenGrounder._doc_block` attaches a linked
+section's prose to a symbol's source in the codegen context. A section listing thirty file paths
+in a table now attaches to thirty modules, and a 38% rise in `MENTIONS` edges lands on every
+consumer that treats one as a signal — including `insights.py`, where a `MENTIONS` edge counts
+as a *use* and therefore suppresses dead-code findings. **Measure that after, do not assume it.**
+
+## 5. Invariants
+
+- **Exactly one, or nothing.** A path owning two or more modules — C/C++ headers are the case
+  that exists — draws no edge. Same *skip rather than guess* rule that holds `CALLS` precision
+  at 1.00.
+- **No new node or edge kind.** `Doc --MENTIONS--> Module` is the existing shape; only the
+  anchor changes.
+- **Deterministic and model-free.** The mapping is `provenance.file`, already in the graph.
+- **The extractor is not consulted twice.** Resolution reads the batch `DocReconciler` was built
+  from, so binding still cannot be influenced by the documents being bound.
+
+## 6. Non-goals
+
+- **Binding a path to a symbol *inside* the file.** The document named the file; the module is
+  the honest granularity.
+- **Reaching the 394.** They need meaning rather than string equality, which needs a model,
+  which collides with the determinism that makes `understand --check` a gate.
+- **Raising the number by relaxing the one-anchor rule** anywhere else.
+
+## 7. Open questions
+
+1. **Does the 38% edge growth degrade codegen grounding?** `_doc_block` is the consumer most
+   exposed. Unmeasured, and the reason §4 says measure after.
+2. **How many of the 394 cannot bind by construction?** The walkthrough estimates "about a
+   tenth" of drift; nothing has counted it for this population. That number should exist before
+   a second tier is designed, not after.
+3. **Should a file-derived `MENTIONS` edge be distinguishable from a symbol-derived one?** A
+   consumer wanting the higher-precision signal currently cannot tell them apart. Deferred: it
+   changes the edge shape, and nothing has asked for it yet.


### PR DESCRIPTION
Spec first, per D2. **No code in this PR.**

## The fact we already have and throw away

A section citing `src/orchestrator/pkg/store.py` resolves that path, finds it, and draws **no edge**. `bind` records the hit in `anchor_files`; `link_docs` emits only for `anchor_ids`.

That path maps to exactly **one** `Module` node — `py:orchestrator.pkg.store`. Not a guess, not a heuristic: the same provenance the extractor already wrote.

The walkthrough currently defends this — *"naming a path, not a symbol, and there is no symbol edge to draw"*. **A `Module` is a node.** The premise is false for every path the extractor produced a module from.

## Measured

| file-only mentions | | |
|---|---|---|
| → exactly one `Module` | **938** | ~926 distinct edges |
| → more than one | **0** | would be skipped |
| → no `Module` | 440 | assets, configs, `.md` |

| | before | after |
|---|---|---|
| sections binding to nothing | **874** | **766** |
| share of all sections | 55% | **48%** |
| `MENTIONS` edges | 2,453 | ~3,379 (**+38%**) |

**The 55% is overstated, and the spec says so.** 367 of the 874 contain no symbol-shaped mention at all — a heading, a table of links. Nothing to bind, no failure to fix. The real failure population is **507**; 108 are reached here.

## It corrects a recommendation merged yesterday

[#292](https://github.com/synaptixs/spine/pull/292) called the ambiguous mentions *"the tractable half, and the half a deterministic rule might still reach."* **Measured, that is false:**

| Of 507 failing sections | reached by |
|---|---|
| 108 | this spec |
| **5** | resolving ambiguity (only 48 of 1,966 mentions have all anchors in one owning module) |
| **0** | using this spec's bindings as context to disambiguate the rest |
| **394** | nothing deterministic |

The compounding idea — bind the file, then use that module to pick among a mention's candidates — sounded right and rescues nothing. After this ships **the gap is 48% and no further deterministic rule is known**. That end state is written down *before* anyone proposes a model tier.

## Decision A, and its cost

Bind every qualifying file mention, not only those in otherwise-empty sections. Under the narrower option, whether the graph records a claim would depend on whether some *other* sentence nearby named a symbol — two documents making the same claim recorded differently. Not a property a source of truth should have.

**Cost named and accepted:** `PKGCodegenGrounder._doc_block` grounding and `insights.py` dead-code suppression both ride on `MENTIONS`, and a 38% rise lands on them. Measure after; do not assume.

## Note on the figures

§2 records that its numbers were measured **before this document existed** — writing a spec about the binding figures changes them, since the page is itself ingested. The walkthrough's nine trended claims carry the live values and are re-derived here.

`state-numbers.py --check` and `ruff format --check .` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)