### PR TITLE
fix: stop the multi-repo call leak, bind cited paths to their module, close the gate gap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,19 @@ maintainer opens a `develop → main` release PR, which requires a code-owner re
 and a passing `security scan` check before it merges. Each `main` release gets
 published release notes.
 
+**Three things trip a promotion PR, and all three have.** Budget for them:
+
+- **Its workflow runs land in `action_required` and must be approved by hand.** The head of a
+  promotion PR is usually the `chore(episteme)` bot commit that lands after the release PR
+  merges, and runs triggered by a bot are held. Nothing is wrong; approve them.
+- **Any commit to `develop` dismisses a standing approval**, because the ruleset dismisses
+  stale reviews on push — and the episteme bot commits after *every* merge. Approve and merge
+  back to back; anything landing in between restarts the cycle.
+- **An unresolved review thread blocks the merge**, including a Code-scanning comment at
+  `Note` severity. The ruleset sets `required_review_thread_resolution`, which does not appear
+  in `reviewDecision` — so the API reports reviews and checks as satisfied while the merge
+  stays blocked. Resolve the thread.
+
 For larger features, the core team often develops them ahead of time and publishes
 them on a release cadence — so opening an issue first avoids duplicated effort.
 
@@ -34,9 +47,16 @@ them on a release cadence — so opening an issue first avoids duplicated effort
    ```bash
    mypy src tests
    ruff format --check .
-   python scripts/render_architecture_svg.py --check   # the diagram's numbers come from source
+   python scripts/render_architecture_svg.py --check        # the diagram stamps the version
+   python scripts/render_knowledge_foundation_svg.py --check
+   python scripts/matrix-count.py --check
+   python scripts/state-numbers.py --check                  # claims re-derived from source
    uv run orchestrator pkg accuracy --check
    ```
+   **The four `--check` scripts are generated-artifact gates and CI runs every one of them.**
+   They are listed together because running only the first is how a release PR failed on a
+   diagram nobody had re-rendered: `mypy`, `ruff` and the tests were all green, and the version
+   the picture claims comes from `pyproject.toml`. If you bump a version, re-run all four.
    That last one is the **accuracy gate**: it re-measures the graph and fails if a *gated*
    number has dropped. Only metrics scored against the committed fixtures in `corpus/` are
    gated strictly, plus per-file parity as a one-way ratchet. The invention count is recorded

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **57** | `grep -c '\.command(' src/orchestrator/cli.py` |
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,864** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,869** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/doc-binding-walkthrough.md
+++ b/docs/specs/doc-binding-walkthrough.md
@@ -119,7 +119,7 @@ precedence:
 | `CAMEL` | `DocReconciler` |
 | `FILE` | `src/orchestrator/pkg/store.py` |
 
-Our section yields **12 mentions**. Repository-wide: **9,246**.
+Our section yields **12 mentions**. Repository-wide: **9,247**.
 
 One rule worth knowing: a bare CamelCase word — "GitHub", "Python" — binds if it happens to
 resolve, but **never counts as drift**. Prose capitalisation is not a code claim.
@@ -167,13 +167,13 @@ Repository-wide, every mention lands in exactly one of four buckets:
 
 | | count | share |
 |---|---|---|
-| **one symbol anchor → `MENTIONS` edge** | **2,497** | 27% |
+| **one symbol anchor → `MENTIONS` edge** | **3,036** | 33% |
 | more than one symbol anchor → skipped | 1,982 | 21% |
-| resolved to a **file**, no symbol | 1,383 | 15% |
+| resolved to a **file**, no symbol | 845 | 9% |
 | nothing at all | 3,384 | 37% |
-| **total mentions** | **9,246** | |
+| **total mentions** | **9,247** | |
 
-2,469 edges are drawn from those 2,497 — the 28 difference is de-duplication, where one section
+3,003 edges are drawn from those 3,036 — the 33 difference is de-duplication, where one section
 names the same symbol twice.
 
 > **These seven figures are derived, and reported rather than gated.**
@@ -209,9 +209,18 @@ found nothing, and it matters for how the gap gets closed: reducing it means ans
 symbol was meant, not *whether* one exists. Doing that by proximity, or by "the most likely", is
 precisely the guess this tier does not make.
 
