### PR TITLE
docs(specs): add a two-page multi-repo walkthrough, and record a defect it found

### DIFF
--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -1,7 +1,7 @@
 # Spec index — every design record, and where it stands
 
 **Generated 2026-08-15 against 3.18.1; refreshed 2026-08-21 for the completed GraphIR
-programme; recounted 2026-09-01 at 3.27.0.** `docs/specs/` holds **82** markdown files —
+programme; recounted 2026-09-01 at 3.27.0.** `docs/specs/` holds **83** markdown files —
 **78 specs** plus three navigation documents ([README](README.md), this index,
 [STATE-OF-SPINE](STATE-OF-SPINE.md)) — with 6 archived and 10 build documents. The count read
 *63* until 2026-08-21, and **five specs were not listed at all**, including this file's own
@@ -10,7 +10,7 @@ things is the failure it was built to catch, so the count is now stated as a der
 can re-run:
 
 ```
-ls docs/specs/*.md | wc -l          # 82
+ls docs/specs/*.md | wc -l          # 83
 ```
 
 **It rotted anyway.** The line read *70* from 2026-08-21 until 2026-08-28 while the directory
@@ -129,6 +129,7 @@ Analysis, comparisons, test plans and assets. No completion state applies.
 | [codegen-model-comparison-results](codegen-model-comparison-results.md) · [external-repo-grounding-results](external-repo-grounding-results.md) | The two measurements behind the matrix's ⁴ rows — 200 and 60 ticket-runs (2026-08-16) |
 | [parsing-and-the-pkg](parsing-and-the-pkg.md) | How source becomes graph facts, front-end by front-end (2026-08-16) |
 | [document-ingestion-reference](document-ingestion-reference.md) | How *prose* becomes graph facts, format by format — the five stages, per-format behaviour, bounds, and the measured cost of losing headings (2026-08-29) |
+| [multi-repo-walkthrough](multi-repo-walkthrough.md) | What happens when you point Spine at three repositories: declare, extract, merge with scoped ids, join across the boundary, read. The mechanism at two pages, beside the roadmap's design record (2026-09-01) |
 | [doc-file-binding](doc-file-binding.md) | The first deterministic move against the 55% of `Doc` sections that bind to nothing: a cited path owns exactly one `Module`, and the edge was being discarded. Measures what it reaches — 108 sections — and, more usefully, what nothing deterministic reaches (2026-09-01) |
 | [doc-binding-walkthrough](doc-binding-walkthrough.md) | How prose becomes a `MENTIONS` edge, in six steps and then traced through one real page with the actual anchor counts — the mechanism, not the format-by-format reference beside it (2026-09-01) |
 | [ticket-to-landing-sites](ticket-to-landing-sites.md) | How a ticket's words become `file:line` landing sites — tokenising, scoring, and what the result is bound to (2026-08-25) |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -3,7 +3,7 @@
 **The one document to read.** Verified against source on **2026-09-01**, at the 3.27.0 release
 cut. Every number below was re-measured that day.
 
-> **Why this exists.** `docs/specs/` holds **82** markdown files — **79 specs** plus this
+> **Why this exists.** `docs/specs/` holds **83** markdown files — **80 specs** plus this
 > page, [`README`](README.md) and [`SPEC-INDEX`](SPEC-INDEX.md) — with 6 archived, 10 build
 > documents, and 17 root-level user documents.
 > Answering "where do we stand?" required opening five of them and reconciling three that

--- a/docs/specs/doc-binding-walkthrough.md
+++ b/docs/specs/doc-binding-walkthrough.md
@@ -89,7 +89,7 @@ Each reader converts its format into **markdown-shaped text**: HTML's `<h1>`, Wo
 style and a spreadsheet's sheet name all become an ATX `#` heading. Everything downstream reads
 that one shape and never learns which format it came from.
 
-The splitter then cuts on headings. **Measured here: 1,592 `Doc` nodes** across the repository —
+The splitter then cuts on headings. **Measured here: 1,601 `Doc` nodes** across the repository —
 sections, not files.
 
 Our subject becomes:
