### PR TITLE
feat(pkg): Endpoint nodes for TypeScript (Express) and Go (Gin)

### DIFF
--- a/KNOWLEDGE_GRAPH.md
+++ b/KNOWLEDGE_GRAPH.md
@@ -127,11 +127,11 @@ a variable yields no edge, because a wrong edge is worse than an absent one.
 |---|---|---|---|---|---|---|---|---|
 | `python` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | · | · |
 | `java` | ✓ | ✓ | ✓ | ✓ | ✓ | · | · | · |
-| `typescript` | ✓ | ✓ | ✓ | ✓ | · | · | · | · |
+| `typescript` | ✓ | ✓ | ✓ | ✓ | ✓ | · | · | · |
 | `csharp` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | · | · |
 | `c` | ✓ | ✓ | ✓ | ✓ | · | · | · | · |
 | `cpp` | ✓ | ✓ | ✓ | ✓ | · | · | · | · |
-| `go` | ✓ | ✓ | ✓ | ✓ | · | · | · | · |
+| `go` | ✓ | ✓ | ✓ | ✓ | ✓ | · | · | · |
 | `sql` | ✓ | · | ✓ | ✓ | · | ✓ | · | · |
 
 **Edges**
@@ -140,11 +140,11 @@ a variable yields no edge, because a wrong edge is worse than an absent one.
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | `python` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | · | · |
 | `java` | ✓ | ✓ | ✓ | ✓ | · | · | ✓ | · | · | · | · |
-| `typescript` | ✓ | ✓ | ✓ | ✓ | · | · | · | · | · | · | · |
+| `typescript` | ✓ | ✓ | ✓ | ✓ | · | · | ✓ | · | · | · | · |
 | `csharp` | ✓ | ✓ | ✓ | ✓ | · | · | ✓ | · | ✓ | · | · |
 | `c` | ✓ | ✓ | ✓ | · | · | · | · | · | ✓ | · | · |
 | `cpp` | ✓ | ✓ | ✓ | ✓ | · | · | · | · | ✓ | · | · |
-| `go` | ✓ | ✓ | ✓ | ✓ | · | · | · | · | ✓ | · | · |
+| `go` | ✓ | ✓ | ✓ | ✓ | · | · | ✓ | · | ✓ | · | · |
 | `sql` | · | ✓ | ✓ | · | ✓ | ✓ | · | · | ✓ | · | · |
 
 Read a `·` as *this front-end has no code that emits that kind* — not as *your repo

--- a/corpus/go/gin_routes/.repo/go.mod
+++ b/corpus/go/gin_routes/.repo/go.mod
@@ -1,0 +1,3 @@
+module example.com/svc
+
+go 1.22

--- a/corpus/go/gin_routes/.repo/main.go
+++ b/corpus/go/gin_routes/.repo/main.go
@@ -1,0 +1,22 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+func listOrders(c *gin.Context) {}
+
+func main() {
+	r := gin.Default()
+
+	// A group is a router whose prefix is its parent's plus its own.
+	v1 := r.Group("/v1")
+	v1.GET("/orders", listOrders)
+
+	// An inline handler: an endpoint, but no symbol to hang EXPOSES on.
+	v1.POST("/orders", func(c *gin.Context) {})
+
+	r.GET("/health", listOrders)
+
+	// CONTROL: a path held in a variable must yield nothing at all.
+	path := "/dynamic"
+	r.GET(path, listOrders)
+}

--- a/corpus/go/gin_routes/expected.json
+++ b/corpus/go/gin_routes/expected.json
@@ -1,0 +1,59 @@
+{
+  "language": "go",
+  "case": "gin_routes",
+  "why": "The Go half of the same gap: no Go front-end emitted `Endpoint`, so a Gin handler had zero callers and a Go service could not be a *provider* in a cross-repo join. Pins `Group` prefix composition, the inline-handler shape that must yield an endpoint but no fabricated `EXPOSES`, and the control: a path held in a variable yields nothing. `net/http`'s verbless `HandleFunc` is deliberately unread \u2014 see `endpoints-typescript-go.md` D2.",
+  "root": ".repo",
+  "nodes": [
+    {
+      "id": "go:<root>",
+      "kind": "Module"
+    },
+    {
+      "id": "go:<root>.listOrders",
+      "kind": "Function"
+    },
+    {
+      "id": "go:<root>.main",
+      "kind": "Function"
+    },
+    {
+      "id": "go:endpoint:GET /v1/orders",
+      "kind": "Endpoint"
+    },
+    {
+      "id": "go:endpoint:POST /v1/orders",
+      "kind": "Endpoint"
+    },
+    {
+      "id": "go:endpoint:GET /health",
+      "kind": "Endpoint"
+    }
+  ],
+  "edges": [
+    {
+      "src": "go:<root>",
+      "dst": "go:github.com/gin-gonic/gin",
+      "kind": "IMPORTS"
+    },
+    {
+      "src": "go:<root>",
+      "dst": "go:<root>.listOrders",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "go:<root>",
+      "dst": "go:<root>.main",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "go:endpoint:GET /v1/orders",
+      "dst": "go:<root>.listOrders",
+      "kind": "EXPOSES"
+    },
+    {
+      "src": "go:endpoint:GET /health",
+      "dst": "go:<root>.listOrders",
+      "kind": "EXPOSES"
+    }
+  ]
+}

--- a/corpus/multirepo/http_join_typescript_provider/.api/app/server.ts
+++ b/corpus/multirepo/http_join_typescript_provider/.api/app/server.ts
@@ -1,0 +1,11 @@
+import express from "express";
+
+const app = express();
+const v1 = express.Router();
+
+export function createOrder(req: any, res: any): string {
+  return "created";
+}
+
+v1.post("/orders", createOrder);
+app.use("/v1", v1);

