### PR TITLE
fix(codegen): a bad draw is not a loop — an empty submission gets a second correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## Unreleased
 
+### Fixed
+
+- **An empty codegen submission gets a second correction — a bad draw is not a
+  loop.** The corrective retry allowed one correction per failure kind, on the
+  reasoning that a kind failing twice is looping rather than fixing. That holds for
+  a deterministic failure (the same bad edit anchor, the same unparseable output)
+  and not for an empty submission: codegen samples at the provider default, so a
+  run that answered `summary='placeholder'` and no files drew badly rather than
+  reasoned badly, and the remedy for a bad draw is another draw. `empty` now gets
+  two corrections (`_CORRECTIONS_PER_KIND`), every other kind keeps one, and the
+  overall attempt cap grows by exactly one so the allowance is spendable. Follows
+  #154, which routed placeholder-only submissions into this retry.
+
 ### Removed
 
 - **The terminal UI (`orchestrator tui`) and the `tui` extra.** Every action it

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
 | Source modules | **342** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,888** across 299 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,892** across 299 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/src/orchestrator/sdlc/codegen.py
+++ b/src/orchestrator/sdlc/codegen.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import re
+from collections import Counter
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1536,7 +1537,7 @@ class LLMCodegenAdapter:
         nothing there is a real failure.
         """
         text = await self._complete(system, user)
-        # One corrective attempt per KIND of failure, not one shared by all of them.
+        # A corrective allowance per KIND of failure, not one shared by all of them.
         #
         # It used to be a single retry for every kind, and a live run showed why that is
         # too few: the model submitted no files, spent the one retry recovering from that,
@@ -1544,20 +1545,23 @@ class LLMCodegenAdapter:
         # very thing the retry exists for, had no attempt left. Same shape as three checks
         # sharing one `--max-refine` pool.
         #
-        # Per-kind also keeps the old guarantee: a kind that fails twice is looping, not
-        # fixing, so it stops. `_MAX_GENERATE_ATTEMPTS` bounds the whole thing regardless.
-        spent: set[str] = set()
+        # Per-kind also keeps the old guarantee: a kind that fails past its allowance is
+        # looping, not fixing, so it stops. The allowance is one for a deterministic kind
+        # and two for `empty` — see `_CORRECTIONS_PER_KIND` for why an empty submission is
+        # a bad draw rather than a loop. `_MAX_GENERATE_ATTEMPTS` bounds the whole thing
+        # regardless.
+        spent: Counter[str] = Counter()
         for _ in range(_MAX_GENERATE_ATTEMPTS):
             try:
                 return self._apply(text, root, allow_empty=allow_empty)
             except CodegenError as exc:
                 kind = _failure_kind(exc)
-                if kind in spent:  # already corrected this once — a third go is a loop
+                if spent[kind] >= _CORRECTIONS_PER_KIND.get(kind, _DEFAULT_CORRECTIONS):
                     raise
                 suffix = self._corrective_suffix(exc, root)
                 if suffix is None:
                     raise
-                spent.add(kind)
+                spent[kind] += 1
                 text = await self._complete(system, f"{user}{suffix}")
         raise CodegenError("codegen retries did not produce a usable change")  # unreachable
 
@@ -2351,7 +2355,15 @@ def _coverage_gap_block(gaps: list[str]) -> str:
     )
 
 
-_MAX_GENERATE_ATTEMPTS = 4  # first try plus one correction per failure kind
+_MAX_GENERATE_ATTEMPTS = 5  # first try plus the corrections allowed below
+# One correction per kind, because a kind that fails twice is looping rather than fixing —
+# the same bad anchor, the same unparseable output. That reasoning holds for a deterministic
+# failure and not for an empty submission: codegen samples at the provider default, so a run
+# that answered `summary='placeholder'` and no files drew badly rather than reasoned badly,
+# and the remedy for a bad draw is another draw. `_MAX_GENERATE_ATTEMPTS` still bounds the
+# whole loop, so the worst case grows by one attempt.
+_CORRECTIONS_PER_KIND: dict[str, int] = {"empty": 2}
+_DEFAULT_CORRECTIONS = 1
 
 
 def _failure_kind(exc: CodegenError) -> str:

--- a/tests/sdlc/test_codegen.py
+++ b/tests/sdlc/test_codegen.py
@@ -212,13 +212,17 @@ async def test_a_submission_with_no_files_is_retried_then_refused(tmp_path: Path
     the right shape and simply submitted nothing — the schema allows it, since `required`
     means present, not non-empty. A live run died here after a clean implement pass
     because author_tests came back empty and nothing asked it to try again."""