@@ -119,7 +119,7 @@ precedence:
 | `CAMEL` | `DocReconciler` |
 | `FILE` | `src/orchestrator/pkg/store.py` |
 
-Our section yields **12 mentions**. Repository-wide: **9,218**.
+Our section yields **12 mentions**. Repository-wide: **9,246**.
 
 One rule worth knowing: a bare CamelCase word — "GitHub", "Python" — binds if it happens to
 resolve, but **never counts as drift**. Prose capitalisation is not a code claim.
@@ -167,13 +167,13 @@ Repository-wide, every mention lands in exactly one of four buckets:
 
 | | count | share |
 |---|---|---|
-| **one symbol anchor → `MENTIONS` edge** | **2,493** | 27% |
-| more than one symbol anchor → skipped | 1,974 | 21% |
-| resolved to a **file**, no symbol | 1,382 | 15% |
-| nothing at all | 3,369 | 37% |
-| **total mentions** | **9,218** | |
+| **one symbol anchor → `MENTIONS` edge** | **2,497** | 27% |
+| more than one symbol anchor → skipped | 1,982 | 21% |
+| resolved to a **file**, no symbol | 1,383 | 15% |
+| nothing at all | 3,384 | 37% |
+| **total mentions** | **9,246** | |
 
-2,465 edges are drawn from those 2,493 — the 28 difference is de-duplication, where one section
+2,469 edges are drawn from those 2,497 — the 28 difference is de-duplication, where one section
 names the same symbol twice.
 
 > **These seven figures are derived, and reported rather than gated.**
@@ -202,20 +202,20 @@ names the same symbol twice.
 > The conclusion followed the bad number. It read *"ambiguity, not absence, is the larger
 > loss"*, and that is **false**: absence is 3,343 against ambiguity's 1,959.
 
-**What is true, and still worth saying:** ambiguity is not a rounding error. **1,974 mentions
+**What is true, and still worth saying:** ambiguity is not a rounding error. **1,982 mentions
 found real code and were deliberately dropped** for naming more than one thing — 29% of
-everything that fails to become an edge. That is qualitatively different from the 3,369 that
+everything that fails to become an edge. That is qualitatively different from the 3,384 that
 found nothing, and it matters for how the gap gets closed: reducing it means answering *which*
 symbol was meant, not *whether* one exists. Doing that by proximity, or by "the most likely", is
 precisely the guess this tier does not make.
 
-The 1,382 file-only mentions are a third category and mostly correct behaviour: prose citing
+The 1,383 file-only mentions are a third category and mostly correct behaviour: prose citing
 `src/orchestrator/pkg/store.py` is naming a path, not a symbol, and there is no symbol edge to
 draw.
 
 ## Step 6 — drift, in detail
 
-Of the 3,369 mentions that matched nothing, most are prose: ordinary words in backticks, URLs,
+Of the 3,384 mentions that matched nothing, most are prose: ordinary words in backticks, URLs,
 filenames. `symbolish_drift` narrows to identifier-shaped claims, leaving **about 900** on this
 repository. Examples, all real:
 
@@ -258,7 +258,7 @@ never as a defect count.
 > as symbol claims and the drift list reported **58 filenames as prose naming code that does not
 > exist**. Extensions were added to `_URL_TAILS` and checked in `_can_drift` — shipped in
 > **3.27.0**. Drift went
-> **1,662 → 1,604** and **not one `MENTIONS` edge changed** — the same 2,465 (source, target)
+> **1,665 → 1,607** and **not one `MENTIONS` edge changed** — the same 2,469 (source, target)
 > pairs before and after, and the only binding bucket that moves is *nothing at all*, by the 12
 > filenames that stop being mentions at all. A naming asymmetry, not a coverage gap.
 > `README.md` and `src/a/b.py` keep their disk check, because a document linking a file that is
@@ -295,10 +295,10 @@ inference over the graph changing, not the graph being rewritten.
 
 ## The open gap
 
