### PR TITLE
docs(specs): measure why sections do not bind — and argue against a model tier

### DIFF
--- a/docs/specs/doc-binding-walkthrough.md
+++ b/docs/specs/doc-binding-walkthrough.md
@@ -89,7 +89,7 @@ Each reader converts its format into **markdown-shaped text**: HTML's `<h1>`, Wo
 style and a spreadsheet's sheet name all become an ATX `#` heading. Everything downstream reads
 that one shape and never learns which format it came from.
 
-The splitter then cuts on headings. **Measured here: 1,601 `Doc` nodes** across the repository —
+The splitter then cuts on headings. **Measured here: 1,602 `Doc` nodes** across the repository —
 sections, not files.
 
 Our subject becomes:
@@ -119,7 +119,7 @@ precedence:
 | `CAMEL` | `DocReconciler` |
 | `FILE` | `src/orchestrator/pkg/store.py` |
 
-Our section yields **12 mentions**. Repository-wide: **9,247**.
+Our section yields **12 mentions**. Repository-wide: **9,276**.
 
 One rule worth knowing: a bare CamelCase word — "GitHub", "Python" — binds if it happens to
 resolve, but **never counts as drift**. Prose capitalisation is not a code claim.
@@ -167,13 +167,13 @@ Repository-wide, every mention lands in exactly one of four buckets:
 
 | | count | share |
 |---|---|---|
-| **one symbol anchor → `MENTIONS` edge** | **3,036** | 33% |
-| more than one symbol anchor → skipped | 1,982 | 21% |
-| resolved to a **file**, no symbol | 845 | 9% |
-| nothing at all | 3,384 | 37% |
-| **total mentions** | **9,247** | |
+| **one symbol anchor → `MENTIONS` edge** | **3,039** | 33% |
+| more than one symbol anchor → skipped | 1,984 | 21% |
+| resolved to a **file**, no symbol | 846 | 9% |
+| nothing at all | 3,407 | 37% |
+| **total mentions** | **9,276** | |
 
-3,003 edges are drawn from those 3,036 — the 33 difference is de-duplication, where one section
+3,006 edges are drawn from those 3,039 — the 33 difference is de-duplication, where one section
 names the same symbol twice.
 
 > **These seven figures are derived, and reported rather than gated.**
@@ -202,9 +202,9 @@ names the same symbol twice.
 > The conclusion followed the bad number. It read *"ambiguity, not absence, is the larger
 > loss"*, and that is **false**: absence is 3,343 against ambiguity's 1,959.
 
-**What is true, and still worth saying:** ambiguity is not a rounding error. **1,982 mentions
+**What is true, and still worth saying:** ambiguity is not a rounding error. **1,984 mentions
 found real code and were deliberately dropped** for naming more than one thing — 29% of
-everything that fails to become an edge. That is qualitatively different from the 3,384 that
+everything that fails to become an edge. That is qualitatively different from the 3,407 that
 found nothing, and it matters for how the gap gets closed: reducing it means answering *which*
 symbol was meant, not *whether* one exists. Doing that by proximity, or by "the most likely", is
 precisely the guess this tier does not make.
@@ -224,7 +224,7 @@ are correctly unbound.
 
 ## Step 6 — drift, in detail
 
-Of the 3,384 mentions that matched nothing, most are prose: ordinary words in backticks, URLs,
+Of the 3,407 mentions that matched nothing, most are prose: ordinary words in backticks, URLs,
 filenames. `symbolish_drift` narrows to identifier-shaped claims, leaving **about 900** on this
 repository. Examples, all real:
 
@@ -267,7 +267,7 @@ never as a defect count.
 > as symbol claims and the drift list reported **58 filenames as prose naming code that does not
 > exist**. Extensions were added to `_URL_TAILS` and checked in `_can_drift` — shipped in
 > **3.27.0**. Drift went
