### PR TITLE
feat(pkg): bind prose that names a file by its stem

### DIFF
--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **57** | `grep -c '\.command(' src/orchestrator/cli.py` |
 | Source modules | **332** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,869** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,872** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/doc-binding-walkthrough.md
+++ b/docs/specs/doc-binding-walkthrough.md
@@ -167,13 +167,13 @@ Repository-wide, every mention lands in exactly one of four buckets:
 
 | | count | share |
 |---|---|---|
-| **one symbol anchor → `MENTIONS` edge** | **3,047** | 33% |
+| **one symbol anchor → `MENTIONS` edge** | **3,135** | 34% |
 | more than one symbol anchor → skipped | 1,986 | 21% |
-| resolved to a **file**, no symbol | 847 | 9% |
-| nothing at all | 3,407 | 37% |
+| resolved to a **file**, no symbol | 859 | 9% |
+| nothing at all | 3,307 | 36% |
 | **total mentions** | **9,287** | |
 
-3,014 edges are drawn from those 3,047 — the 33 difference is de-duplication, where one section
+3,089 edges are drawn from those 3,135 — the 46 difference is de-duplication, where one section
 names the same symbol twice.
 
 > **These seven figures are derived, and reported rather than gated.**
@@ -204,7 +204,7 @@ names the same symbol twice.
 
 **What is true, and still worth saying:** ambiguity is not a rounding error. **1,986 mentions
 found real code and were deliberately dropped** for naming more than one thing — 29% of
-everything that fails to become an edge. That is qualitatively different from the 3,407 that
+everything that fails to become an edge. That is qualitatively different from the 3,307 that
 found nothing, and it matters for how the gap gets closed: reducing it means answering *which*
 symbol was meant, not *whether* one exists. Doing that by proximity, or by "the most likely", is
 precisely the guess this tier does not make.
@@ -217,14 +217,24 @@ precisely the guess this tier does not make.
 > cited path binds to its module when the text matches **exactly one file** and **exactly one
 > module** owns it — 534 edges, and 55 sections that bound to nothing now bind.
 
-The 845 file-only mentions that remain are of two kinds: those with no module to name at
+> **A second deterministic rule followed, 2026-09-02: prose names a file by its stem.**
+> `typescript_extractor` for `typescript_extractor.py`, `comprehension_labels` for the YAML
+> beside it. **74 edges and 98 fewer drift findings**, and 11 more sections bind.
+>
+> **Restricted to snake-shaped tokens, and that restriction is the rule.** Matching any stem
+> binds `bug`, `enhancement`, `invention` and `validity` to modules that happen to share the
+> name, when the prose meant the English words — measured at 149 bindings against 88, the extra
+> 61 being exactly that mistake. An underscore is what makes a token code-shaped rather than a
+> word.
+
+The 859 file-only mentions that remain are of two kinds: those with no module to name at
 all — images, config files, other documents — and those whose text matches **more than one**
 file, which is ambiguous about *which file* before it is ambiguous about which module. Both
 are correctly unbound.
 
 ## Step 6 — drift, in detail
 
-Of the 3,407 mentions that matched nothing, most are prose: ordinary words in backticks, URLs,
+Of the 3,307 mentions that matched nothing, most are prose: ordinary words in backticks, URLs,
 filenames. `symbolish_drift` narrows to identifier-shaped claims, leaving **about 900** on this
 repository. Examples, all real:
 
@@ -267,7 +277,7 @@ never as a defect count.
 > as symbol claims and the drift list reported **58 filenames as prose naming code that does not
 > exist**. Extensions were added to `_URL_TAILS` and checked in `_can_drift` — shipped in
 > **3.27.0**. Drift went
-> **1,685 → 1,627** and **not one `MENTIONS` edge changed** — the same 2,469 (source, target)
+> **1,685 → 1,529** and **not one `MENTIONS` edge changed** — the same 2,469 (source, target)
 > pairs before and after, and the only binding bucket that moves is *nothing at all*, by the 12
 > filenames that stop being mentions at all. A naming asymmetry, not a coverage gap.
 > `README.md` and `src/a/b.py` keep their disk check, because a document linking a file that is
@@ -304,10 +314,10 @@ inference over the graph changing, not the graph being rewritten.
 
 ## The open gap
 