--- a/corpus/multirepo/http_join_typescript_provider/.web/app/client.py
+++ b/corpus/multirepo/http_join_typescript_provider/.web/app/client.py
@@ -1,0 +1,12 @@
+"""A Python consumer of a Node service."""
+
+import httpx
+
+
+def place_order() -> object:
+    return httpx.post("/v1/orders")
+
+
+def check_health() -> object:
+    # CONTROL: nothing serves this. A joiner that joins everything emits an edge here.
+    return httpx.get("/health")

--- a/corpus/multirepo/http_join_typescript_provider/expected.json
+++ b/corpus/multirepo/http_join_typescript_provider/expected.json
@@ -1,0 +1,36 @@
+{
+  "language": "multirepo",
+  "case": "http_join_typescript_provider",
+  "requires": ["python", "typescript"],
+  "roots": {
+    "api": ".api",
+    "web": ".web"
+  },
+  "joins": [
+    {"kind": "http", "consumer": "web", "provider": "api"}
+  ],
+  "why": "The first cross-repo edge in the PKG whose provider is not Python, Java or C#. The `http` joiner matches a consumer's unresolved calls against the *provider's* `Endpoint` nodes, and no TypeScript or Go front-end emitted any — so a Node service could not be a provider at all, and multi-repo comprehension silently worked only for three languages. This is the fixture that says so: it scored zero CONSUMES before `typescript_routes` existed. A Node *consumer* is still impossible — the unresolved-call side-channel is Python-only — which is why the consumer here is Python.",
+  "nodes": [
+    {"id": "py:web@app.client", "kind": "Module"},
+    {"id": "py:web@app.client.place_order", "kind": "Function"},
+    {"id": "py:web@app.client.check_health", "kind": "Function"},
+    {"id": "ts:api@app/server", "kind": "Module"},
+    {"id": "ts:api@app/server.createOrder", "kind": "Function"},
+    {"id": "ts:api@endpoint:POST /v1/orders", "kind": "Endpoint"}
+  ],
+  "edges": [
+    {"src": "py:web@app.client", "dst": "py:web@app.client.place_order", "kind": "CONTAINS"},
+    {"src": "py:web@app.client", "dst": "py:web@app.client.check_health", "kind": "CONTAINS"},
+    {"src": "ts:api@app/server", "dst": "ts:api@app/server.createOrder", "kind": "CONTAINS"},
+    {"src": "py:web@app.client", "dst": "py:httpx", "kind": "IMPORTS"},
+    {"src": "ts:api@app/server", "dst": "ts:express", "kind": "IMPORTS"},
+    {"src": "py:web@app.client.place_order", "dst": "py:httpx.post", "kind": "CALLS"},
+    {"src": "py:web@app.client.check_health", "dst": "py:httpx.get", "kind": "CALLS"},
+    {"src": "ts:api@endpoint:POST /v1/orders", "dst": "ts:api@app/server.createOrder", "kind": "EXPOSES"},
+    {"src": "py:web@app.client.place_order", "dst": "ts:api@endpoint:POST /v1/orders", "kind": "CONSUMES"}
+  ],
+  "false_positives": [],
+  "excluded": [
+    "`check_health` calling GET /health is NOT labelled: the TypeScript provider does not serve it, so no edge is correct. It is the control — a joiner that matched everything would emit an edge here and lose precision."
+  ]
+}

--- a/corpus/typescript/express_routes/.repo/app/server.ts
+++ b/corpus/typescript/express_routes/.repo/app/server.ts
@@ -1,0 +1,25 @@
+import express from "express";
+
+const app = express();
+const v1 = express.Router();
+
+export function listOrders(req: any, res: any): string {
+  return "orders";
+}
+
+// A named handler on a mounted router: endpoint at the composed path, and an EXPOSES edge.
+v1.get("/orders", listOrders);
+
+// The dominant Express shape. An endpoint, but no handler symbol to point at.
+v1.post("/orders", (req: any, res: any) => {
+  return 1;
+});
+
+app.use("/v1", v1);
+
+// Unmounted router: the endpoint stands at its local path.
+app.get("/health", listOrders);
+
+// CONTROL: a computed path must yield nothing at all.
+const base = "/dynamic";
+app.get(`${base}/thing`, listOrders);

--- a/corpus/typescript/express_routes/expected.json
+++ b/corpus/typescript/express_routes/expected.json
@@ -1,0 +1,50 @@
+{
+  "language": "typescript",
+  "case": "express_routes",
+  "why": "Before this, no TypeScript front-end emitted `Endpoint` \u2014 so a route handler had zero callers and `impact_of` called a public endpoint safe to refactor, and a Node service could not be a *provider* in a cross-repo join at all. Pins the composed mount (`app.use` + `router.get`), the inline-arrow shape that must yield an endpoint but no fabricated `EXPOSES`, and the control: a template-literal path yields nothing. See `endpoints-typescript-go.md`.",
+  "root": ".repo",
+  "nodes": [
+    {
+      "id": "ts:app/server",
+      "kind": "Module"
+    },
+    {
+      "id": "ts:app/server.listOrders",
+      "kind": "Function"
+    },
+    {
+      "id": "ts:endpoint:GET /v1/orders",
+      "kind": "Endpoint"
+    },
+    {
+      "id": "ts:endpoint:POST /v1/orders",
+      "kind": "Endpoint"
+    },
+    {
+      "id": "ts:endpoint:GET /health",
+      "kind": "Endpoint"
+    }
+  ],
+  "edges": [
+    {
+      "src": "ts:app/server",
+      "dst": "ts:express",
+      "kind": "IMPORTS"
+    },
+    {
+      "src": "ts:app/server",
+      "dst": "ts:app/server.listOrders",
+      "kind": "CONTAINS"
+    },
+    {
+      "src": "ts:endpoint:GET /v1/orders",
+      "dst": "ts:app/server.listOrders",
+      "kind": "EXPOSES"
+    },
+    {
+      "src": "ts:endpoint:GET /health",
+      "dst": "ts:app/server.listOrders",
+      "kind": "EXPOSES"
+    }
+  ]
+}

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -27,8 +27,8 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Version | **3.28.0** | cutting now; 3.27.0 is the last on PyPI until this ships |
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **57** | `grep -c '\.command(' src/orchestrator/cli.py` |
-| Source modules | **332** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,872** across 297 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Source modules | **334** | `find src/orchestrator -name '*.py'` |
+| Test functions | **2,879** across 298 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/doc-binding-walkthrough.md
+++ b/docs/specs/doc-binding-walkthrough.md
@@ -167,13 +167,13 @@ Repository-wide, every mention lands in exactly one of four buckets:
 
 | | count | share |
 |---|---|---|