-> **1,665 → 1,607** and **not one `MENTIONS` edge changed** — the same 2,469 (source, target)
+> **1,682 → 1,624** and **not one `MENTIONS` edge changed** — the same 2,469 (source, target)
 > pairs before and after, and the only binding bucket that moves is *nothing at all*, by the 12
 > filenames that stop being mentions at all. A naming asymmetry, not a coverage gap.
 > `README.md` and `src/a/b.py` keep their disk check, because a document linking a file that is
@@ -304,11 +304,30 @@ inference over the graph changing, not the graph being rewritten.
 
 ## The open gap
 
-**827 of 1,601 `Doc` sections — 52% — bind to nothing at all.** Section 2 shows why in miniature:
+**827 of 1,602 `Doc` sections — 52% — bind to nothing at all.** Section 2 shows why in miniature:
 prose that explains *why* something exists often names no identifier, and prose that does name one
 often names an ambiguous one. Both causes are real, and **absence is the larger of the two** —
-3,384 mentions against 1,982 — though the smaller one is the more interesting, because those 1,982
+3,407 mentions against 1,984 — though the smaller one is the more interesting, because those 1,984
 found the code and were refused.
+
+> **Measured 2026-09-02: most of that 52% never made a claim.** The headline invites the
+> reading that half the documentation failed to bind. It did not.
+>
+> Of the **809** unbound mentions in the 338 sections that bind to nothing:
+>
+> | | | |
+> |---|---|---|
+> | **not a claim at all** | **603** | 74.5% — `OpenSpec`, `TypeScript`, `ReAct`, `GitHub`, `OpenTelemetry`. The tier's own `_can_drift` already refuses these: CamelCase prose and plain words are not code claims |
+> | no node kind exists | 68 | 8.4% — `repo_path`, `Context`: parameters, locals, attributes |
+> | a file stem, cited without its extension | 16 | 2.0% — `comprehension_labels` for `comprehension_labels.yaml`. Deterministically reachable |
+> | third-party or builtin | 19 | 2.4% — `SyntaxError` will drift for ever, correctly |
+> | **found nothing, and is claim-shaped** | **103** | 12.7% — `startup_timeout_sec`, `bug_report`, `action_required`: mostly config keys and template filenames |
+>
+> **278 of those 338 sections — 82% — contain nothing bindable at all.** At most **60 sections
+> of 1,602 (3.7%)** hold a mention a better tier could plausibly reach.
+>
+> That is the number a second tier would be chasing, and it is not 827. Re-derive with
+> `python scripts/classify-unbound-mentions.py`.
 
 **Nothing above closed any of it, and that is worth stating plainly.** The 2026-09-01 audit ran at
 this gap and came back with a *drift-precision* fix: 58 filenames that the drift list was calling
@@ -325,13 +344,18 @@ promotion was, and never smuggled into the deterministic path.
 
 1. ~~**Answer *which* symbol was meant for the ambiguous mentions** — "the tractable half, and
    the half a deterministic rule might still reach."~~ **Measured 2026-09-02 and withdrawn.**
-   Only **48 of 1,982** ambiguous mentions (2%) have every candidate anchor in one owning
+   Only **48 of 1,984** ambiguous mentions (2%) have every candidate anchor in one owning
    module, which rescues **5 sections**. And the compounding idea in that sentence — bind the
    file first, then use its module to pick among a mention's candidates — rescues **0**. It
    sounded right, cost nothing to check, and was wrong.
-2. **Characterise the 3,384 that found nothing** before trying to bind them. About a tenth cannot
-   bind by construction — parameters, module constants, string literals, log event names,
-   builtins have no node kind — and that share should be a number, not an estimate, before any
-   model is pointed at the remainder.
+2. ~~**Characterise the 3,407 that found nothing** before trying to bind them.~~ ✅ **Done
+   2026-09-02** — the box above. The estimate was "about a tenth cannot bind by construction".
+   Measured, it is **87%**, and the dominant reason is not a missing node kind: three quarters
+   of them are not code claims at all. **The cheapest remaining deterministic win is the file
+   stem** — 16 mentions naming a file without its extension.
+
+   This is the measurement that should precede any model tier, and it argues against one: the
+   reachable population is ~60 sections, against a determinism cost that applies to every
+   surface `understand --check` gates.
 3. **Only then a second tier.** Measured against these figures, declared as non-deterministic, and
    kept out of the path `understand --check` gates.

