### PR TITLE
feat(plugin): the tiers are annotations a host can act on, and doctor names its install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,27 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## Unreleased
 
+### Added
+
+- **The MCP server's tiers are metadata a host can act on.** Every plugin tool is
+  registered with MCP tool annotations derived from its tier — read-only,
+  destructive, idempotent, open-world — so a host that confirms before destructive
+  calls confirms before `sdlc_feature`, `sdlc_start_run` and `sdlc_decide_gate`,
+  and not before `map_repo`. The tier table is total by construction: a tool
+  registered without one is refused, and a test says so first. Design record:
+  `docs/specs/mcp-plugin-surface.md`, which also fixes the extension order — the
+  six known gaps before any new surface.
+- **`doctor` says which install is answering.** The tool and the CLI both report
+  the package version, interpreter, MCP SDK version and the extras present. The
+  case it exists for: a host launched an `orchestrator-mcp` console script left
+  behind by an older checkout's venv (Spine 3.9.3, no `mcp` module) and the only
+  symptom was "Connection closed".
+
 ### Fixed
+
+- **`__all__` in `orchestrator.plugin.server` exports every registered tool.** Four
+  (`sdlc_plan`, `sdlc_approve`, `docs_for`, `pkg_joins`) were registered but not
+  exported; a test now holds the two in step.
 
 - **An empty codegen submission gets a second correction — a bad draw is not a
   loop.** The corrective retry allowed one correction per failure kind, on the

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -211,6 +211,14 @@ At a glance:
 > `file:line`). To serve them to a **remote** host over HTTP, run the streamable‑HTTP server
 > (`orchestrator-mcp --http`, bearer/OAuth auth from env) — it registers the same tools.
 
+> **The tiers are metadata your host can act on.** Every tool is registered with MCP tool
+> annotations derived from its tier — *read‑only*, *destructive*, *idempotent*, *open‑world* — so a
+> host that asks before destructive calls asks before `sdlc_feature`, `sdlc_start_run` and
+> `sdlc_decide_gate`, and not before `map_repo`. The comprehension tools are read‑only and
+> idempotent; `sdlc_plan`/`sdlc_approve` write (under `.spine/`) but destroy nothing; only
+> `doctor`, `pkg_joins`, `sdlc_plan` and `sdlc_approve` never leave the machine — everything else
+> may clone a URL or read a remote source. See [`docs/specs/mcp-plugin-surface.md`](docs/specs/mcp-plugin-surface.md).
+
 ### Asking across several repositories
 
 The comprehension tools take **one** repository by default, and for a service that is called
@@ -689,6 +697,7 @@ name. Run `orchestrator pkg accuracy` to see the current numbers yourself.
 | Claude doesn't see Spine's tools | Restart Claude Code or run `/reload-plugins`. Check `/mcp` and `/plugin`. |
 | `doctor` says the LLM provider is missing | Your `.env` isn't being found — launch Claude Code from a project with a `.env`, or use the raw‑MCP form (§3b) and set `ORCHESTRATOR_DOTENV` to its **absolute** path. |
 | `orchestrator-mcp: command not found` | The server isn't on PATH. `pip install 'synaptixs-spine[all]'`, or point `command` at the absolute path of the console script. |
+| The server connects and dies ("Connection closed"), or tools are missing | A **stale** `orchestrator-mcp` on PATH — a console script left by an older checkout's venv. Ask Claude to run `doctor` (or run `orchestrator doctor`): its `server` block names the **version, interpreter and MCP SDK** answering. If they aren't the install you expect: `uv tool install --force 'synaptixs-spine[all]'` (or reinstall into the venv you meant), then restart the host. |
 | Codegen times out | Set a faster model: `ORCHESTRATOR_INTAKE_MODEL=...` (or `SDLC_CODEGEN_MODEL`). |
 | "live needs a repo to push to" | Pass `repo=...` or set `SDLC_REPO_URL`; ensure `GITHUB_TOKEN`/`GH_TOKEN` is set. |
 | A `live` call refuses to write | That's the gate — pass `confirm=true` together with `live=true`. |

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -1,8 +1,8 @@
 # Spec index — every design record, and where it stands
 
 **Generated 2026-08-15 against 3.18.1; refreshed 2026-08-21 for the completed GraphIR