-**876 of 1,592 `Doc` sections — 55% — bind to nothing at all.** Section 2 shows why in miniature:
+**882 of 1,601 `Doc` sections — 55% — bind to nothing at all.** Section 2 shows why in miniature:
 prose that explains *why* something exists often names no identifier, and prose that does name one
 often names an ambiguous one. Both causes are real, and **absence is the larger of the two** —
-3,369 mentions against 1,974 — though the smaller one is the more interesting, because those 1,974
+3,384 mentions against 1,982 — though the smaller one is the more interesting, because those 1,982
 found the code and were refused.
 
 **Nothing above closed any of it, and that is worth stating plainly.** The 2026-09-01 audit ran at
@@ -314,11 +314,11 @@ promotion was, and never smuggled into the deterministic path.
 
 **What would count as progress**, in the order the evidence supports:
 
-1. **Answer *which* symbol was meant for the 1,974 ambiguous mentions.** They found real code and
+1. **Answer *which* symbol was meant for the 1,982 ambiguous mentions.** They found real code and
    were refused; the anchor set is already computed. This is the tractable half, and it is the
    half a deterministic rule might still reach — a mention in a document that already binds to
    one module is likelier to mean that module's symbol.
-2. **Characterise the 3,369 that found nothing** before trying to bind them. About a tenth cannot
+2. **Characterise the 3,384 that found nothing** before trying to bind them. About a tenth cannot
    bind by construction — parameters, module constants, string literals, log event names,
    builtins have no node kind — and that share should be a number, not an estimate, before any
    model is pointed at the remainder.