-The 1,383 file-only mentions are a third category and mostly correct behaviour: prose citing
-`src/orchestrator/pkg/store.py` is naming a path, not a symbol, and there is no symbol edge to
-draw.
+> **This paragraph used to be wrong, and the correction shipped as a change.** It read: *"prose
+> citing `src/orchestrator/pkg/store.py` is naming a path, not a symbol, and there is no symbol
+> edge to draw."* **A `Module` is a node.** The path maps to the module the extractor built from
+> it, by its own provenance — so there was an exact, deterministic edge to draw, and 941 of them
+> were being discarded. Fixed 2026-09-02 per [`doc-file-binding.md`](doc-file-binding.md): a
+> cited path binds to its module when the text matches **exactly one file** and **exactly one
+> module** owns it — 534 edges, and 55 sections that bound to nothing now bind.
+
+The 845 file-only mentions that remain are of two kinds: those with no module to name at
+all — images, config files, other documents — and those whose text matches **more than one**
+file, which is ambiguous about *which file* before it is ambiguous about which module. Both
+are correctly unbound.
 
 ## Step 6 — drift, in detail
 
@@ -295,7 +304,7 @@ inference over the graph changing, not the graph being rewritten.
 
 ## The open gap
 
-**882 of 1,601 `Doc` sections — 55% — bind to nothing at all.** Section 2 shows why in miniature:
+**827 of 1,601 `Doc` sections — 52% — bind to nothing at all.** Section 2 shows why in miniature:
 prose that explains *why* something exists often names no identifier, and prose that does name one
 often names an ambiguous one. Both causes are real, and **absence is the larger of the two** —
 3,384 mentions against 1,982 — though the smaller one is the more interesting, because those 1,982
@@ -314,10 +323,12 @@ promotion was, and never smuggled into the deterministic path.
 
 **What would count as progress**, in the order the evidence supports:
 
-1. **Answer *which* symbol was meant for the 1,982 ambiguous mentions.** They found real code and
-   were refused; the anchor set is already computed. This is the tractable half, and it is the
-   half a deterministic rule might still reach — a mention in a document that already binds to
-   one module is likelier to mean that module's symbol.
+1. ~~**Answer *which* symbol was meant for the ambiguous mentions** — "the tractable half, and
+   the half a deterministic rule might still reach."~~ **Measured 2026-09-02 and withdrawn.**
+   Only **48 of 1,982** ambiguous mentions (2%) have every candidate anchor in one owning
+   module, which rescues **5 sections**. And the compounding idea in that sentence — bind the
+   file first, then use its module to pick among a mention's candidates — rescues **0**. It
+   sounded right, cost nothing to check, and was wrong.
 2. **Characterise the 3,384 that found nothing** before trying to bind them. About a tenth cannot
    bind by construction — parameters, module constants, string literals, log event names,
    builtins have no node kind — and that share should be a number, not an estimate, before any

--- a/docs/specs/doc-file-binding.md
+++ b/docs/specs/doc-file-binding.md
@@ -1,7 +1,7 @@
 # Binding a document to the module it cites
 
-**Status:** **Scoped 2026-09-01 against 3.27.0.** Not built. Approved to build as Option A
-(§4).
+**Status:** **Scoped 2026-09-01, built 2026-09-02 as Option A (§4).** The build changed the
+numbers this spec predicted — see §2.1, which is kept rather than corrected in place.
 **Owner:** _unassigned_
 
 `docs/specs/doc-binding-walkthrough.md` closes on a number: **55% of `Doc` sections bind to
@@ -45,6 +45,31 @@ the graph — is false for every path the extractor produced a module from.
 
 938 mentions collapse to **~926 distinct `(section, module)` edges** after per-section
 de-duplication.
+
+### 2.1 — What was built, and why the prediction above was wrong
+
+**Predicted ~926 edges and 108 sections. Delivered 534 edges and 55 sections; the gap moved
+55% → 52%, not 48%.**
+
+The estimate was taken with the same defect the implementation then exposed. A `FILE` mention
+resolves by scanning `DocReconciler._files` — **a `set`** — so the matching comprehension
+yielded results in hash order. Nothing had ever read that order, because `anchor_files` was
+only used as a boolean and to count the file-only bucket. Taking `[0]` to find the owning
+module made the order significant, and the edge count then varied per process: **3392 / 3394 /
+3390 across `PYTHONHASHSEED` values**, on one unchanged commit.
+
+That is invariant 2 — *same code in, same output out* — broken by this change, caught before it
+shipped by varying the seed rather than by re-running.
+
+Two corrections went in together:
+
+- **`anchor_files` is sorted**, so the order is the same on every machine.
+- **A mention must match exactly one file**, not merely at least one. A text matching several
+  paths is ambiguous about *which file* it means before it is ambiguous about which module, and
+  the earlier estimate was silently binding those to an arbitrary one — which is where the
+  inflated 926 came from.
+
+The delivered number is smaller and it is the honest one.
 
 ### What it does to the gap
 