-programme; recounted 2026-09-03 at 3.30.0.** `docs/specs/` holds **85** markdown files —
-**78 specs** plus three navigation documents ([README](README.md), this index,
+programme; recounted 2026-09-03 at 3.30.0.** `docs/specs/` holds **86** markdown files —
+**79 specs** plus three navigation documents ([README](README.md), this index,
 [STATE-OF-SPINE](STATE-OF-SPINE.md)) — with 6 archived and 10 build documents. The count read
 *63* until 2026-08-21, and **five specs were not listed at all**, including this file's own
 companion matrix and both measurements it cites as evidence. An inventory that silently omits
@@ -10,7 +10,7 @@ things is the failure it was built to catch, so the count is now stated as a der
 can re-run:
 
 ```
-ls docs/specs/*.md | wc -l          # 85
+ls docs/specs/*.md | wc -l          # 86
 ```
 
 **It rotted anyway.** The line read *70* from 2026-08-21 until 2026-08-28 while the directory
@@ -93,6 +93,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [gap6-benchmarks-roadmap](gap6-benchmarks-roadmap.md) | ✅ **Complete 2026-09-01** | All three phases: harness, 38-label gold set, ratchet gate. top-1 0.32 / top-10 0.71 against 0.085 chance; published as [BENCHMARK.md](../../BENCHMARK.md). This row read *Not started* for a day after the spec said COMPLETE |
 | [codegen-benchmark-roadmap](codegen-benchmark-roadmap.md) | Not started | **New 2026-08-15.** SWE-bench comparability → `resolved`-vs-`mergeable` delta |
 | [codex-plugin-keyless-roadmap](codex-plugin-keyless-roadmap.md) | Not started | **New 2026-08-15.** Phase 0 is a blocking spike |
+| [mcp-plugin-surface](mcp-plugin-surface.md) | Phase 1 in progress | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
 | [phase5-agentic-codegen-loop](phase5-agentic-codegen-loop.md) | Proposed, under review | "The hinge phase" |
 | [autonomous-run-agent](autonomous-run-agent.md) | Proposed, no branch | 9 phases; 0–3 strictly serial |
 | [catalog-then-compose-roadmap](catalog-then-compose-roadmap.md) | Proposed, under review | Scope confirmed: Phases 0–3 |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -3,7 +3,7 @@
 **The one document to read.** Verified against source on **2026-09-03**, at the 3.30.0 release
 cut. Every number below was re-measured that day.
 
-> **Why this exists.** `docs/specs/` holds **85** markdown files — **82 specs** plus this
+> **Why this exists.** `docs/specs/` holds **86** markdown files — **83 specs** plus this
 > page, [`README`](README.md) and [`SPEC-INDEX`](SPEC-INDEX.md) — with 6 archived, 10 build
 > documents, and 17 root-level user documents.
 > Answering "where do we stand?" required opening five of them and reconciling three that
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
 | Source modules | **342** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,892** across 299 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,904** across 300 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/mcp-plugin-surface.md
+++ b/docs/specs/mcp-plugin-surface.md
@@ -1,0 +1,158 @@
+# The MCP plugin surface — what it is, what it lacks, and the order to extend it
+
+**Status:** Phase 1 in progress (this record's first PR). **Written 2026-09-04 against 3.30.0**,
+after #316 removed the terminal UI and left the plugin as the only non-browser operator face.
+**Owner:** _unassigned_
+
+**One-liner:** Spine already *is* an MCP server with 20 tools in three tiers; the work is not a
+new server but closing six known gaps in this one, in an order that retires the gaps before
+adding any surface.
+
+> **Read this before adding a tool.** A tool without a tier does not register (`_TIER` in
+> `plugin/server.py`), and the tier decides the annotations a host sees. Decide what the tool can
+> cost first; the code refuses to let you skip that.
+
+---
+
+## 1. What is true at 3.30.0
+
+Verified by reading `src/orchestrator/plugin/`, `plugins/spine/`, `tests/plugin/`, and by building
+the server from the checkout and listing its tools.
+
+Two packages carry the letters "mcp", and they are inverses:
+
+| Package | Role |
+|---|---|
+| `orchestrator/plugin/` | Spine **is** the server. This record. |
+| `orchestrator/mcp/` | Spine **uses** servers: onboarding, allow-lists; `agentic/mcp_tools.py` bridges them into the codegen loop. |
+
+The server is a façade over the real engine. Tool implementations are module-level functions in
+`plugin/server.py`, testable without the `mcp` extra; `build_server()` lazy-imports the SDK
+(`mcp.server.MCPServer`, SDK v2) and registers the `_TOOLS` tuple.
+
+**Transports.** stdio by default (a desktop host launches `orchestrator-mcp` as a subprocess;
+`.mcp.json` and the plugin manifest both point at it with no args). `--http` serves
+streamable-http for hosted clients, with `--host/--port/--path/--stateless` and
+`ORCHESTRATOR_MCP_HOST/PORT/PATH` fallbacks. `ORCHESTRATOR_DOTENV` names an absolute `.env`,
+because a host's cwd is not the repo.
+
+**Auth (HTTP only).** An OAuth 2.1 resource server: it verifies bearer tokens and never mints
+them. Introspection (`ORCHESTRATOR_MCP_INTROSPECTION_URL` + client id/secret, issuer and resource
+URLs) or a static shared secret (`ORCHESTRATOR_MCP_TOKEN`, constant-time compare). One scope list
+for the whole server (`ORCHESTRATOR_MCP_REQUIRED_SCOPES`, default `sdlc`). A non-loopback bind
+with neither configured is refused unless `--allow-unauthenticated`.
+
+**Packaging.** A Claude Code plugin at `plugins/spine/` bundling the `understand-codebase` skill;
+marketplace entry in `.claude-plugin/marketplace.json`; `pip install 'synaptixs-spine[all]'`.
+
+## 2. The 20 tools, in three tiers
+
+The tiers are separated by what a tool can cost you if it is wrong. An assistant works **down**
+them: comprehend, then plan and get the plan approved, then build.
+
+| Tier | Tools | Cost |
+|---|---|---|
+| **1 · comprehend** | `doctor`, `map_repo`, `blast_radius`, `explain_symbol`, `investigate`, `localize`, `regression_gaps`, `root_cause`, `docs_for`, `pkg_joins`, `read_memory_bank`, `pkg_grounding`, `ingest_preview` | No credentials, no model, deterministic. `root_cause(use_llm=true)` is the one opt-in model call, and it still never changes code. `repo_path` is a local path or a git URL; `blast_radius` and `investigate` answer across repositories via `repos` (`.spine/repos.yaml`). |
+| **2 · plan** | `sdlc_plan`, `sdlc_approve` | Writes only under `.spine/`. Still no model, no credentials — which is what lets a host with its own model drive Spine on a machine where Spine has neither. |
+| **3 · run** | `sdlc_feature`, `sdlc_start_run`, `sdlc_run_status`, `sdlc_decide_gate`, `sdlc_run_result` | Spends tokens. `live=true` (or `create_jira=true`) writes where it cannot be taken back and needs `confirm=true` on top of the host's own confirmation. The run set needs the Temporal backend. |
+
+### The tiers as annotations (Phase 1)
+
+Prose tiers are read by people. MCP `ToolAnnotations` are read by hosts, which use them to decide
+what to confirm. From Phase 1 every registration carries the four hints, derived from `_TIER`:
+
+| Tools | read-only | destructive | idempotent | open-world |
+|---|---|---|---|---|
+| Tier 1 | yes | no | yes | yes — `repo_path` may be a URL, a `source` may be remote |
+| `doctor`, `pkg_joins` | yes | no | yes | no — local only |
+| `sdlc_plan`, `sdlc_approve` | no | no | yes — re-running rewrites the same document | no |
+| `sdlc_run_status`, `sdlc_run_result` | yes | no | yes | yes — they read Temporal |
+| `sdlc_feature`, `sdlc_start_run`, `sdlc_decide_gate` | no | yes | no | yes |
+
+Deciding a gate is destructive because a rejection ends a run. `_TIER` is total by construction:
+`_register_tools` raises for a tool it does not list, and `tests/plugin` asserts the table and
+`_TOOLS` name the same set, so a new tool cannot reach a host with its cost unstated.
+
+## 3. The gaps
+
+Numbered, because §5 retires them by number.
+
+1. **No operator-ops tools.** Nothing lists registry runs or pending approvals generically;
+   `sdlc_decide_gate` covers only an sdlc run's own gates. This is what the removed TUI did.
+2. **`__all__` drifted from `_TOOLS`.** Four registered tools were not exported. *(Closed in
+   Phase 1, with a test.)*
+3. **The tiers were prose only.** A host could not tell a read-only tool from a money-spending
+   one. *(Closed in Phase 1 — §2.)*
+4. **One scope for everything.** A token that may call `map_repo` may call `sdlc_feature`.
+5. **The back half of the pipeline is CLI-only.** `sdlc address-review`, `sdlc complete`,
+   `sdlc remediate`, `sdlc baseline`, `design`, `audit`, `profile`, `understand`, `state` exist
+   as commands and not as tools. An assistant can open the PR but cannot drive what follows.
+6. **A stale install was invisible.** The `orchestrator-mcp` on one machine's PATH pointed at
+   another checkout's venv (Spine 3.9.3, no `mcp` module); the host saw "Connection closed" and
+   nothing said why. *(Closed in Phase 1: `doctor` reports version, interpreter, SDK and extras,
+   as a tool and as a CLI header.)*
+
+## 4. Proposals
+
+Each is scoped to one PR. The number is a name, not an order — §5 is the order.
+
+- **4.1 Annotations and typed output.** Annotations: Phase 1. Typed output schemas (a model per
+  tool instead of `dict[str, Any]`) are deferred to their own PR: the SDK already advertises an
+  open-object schema, and real models touch twenty return shapes and their tests.
+- **4.2 Operator-ops tools.** `runs_list`, `run_trace`, `approvals_list`, `approval_decide` over
+  the registry `/v1` API with `X-API-Key`, reinstating the removed 52-line registry client as
+  `plugin/registry_client.py`. Config via `ORCHESTRATOR_API_URL` / `ORCHESTRATOR_API_KEY`.
+- **4.3 Per-tier scopes on HTTP.** `spine:read`, `spine:plan`, `spine:run`, checked per tool at
+  registration; `sdlc` accepted as an alias for one release.
+- **4.4 `understand_repo` and `current_state` as tools.** Both deterministic by invariant, so
+  they fit tier 2 without new policy. Today `read_memory_bank` can only read a bank someone
+  already committed.
+- **4.5 The post-PR loop.** `sdlc_address_review`, `sdlc_complete`, `sdlc_remediate`,
+  `sdlc_baseline`, `design` as tier-3 tools under the same `live`/`confirm` gate.
+- **4.6 Resources.** `spine://episteme/{repo}/{section}`, `spine://plan/{repo}/{intent}`,
+  `spine://state/{repo}` as MCP resources — listable, subscribable, attachable as context.
+- **4.7 Prompts.** The `understand-codebase` skill's guidance registered as MCP prompts so Codex,
+  Desktop and claude.ai get the "which tool, in which order" workflow through the protocol.
+- **4.8 Progress.** Per-phase progress notifications from `sdlc_feature` and
+  `root_cause(use_llm=true)`, which run for minutes with no signal today.
+- **4.9 Self-describing `doctor`.** Phase 1.
+- **4.10 Multi-repo parity.** `explain_symbol`, `regression_gaps`, `localize`, `docs_for` take
+  `repos` like `blast_radius` and `investigate` do.
+- **4.11 Per-principal audit on HTTP.** Tier-3 invocations recorded against the token principal,
+  in the registry's existing audit log.
+
+## 5. Order — gaps first
+
+### Phase 1 — retire the gaps
+
+| Step | Gap | Work | State |
+|---|---|---|---|
+| 1 | 6 | Fix the stale install; ship 4.9. | **this PR** |
+| 2 | 2 | Sync `__all__`; a test holds it. | **this PR** |
+| 3 | 3 | 4.1 annotations (typed output deferred). | **this PR** |
+| 4 | 1 | 4.2 operator-ops tools. | next |
+| 5 | 4 | 4.3 scopes — before step 4 is served over HTTP to anyone else. | after 4 |
+| 6 | 5 | 4.4, then 4.5. | after 5 |
+
+### Phase 2 — extensions, once §3 is empty
+
+4.7 and 4.6 (protocol parity), then 4.8, 4.10, 4.11 as the run tier sees real use, and the
+typed-output half of 4.1 on its own.
+
+## Invariants
+
+- **A tool without a tier does not register.** The refusal lives in `_register_tools`, not in a
+  review checklist.
+- **Annotations are derived, never hand-copied.** `tool_annotations(name)` is the one source;
+  the protocol-level test compares what a host sees against it field for field.
+- **Tier 1 and 2 stay model-free and credential-free.** That is the property the keyless
+  roadmap ([codex-plugin-keyless-roadmap](codex-plugin-keyless-roadmap.md)) depends on.
+- **The tool implementations stay importable without the `mcp` extra.** Everything that needs
+  the SDK is inside `build_server` / `_register_tools`.
+
+## Non-goals
+
+- A second MCP server. There is one; it grows.
+- A terminal UI. Removed in #316 for adding no capability the other faces lacked; 4.2 is its
+  successor where an assistant is the operator.
+- Deploy or rollback tooling. The pipeline ends at the merge.

--- a/src/orchestrator/cli/start.py
+++ b/src/orchestrator/cli/start.py
@@ -54,12 +54,15 @@ def doctor() -> None:
     real exported variable still wins over the file.
     """
     from orchestrator.core.env import load_local_env
-    from orchestrator.doctor import render_report, run_env_checks
+    from orchestrator.doctor import render_identity, render_report, run_env_checks, server_identity
 
     loaded = load_local_env()
     if loaded:
         typer.echo(f"Loaded {loaded} variable(s) from .env\n")
 
+    # Which install is answering, before what it found: a stale console script on PATH
+    # reports on the wrong version's environment, and nothing below would say so.
+    typer.echo(render_identity(server_identity()) + "\n")
     results = run_env_checks()
     report = render_report(results)
     typer.echo(report)

--- a/src/orchestrator/doctor.py
+++ b/src/orchestrator/doctor.py
@@ -7,9 +7,14 @@ scaffold can never drift apart.
 
 from __future__ import annotations
 
+import importlib.metadata
+import importlib.util
 import os
+import platform
+import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -127,6 +132,81 @@ def run_env_checks(env: Mapping[str, str] | None = None) -> list[CheckResult]:
     if env is None:
         env = os.environ
     return [check_group(group, env) for group in ENV_GROUPS]
+
+
+#: Which importable module proves an optional extra is installed. One probe per extra —
+#: the first package the extra pulls in that nothing else does — so the answer is
+#: "is this extra present", not "is some dependency present".
+EXTRA_PROBES: Mapping[str, str] = {
+    "mcp": "mcp",
+    "java": "tree_sitter_java",
+    "typescript": "tree_sitter_typescript",
+    "csharp": "tree_sitter_c_sharp",
+    "c": "tree_sitter_c",
+    "cpp": "tree_sitter_cpp",
+    "go": "tree_sitter_go",
+    "sql": "sqlglot",
+    "docs": "pypdf",
+    "office": "docx",
+    "sdlc": "pytest",
+    "security": "semgrep",
+    "otel": "opentelemetry.sdk",
+}
+
+PACKAGE = "synaptixs-spine"
+
+
+def _dist_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def server_identity() -> dict[str, Any]:
+    """Who is answering: the package version, the interpreter, the SDK, the extras.
+
+    The readiness checks say whether the *environment* is ready; this says which
+    *install* is doing the checking. The case it exists for: a host launched an
+    ``orchestrator-mcp`` console script left behind by an older checkout's venv —
+    Spine 3.9.3 with no ``mcp`` module — and the only symptom was "Connection
+    closed". With the interpreter path and the version in the report, that is a
+    one-line diagnosis instead of an afternoon.
+    """
+    return {
+        "package": PACKAGE,
+        "version": _dist_version(PACKAGE),
+        "python": platform.python_version(),
+        "interpreter": sys.executable,
+        "mcp_sdk": _dist_version("mcp"),
+        "extras": {extra: _importable(module) for extra, module in EXTRA_PROBES.items()},
+    }
+
+
+def _importable(module: str) -> bool:
+    """``find_spec`` without the trap: for a dotted name it imports the parent first, and
+    raises ``ModuleNotFoundError`` when that parent is absent — which is exactly the case
+    an "is this extra installed" probe exists to answer with ``False``."""
+    try:
+        return importlib.util.find_spec(module) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def render_identity(identity: Mapping[str, Any]) -> str:
+    """Three lines a human can compare against ``pip show`` / ``which``."""
+    version = identity.get("version") or "not installed as a distribution"
+    sdk = identity.get("mcp_sdk")
+    extras = identity.get("extras") or {}
+    present = ", ".join(sorted(k for k, v in extras.items() if v)) or "none"
+    return "\n".join(
+        [
+            f"{identity.get('package')} {version} · python {identity.get('python')} · "
+            f"mcp sdk {sdk or 'not installed'}",
+            f"interpreter: {identity.get('interpreter')}",
+            f"extras: {present}",
+        ]
+    )
 
 
 def render_report(results: Sequence[CheckResult]) -> str:

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -41,8 +41,15 @@ authorization on top of whatever confirmation the host already asks for. Safe mo
 An assistant should work down the tiers, not up: comprehend, then plan and get the plan
 approved, then build. A run that starts at tier 3 is one nobody reviewed.
 
+**The tiers are metadata, not only prose.** Every tool is registered with MCP
+``ToolAnnotations`` derived from its tier (``_TIER`` → ``tool_annotations``): read-only,
+destructive, idempotent, open-world. A host uses those for its confirmation UX, so the
+tier model is enforced by the client rather than by a docstring a model may not read.
+A tool without a tier does not register — ``_register_tools`` raises, and a test says so
+before a host does.
+
 Tool *implementations* are module-level functions (unit-testable without the ``mcp``
-extra); ``build_server`` lazy-imports ``FastMCP`` and registers them.
+extra); ``build_server`` lazy-imports the SDK's server class and registers them.
 """
 
 from __future__ import annotations
@@ -54,12 +61,16 @@ from typing import Any
 
 
 def doctor() -> dict[str, Any]:
-    """Report environment readiness (LLM provider, Confluence/Jira, MCP, …)."""
-    from orchestrator.doctor import run_env_checks
+    """Report environment readiness (LLM provider, Confluence/Jira, MCP, …) and which
+    install is answering: ``server`` carries the package version, the interpreter, the
+    MCP SDK version and the extras present — so a stale console script on a host's PATH
+    is visible from the host, not just from a shell."""
+    from orchestrator.doctor import run_env_checks, server_identity
 
     results = run_env_checks()
     return {
         "all_passed": all(r.passed for r in results),
+        "server": server_identity(),
         "checks": [{"name": r.name, "passed": r.passed, "detail": r.detail} for r in results],
     }
 
@@ -940,6 +951,72 @@ _TOOLS = (
 )
 
 
+@dataclass(frozen=True)
+class Tier:
+    """What a tool can cost you if it is wrong, in the four hints MCP hosts understand."""
+
+    name: str
+    read_only: bool
+    destructive: bool
+    idempotent: bool
+    open_world: bool
+
+
+#: Read-only comprehension. ``open_world`` because ``repo_path`` may be a git URL (a
+#: shallow clone) and a requirements ``source`` may be Confluence or Notion.
+COMPREHEND = Tier("comprehend", read_only=True, destructive=False, idempotent=True, open_world=True)
+#: The same, for tools that only ever read this machine.
+COMPREHEND_LOCAL = Tier("comprehend", read_only=True, destructive=False, idempotent=True, open_world=False)
+#: Plan and decide: writes under ``.spine/`` only, re-running rewrites the same document.
+PLAN = Tier("plan", read_only=False, destructive=False, idempotent=True, open_world=False)
+#: Observing a run: reads Temporal state, changes nothing.
+RUN_OBSERVE = Tier("run", read_only=True, destructive=False, idempotent=True, open_world=True)
+#: Driving a run: spends money, and with ``live``/``confirm`` writes where it cannot be
+#: taken back. A rejected gate ends a run, which is why deciding one is destructive too.
+RUN = Tier("run", read_only=False, destructive=True, idempotent=False, open_world=True)
+
+#: Every registered tool's tier, by function name. Keep it total: registration refuses a
+#: tool that is missing here, and ``tests/plugin`` asserts the two stay in step.
+_TIER: dict[str, Tier] = {
+    "doctor": COMPREHEND_LOCAL,
+    "ingest_preview": COMPREHEND,
+    "pkg_grounding": COMPREHEND,
+    "read_memory_bank": COMPREHEND,
+    "map_repo": COMPREHEND,
+    "blast_radius": COMPREHEND,
+    "explain_symbol": COMPREHEND,
+    "investigate": COMPREHEND,
+    "localize": COMPREHEND,
+    "regression_gaps": COMPREHEND,
+    "root_cause": COMPREHEND,  # `use_llm` spends tokens; it still never changes code
+    "pkg_joins": COMPREHEND_LOCAL,
+    "sdlc_plan": PLAN,
+    "sdlc_approve": PLAN,
+    "docs_for": COMPREHEND,
+    "sdlc_feature": RUN,
+    "sdlc_start_run": RUN,
+    "sdlc_run_status": RUN_OBSERVE,
+    "sdlc_decide_gate": RUN,
+    "sdlc_run_result": RUN_OBSERVE,
+}
+
+
+def tool_annotations(name: str) -> dict[str, bool]:
+    """The MCP ``ToolAnnotations`` fields for a registered tool, as plain data.
+
+    Plain so it is testable without the ``mcp`` extra; ``_register_tools`` wraps it in
+    the SDK type. Raises ``KeyError`` for a tool with no tier — deliberately, so a new
+    tool cannot reach a host with its cost unstated.
+    """
+    tier = _TIER[name]
+    return {
+        "read_only_hint": tier.read_only,
+        "destructive_hint": tier.destructive,
+        "idempotent_hint": tier.idempotent,
+        "open_world_hint": tier.open_world,
+    }
+
+
 def _import_server_class() -> Any:
     """The SDK's server class — ``MCPServer`` since v2 (was ``mcp.server.fastmcp.FastMCP``).
 
@@ -956,8 +1033,21 @@ def _import_server_class() -> Any:
 
 
 def _register_tools(server: Any) -> Any:
+    from mcp.types import ToolAnnotations
+
     for fn in _TOOLS:
-        server.tool()(fn)
+        try:
+            hints = tool_annotations(fn.__name__)
+        except KeyError as exc:
+            raise RuntimeError(f"tool {fn.__name__!r} has no tier in _TIER — say what it can cost") from exc
+        server.tool(
+            annotations=ToolAnnotations(
+                read_only_hint=hints["read_only_hint"],
+                destructive_hint=hints["destructive_hint"],
+                idempotent_hint=hints["idempotent_hint"],
+                open_world_hint=hints["open_world_hint"],
+            )
+        )(fn)
     return server
 
 
@@ -1030,23 +1120,29 @@ def build_http_server(
 
 
 __all__ = [
-    "HttpServer",
     "blast_radius",
     "build_http_server",
     "build_server",
+    "docs_for",
     "doctor",
     "explain_symbol",
+    "HttpServer",
     "ingest_preview",
     "investigate",
     "localize",
     "map_repo",
     "pkg_grounding",
+    "pkg_joins",
     "read_memory_bank",
     "regression_gaps",
     "root_cause",
+    "sdlc_approve",
     "sdlc_decide_gate",
     "sdlc_feature",
+    "sdlc_plan",
     "sdlc_run_result",
     "sdlc_run_status",
     "sdlc_start_run",
+    "Tier",
+    "tool_annotations",
 ]

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -47,6 +47,18 @@ def test_doctor_returns_readiness_structure() -> None:
     assert {"LLM provider", "Confluence", "Jira"} <= names
 
 
+def test_doctor_says_which_install_is_answering() -> None:
+    """The stale-install case: a host launched an ``orchestrator-mcp`` from an old venv
+    and saw only "Connection closed". The tool now names its version, interpreter and SDK
+    so the host can see the mismatch."""
+    import sys
+
+    server = doctor()["server"]
+    assert server["package"] == "synaptixs-spine"
+    assert server["interpreter"] == sys.executable
+    assert "mcp" in server["extras"]
+
+
 def test_pkg_grounding_surfaces_existing_symbols(tmp_path: Path) -> None:
     (tmp_path / "ledger.py").write_text(LEDGER, encoding="utf-8")
     out = pkg_grounding(str(tmp_path), "persist the token ledger to disk")
@@ -403,6 +415,87 @@ def test_http_server_wires_static_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     # Auth is configured, so a public bind is permitted and the tools are registered.
     assert built.server.settings.auth is not None
     assert built.transport["port"] == 8080 and built.transport["host"] == "0.0.0.0"
+
+
+# ---- the tiers are metadata: annotations a host can act on -------------------------
+
+
+def test_every_registered_tool_has_a_tier() -> None:
+    """Total by construction: a tool added to ``_TOOLS`` without a ``_TIER`` entry fails
+    here, before it reaches a host with its cost unstated."""
+    from orchestrator.plugin.server import _TIER, _TOOLS
+
+    assert {fn.__name__ for fn in _TOOLS} == set(_TIER)
+
+
+def test_tiers_say_what_a_tool_can_cost() -> None:
+    from orchestrator.plugin.server import _TOOLS, tool_annotations
+
+    hints = {fn.__name__: tool_annotations(fn.__name__) for fn in _TOOLS}
+    spends_and_writes = {"sdlc_feature", "sdlc_start_run", "sdlc_decide_gate"}
+    plans = {"sdlc_plan", "sdlc_approve"}
+    observes_a_run = {"sdlc_run_status", "sdlc_run_result"}
+    comprehension = set(hints) - spends_and_writes - plans - observes_a_run
+
+    for name in comprehension | observes_a_run:
+        assert hints[name]["read_only_hint"] and not hints[name]["destructive_hint"], name
+    for name in plans:
+        assert not hints[name]["read_only_hint"] and not hints[name]["destructive_hint"], name
+        assert hints[name]["idempotent_hint"], name  # re-running rewrites the same document
+    for name in spends_and_writes:
+        assert not hints[name]["read_only_hint"] and hints[name]["destructive_hint"], name
+        assert not hints[name]["idempotent_hint"], name
+    # `use_llm` spends tokens, but the tool still never changes code.
+    assert hints["root_cause"]["read_only_hint"]
+    # Only these never leave the machine; everything else may clone a URL or read a source.
+    assert {n for n, h in hints.items() if not h["open_world_hint"]} == {
+        "doctor",
+        "pkg_joins",
+        "sdlc_plan",
+        "sdlc_approve",
+    }
+
+
+def test_an_untiered_tool_is_refused_at_registration() -> None:
+    from orchestrator.plugin.server import tool_annotations
+
+    with pytest.raises(KeyError):
+        tool_annotations("a_tool_nobody_classified")
+
+
+def test_all_exports_every_registered_tool() -> None:
+    """``__all__`` drifted from ``_TOOLS`` once (four tools registered but not exported);
+    the export list is what a reader and ``from … import *`` trust."""
+    import orchestrator.plugin.server as mod
+
+    assert {fn.__name__ for fn in mod._TOOLS} <= set(mod.__all__)
+    assert mod.__all__ == sorted(mod.__all__, key=lambda x: (x.lower(), x))
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="needs the 'mcp' extra")
+async def test_annotations_reach_the_host() -> None:
+    """What the host sees is the tier table, field for field — not a hand-copied subset."""
+    from orchestrator.plugin.server import _TOOLS, build_server, tool_annotations
+
+    tools = {t.name: t for t in await build_server().list_tools()}
+    assert set(tools) == {fn.__name__ for fn in _TOOLS}
+    for name, tool in tools.items():
+        assert tool.annotations is not None, name
+        assert tool.annotations.model_dump(exclude_none=True, exclude={"title"}) == tool_annotations(name), (
+            name
+        )
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="needs the 'mcp' extra")
+def test_registration_refuses_a_tool_without_a_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    import orchestrator.plugin.server as mod
+
+    def orphan() -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr(mod, "_TOOLS", (*mod._TOOLS, orphan))
+    with pytest.raises(RuntimeError, match="no tier"):
+        mod.build_server()
 
 
 # ---- dogfood: drive the real stdio server (needs the `mcp` extra) -----------

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from orchestrator.doctor import CheckResult, render_report, run_env_checks
+from orchestrator.doctor import (
+    EXTRA_PROBES,
+    CheckResult,
+    render_identity,
+    render_report,
+    run_env_checks,
+    server_identity,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -316,3 +323,67 @@ class TestCheckResult:
         assert r.name == "foo"
         assert r.passed is False
         assert r.detail == "missing bar"
+
+
+# ---- server_identity: which install is answering ------------------------------------
+
+
+def test_server_identity_names_the_running_install() -> None:
+    import sys
+
+    ident = server_identity()
+    assert ident["package"] == "synaptixs-spine"
+    assert ident["interpreter"] == sys.executable
+    assert ident["python"].count(".") == 2
+    # The dev checkout is installed as a distribution, so the version is known here.
+    assert ident["version"] is not None
+    # Every probed extra answers with a bool — never a missing key, never an exception.
+    assert set(ident["extras"]) == set(EXTRA_PROBES)
+    assert all(isinstance(v, bool) for v in ident["extras"].values())
+
+
+def test_extra_probes_are_modules_not_distributions() -> None:
+    """The probe is an import name (``docx``), not the PyPI name (``python-docx``):
+    ``find_spec`` answers for modules, and a probe that names a distribution is a probe
+    that always says "absent"."""
+    assert all("-" not in module for module in EXTRA_PROBES.values())
+
+
+def test_render_identity_is_comparable_against_which_and_pip_show() -> None:
+    text = render_identity(
+        {
+            "package": "synaptixs-spine",
+            "version": "3.9.3",
+            "python": "3.12.4",
+            "interpreter": "/old/checkout/.venv/bin/python3",
+            "mcp_sdk": None,
+            "extras": {"mcp": False, "java": True},
+        }
+    )
+    lines = text.splitlines()
+    assert lines[0] == "synaptixs-spine 3.9.3 · python 3.12.4 · mcp sdk not installed"
+    assert lines[1] == "interpreter: /old/checkout/.venv/bin/python3"
+    assert lines[2] == "extras: java"
+
+
+def test_render_identity_survives_an_uninstalled_distribution() -> None:
+    text = render_identity(
+        {
+            "package": "synaptixs-spine",
+            "version": None,
+            "python": "3.12.4",
+            "interpreter": "/x",
+            "mcp_sdk": "2.1.0",
+            "extras": {},
+        }
+    )
+    assert "not installed as a distribution" in text and "extras: none" in text
+
+
+def test_a_dotted_probe_with_no_parent_package_reads_absent() -> None:
+    """``find_spec("opentelemetry.sdk")`` raises when ``opentelemetry`` itself is missing;
+    the probe must answer False, not crash the whole report."""
+    from orchestrator.doctor import _importable
+
+    assert _importable("no_such_parent_pkg_xyz.child") is False
+    assert _importable("os.path") is True


### PR DESCRIPTION
## Summary

MCP phase 1, steps 1–3 of the new design record [`docs/specs/mcp-plugin-surface.md`](docs/specs/mcp-plugin-surface.md) — closing gaps 6, 2 and 3 before any new surface is added.

- **The tiers are metadata.** Every plugin tool is registered with MCP `ToolAnnotations` derived from its tier — read-only, destructive, idempotent, open-world — so a host that confirms before destructive calls confirms before `sdlc_feature`, `sdlc_start_run` and `sdlc_decide_gate`, and not before `map_repo`. `_TIER` is total by construction: `_register_tools` refuses a tool it does not list, and a test holds the table and `_TOOLS` to the same set. A protocol-level test compares what a host sees against `tool_annotations(name)` field for field.
- **`doctor` names its install.** The tool (a `server` block) and the CLI (a header) report package version, interpreter, MCP SDK version and which extras import. The case: a host launched an `orchestrator-mcp` console script left by an older checkout's venv (Spine 3.9.3, no `mcp` module) and the only symptom was "Connection closed".
- **`__all__` exports every registered tool.** Four were missing; a test now holds it.

## Annotations by tier

| Tools | read-only | destructive | idempotent | open-world |
|---|---|---|---|---|
| Tier 1 comprehension | yes | no | yes | yes (`repo_path` may be a URL, a `source` may be remote) |
| `doctor`, `pkg_joins` | yes | no | yes | no |
| `sdlc_plan`, `sdlc_approve` | no | no | yes | no |
| `sdlc_run_status`, `sdlc_run_result` | yes | no | yes | yes |
| `sdlc_feature`, `sdlc_start_run`, `sdlc_decide_gate` | no | yes | no | yes |

Typed output schemas (a model per tool) are deferred to their own PR — the SDK already advertises an open-object schema.

## Files

- `plugin/server.py`: `Tier`, `_TIER`, `tool_annotations`, annotated registration, `doctor.server`, `__all__`.
- `doctor.py`: `server_identity()`, `render_identity()`, `EXTRA_PROBES`. `cli/start.py`: the header.
- Tests: 12 new across `tests/plugin/test_server.py` and `tests/test_doctor.py`.
- Docs: the spec + SPEC-INDEX row and counts, CLAUDE_GUIDE §6 paragraph and §11 troubleshooting row, CHANGELOG Unreleased, STATE-OF-SPINE counts.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`, `matrix-count --check`, `state-numbers --check`: pass
- Full pytest: 3324 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)