--- a/docs/specs/multi-repo-walkthrough.md
+++ b/docs/specs/multi-repo-walkthrough.md
@@ -1,0 +1,152 @@
+# Many repositories, one graph — a walkthrough
+
+**Written 2026-09-01 against 3.27.0.** High-level by design: the mechanism, not the design
+record. [`multi-repo-roadmap.md`](multi-repo-roadmap.md) is the *why*, the four phases and the
+identity decision; this page is *what happens when you point Spine at three repositories*.
+
+---
+
+## Executive summary
+
+A product is rarely one repository. The storefront calls the billing service, both read the
+same `orders` table, and a shared library sits under each. Ask any single-repo tool *"what
+breaks if I change this?"* and it answers confidently about a third of the system.
+
+**You declare the repositories; Spine builds one graph across all of them, and draws the edges
+that cross the boundary.** A ticket landing in `web` then reports the dependents it has in
+`billing`. Three commands:
+
+```bash
+orchestrator pkg joins --propose          # read the code, suggest the topology
+orchestrator pkg extract --repos .spine/repos.yaml
+orchestrator investigate "<ticket>" --repos .spine/repos.yaml
+```
+
+**It stays deterministic and model-free**, and it keeps the rule the rest of the graph keeps:
+*where the answer is ambiguous, draw nothing*. Comprehension only — multi-repo **delivery** is
+an explicit non-goal.
+
+---
+
+## Step 1 — You declare the repositories
+
+One file, `.spine/repos.yaml`. Everything Spine knows about your topology, you told it.
+
+```yaml
+repos:                       # required — a key you choose -> a local path
+  web:     ../storefront
+  billing: ../billing-service
+joins:                       # optional — declared, not guessed
+  - kind: http               # http | data | package
+    consumer: web
+    provider: billing
+    base: /v1                # http only
+```
+
+That is the whole format. **Local paths only** — no URL, branch or clone; Spine reads what is
+already on disk. Keys are validated (`^[A-Za-z0-9][A-Za-z0-9._-]*$`) and a bad one is **refused,
+never sanitised**; two keys may not point at the same directory; a path that does not exist is
+an error naming the file.
+
+Repos and joins are both **sorted** before use, so two spellings of the same file produce the
+same graph.
+
+**You do not have to write the `joins:` block yourself.** `pkg joins --propose` reads the code
+and prints one you can paste, with the evidence as comments — and it only proposes a join that
+would actually create edges.
+
+## Step 2 — Each repository is extracted on its own
+
+Every repo goes through the ordinary single-repo path, unchanged, and is cached under its own
+commit. Nothing about extraction knows that other repositories exist.
+
+A repo is only cached when it is a git checkout with a **clean tree**. **Trust is
+whole-graph:** one repository with uncommitted work marks the merged result untrusted, and the
+command says so loudly, because a graph you cannot reproduce should not be quoted.
+
+## Step 3 — The repositories are merged, and identity stays unambiguous
+
+Two repositories can both define `shop.cart.Cart`. Merging without care silently fuses them.
+
+At merge time — and **only** at merge time — every id gains its repo key after the language
+prefix:
+
+```
+py:shop.cart.Cart      ->   py:web@shop.cart.Cart
+                            py:billing@shop.cart.Cart
+```
+
+Two consequences worth knowing:
+
+- **Third-party nodes are deliberately *not* scoped.** `py:httpx` stays `py:httpx`, so when both
+  repositories import it, the graph shows one library with two dependents — which is the true
+  answer.
+- **Single-repo extraction is byte-identical.** Scoping is applied by the merge, so nothing
+  changes for anyone using one repository.
+
+Provenance also gains the repo, so every fact still says where it came from.
+
+## Step 4 — The joiners cross the boundary
+
+Three joiners, all deterministic, and **none of them will join to a repository you did not
+declare.** That is where precision comes from: the topology is your claim, not Spine's guess.
+
+| Join | What it looks at | What it does |
+|---|---|---|
+| **`http`** | calls in `web` that matched **no endpoint in `web`**, against `billing`'s `Endpoint` nodes | draws a `CONSUMES` edge |
+| **`data`** | `Entity` nodes with the same name in both | collapses them into one, repointing reads and writes |
+| **`package`** | a placeholder in `web` for something `billing` actually defines | repoints the import — and the calls through it — at the real node |
+
+**HTTP matching is exact or nothing.** The verb must match, then the route, either literally or
+through a template where `{param}` matches exactly one path segment and never across a `/`. If
+**two** provider routes match, no edge is drawn and the call is recorded as *ambiguous*. This is
+the same *skip rather than guess* rule that holds `CALLS` precision at 1.00 — a fabricated
+cross-repo edge would send a reader into a service that never receives the request.
+
+**What did not join is reported, not hidden.** `pkg joins --check` prints how many candidate
+calls were placed, groups the rest by reason (`no-declared-provider`, `no-matching-endpoint`,
+`ambiguous`), and **flags a declared join that placed nothing** — which is how you find a
+topology entry that has gone stale.
+
+## Step 5 — What reads it
+
+| Surface | What it does with the merged graph |
+|---|---|
+| `investigate --repos` | a ticket's landing sites, plus **"N dependent(s) in other repos"** |
+| `pkg extract --repos` | the merged graph, per-repo cache status, per-edge-kind counts |
+| `pkg joins --check` / `--propose` | placement rate; a pasteable topology block |
+| MCP `blast_radius`, `investigate`, `pkg_joins` | the same answers to an assistant, each carrying whether the graph is reproducible |
+
+## The impact on the PKG
+
+**No new node kinds and no new edge kinds.** `CONSUMES` already existed for client/server pairs
+inside one repository; multi-repo reuses the vocabulary rather than extending it. That is why
+every existing surface reads a merged graph without being taught to.
+
+**Two of the three joiners make the graph *smaller*.** `data` and `package` collapse a
+duplicate — the entity the consumer thought it owned, the placeholder standing in for a real
+module — so the merged graph has fewer nodes than the sum of its parts, and they are the right
+ones. Only `http` adds edges.
+
+**Measured, on the fixtures:** cross-repo `CONSUMES` scores **recall 0.67, precision 1.00**, and
+is gated — a drop fails the build. The one miss is known and named: an f-string route
+(`f"/v1/orders/{order_id}"`) that the client reader cannot resolve to a literal path.
+
+**The number from a real pair of production repositories has not been taken.** 0.67 is against a
+fixture built to be joinable, and should not be quoted as what your repositories will score.
+
+## What this does not do
+
+- **Multi-repo delivery.** Comprehension only; a change still lands in one repository.
+- **Remote repositories.** Local paths on disk.
+- **`--intents` with `--repos`** — refused, because `git blame` is per checkout.
+- **Cross-repo `MENTIONS`**, and repo as a dimension in `state` / `understand` — not built.
+- **A bound on repository count.** There is no cap; nothing has been measured at scale.
+
+> **One known defect, found while writing this page (2026-09-01).** `pkg extract --repos` and
+> `investigate --repos` pass a single extractor for every repository, and the front-end's
+> unmatched-call list survives between repositories. On a cold cache the second repo's join
+> candidates therefore include the first repo's calls, which can place a `CONSUMES` edge whose
+> source node does not exist in the graph. `pkg joins` is unaffected — it builds a fresh
+> extractor per repo — which means **the joins report and the extracted graph can disagree**.
+> Reproduced against 3.27.0; not yet fixed.