-    llm = _ScriptedLLM(['{"summary": "I did nothing"}', '{"summary": "still nothing"}'])
+    llm = _ScriptedLLM(
+        ['{"summary": "I did nothing"}', '{"summary": "still nothing"}', '{"summary": "nor now"}']
+    )
     adapter = LLMCodegenAdapter(llm)
 
     with pytest.raises(CodegenError):
         await adapter.implement(spec=_SPEC, path=str(tmp_path), issue_key="SDLC-1")
 
-    assert len(llm.calls) == 2  # one corrective retry, then it gives up
+    # Two corrective retries for `empty`, then it gives up — an empty submission is a bad
+    # sample rather than a loop, so the second correction is another draw, not a repeat.
+    assert len(llm.calls) == 3
     assert "SUBMITTED NO FILES" in llm.calls[1][1].content
     assert "I did nothing" in llm.calls[1][1].content  # its own words, fed back
 
@@ -824,15 +828,18 @@ async def test_anchor_repair_gives_up_after_one_retry(tmp_path: Path) -> None:
     assert len(llm.calls) == 2  # initial + exactly one repair
 
 
-async def test_the_empty_retry_is_spent_once(tmp_path: Path) -> None:
-    """One corrective pass, not a loop: a model that submits nothing twice has said its
-    piece, and a third call would just pay to watch it repeat."""
+async def test_the_empty_retry_is_bounded(tmp_path: Path) -> None:
+    """Was `..._is_spent_once`, on the reasoning that "a third call would just pay to watch
+    it repeat". That holds for a deterministic failure and not for this one: codegen samples
+    at the provider default, so an empty submission is a bad *draw* — a live run answered
+    `summary='placeholder'` — and the remedy for a bad draw is another draw. Two
+    corrections, then it stops: still bounded, just not at one."""
     empty = json.dumps({"files": [], "summary": "nothing"})
-    llm = _ScriptedLLM([empty, empty])
+    llm = _ScriptedLLM([empty, empty, empty])
     adapter = LLMCodegenAdapter(llm)
     with pytest.raises(CodegenError, match="no 'files'"):
         await adapter.implement(spec=_SPEC, path=str(tmp_path), issue_key="E-1")
-    assert len(llm.calls) == 2
+    assert len(llm.calls) == 3
 
 
 async def test_new_root_module_shadowing_stdlib_is_rejected(tmp_path: Path) -> None:
@@ -2078,3 +2085,67 @@ async def test_refine_with_nothing_to_do_is_still_a_no_op(tmp_path: Path) -> Non
 
     assert change.files == []
     assert "nothing to change" in change.summary