-| **one symbol anchor → `MENTIONS` edge** | **3,145** | 34% |
-| more than one symbol anchor → skipped | 2,001 | 21% |
+| **one symbol anchor → `MENTIONS` edge** | **3,141** | 34% |
+| more than one symbol anchor → skipped | 2,005 | 21% |
 | resolved to a **file**, no symbol | 871 | 9% |
 | nothing at all | 3,347 | 36% |
 | **total mentions** | **9,364** | |
 
-3,098 edges are drawn from those 3,145 — the 47 difference is de-duplication, where one section
+3,094 edges are drawn from those 3,141 — the 47 difference is de-duplication, where one section
 names the same symbol twice.
 
 > **These seven figures are derived, and reported rather than gated.**
@@ -202,7 +202,7 @@ names the same symbol twice.
 > The conclusion followed the bad number. It read *"ambiguity, not absence, is the larger
 > loss"*, and that is **false**: absence is 3,343 against ambiguity's 1,959.
 
-**What is true, and still worth saying:** ambiguity is not a rounding error. **2,001 mentions
+**What is true, and still worth saying:** ambiguity is not a rounding error. **2,005 mentions
 found real code and were deliberately dropped** for naming more than one thing — 29% of
 everything that fails to become an edge. That is qualitatively different from the 3,347 that
 found nothing, and it matters for how the gap gets closed: reducing it means answering *which*
@@ -314,10 +314,10 @@ inference over the graph changing, not the graph being rewritten.
 
 ## The open gap
 
-**819 of 1,611 `Doc` sections — 51% — bind to nothing at all.** Section 2 shows why in miniature:
+**821 of 1,611 `Doc` sections — 51% — bind to nothing at all.** Section 2 shows why in miniature:
 prose that explains *why* something exists often names no identifier, and prose that does name one
 often names an ambiguous one. Both causes are real, and **absence is the larger of the two** —
-3,347 mentions against 2,001 — though the smaller one is the more interesting, because those 2,001
+3,347 mentions against 2,005 — though the smaller one is the more interesting, because those 2,005
 found the code and were refused.
 
 > **Measured 2026-09-02: most of that 52% never made a claim.** The headline invites the
@@ -354,7 +354,7 @@ promotion was, and never smuggled into the deterministic path.
 
 1. ~~**Answer *which* symbol was meant for the ambiguous mentions** — "the tractable half, and
    the half a deterministic rule might still reach."~~ **Measured 2026-09-02 and withdrawn.**
-   Only **48 of 2,001** ambiguous mentions (2%) have every candidate anchor in one owning
+   Only **48 of 2,005** ambiguous mentions (2%) have every candidate anchor in one owning
    module, which rescues **5 sections**. And the compounding idea in that sentence — bind the
    file first, then use its module to pick among a mention's candidates — rescues **0**. It
    sounded right, cost nothing to check, and was wrong.

--- a/src/orchestrator/pkg/go_extractor.py
+++ b/src/orchestrator/pkg/go_extractor.py
@@ -142,6 +142,13 @@ class GoExtractor:
             elif kind == "method_declaration":
                 self._method(node, module_id, source, rel, batch, type_methods, bodies)
 
+        # Gin routes: inside function bodies, so scanned over the whole tree rather than the
+        # top-level declarations. Runs after pass 1 so `local_funcs` can resolve a handler name.
+        from orchestrator.pkg.go_routes import emit as _emit_routes
+        from orchestrator.pkg.go_routes import scan_tree as _scan_routes
+
+        _emit_routes(_scan_routes(tree.root_node, source, rel), module_id, local_funcs, batch)
+
         # Pass 2: resolve the precisely-resolvable call sites in each body.
         for body in bodies:
             self._resolve_calls(body, module_id, source, rel, batch, local_funcs, type_methods)