### PR DESCRIPTION
`multi-repo-roadmap.md` is 624 lines of design record. Nothing answered the plain question: **what happens when I point Spine at three repositories?**

This is that page — 152 lines, executive summary then five steps, then what it costs the PKG. The mechanism sibling the roadmap did not have, the way `doc-binding-walkthrough.md` sits beside `doc-ingestion-spec.md`.

## Shape

**Executive summary** → **declare** (`.spine/repos.yaml`, and the fact that `pkg joins --propose` writes it for you) → **extract** each repo on its own → **merge** with ids scoped `py:shop.cart.Cart` → `py:web@shop.cart.Cart` → **join** across the boundary → **read**.

## On the PKG, since this is where people assume wrongly

- **No new node kinds and no new edge kinds.** `CONSUMES` already existed for client/server pairs inside one repository. That is why every existing surface reads a merged graph without being taught to.
- **Two of the three joiners make the graph *smaller*.** `data` and `package` collapse a duplicate — the entity the consumer thought it owned, the placeholder standing in for a real module. The merged graph has fewer nodes than the sum of its parts, and they are the right ones. Only `http` adds edges.
- **Third-party nodes are deliberately not scoped**, so `py:httpx` stays one node with two dependents — the true answer.
- Measured: cross-repo `CONSUMES` **recall 0.67, precision 1.00**, gated. Stated with the caveat that it is a fixture built to be joinable, and **the number from real production repositories has not been taken**.

## A defect it found

I checked the mechanism instead of describing it from memory, and reproduced this before writing it down.

`load_or_extract_repos` carries the comment *"A fresh extractor per repo: `unresolved_calls` accumulates on the instance, and one shared extractor would attribute web's calls to billing"* — then writes `per_repo = extractor or RepoCodeExtractor()`, reusing the caller's instance. **Both `pkg extract --repos` and `investigate --repos` pass one.**

The per-iteration `unresolved_calls.clear()` clears `RepoCodeExtractor`'s own list, but the front-end's survives: front-ends are built once in `__init__`, and `ClientState.clear()` preserves `unmatched` deliberately.

Reproduced:

```
after repo A (web)     : ['/v1/orders']
after repo B (billing) : ['/v1/orders']   <-- billing makes NO http calls
```

On a cold cache this lets `link_joins` place a `CONSUMES` edge whose source id is scoped to a repository the caller does not live in — **a node that does not exist**, which is the fabricated-edge class this graph is built to refuse. `pkg joins` is unaffected (fresh extractor per repo), so **the joins report and the extracted graph can disagree**.

**Recorded in the page's limits, not fixed here.** The fix wants a regression test and a corpus case, not a docs commit.

## Gate

`state-numbers.py --check` (11 gated, 9 trended — all nine re-derived and converged), `ruff format --check .`, `check-mermaid`. Spec count 82 → 83, indexed in `SPEC-INDEX.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)