+
+
+# --- a bad draw is not a loop --------------------------------------------------------
+#
+# One correction per kind, because a kind that fails twice is looping rather than fixing.
+# True of a deterministic failure — the same bad anchor, the same unparseable output — and
+# false of an empty submission: codegen samples at the provider default, so a run that
+# answered `summary='placeholder'` with no files drew badly rather than reasoned badly. The
+# remedy for a bad draw is another draw.
+
+
+async def test_an_empty_submission_gets_a_second_correction(tmp_path: Path) -> None:
+    """Two bad draws in a row must not end the run; the third gets its chance."""
+    from orchestrator.sdlc.codegen import LLMCodegenAdapter
+
+    empty = json.dumps({"summary": "placeholder", "files": []})
+    good = json.dumps({"summary": "done", "files": [{"path": "a.py", "content": "X = 1\n"}]})
+    llm = _ScriptedLLM([empty, empty, good])
+
+    change = await LLMCodegenAdapter(llm).implement(spec={"title": "t"}, path=str(tmp_path), issue_key="S-1")
+
+    assert [Path(f).name for f in change.files] == ["a.py"]
+
+
+async def test_three_empty_submissions_still_stop(tmp_path: Path) -> None:
+    """Bounded: two corrections, not unlimited resampling."""
+    from orchestrator.sdlc.codegen import CodegenError, LLMCodegenAdapter
+
+    empty = json.dumps({"summary": "placeholder", "files": []})
+    llm = _ScriptedLLM([empty] * 6)
+
+    with pytest.raises(CodegenError):
+        await LLMCodegenAdapter(llm).implement(spec={"title": "t"}, path=str(tmp_path), issue_key="S-1")
+
+
+async def test_a_deterministic_kind_still_gets_only_one_correction(tmp_path: Path) -> None:
+    """An anchor that misses twice is a loop — that reasoning is unchanged."""
+    from orchestrator.sdlc.codegen import CodegenError, LLMCodegenAdapter
+
+    (tmp_path / "a.py").write_text("VALUE = 1\n", encoding="utf-8")
+    bad = json.dumps(
+        {"summary": "s", "files": [{"path": "a.py", "edits": [{"find": "NOT THERE", "replace": "x"}]}]}
+    )
+    llm = _ScriptedLLM([bad] * 6)
+
+    with pytest.raises(CodegenError):
+        await LLMCodegenAdapter(llm).implement(spec={"title": "t"}, path=str(tmp_path), issue_key="S-1")
+
+    # First try plus exactly one correction — not two.
+    assert len(llm.calls) == 2
+
+
+def test_the_allowance_table_is_explicit() -> None:
+    """The exception is named, so a reader sees which kind is treated as a draw."""
+    from orchestrator.sdlc.codegen import (
+        _CORRECTIONS_PER_KIND,
+        _DEFAULT_CORRECTIONS,
+        _MAX_GENERATE_ATTEMPTS,
+    )
+
+    assert _CORRECTIONS_PER_KIND == {"empty": 2}
+    assert _DEFAULT_CORRECTIONS == 1
+    # The loop must be able to spend the largest allowance plus the first try.
+    assert max(_CORRECTIONS_PER_KIND.values()) + 1 <= _MAX_GENERATE_ATTEMPTS


### PR DESCRIPTION
## Summary

The corrective retry in `LLMCodegenAdapter` allowed one correction per failure kind, on the reasoning that a kind failing twice is looping rather than fixing. That holds for a deterministic failure — the same bad edit anchor, the same unparseable output — and not for an empty submission: codegen samples at the provider default, so a run that answered `summary='placeholder'` and no files drew badly rather than reasoned badly, and the remedy for a bad draw is another draw.

Follows #154 (SSPN-45), which routed placeholder-only submissions into this retry. Revived from a stash of 2026-08-07; the diff applied to develop unchanged.

## Changes

- `_CORRECTIONS_PER_KIND = {"empty": 2}`, `_DEFAULT_CORRECTIONS = 1`; the loop tracks spend with a `Counter` instead of a set.
- `_MAX_GENERATE_ATTEMPTS` 4 → 5 so the larger allowance is spendable. Worst case grows by exactly one model call.
- Tests: two existing tests adjusted to the new bound; four new ones — a second correction succeeds, three empties still stop, a deterministic kind still gets only one correction, and the allowance table is explicit and fits inside the cap.
- CHANGELOG Unreleased entry; STATE-OF-SPINE test count.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`: pass
- Full pytest: 3313 passed, 3 skipped
- `state-numbers --check`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)