--- a/src/orchestrator/pkg/go_routes.py
+++ b/src/orchestrator/pkg/go_routes.py
@@ -1,0 +1,179 @@
+"""Gin routes in Go source → ``Endpoint`` nodes + ``EXPOSES`` edges.
+
+The Go half of what :mod:`orchestrator.pkg.python_routes` and
+:mod:`orchestrator.pkg.typescript_routes` do, closing the same wrong answer: nothing in Go
+*calls* a Gin handler — the framework does, at runtime — so a route handler has zero callers
+and ``impact_of`` reports *"safe to refactor"* for a public endpoint. It also lets a Go service
+be a **provider** in a cross-repo join, which it could not be before.
+
+============================  ==================================================
+``gin.Default()`` / ``New()``  a variable that is a router, prefix ``""``
+``r.Group("/v1")``             a router whose prefix is its parent's plus ``/v1``
+``r.GET("/orders", h)``        verb from the method, path from a **string literal**
+============================  ==================================================
+
+**Routes live inside function bodies**, not at the top level as they do in TypeScript — Gin is
+wired in ``func main()``. So this walks the whole tree in source order, which is also what makes
+``Group`` resolvable: a group is always declared before it is used.
+
+**Precision: resolve what is literal, skip what is computed.** A path built by ``fmt.Sprintf``
+or held in a variable yields no endpoint. **An inline ``func(c *gin.Context)`` literal yields an
+endpoint but no ``EXPOSES``** — there is no named symbol to point at, and inventing one is the
+fabrication this graph refuses.
+
+``net/http``'s ``HandleFunc`` is deliberately **not** read: it registers a path with no verb,
+the joiner matches on verb equality, and an ``ANY`` endpoint would join to everything. See
+``docs/specs/endpoints-typescript-go.md`` D2.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+
+if TYPE_CHECKING:
+    from tree_sitter import Node as TSNode
+
+#: Gin router methods naming an HTTP verb. ``Any`` is absent for the reason D2 gives.
+_VERBS = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"})
+
+#: Calls returning a fresh engine: ``gin.Default()``, ``gin.New()``.
+_ENGINES = frozenset({"gin.Default", "gin.New"})
+
+
+@dataclass(frozen=True)
+class PendingRoute:
+    """One ``r.GET("/x", h)``, with its router's prefix already applied."""
+
+    verb: str
+    path: str
+    handler: str | None
+    provenance: Provenance
+
+
+@dataclass
+class RouteState:
+    """Routers seen so far, keyed by variable name, each with its composed prefix."""
+
+    prefixes: dict[str, str] = field(default_factory=dict)
+    routes: list[PendingRoute] = field(default_factory=list)
+
+
+def _text(node: TSNode, source: bytes) -> str:
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace")
+
+
+def _string_literal(node: TSNode | None, source: bytes) -> str | None:
+    """An interpreted string literal's value, or ``None`` for anything computed."""
+    if node is None or node.type != "interpreted_string_literal":
+        return None
+    raw = _text(node, source)
+    return raw[1:-1] if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"' else None
+
+
+def _join(*parts: str) -> str:
+    joined = "/".join(p.strip("/") for p in parts if p and p.strip("/"))
+    return "/" + joined if joined else "/"
+
+
+def _walk(node: TSNode) -> Iterator[TSNode]:
+    """Pre-order, which is source order — what makes a ``Group`` resolvable before its use."""
+    yield node
+    for child in node.named_children:
+        yield from _walk(child)
+
+
+def scan_tree(root: TSNode, source: bytes, rel: str) -> RouteState:
+    """Collect routers, groups and routes from one file, in source order."""
+    state = RouteState()
+    for node in _walk(root):
+        if node.type == "short_var_declaration":
+            _scan_binding(node, source, state)
+        elif node.type == "call_expression":
+            _scan_registration(node, source, rel, state)
+    return state
+
+
+def _scan_binding(node: TSNode, source: bytes, state: RouteState) -> None:
+    """``r := gin.Default()`` and ``v1 := r.Group("/v1")`` both bind a router."""
+    left, right = node.child_by_field_name("left"), node.child_by_field_name("right")
+    if left is None or right is None or not left.named_children or not right.named_children:
+        return
+    name_node, value = left.named_children[0], right.named_children[0]
+    if value.type != "call_expression":
+        return
+    fn = value.child_by_field_name("function")
+    if fn is None:
+        return
+    name, called = _text(name_node, source), _text(fn, source)
+    if called in _ENGINES:
+        state.prefixes[name] = ""
+        return
+    if fn.type == "selector_expression":
+        obj, prop = fn.child_by_field_name("operand"), fn.child_by_field_name("field")
+        if obj is None or prop is None or _text(prop, source) != "Group":
+            return
+        parent = _text(obj, source)
+        if parent not in state.prefixes:
+            return
+        args = value.child_by_field_name("arguments")
+        parts = list(args.named_children) if args is not None else []
+        prefix = _string_literal(parts[0], source) if parts else None
+        if prefix is None:
+            return  # a computed group prefix: no router, rather than a wrong path
+        state.prefixes[name] = _join(state.prefixes[parent], prefix)
+
+
+def _scan_registration(node: TSNode, source: bytes, rel: str, state: RouteState) -> None:
+    """``r.GET("/orders", listOrders)`` → a route at the router's composed prefix."""
+    fn = node.child_by_field_name("function")
+    if fn is None or fn.type != "selector_expression":
+        return
+    obj, prop = fn.child_by_field_name("operand"), fn.child_by_field_name("field")
+    if obj is None or prop is None:
+        return
+    receiver, verb = _text(obj, source), _text(prop, source)
+    if verb not in _VERBS or receiver not in state.prefixes:
+        return
+    args = node.child_by_field_name("arguments")
+    parts = list(args.named_children) if args is not None else []
+    if not parts:
+        return
+    path = _string_literal(parts[0], source)
+    if path is None:
+        return
+    handler = None
+    if len(parts) > 1 and parts[-1].type == "identifier":
+        handler = _text(parts[-1], source)
+    full = _join(state.prefixes[receiver], path)
+    state.routes.append(PendingRoute(verb, full, handler, Provenance(rel, node.start_point[0] + 1)))
+
+
+def emit(state: RouteState, module_id: str, local_funcs: set[str], batch: FactBatch) -> None:
+    """Add each route's ``Endpoint``, and its ``EXPOSES`` when the handler is a known function."""
+    for route in state.routes:
+        endpoint_id = f"go:endpoint:{route.verb} {route.path}"
+        batch.add_node(
+            Node(
+                endpoint_id,
+                NodeKind.ENDPOINT,
+                f"{route.verb} {route.path}",
+                "go",
+                route.provenance,
+            )
+        )
+        if route.handler is not None and route.handler in local_funcs:
+            batch.add_edge(
+                Edge(
+                    endpoint_id,
+                    f"{module_id}.{route.handler}",
+                    EdgeKind.EXPOSES,
+                    route.provenance,
+                )
+            )
+
+
+__all__ = ["PendingRoute", "RouteState", "emit", "scan_tree"]