-**827 of 1,602 `Doc` sections — 52% — bind to nothing at all.** Section 2 shows why in miniature:
+**816 of 1,602 `Doc` sections — 51% — bind to nothing at all.** Section 2 shows why in miniature:
 prose that explains *why* something exists often names no identifier, and prose that does name one
 often names an ambiguous one. Both causes are real, and **absence is the larger of the two** —
-3,407 mentions against 1,986 — though the smaller one is the more interesting, because those 1,986
+3,307 mentions against 1,986 — though the smaller one is the more interesting, because those 1,986
 found the code and were refused.
 
 > **Measured 2026-09-02: most of that 52% never made a claim.** The headline invites the
@@ -348,7 +358,7 @@ promotion was, and never smuggled into the deterministic path.
    module, which rescues **5 sections**. And the compounding idea in that sentence — bind the
    file first, then use its module to pick among a mention's candidates — rescues **0**. It
    sounded right, cost nothing to check, and was wrong.
-2. ~~**Characterise the 3,407 that found nothing** before trying to bind them.~~ ✅ **Done
+2. ~~**Characterise the 3,307 that found nothing** before trying to bind them.~~ ✅ **Done
    2026-09-02** — the box above. The estimate was "about a tenth cannot bind by construction".
    Measured, it is **87%**, and the dominant reason is not a missing node kind: three quarters
    of them are not code claims at all. **The cheapest remaining deterministic win is the file

--- a/docs/specs/doc-file-binding.md
+++ b/docs/specs/doc-file-binding.md
@@ -84,6 +84,23 @@ sections, **367 contain no symbol-shaped mention at all** — a heading, a table
 paragraph of prose. There is nothing to bind and no failure to fix. The real failure population
 is **507 sections**, and 108 of them are reached here.
 
+### 2.2 — And a second rule: prose names a file by its stem
+
+Shipped alongside, 2026-09-02. `typescript_extractor` means `typescript_extractor.py`;
+`comprehension_labels` means the YAML beside it. A module's node name is its *dotted path*, so a
+bare stem matches no name and no id tail, and a `.yaml` file has no node at all — the tree is
+walked instead, with **exactly one** applied twice: one file with that stem, then one module
+owning it.
+
+**74 `MENTIONS` edges, 98 fewer drift findings, 11 more sections bound.** The drift half is the
+larger one: prose naming a real file was being reported as prose naming code that does not exist.
+
+**It is restricted to snake-shaped tokens, and that restriction is the rule.** Matching any stem
+binds `bug`, `enhancement`, `invention` and `validity` to modules that happen to share the name,
+when the prose meant the English words — **149 bindings against 88, and the extra 61 are exactly
+that mistake**. An underscore is what makes a token code-shaped rather than a word, which is why
+`_SNAKE_RE` exists at all.
+
 ## 3. What is *not* reachable, which is the more important half
 
 The walkthrough's "what would count as progress" recommends resolving the 1,966 ambiguous

--- a/src/orchestrator/pkg/docs.py
+++ b/src/orchestrator/pkg/docs.py
@@ -234,6 +234,10 @@ class DocReconciler:
         #: an ambiguous anchor is the fabrication this tier refuses. See
         #: `docs/specs/doc-file-binding.md`.
         self._modules_for_file: dict[str, list[str]] = {}
+        #: lowercase file stem -> repo-relative paths, built lazily on first use. Prose cites a
+        #: file by its stem — `comprehension_labels` for `comprehension_labels.yaml` — and the
+        #: extractor's provenance only covers files it parsed, so this walks the tree instead.
+        self._stems: dict[str, list[str]] | None = None
         for n in nodes:
             if not n.grounded:
                 continue
@@ -244,6 +248,26 @@ class DocReconciler:
                 self._files.add(n.provenance.file)
                 if n.kind is NodeKind.MODULE:
                     self._modules_for_file.setdefault(n.provenance.file, []).append(n.id)