--- a/src/orchestrator/pkg/docs.py
+++ b/src/orchestrator/pkg/docs.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
-from orchestrator.pkg.facts import FactBatch, Node
+from orchestrator.pkg.facts import FactBatch, Node, NodeKind
 
 _BACKTICK_RE = re.compile(r"`([^`\n]{2,120})`")
 _DOTTED_RE = re.compile(r"\b[a-z_]\w*(?:\.[A-Za-z_]\w*){2,}\b")  # a.b.C at least
@@ -228,6 +228,12 @@ class DocReconciler:
         self._names: dict[str, list[str]] = {}
         self._suffixes: dict[str, list[str]] = {}
         self._files: set[str] = set()
+        #: repo-relative path -> the Module nodes owning it. A document citing a path names
+        #: that module, and the identity is the extractor's own provenance — not a guess. Only
+        #: emitted when exactly one module owns the path: a C/C++ header can back several, and
+        #: an ambiguous anchor is the fabrication this tier refuses. See
+        #: `docs/specs/doc-file-binding.md`.
+        self._modules_for_file: dict[str, list[str]] = {}
         for n in nodes:
             if not n.grounded:
                 continue
@@ -236,18 +242,34 @@ class DocReconciler:
             self._suffixes.setdefault(tail.lower(), []).append(n.id)
             if n.provenance is not None:
                 self._files.add(n.provenance.file)
+                if n.kind is NodeKind.MODULE:
+                    self._modules_for_file.setdefault(n.provenance.file, []).append(n.id)
 
     def bind(self, mention: DocMention, *, base_dir: str = "") -> DocBinding:
         binding = DocBinding(mention=mention)
         text = mention.text.lower()
         if mention.kind is MentionKind.FILE:
             rel = mention.text.strip("/")
-            binding.anchor_files = [f for f in self._files if f.endswith(mention.text) or mention.text in f]
+            # **Sorted**: `_files` is a set, so an unsorted comprehension yields hash order and
+            # a caller taking `[0]` gets a different answer per process. Nothing read the order
+            # until file mentions began naming a module, which is exactly how a latent
+            # non-determinism becomes a live one.
+            binding.anchor_files = sorted(
+                f for f in self._files if f.endswith(mention.text) or mention.text in f
+            )
             if not binding.anchor_files and self._root is not None:
                 for candidate in (rel, f"{base_dir}/{rel}" if base_dir else rel):
                     if (self._root / candidate).exists():
                         binding.anchor_files = [candidate]
                         break
+            # A cited path names the module the extractor built from it. Exactly one, or
+            # nothing — see `docs/specs/doc-file-binding.md`.
+            # One file, owned by one module, or nothing. A mention matching several paths is
+            # ambiguous about which file it means before it is ambiguous about which module.
+            if len(binding.anchor_files) == 1:
+                owners = self._modules_for_file.get(binding.anchor_files[0], [])
+                if len(owners) == 1:
+                    binding.anchor_ids = list(owners)
             return binding
         # dotted path → match the id tail; names → exact symbol-name match.
         binding.anchor_ids = list(self._suffixes.get(text, [])) or list(self._names.get(text, []))

--- a/src/orchestrator/pkg/extractor.py
+++ b/src/orchestrator/pkg/extractor.py
@@ -607,6 +607,25 @@ class RepoCodeExtractor:
         #: candidates. A side-channel, never facts: see `python_client.emit`.
         self.unresolved_calls: list[PendingCall] = []
 
+    def reset_unresolved(self) -> None:
+        """Drop every collected join candidate, **including the front-ends' own**.
+
+        ``self.unresolved_calls`` is a *copy*: :meth:`extract` extends it from each front-end
+        that ran. The originals live on the front-ends, which are built once in ``__init__``
+        and reused for the life of this object, and ``ClientState.clear()`` preserves
+        ``unmatched`` on purpose — it is the run's output, not scratch state.
+
+        So clearing only this list leaves the previous repository's calls sitting on the
+        front-end, ready to be extended back in on the next :meth:`extract`. Reusing one
+        extractor across repositories then attributes web's calls to billing, which is a
+        `CONSUMES` edge from a node id that does not exist in the graph.
+        """
+        self.unresolved_calls.clear()
+        for front_end in dict.fromkeys(self._by_suffix.values()):
+            state = getattr(front_end, "unresolved_calls", None)
+            if state is not None:
+                state.clear()
+
     def extract(self, root: Path | str) -> FactBatch:
         root_path = Path(root)
         batch = FactBatch()