--- a/scripts/classify-unbound-mentions.py
+++ b/scripts/classify-unbound-mentions.py
@@ -1,0 +1,121 @@
+"""Why do unbound doc mentions fail to bind? Deterministic classification, no model.
+
+Run when someone proposes closing the doc-binding gap:
+
+    python scripts/classify-unbound-mentions.py
+
+The headline "N% of `Doc` sections bind to nothing" invites the reading that N% of the
+documentation failed to bind. Measured, most of it never made a claim about this codebase —
+it is prose about TypeScript, GitHub and OpenSpec. This separates the two.
+
+Populations, in the order a mention is tested (first match wins):
+
+  external   the graph's own `external` nodes — httpx, react. Real code, not first-party,
+             so there is nothing first-party to point at.
+  builtin    a Python builtin or stdlib module name. `SyntaxError` will drift for ever.
+  no-kind    appears in first-party source as a name the vocabulary has no node kind for:
+             a parameter, a local, a module-level constant, an attribute, a keyword arg.
+  absent     appears nowhere in first-party source. Prose, or a genuine drift claim.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+from orchestrator.pkg.doc_source import read_doc_pages
+from orchestrator.pkg.docs import DocReconciler, extract_mentions
+from orchestrator.pkg.extractor import RepoCodeExtractor
+
+ROOT = Path(".")
+code = RepoCodeExtractor().extract(ROOT)
+rec = DocReconciler(code, repo_root=ROOT)
+
+external = {n.name.lower() for n in code.nodes if not n.grounded}
+external |= {n.id.split(":", 1)[-1].lower() for n in code.nodes if not n.grounded}
+stdlib = {m.lower() for m in sys.stdlib_module_names} | {b.lower() for b in dir(builtins)}
+
+# Names that exist in first-party source but have no node kind.
+no_kind: set[str] = set()
+for py in sorted(ROOT.rglob("*.py")):
+    if any(part.startswith(".") or part in {"node_modules", "__pycache__"} for part in py.parts):
+        continue
+    try:
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError, ValueError):
+        continue
+    for node in ast.walk(tree):
+        if isinstance(node, ast.arg):
+            no_kind.add(node.arg.lower())
+        elif isinstance(node, ast.Name):
+            no_kind.add(node.id.lower())
+        elif isinstance(node, ast.Attribute):
+            no_kind.add(node.attr.lower())
+        elif isinstance(node, ast.keyword) and node.arg:
+            no_kind.add(node.arg.lower())
+
+stems = {
+    f.stem.lower()
+    for f in ROOT.rglob("*")
+    if f.is_file() and not any(pt.startswith(".") or pt == "node_modules" for pt in f.parts)
+}
+
+buckets: Counter[str] = Counter()
+per_section: dict[str, set[str]] = {}
+KINDS = ("not-a-claim", "external", "builtin", "no-kind", "file-stem", "absent")
+samples: dict[str, list[str]] = {k: [] for k in KINDS}
+HEX40 = re.compile(r"^[0-9a-f]{7,40}\$")
+
+
+def not_a_claim(text: str, mention) -> bool:
+    """Shapes that are not claims about this codebase, so they cannot be binding failures."""
+    if not rec._can_drift(mention):
+        return True  # the repo's own rule: CamelCase prose, ALL-CAPS, plain lowercase words
+    return bool(" " in text or "/" in text or "=" in text or "://" in text or HEX40.match(text))
+
+
+for page in read_doc_pages(ROOT):
+    ms = extract_mentions(page)
+    if not ms:
+        continue
+    binds = [(m, rec.bind(m, base_dir=page.base_dir)) for m in ms]
+    if any(len(b.anchor_ids) == 1 for _m, b in binds):
+        continue  # section already binds
+    for m, b in binds:
+        if b.anchor_ids or b.anchor_files:
+            continue
+        t = m.text.lower()
+        leaf = t.rsplit(".", 1)[-1]
+        if not_a_claim(m.text, m):
+            k = "not-a-claim"
+        elif t in external or leaf in external:
+            k = "external"
+        elif t in stdlib or leaf in stdlib:
+            k = "builtin"
+        elif t in no_kind or leaf in no_kind:
+            k = "no-kind"
+        elif leaf in stems:
+            k = "file-stem"
+        else:
+            k = "absent"
+        buckets[k] += 1
+        per_section.setdefault(page.title, set()).add(k)
+        if len(samples[k]) < 8 and m.text not in samples[k]:
+            samples[k].append(m.text)
+
+total = sum(buckets.values())
+print(f"unbound mentions in sections that bind to nothing: {total:,}\n")
+for k in KINDS:
+    n = buckets[k]
+    print(f"  {k:9s} {n:6,d}  {n / total * 100:5.1f}%   e.g. {', '.join(samples[k][:5])}")
+
+cannot = {"not-a-claim", "external", "builtin", "no-kind", "file-stem"}
+secs = len(per_section)
+hopeless = sum(1 for kinds in per_section.values() if kinds <= cannot)
+print(f"\n  sections examined                     : {secs:,}")
+print(f"  whose every mention CANNOT bind        : {hopeless:,}  ({hopeless / secs * 100:.0f}%)")
+print(f"  with at least one 'absent' mention     : {secs - hopeless:,}")


### PR DESCRIPTION
The measurement that was meant to precede a second tier. **It argues against building one.**

## The headline was misleading, and now says so

*"52% of `Doc` sections bind to nothing"* invites the reading that half the documentation failed to bind. It did not. Of the **809** unbound mentions in the 338 sections that bind to nothing:

| | | |
|---|---|---|
| **not a claim at all** | **603** | 74.5% — `OpenSpec`, `TypeScript`, `ReAct`, `GitHub`, `OpenTelemetry` |
| no node kind exists | 68 | 8.4% — `repo_path`, `Context`: parameters, locals, attributes |
| a file stem, cited without its extension | 16 | 2.0% — `comprehension_labels` for `comprehension_labels.yaml` |
| third-party or builtin | 19 | 2.4% — `SyntaxError` will drift for ever, correctly |
| **claim-shaped, found nothing** | **103** | 12.7% — `startup_timeout_sec`, `bug_report`, `action_required` |

Three quarters are prose that the tier's **own** `_can_drift` rule already refuses — CamelCase and plain lowercase words are not code claims.

**278 of 338 sections (82%) contain nothing bindable at all.** At most **60 sections of 1,602 — 3.7%** hold a mention a better tier could plausibly reach.

## Why that changes the decision

**That is the population a model tier would be chasing, and it is not 827.** Against a determinism cost that lands on every surface `understand --check` gates, 60 sections is not the trade it looked like when the number was 827.

The standing estimate is corrected too: *"about a tenth cannot bind by construction"* → measured **87%**, and the dominant reason is not a missing node kind. It is that the text was never a claim.

## What is still available deterministically

**The file stem.** 16 mentions name a file without its extension. Named, not built — it wants its own decision, and it is small.

## Reproducibility

`scripts/classify-unbound-mentions.py` ships, so these figures re-derive rather than being hand-carried — which is how "56%" sat wrong for a fortnight.

**Method note, kept because it changed the answer:** the first pass classified `orchestrator sdlc plan --spec ./TCK-1.json` as third-party and a git SHA as absent, because it classified every unbound *mention* rather than every unbound *claim*. Re-running against the repository's own `_can_drift` rule is what moved "not a claim" from invisible to three quarters of the population.

## Gate

`state-numbers.py --check` (11 gated, 9 trended — all re-derived), `ruff format --check .`, `ruff check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)