--- a/src/orchestrator/pkg/scoreboard.json
+++ b/src/orchestrator/pkg/scoreboard.json
@@ -8,9 +8,9 @@
       },
       "note": "provenance measured on this repo, offline; the pinned corpus is run explicitly",
       "provenance": {
-        "anchored": 10994,
-        "excluded": 769,
-        "resolved": 10994,
+        "anchored": 11058,
+        "excluded": 773,
+        "resolved": 11058,
         "unreadable": 0
       }
     },
@@ -133,31 +133,46 @@
               "matched": 3
             },
             "CONTAINS": {
-              "emitted": 15,
-              "expected": 15,
-              "matched": 15
+              "emitted": 17,
+              "expected": 17,
+              "matched": 17
+            },
+            "EXPOSES": {
+              "emitted": 2,
+              "expected": 2,
+              "matched": 2
             },
             "IMPLEMENTS": {
+              "emitted": 1,
+              "expected": 1,
+              "matched": 1
+            },
+            "IMPORTS": {
               "emitted": 1,
               "expected": 1,
               "matched": 1
             }
           },
           "nodes": {
+            "Endpoint": {
+              "emitted": 3,
+              "expected": 3,
+              "matched": 3
+            },
             "Field": {
               "emitted": 2,
               "expected": 2,
               "matched": 2
             },
             "Function": {
-              "emitted": 10,
-              "expected": 10,
-              "matched": 10
+              "emitted": 12,
+              "expected": 12,
+              "matched": 12
             },
             "Module": {
-              "emitted": 3,
-              "expected": 3,
-              "matched": 3
+              "emitted": 4,
+              "expected": 4,
+              "matched": 4
             },
             "Type": {
               "emitted": 3,
@@ -210,24 +225,24 @@
         "multirepo": {
           "edges": {
             "CALLS": {
-              "emitted": 10,
-              "expected": 10,
-              "matched": 10
+              "emitted": 12,
+              "expected": 12,
+              "matched": 12
             },
             "CONSUMES": {
-              "emitted": 2,
-              "expected": 3,
-              "matched": 2
+              "emitted": 3,
+              "expected": 4,
+              "matched": 3
             },
             "CONTAINS": {
-              "emitted": 22,
-              "expected": 22,
-              "matched": 22
+              "emitted": 25,
+              "expected": 25,
+              "matched": 25
             },
             "EXPOSES": {
-              "emitted": 2,
-              "expected": 2,
-              "matched": 2
+              "emitted": 3,
+              "expected": 3,
+              "matched": 3
             },
             "IMPLEMENTS": {
               "emitted": 5,
@@ -235,9 +250,9 @@
               "matched": 5
             },
             "IMPORTS": {
-              "emitted": 9,
-              "expected": 9,
-              "matched": 9
+              "emitted": 11,
+              "expected": 11,
+              "matched": 11
             },
             "READS": {
               "emitted": 3,
@@ -252,9 +267,9 @@
           },
           "nodes": {
             "Endpoint": {
-              "emitted": 2,
-              "expected": 2,
-              "matched": 2
+              "emitted": 3,
+              "expected": 3,
+              "matched": 3
             },
             "Entity": {
               "emitted": 2,
@@ -267,14 +282,14 @@
               "matched": 3
             },
             "Function": {
-              "emitted": 12,
-              "expected": 12,
-              "matched": 12
+              "emitted": 15,
+              "expected": 15,
+              "matched": 15
             },
             "Module": {
-              "emitted": 6,
-              "expected": 6,
-              "matched": 6
+              "emitted": 8,
+              "expected": 8,
+              "matched": 8
             },
             "Type": {
               "emitted": 5,
@@ -393,9 +408,14 @@
               "matched": 12
             },
             "CONTAINS": {
-              "emitted": 33,
-              "expected": 33,
-              "matched": 33
+              "emitted": 34,
+              "expected": 34,
+              "matched": 34
+            },
+            "EXPOSES": {
+              "emitted": 2,
+              "expected": 2,
+              "matched": 2
             },
             "IMPLEMENTS": {
               "emitted": 2,
@@ -403,26 +423,31 @@
               "matched": 2
             },
             "IMPORTS": {
-              "emitted": 3,
-              "expected": 3,
-              "matched": 3
+              "emitted": 4,
+              "expected": 4,
+              "matched": 4
             }
           },
           "nodes": {
+            "Endpoint": {
+              "emitted": 3,
+              "expected": 3,
+              "matched": 3
+            },
             "Field": {
               "emitted": 4,
               "expected": 4,
               "matched": 4
             },
             "Function": {
-              "emitted": 21,
-              "expected": 21,
-              "matched": 21
+              "emitted": 22,
+              "expected": 22,
+              "matched": 22
             },
             "Module": {
-              "emitted": 9,
-              "expected": 9,
-              "matched": 9
+              "emitted": 10,
+              "expected": 10,
+              "matched": 10
             },
             "Type": {
               "emitted": 8,
@@ -435,10 +460,10 @@
       "skipped_languages": []
     },
     "drift": {
-      "count": 913,
-      "docs": 1583,
+      "count": 836,
+      "docs": 1611,
       "gated": false,
-      "mentions": 9151,
+      "mentions": 9364,
       "note": "recorded, never gated \u2014 an upper bound: a tenth of the population cannot bind by construction. See GATES"
     },
     "invention": {
@@ -450,12 +475,12 @@
           "invented": 0,
           "shadowable": 0,
           "status": "measured",
-          "total_calls": 17232,
+          "total_calls": 17335,
           "unexamined": 0
         }
       },
       "note": "gated at zero per language, not against this baseline \u2014 see GATES",
-      "total_calls": 17232
+      "total_calls": 17335
     },
     "parity": {
       "declared": 75,

--- a/src/orchestrator/pkg/typescript_extractor.py
+++ b/src/orchestrator/pkg/typescript_extractor.py
@@ -127,6 +127,15 @@ class TypeScriptExtractor:
                 _emit_function(node, module_id, source, rel, batch, funcs, local_funcs)
             elif node.type in _FUNC_CONST_DECLS:
                 self._emit_const_functions(node, module_id, source, rel, batch, funcs, local_funcs)
+        # Express routes: top-level expression statements the declaration walk above skips.
+        # Emitted here rather than in `finalize` because a mount (`app.use("/v1", r)`) and the
+        # router it mounts are the same variable in the same module; a router imported from
+        # another file keeps its local path, which `emit` documents as the deliberate exception.
+        from orchestrator.pkg.typescript_routes import emit as _emit_routes
+        from orchestrator.pkg.typescript_routes import scan_module as _scan_routes
+
+        _emit_routes(_scan_routes(decls, source, rel, local_funcs), batch)
+
         for fid, type_id, body in funcs:
             _calls(
                 fid,

--- a/src/orchestrator/pkg/typescript_routes.py
+++ b/src/orchestrator/pkg/typescript_routes.py
@@ -1,0 +1,195 @@
+"""Express routes in TypeScript source → ``Endpoint`` nodes + ``EXPOSES`` edges.
+
+**The gap this closes is a wrong answer, not a missing one**, and it is the same one
+:mod:`orchestrator.pkg.python_routes` closes for Python: nothing in TypeScript *calls* an
+Express handler — the framework does, at runtime, through the router. So a route handler has
+zero callers, and ``impact_of`` answers *"safe to refactor"* for a public endpoint whose blast
+radius is every client of ``GET /v1/orders``.
+
+It also unblocks something larger. The multi-repo ``http`` joiner matches a consumer's
+unresolved calls against the **provider's** ``Endpoint`` nodes, so before this a Node service
+could not be a *provider* in a cross-repo join at all — multi-repo comprehension worked only
+when the provider was Java, C# or Python. See ``docs/specs/endpoints-typescript-go.md``.
+
+Read from the same tree-sitter CST the front-end already parses — no new dependency:
+
+============================  ==================================================
+``express()`` / ``Router()``  a variable that is a router
+``app.get("/x", h)``          verb from the method, path from a **string literal**
+``app.use("/v1", router)``    a mount, applied to that router's routes
+============================  ==================================================
+
+Ids mirror the C# and Python scheme exactly (``ts:endpoint:GET /v1/orders``), so every renderer
+that already understands an endpoint composes for free.
+
+**Precision: resolve what is literal, skip what is computed.** A path built from a template
+literal or held in a variable yields *no* endpoint, because a wrong path is presented as
+grounded by every surface downstream.
+
+**An inline handler yields an endpoint but no ``EXPOSES`` edge.** ``app.get("/x", (req, res) =>
+…)`` is the dominant Express shape and there is no named symbol to point at. The route is still
+a fact worth recording — it is what the joiner matches — but inventing a handler id to hang an
+edge on would be the fabrication this graph refuses. The edge appears when the handler is a
+named function this module declares.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+
+if TYPE_CHECKING:
+    from tree_sitter import Node as TSNode
+
+#: Express router methods that name an HTTP verb. ``all`` is deliberately absent: it registers
+#: every verb, and the joiner matches on verb equality, so an ``ALL`` endpoint would either join
+#: to nothing or to everything.
+_VERBS = frozenset({"get", "post", "put", "patch", "delete", "head", "options"})
+
+#: Calls that produce a router: ``express()``, ``express.Router()``, ``Router()``.
+_ROUTER_FACTORIES = frozenset({"express", "express.Router", "Router"})
+
+
+@dataclass(frozen=True)
+class PendingRoute:
+    """One ``app.get("/x", h)``, before its mounts are known."""
+
+    router: str
+    verb: str
+    path: str
+    handler_id: str | None
+    provenance: Provenance
+
+
+@dataclass
+class RouteState:
+    """What one module contributes. Mounts are per-module — see ``emit``."""
+
+    routers: set[str] = field(default_factory=set)
+    routes: list[PendingRoute] = field(default_factory=list)
+    mounts: dict[str, list[str]] = field(default_factory=dict)
+
+
+def _text(node: TSNode, source: bytes) -> str:
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace")
+
+
+def _string_literal(node: TSNode | None, source: bytes) -> str | None:
+    """The value of a plain string argument, or ``None`` for anything computed.
+
+    A ``template_string`` is refused even when it has no substitution: the shape is the signal
+    a reader relies on, and admitting the empty case invites admitting the interpolated one.
+    """
+    if node is None or node.type != "string":
+        return None
+    raw = _text(node, source)
+    return raw[1:-1] if len(raw) >= 2 and raw[0] in "\"'" and raw[-1] == raw[0] else None
+
+
+def _join(*parts: str) -> str:
+    """Compose a path from prefixes, collapsing the slashes their spellings disagree on."""
+    joined = "/".join(p.strip("/") for p in parts if p and p.strip("/"))
+    return "/" + joined if joined else "/"
+
+
+def scan_module(
+    decls: Iterable[TSNode | None], source: bytes, rel: str, local_funcs: dict[str, str]
+) -> RouteState:
+    """Collect routers, routes and mounts from one module's top-level declarations."""
+    state = RouteState()
+    for node in decls:
+        if node is None:
+            continue
+        _scan_router_bindings(node, source, state)
+    for node in decls:
+        if node is None:
+            continue
+        _scan_registrations(node, source, rel, local_funcs, state)
+    return state
+
+
+def _scan_router_bindings(node: TSNode, source: bytes, state: RouteState) -> None:
+    """``const app = express()`` / ``const r = express.Router()`` → ``app``, ``r`` are routers."""
+    if node.type not in {"lexical_declaration", "variable_declaration"}:
+        return
+    for child in node.named_children:
+        if child.type != "variable_declarator":
+            continue
+        name = child.child_by_field_name("name")
+        value = child.child_by_field_name("value")
+        if name is None or value is None or value.type != "call_expression":
+            continue
+        fn = value.child_by_field_name("function")
+        if fn is not None and _text(fn, source) in _ROUTER_FACTORIES:
+            state.routers.add(_text(name, source))
+
+
+def _scan_registrations(
+    node: TSNode, source: bytes, rel: str, local_funcs: dict[str, str], state: RouteState
+) -> None:
+    """``app.get("/x", h)`` → a route; ``app.use("/v1", r)`` → a mount."""
+    if node.type != "expression_statement":
+        return
+    call = node.named_children[0] if node.named_children else None
+    if call is None or call.type != "call_expression":
+        return
+    fn = call.child_by_field_name("function")
+    if fn is None or fn.type != "member_expression":
+        return
+    obj, prop = fn.child_by_field_name("object"), fn.child_by_field_name("property")
+    if obj is None or prop is None:
+        return
+    receiver, method = _text(obj, source), _text(prop, source)
+    if receiver not in state.routers:
+        return
+    args = call.child_by_field_name("arguments")
+    parts = [a for a in args.named_children] if args is not None else []
+    if not parts:
+        return
+    path = _string_literal(parts[0], source)
+    if path is None:
+        return  # computed path: no endpoint, rather than a wrong one
+    line = node.start_point[0] + 1
+
+    if method == "use":
+        for arg in parts[1:]:
+            if arg.type == "identifier":
+                state.mounts.setdefault(_text(arg, source), []).append(path)
+        return
+    if method not in _VERBS:
+        return
+    handler_id = None
+    if len(parts) > 1 and parts[-1].type == "identifier":
+        handler_id = local_funcs.get(_text(parts[-1], source))
+    state.routes.append(PendingRoute(receiver, method.upper(), path, handler_id, Provenance(rel, line)))
+
+
+def emit(state: RouteState, batch: FactBatch) -> None:
+    """Compose each route's full path and add its ``Endpoint`` — and its ``EXPOSES`` if named.
+
+    A router mounted twice yields two endpoints, which is the truth: the handler serves both
+    paths. **A router with no resolvable mount yields one, at its local path** — dropping it
+    would restore exactly the false negative this module exists to kill, a public handler with
+    no inbound edge that ``impact_of`` then calls safe.
+    """
+    for route in state.routes:
+        for mount in state.mounts.get(route.router) or [""]:
+            full = _join(mount, route.path)
+            endpoint_id = f"ts:endpoint:{route.verb} {full}"
+            batch.add_node(
+                Node(
+                    endpoint_id,
+                    NodeKind.ENDPOINT,
+                    f"{route.verb} {full}",
+                    "typescript",
+                    route.provenance,
+                )
+            )
+            if route.handler_id is not None:
+                batch.add_edge(Edge(endpoint_id, route.handler_id, EdgeKind.EXPOSES, route.provenance))
+
+
+__all__ = ["PendingRoute", "RouteState", "emit", "scan_module"]

--- a/tests/pkg/test_routes_ts_go.py
+++ b/tests/pkg/test_routes_ts_go.py
@@ -1,0 +1,116 @@
+"""Express and Gin routes → `Endpoint` nodes.
+
+Before these, **only Java and C# emitted `Endpoint` among the tree-sitter front-ends**. Two
+consequences, and the second is the larger one: a route handler had zero callers, so
+`impact_of` called a public endpoint safe to refactor; and the multi-repo `http` joiner matches
+against the *provider's* endpoints, so a Node or Go service could not be a provider at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from orchestrator.pkg.extractor import RepoCodeExtractor
+from orchestrator.pkg.facts import EdgeKind, NodeKind
+
+EXPRESS = """
+import express from "express";
+const app = express();
+const v1 = express.Router();
+export function listOrders(req: any, res: any): string { return "ok"; }
+v1.get("/orders", listOrders);
+v1.post("/orders", (req: any, res: any) => { return 1; });
+app.use("/v1", v1);
+app.get("/health", listOrders);
+const base = "/dyn";
+app.get(`${base}/thing`, listOrders);
+"""
+
+GIN = """package main
+
+import "github.com/gin-gonic/gin"
+
+func listOrders(c *gin.Context) {}
+
+func main() {
+\tr := gin.Default()
+\tv1 := r.Group("/v1")
+\tv1.GET("/orders", listOrders)
+\tv1.POST("/orders", func(c *gin.Context) {})
+\tr.GET("/health", listOrders)
+\tpath := "/dyn"
+\tr.GET(path, listOrders)
+}
+"""
+
+
+def _graph(tmp_path: Path, name: str, body: str) -> tuple[set[str], set[tuple[str, str]]]:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    if name.endswith(".go"):
+        (repo / "go.mod").write_text("module example.com/svc\n\ngo 1.22\n", encoding="utf-8")
+    (repo / name).write_text(body, encoding="utf-8")
+    batch = RepoCodeExtractor().extract(repo)
+    endpoints = {n.id for n in batch.nodes if n.kind is NodeKind.ENDPOINT}
+    exposes = {(e.src, e.dst) for e in batch.edges if e.kind is EdgeKind.EXPOSES}
+    return endpoints, exposes
+
+
+def test_express_composes_a_mounted_route(tmp_path: Path) -> None:
+    """`app.use("/v1", v1)` is in a different statement from `v1.get("/orders")`."""
+    endpoints, _ = _graph(tmp_path, "server.ts", EXPRESS)
+    assert "ts:endpoint:GET /v1/orders" in endpoints
+    assert "ts:endpoint:POST /v1/orders" in endpoints
+
+
+def test_express_leaves_an_unmounted_route_at_its_local_path(tmp_path: Path) -> None:
+    """Dropping it restores the false negative this exists to kill: a handler with no edge."""
+    endpoints, _ = _graph(tmp_path, "server.ts", EXPRESS)
+    assert "ts:endpoint:GET /health" in endpoints
+
+
+def test_express_refuses_a_computed_path(tmp_path: Path) -> None:
+    """A template literal yields nothing. A wrong path is presented as grounded downstream."""
+    endpoints, _ = _graph(tmp_path, "server.ts", EXPRESS)
+    assert not [e for e in endpoints if "dyn" in e or "thing" in e]
+    assert len(endpoints) == 3
+
+
+def test_an_inline_handler_gets_an_endpoint_but_no_exposes(tmp_path: Path) -> None:
+    """The dominant Express shape has no named symbol. The route is still a fact.
+
+    Emitting `EXPOSES` anyway would need an invented handler id — the fabrication this graph
+    refuses — while dropping the endpoint would lose the thing the joiner matches on.
+    """
+    endpoints, exposes = _graph(tmp_path, "server.ts", EXPRESS)
+    assert "ts:endpoint:POST /v1/orders" in endpoints
+    assert not [dst for src, dst in exposes if src == "ts:endpoint:POST /v1/orders"]
+    assert ("ts:endpoint:GET /v1/orders", "ts:server.listOrders") in exposes
+
+
+def test_gin_composes_a_group_prefix(tmp_path: Path) -> None:
+    """`v1 := r.Group("/v1")` then `v1.GET("/orders")`, resolved in source order."""
+    endpoints, exposes = _graph(tmp_path, "main.go", GIN)
+    assert "go:endpoint:GET /v1/orders" in endpoints
+    assert "go:endpoint:POST /v1/orders" in endpoints
+    assert ("go:endpoint:GET /v1/orders", "go:<root>.listOrders") in exposes
+
+
+def test_gin_refuses_a_path_held_in_a_variable(tmp_path: Path) -> None:
+    endpoints, _ = _graph(tmp_path, "main.go", GIN)
+    assert not [e for e in endpoints if "dyn" in e]
+    assert len(endpoints) == 3
+
+
+def test_net_http_handlefunc_yields_nothing(tmp_path: Path) -> None:
+    """Deliberate, per the spec's D2: it registers a path with **no verb**.
+
+    The joiner matches on verb equality, so an `ANY` endpoint would join to everything.
+    """
+    body = (
+        'package main\n\nimport "net/http"\n\n'
+        "func handle(w http.ResponseWriter, r *http.Request) {}\n\n"
+        'func main() {\n\thttp.HandleFunc("/legacy", handle)\n}\n'
+    )
+    endpoints, _ = _graph(tmp_path, "main.go", body)
+    assert endpoints == set()


### PR DESCRIPTION
Implements [`endpoints-typescript-go.md`](docs/specs/endpoints-typescript-go.md), merged in [#300](https://github.com/synaptixs/spine/pull/300). Built on D1–D3 as recommended: **Express and Gin only**, **`net/http` unread**, both languages under one spec.

## The edge that was impossible yesterday

```
py:web@app.client.place_order  --CONSUMES-->  ts:api@endpoint:POST /v1/orders
```

The multi-repo `http` joiner matches a consumer's unresolved calls against the **provider's** `Endpoint` nodes. With none emitted, **a Node or Go service could not be a provider in a cross-repo join at all** — multi-repo comprehension shipped in 3.22.0 and worked only when the provider was Java, C# or Python, and nothing said so.

`corpus/multirepo/http_join_typescript_provider` pins it, with an unserved `/health` call as the control.

Single-repo, it closes the wrong answer `python_routes.py` exists to kill: nothing *calls* an HTTP handler — the framework does, at runtime — so a route handler had **zero callers** and `impact_of` answered "safe to refactor" about a public endpoint. Live for every Go and TypeScript service until now.

## Three precision decisions, each with a control in the fixtures

| | |
|---|---|
| **A computed path yields nothing** | a template literal, or a path held in a variable. A wrong path is presented as grounded by every surface downstream |
| **An inline handler yields an endpoint but no `EXPOSES`** | `app.get("/x", (req,res) => …)` is the dominant Express shape and has no named symbol. Emitting the edge needs an invented id; dropping the endpoint loses what the joiner matches on |
| **`net/http`'s `HandleFunc` is unread** | D2 — it registers a path with **no verb**, the joiner matches on verb equality, and `ANY` would join to everything |

Mounts compose (`app.use("/v1", r)`, `r.Group("/v1")`), and a router with no resolvable mount keeps its local path — the same deliberate exception `python_routes` documents, because dropping it restores the false negative.

## Measured

| | |
|---|---|
| `typescript` | `Endpoint` **3/3**, `EXPOSES` **2/2** — neither existed |
| `go` | `Endpoint` **3/3**, `EXPOSES` **2/2** — neither existed |
| `multirepo` | `CONSUMES` **2/3 → 3/4** |

Three corpus cases at 1.00 precision and recall. Seven unit tests, **six fail with the feature disabled**; the seventh is the `net/http` negative, which passes either way and guards against a future change minting verbless endpoints. Scoreboard regenerated — every delta is new capability or improvement, no regressions.

## What the local gate caught

Four real downstream consequences, each of which CI would have surfaced one round-trip at a time:

1. 13 missing type annotations in the new modules
2. **source modules 332 → 334** — a gated claim
3. **test functions 2,872 → 2,879, files 297 → 298** — gated
4. the **published capability matrix**, generated from the front-ends, which now legitimately shows `typescript` and `go` with `Endpoint`:

```
-| `typescript` | ✓ | ✓ | ✓ | ✓ | · | · | · | · |
+| `typescript` | ✓ | ✓ | ✓ | ✓ | ✓ | · | · | · |
```

## Gate

All four generated-artifact checks, `ruff format --check .`, `mypy src tests` (665 files), `pkg accuracy --check`, `check-mermaid` 47/47, **3,297 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)