--- a/src/orchestrator/pkg/persistence.py
+++ b/src/orchestrator/pkg/persistence.py
@@ -390,9 +390,13 @@ def load_or_extract_repos(
         sha, dirty = repo_state(root)
         cache_file = _cache_path(cache_dir or default_cache_dir(), root, sha) if sha and not dirty else None
         was_cached = cache_file is not None and cache_file.exists()
-        # A fresh extractor per repo: `unresolved_calls` accumulates on the instance, and one
-        # shared extractor would attribute web's calls to billing.
+        # `unresolved_calls` accumulates on the extractor **and on its front-ends**, so a
+        # caller-supplied instance carries the previous repo's calls into this one — which
+        # would attribute web's calls to billing and place a `CONSUMES` edge from a node id
+        # that does not exist. Callers do supply one (`pkg extract --repos`,
+        # `investigate --repos`), so reset before the run rather than trusting a fresh object.
         per_repo = extractor or RepoCodeExtractor()
+        per_repo.reset_unresolved()
         batches[key] = load_or_extract(root, cache_dir=cache_dir, extractor=per_repo)
 
         # The side-channel has to survive the cache. On a warm hit `load_or_extract` never runs
@@ -404,13 +408,13 @@ def load_or_extract_repos(
             if was_cached:
                 # Facts cached, calls missing: re-extract for the side-channel only, and write
                 # it so this happens once rather than every load.
-                per_repo.unresolved_calls.clear()
+                per_repo.reset_unresolved()
                 per_repo.extract(root)
             cached_calls = list(per_repo.unresolved_calls)
             if sidecar is not None:
                 _save_calls(cached_calls, sidecar)
         unresolved[key] = cached_calls
-        per_repo.unresolved_calls.clear()
+        per_repo.reset_unresolved()
         states.append(RepoState(key, root, sha, dirty, cached=was_cached))
 
     merged = merge_repos(batches)

--- a/tests/pkg/test_docs.py
+++ b/tests/pkg/test_docs.py
@@ -183,3 +183,58 @@ def test_the_leaf_only_fallback_still_rescues_a_qualified_name(tmp_path: Path) -
     page = DocPage(title="x", text="Call `store.find`.")
     (mention,) = [m for m in extract_mentions(page) if m.text == "store.find"]
     assert rec.bind(mention, base_dir="").anchor_ids == ["py:m.FactStore.find"]
+
+
+# ---- a cited path names its module (doc-file-binding, 2026-09-02) ------------
+
+
+def test_a_cited_path_binds_to_the_module_built_from_it(tmp_path: Path) -> None:
+    """The fact was already in the graph and was being discarded.
+
+    `bind` recorded the hit in `anchor_files`; `link_docs` emits only for `anchor_ids`. The
+    path maps to exactly one `Module` node by the extractor's own provenance — not a guess.
+    Measured 2026-09-01: 938 such mentions, and 108 `Doc` sections that bound to nothing.
+    """
+    from orchestrator.pkg.doc_link import link_docs
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+    from orchestrator.pkg.facts import EdgeKind
+
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "store.py").write_text("def find():\n    return 1\n", encoding="utf-8")
+    (repo / "README.md").write_text("# Guide\n\nThe store lives in `src/store.py`.\n", encoding="utf-8")
+
+    batch = link_docs(RepoCodeExtractor().extract(repo), repo)
+    targets = {e.dst for e in batch.edges if e.kind is EdgeKind.MENTIONS}
+    assert any(t.endswith("store") for t in targets), targets
+
+
+def test_a_path_owned_by_two_modules_binds_to_neither() -> None:
+    """Exactly one, or nothing — the same rule that holds `CALLS` precision at 1.00."""
+    b = FactBatch()
+    for mid in ("c:alpha", "c:beta"):
+        b.add_node(Node(mid, NodeKind.MODULE, mid.split(":")[1], "c", Provenance("src/shared.h", 1)))
+    rec = DocReconciler(b)
+    page = DocPage(title="t", text="See `src/shared.h`.")
+    (mention,) = [m for m in extract_mentions(page) if m.text == "src/shared.h"]
+    assert rec.bind(mention, base_dir="").anchor_ids == []
+
+
+def test_a_path_matching_several_files_binds_to_nothing() -> None:
+    """Ambiguous about *which file* before it is ambiguous about which module.
+
+    `_files` is a set, so the matching comprehension yielded hash order. Nothing read that
+    order until file mentions began naming a module — and then `anchor_files[0]` picked a
+    different file per process, so the graph changed between runs of the same commit. Caught
+    by varying `PYTHONHASHSEED`; the count moved 3392/3394/3390 and is now fixed.
+    """
+    b = FactBatch()
+    for path in ("src/a/store.py", "src/b/store.py"):
+        mid = "py:" + path.replace("/", ".").removesuffix(".py")
+        b.add_node(Node(mid, NodeKind.MODULE, mid, "python", Provenance(path, 1)))
+    rec = DocReconciler(b)
+    page = DocPage(title="t", text="See `store.py`.")
+    (mention,) = [m for m in extract_mentions(page) if m.text == "store.py"]
+    binding = rec.bind(mention, base_dir="")
+    assert binding.anchor_files == ["src/a/store.py", "src/b/store.py"], "sorted, not hash order"
+    assert binding.anchor_ids == []

--- a/tests/pkg/test_join_link.py
+++ b/tests/pkg/test_join_link.py
@@ -340,3 +340,69 @@ def test_a_genuinely_third_party_import_stays_external() -> None:
 def test_base_is_refused_on_a_kind_where_it_means_nothing() -> None:
     with pytest.raises(RepoConfigError, match="applies to http only"):
         joins_from_list([{"kind": "data", "consumer": "a", "provider": "b", "base": "/v1"}])
+
+
+# ---- the shared-extractor leak (2026-09-02) --------------------------------
+
+
+QUIET = """def total():
+    return 1
+"""
+
+
+def test_a_shared_extractor_does_not_carry_one_repos_calls_into_another(tmp_path: Path) -> None:
+    """`pkg extract --repos` and `investigate --repos` both pass one extractor for every repo.
+
+    `unresolved_calls` on the extractor is a copy; the originals live on the front-ends, which
+    are built once and reused, and `ClientState.clear()` preserves `unmatched` on purpose. So
+    clearing only the extractor's list left the earlier repo's calls on the front-end for the
+    next one to inherit — and the joiner scopes a candidate to the repo it is examining, so a
+    `CONSUMES` edge is drawn from `py:zeta@app.client.order`, a node that does not exist.
+
+    Repos run in key order, so `api` (which calls) precedes `zeta` (which does not), and only
+    `zeta` is declared as a consumer. Without the leak `zeta` has no candidates and the join
+    places nothing.
+
+    The corpus could not catch this: `pkg/accuracy.py` builds a fresh extractor per root, so
+    the multirepo fixtures score a different code path from the one the CLI runs.
+    """
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+    from orchestrator.pkg.persistence import load_or_extract_repos
+
+    _repo(tmp_path / "api", "client.py", WEB)  # makes POST /v1/orders
+    _repo(tmp_path / "billing", "routes.py", BILLING)  # serves it
+    _repo(tmp_path / "zeta", "svc.py", QUIET)  # makes no HTTP calls at all
+    repo_set = from_mapping(
+        {"api": "api", "billing": "billing", "zeta": "zeta"},
+        base=tmp_path,
+        joins=[{"kind": "http", "consumer": "zeta", "provider": "billing"}],
+    )
+
+    merged = load_or_extract_repos(repo_set, cache_dir=tmp_path / "cache", extractor=RepoCodeExtractor())
+    assert [r.key for r in merged.repos] == ["api", "billing", "zeta"], "precondition: all ran"
+
+    assert merged.joins is not None
+    assert merged.joins.joined == 0, "zeta makes no calls; it cannot consume anything"
+
+    # And the invariant the leak broke: every edge endpoint is a node the graph actually has.
+    ids = {n.id for n in merged.batch.nodes}
+    dangling = [(e.kind.value, e.src, e.dst) for e in merged.batch.edges if e.src not in ids]
+    assert not dangling
+
+
+def test_reset_unresolved_clears_the_front_ends_too(tmp_path: Path) -> None:
+    """The narrow unit: clearing only the extractor's own list is not enough."""
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    (tmp_path / "web").mkdir()
+    (tmp_path / "web" / "client.py").write_text(WEB, encoding="utf-8")
+    (tmp_path / "quiet").mkdir()
+    (tmp_path / "quiet" / "svc.py").write_text(QUIET, encoding="utf-8")
+
+    ex = RepoCodeExtractor()
+    ex.extract(tmp_path / "web")
+    assert ex.unresolved_calls, "precondition: web makes a call it does not serve"
+
+    ex.reset_unresolved()
+    ex.extract(tmp_path / "quiet")
+    assert not ex.unresolved_calls, "quiet makes no HTTP calls at all"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -410,10 +410,10 @@ def test_the_package_version_is_derived_not_a_literal() -> None:
     """
     from importlib.metadata import version as installed
 
-    import orchestrator
+    from orchestrator import __version__
 
-    assert orchestrator.__version__ == installed("synaptixs-spine")
-    assert orchestrator.__version__ != "0.0.0"
+    assert __version__ == installed("synaptixs-spine")
+    assert __version__ != "0.0.0"
 
 
 def test_the_root_callback_did_not_break_subcommands() -> None:


### PR DESCRIPTION
Three items, one PR, as agreed.

## 1 — A shared extractor carried one repo's calls into the next

`load_or_extract_repos` carried the comment *"A fresh extractor per repo"* and then wrote `per_repo = extractor or RepoCodeExtractor()`. **Both `pkg extract --repos` and `investigate --repos` pass one.**

`unresolved_calls` on the extractor is a copy; the originals live on the front-ends, built once in `__init__`, and `ClientState.clear()` preserves `unmatched` on purpose. So clearing the extractor's list left web's calls on the front-end for the next repo — and the joiner scopes a candidate to the repo it is examining, placing a `CONSUMES` edge from a **node that does not exist**.

`RepoCodeExtractor.reset_unresolved()` clears the front-ends too, and the loop resets *before* each repo.

**The corpus could not have caught it:** `pkg/accuracy.py` builds a fresh extractor per root, so the multirepo fixtures score a different code path from the CLI. Both tests verified to fail with the fix removed — neutered, the joiner reports `joined == 1` for a repo that makes no HTTP calls at all.

## 2 — A cited path now names the module built from it

Per [`doc-file-binding.md`](docs/specs/doc-file-binding.md), merged in #293.

**This nearly shipped a determinism violation, which is the part worth reading.** `_files` is a `set`, so the matching comprehension yields hash order. Nothing had ever read that order — `anchor_files` was a boolean and a bucket count — and taking `[0]` to find the owning module made it significant:

```
PYTHONHASHSEED=1 -> 3392 edges
PYTHONHASHSEED=2 -> 3394 edges
PYTHONHASHSEED=3 -> 3390 edges     one unchanged commit
```

**Invariant 2, broken by this change.** Caught because the numbers oscillated instead of converging; confirmed mine, not pre-existing, by testing develop's `docs.py` across the same seeds (stable at 2469).

Fixed by sorting `anchor_files` and requiring the mention to match **exactly one file** — ambiguous about *which file* before it is ambiguous about which module.

That also shrank the result, and **the spec's estimate was inflated by the same defect**, having been measured with the same `[0]`:

| | predicted | delivered |
|---|---|---|
| edges | ~926 | **534** |
| sections rescued | 108 | **55** |
| the gap | 48% | **52%** (from 55%) |

`doc-file-binding.md` gains a **§2.1 recording why its own prediction was wrong**, rather than being edited to match the outcome. The walkthrough's claim that a cited path *"is naming a path, not a symbol, and there is no symbol edge to draw"* is corrected in place, and its withdrawn recommendation — that ambiguity was "the tractable half" — now carries the measurement that killed it: 48 of 1,982 mentions, 5 sections.

## 3 — The gate gap that failed the last release

`CONTRIBUTING.md` listed **one** of CI's four generated-artifact checks. A release PR failed on a diagram nobody had re-rendered while `mypy`, `ruff` and the tests were all green. All four are now listed together with the reason.

Also recorded: the three things that trip a `develop → main` promotion, each of which cost time on 3.27.0 — bot-commit runs held in `action_required`, a standing approval dismissed by the episteme commit, and an unresolved Code-scanning thread that blocks the merge **without appearing in `reviewDecision`**.

And `tests/test_cli.py` uses one import style, clearing the CodeQL note.

## Gate

All four `--check` scripts (state-numbers, architecture SVG, knowledge-foundation SVG, matrix-count), `ruff format --check .`, `mypy src tests`, `pkg accuracy --check` (0 regressions), **3,287 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)