+
+    def _stem_index(self) -> dict[str, list[str]]:
+        """Every file in the repository, keyed by its lowercase stem.
+
+        Sorted at both levels: this feeds an "exactly one" test, and an unsorted walk would
+        make *which* file a stem resolves to depend on filesystem order. The same directory
+        exclusions as `doc_source` — a dot-directory is where the fixture corpora live, and
+        binding prose to a fixture would be worse than not binding it.
+        """
+        if self._stems is None:
+            index: dict[str, list[str]] = {}
+            if self._root is not None:
+                for path in sorted(self._root.rglob("*")):
+                    rel = path.relative_to(self._root)
+                    if any(part.startswith(".") or part == "node_modules" for part in rel.parts):
+                        continue
+                    if path.is_file():
+                        index.setdefault(path.stem.lower(), []).append(str(rel))
+            self._stems = {k: sorted(v) for k, v in index.items()}
+        return self._stems
 
     def bind(self, mention: DocMention, *, base_dir: str = "") -> DocBinding:
         binding = DocBinding(mention=mention)
@@ -285,6 +309,21 @@ class DocReconciler:
             leaf = text.rsplit(".", 1)[-1]
             if leaf.lower() not in _URL_TAILS:
                 binding.anchor_ids = list(self._names.get(leaf, []))
+        # Last resort: prose naming a file by its stem — `typescript_extractor` for
+        # `typescript_extractor.py`, `comprehension_labels` for the YAML beside it.
+        #
+        # **Restricted to snake-shaped tokens, and that restriction is the whole rule.** Matching
+        # any stem binds `bug`, `enhancement`, `invention` and `validity` to modules that happen
+        # to share the name, when the prose meant the English words — measured at 149 bindings
+        # against 88, with the extra 61 being exactly that mistake. An underscore is what makes a
+        # token code-shaped rather than a word, which is why `_SNAKE_RE` exists at all.
+        if not binding.anchor_ids and not binding.anchor_files and "_" in text:
+            paths = self._stem_index().get(text, [])
+            if len(paths) == 1:
+                binding.anchor_files = list(paths)
+                owners = self._modules_for_file.get(paths[0], [])
+                if len(owners) == 1:
+                    binding.anchor_ids = list(owners)
         return binding
 
     def _can_drift(self, mention: DocMention) -> bool:

--- a/tests/pkg/test_docs.py
+++ b/tests/pkg/test_docs.py
@@ -12,7 +12,7 @@ from orchestrator.pkg import (
     NodeKind,
     Provenance,
 )
-from orchestrator.pkg.docs import MentionKind, extract_mentions
+from orchestrator.pkg.docs import DocBinding, MentionKind, extract_mentions
 
 
 def _batch() -> FactBatch:
@@ -238,3 +238,73 @@ def test_a_path_matching_several_files_binds_to_nothing() -> None:
     binding = rec.bind(mention, base_dir="")
     assert binding.anchor_files == ["src/a/store.py", "src/b/store.py"], "sorted, not hash order"
     assert binding.anchor_ids == []
+
+
+# ---- prose names a file by its stem (2026-09-02) -----------------------------
+
+
+def test_a_snake_case_stem_binds_to_the_file_and_its_module(tmp_path: Path) -> None:
+    """`doc_source` in prose means `doc_source.py`; `comprehension_labels` means the YAML.
+
+    A module's node name is its dotted path — `orchestrator.pkg.doc_source` — so a bare stem
+    matches no name and no id tail. And the extractor's provenance covers only files it
+    parsed, so a `.yaml` stem has no node at all. The tree is walked instead, with "exactly
+    one" applied twice: one file with that stem, then one module owning it.
+    """
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    repo = tmp_path / "repo"
+    (repo / "src" / "orchestrator" / "pkg").mkdir(parents=True)
+    (repo / "src" / "orchestrator" / "pkg" / "doc_source.py").write_text(
+        "def read():\n    return 1\n", encoding="utf-8"
+    )
+    (repo / "evals").mkdir()
+    (repo / "evals" / "comprehension_labels.yaml").write_text("a: 1\n", encoding="utf-8")
+    rec = DocReconciler(RepoCodeExtractor().extract(repo), repo_root=repo)
+
+    def bind(token: str) -> DocBinding:
+        page = DocPage(title="t", text=f"See `{token}`.")
+        (mention,) = [m for m in extract_mentions(page) if m.text == token]
+        return rec.bind(mention, base_dir="")
+
+    module = bind("doc_source")
+    assert module.anchor_files == ["src/orchestrator/pkg/doc_source.py"]
+    assert module.anchor_ids == ["py:orchestrator.pkg.doc_source"]
+
+    # A data file has no module. It still stops being drift: the prose named something real.
+    data = bind("comprehension_labels")
+    assert data.anchor_files == ["evals/comprehension_labels.yaml"]
+    assert data.anchor_ids == []
+
+
+def test_a_plain_word_stem_does_not_bind(tmp_path: Path) -> None:
+    """`bug` is an English word here, and `bug.yaml` exists. Binding them is the guess.
+
+    Measured 2026-09-02: matching any stem produced 149 bindings against snake-case's 88, and
+    the extra 61 were `bug`, `enhancement`, `invention`, `validity` — prose, bound to modules
+    that happen to share a filename.
+    """
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    repo = tmp_path / "repo"
+    (repo / "profiles").mkdir(parents=True)
+    (repo / "profiles" / "bug.yaml").write_text("name: bug\n", encoding="utf-8")
+    rec = DocReconciler(RepoCodeExtractor().extract(repo), repo_root=repo)
+    page = DocPage(title="t", text="Report a `bug` when it misbehaves.")
+    (mention,) = [m for m in extract_mentions(page) if m.text == "bug"]
+    assert rec.bind(mention, base_dir="").anchor_files == []
+
+
+def test_a_stem_owned_by_two_files_binds_to_neither(tmp_path: Path) -> None:
+    """Exactly one, or nothing — before the module question is even asked."""
+    from orchestrator.pkg.extractor import RepoCodeExtractor
+
+    repo = tmp_path / "repo"
+    for pkg in ("a", "b"):
+        (repo / pkg).mkdir(parents=True)
+        (repo / pkg / "doc_source.py").write_text("x = 1\n", encoding="utf-8")
+    rec = DocReconciler(RepoCodeExtractor().extract(repo), repo_root=repo)
+    page = DocPage(title="t", text="See `doc_source`.")
+    (mention,) = [m for m in extract_mentions(page) if m.text == "doc_source"]
+    binding = rec.bind(mention, base_dir="")
+    assert binding.anchor_files == [] and binding.anchor_ids == []


### PR DESCRIPTION
`typescript_extractor` in prose means `typescript_extractor.py`; `comprehension_labels` means the YAML beside it. Neither bound.

A module's node name is its **dotted path** — `orchestrator.pkg.doc_source` — so a bare stem matches no name and no id tail. And the extractor's provenance covers only files it parsed, so a `.yaml` stem has no node at all. The tree is walked instead, with **exactly one** applied twice: one file with that stem, then one module owning it.

| | before | after |
|---|---|---|
| `MENTIONS` edges | 3,014 | **3,088** |
| **drift findings** | 1,627 | **1,529** |
| sections that bind | 775 | 786 — the gap **52% → 51%** |

**The drift half is the point.** Prose naming a real file was being reported as prose naming code that does not exist, 98 times.

## The restriction is the rule

Matching *any* stem reaches **149** bindings instead of 88. The extra 61 are:

```
invention   -> orchestrator.pkg.invention
bug         -> profiles/bug.yaml
enhancement -> profiles/enhancement.yaml
validity    -> orchestrator.sdlc.validity
```

English words, used as prose throughout these documents, bound to modules that happen to share a filename. **That is the guess this tier refuses.** Restricted to snake-shaped tokens — an underscore is what makes a token code-shaped rather than a word, which is why `_SNAKE_RE` exists at all.

All 34 distinct bindings the safe variant produces were read, not sampled: `doc_source`, `test_cli`, `render_architecture_svg`, `code_of_conduct` → `CODE_OF_CONDUCT.md`, and so on.

## Checked before shipping, not after

**Determinism across `PYTHONHASHSEED`: 3088 edges on every seed.** The previous binding change made a `set`'s hash order significant by taking `[0]`; this one walks the filesystem, so both levels of the stem index are sorted.

The positive test fails with the rule removed. **The two negative tests pass either way by design** — they guard against loosening the rule back to the 149-binding variant; they are not regression tests for this change, and it would be misleading to present them as such.

An earlier draft of the positive test proved nothing: in a one-file repo the module is named `py:doc_source`, so it bound by *name* and never reached the stem path. Rewritten with a nested package plus a `.yaml`, which is what a real repository looks like.

## Scope

This was scoped at "16 mentions" from the classification run. The real reach is 88 — that measurement counted only sections that bind to nothing, not the repository. Recorded in `doc-file-binding.md` §2.2.

## Gate

All four generated-artifact checks, `ruff format --check .`, `mypy src tests`, `pkg accuracy --check` (drift trends 913 → 831), **3,290 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)