### PR TITLE
feat(plugin): operator tools over the registry — what is running, what is waiting on me

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Added
 
+- **Operator tools in the MCP plugin — the terminal UI's successor.** `registry_runs`,
+  `registry_approvals`, `registry_trace` and `registry_decide` answer "what is
+  running, what is waiting on me" and decide a gate, over HTTP to the registry
+  (`orchestrator up`) with the same `ORCHESTRATOR_API_URL` / `ORCHESTRATOR_API_KEY`
+  every other client reads — so the plugin process needs no database or Temporal
+  access, the registry scopes results to the key's tenant, and the audit log
+  records the key as the actor. `registry_trace` is bounded: the newest `tail`
+  entries plus a `truncated` count. A registry that is down returns `error` + a
+  `hint` rather than failing the call. Deciding is annotated destructive, because
+  a rejection ends the run.
+
 - **The MCP server's tiers are metadata a host can act on.** Every plugin tool is
   registered with MCP tool annotations derived from its tier — read-only,
   destructive, idempotent, open-world — so a host that confirms before destructive

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -201,6 +201,11 @@ At a glance:
 | [`sdlc_approve`](#sdlc_approve) | Record that a **human** read that document and decided. Binds to a digest of it, so a plan that changes afterwards reads as *stale* rather than still approved. | `.spine/` |
 | [`sdlc_feature`](#sdlc_feature) | **Ship it.** One intent end‑to‑end: spec → grounded codegen → tests → branch → *(optionally)* PR. | gated |
 | [`sdlc_start_run` + gate tools](#the-autonomous-run-sdlc_start_run--friends) | Drive the long, autonomous, gated run as a job (needs the Mode‑B backend). | gated |
+| **Operate — what is running, what is waiting on me** | | |
+| [`registry_runs`](#operating-runs-registry_runs--friends) | Recent runs at the registry: id, state, last action, timestamps. | no |
+| [`registry_approvals`](#operating-runs-registry_runs--friends) | The gates waiting on a human, latest first, with risk and the run they belong to. | no |
+| [`registry_trace`](#operating-runs-registry_runs--friends) | A run's audit trail and tool invocations, newest `tail` entries, with what was left out. | no |
+| [`registry_decide`](#operating-runs-registry_runs--friends) | Approve / reject / modify a pending approval so its run continues (or stops). | gated |
 
 > **The comprehension tools are read‑only, need no credentials, and are deterministic** (only
 > `root_cause`'s opt‑in `use_llm` uses a model). They ship with an **`understand-codebase` skill**
@@ -550,6 +555,40 @@ result.
 // tool: sdlc_run_result
 { "sdlc_id": "<id>" }
 ```
+
+#### Operating runs (`registry_runs` + friends)
+
+"What is running, and what is waiting on me?" — the operator questions the web inbox answers,
+for an assistant. These go **over HTTP to the registry** (`orchestrator up`, or
+`ORCHESTRATOR_API_URL` pointing at a running one, with `ORCHESTRATOR_API_KEY`), so the plugin
+needs no database or Temporal access of its own; the registry scopes what you see to your key's
+tenant and records your key as the actor, exactly as it does for the inbox. If the registry is
+down, each returns `error` + a `hint` instead of failing.
+
+> **Ask Claude:** "What's waiting on me?" · "Show me the trace for run `<id>`." · "Approve
+> `sdlc-<id>-0`, rationale: reviewed the intents."
+
+```jsonc
+// tool: registry_runs        → { count, items: [{ sdlc_id, state, last_action, updated_at, … }], markdown }
+{ "limit": 20 }
+
+// tool: registry_approvals   → { count, items: [{ id, title, risk_classification, task_id, … }], markdown }
+{ "limit": 50 }
+
+// tool: registry_trace       → newest `tail` audit entries + tool invocations; `truncated` says what was left out
+{ "sdlc_id": "<id>", "tail": 50 }
+
+// tool: registry_decide      → destructive: a rejection ends the run
+{
+  "approval_id": "sdlc-<id>-0",
+  "action": "approve",              // "approve" | "reject" | "modify_input" (needs modified_input)
+  "rationale": "reviewed the intents"
+}
+```
+
+`sdlc_decide_gate` decides the same gates **in‑process** (no registry, but Temporal + Postgres
+access from the plugin); use it for a run this plugin started when there is no registry, and
+`registry_decide` when there is.
 
 ---
 

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -93,7 +93,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [gap6-benchmarks-roadmap](gap6-benchmarks-roadmap.md) | ✅ **Complete 2026-09-01** | All three phases: harness, 38-label gold set, ratchet gate. top-1 0.32 / top-10 0.71 against 0.085 chance; published as [BENCHMARK.md](../../BENCHMARK.md). This row read *Not started* for a day after the spec said COMPLETE |
 | [codegen-benchmark-roadmap](codegen-benchmark-roadmap.md) | Not started | **New 2026-08-15.** SWE-bench comparability → `resolved`-vs-`mergeable` delta |
 | [codex-plugin-keyless-roadmap](codex-plugin-keyless-roadmap.md) | Not started | **New 2026-08-15.** Phase 0 is a blocking spike |
-| [mcp-plugin-surface](mcp-plugin-surface.md) | Phase 1 in progress | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
+| [mcp-plugin-surface](mcp-plugin-surface.md) | Phase 1: steps 1–4 shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
 | [phase5-agentic-codegen-loop](phase5-agentic-codegen-loop.md) | Proposed, under review | "The hinge phase" |
 | [autonomous-run-agent](autonomous-run-agent.md) | Proposed, no branch | 9 phases; 0–3 strictly serial |
 | [catalog-then-compose-roadmap](catalog-then-compose-roadmap.md) | Proposed, under review | Scope confirmed: Phases 0–3 |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -27,8 +27,8 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Version | **3.30.0** | cutting now; 3.29.1 is the last on PyPI until this ships |
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
-| Source modules | **342** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,904** across 300 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Source modules | **343** | `find src/orchestrator -name '*.py'` |
+| Test functions | **2,916** across 301 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/mcp-plugin-surface.md
+++ b/docs/specs/mcp-plugin-surface.md
@@ -1,10 +1,10 @@
 # The MCP plugin surface — what it is, what it lacks, and the order to extend it
 
-**Status:** Phase 1 in progress (this record's first PR). **Written 2026-09-04 against 3.30.0**,
+**Status:** Phase 1 in progress — steps 1–4 shipped, steps 5–6 open. **Written 2026-09-04 against 3.30.0**,
 after #316 removed the terminal UI and left the plugin as the only non-browser operator face.
 **Owner:** _unassigned_
 
-**One-liner:** Spine already *is* an MCP server with 20 tools in three tiers; the work is not a
+**One-liner:** Spine already *is* an MCP server with 20 tools in three tiers (24 after Phase 1); the work is not a
 new server but closing six known gaps in this one, in an order that retires the gaps before
 adding any surface.
 
@@ -45,7 +45,7 @@ with neither configured is refused unless `--allow-unauthenticated`.
 **Packaging.** A Claude Code plugin at `plugins/spine/` bundling the `understand-codebase` skill;
 marketplace entry in `.claude-plugin/marketplace.json`; `pip install 'synaptixs-spine[all]'`.
 
-## 2. The 20 tools, in three tiers
+## 2. The 24 tools, in three tiers plus an operator set
 
 The tiers are separated by what a tool can cost you if it is wrong. An assistant works **down**
 them: comprehend, then plan and get the plan approved, then build.
@@ -54,6 +54,7 @@ them: comprehend, then plan and get the plan approved, then build.
 |---|---|---|
 | **1 · comprehend** | `doctor`, `map_repo`, `blast_radius`, `explain_symbol`, `investigate`, `localize`, `regression_gaps`, `root_cause`, `docs_for`, `pkg_joins`, `read_memory_bank`, `pkg_grounding`, `ingest_preview` | No credentials, no model, deterministic. `root_cause(use_llm=true)` is the one opt-in model call, and it still never changes code. `repo_path` is a local path or a git URL; `blast_radius` and `investigate` answer across repositories via `repos` (`.spine/repos.yaml`). |
 | **2 · plan** | `sdlc_plan`, `sdlc_approve` | Writes only under `.spine/`. Still no model, no credentials — which is what lets a host with its own model drive Spine on a machine where Spine has neither. |
+| **operate** | `registry_runs`, `registry_approvals`, `registry_trace`, `registry_decide` | Over HTTP to the registry (`orchestrator up`); needs only the API URL and key. Observing is read-only; `registry_decide` is destructive because a rejection ends a run. |
 | **3 · run** | `sdlc_feature`, `sdlc_start_run`, `sdlc_run_status`, `sdlc_decide_gate`, `sdlc_run_result` | Spends tokens. `live=true` (or `create_jira=true`) writes where it cannot be taken back and needs `confirm=true` on top of the host's own confirmation. The run set needs the Temporal backend. |
 
 ### The tiers as annotations (Phase 1)
@@ -67,6 +68,8 @@ what to confirm. From Phase 1 every registration carries the four hints, derived
 | `doctor`, `pkg_joins` | yes | no | yes | no — local only |
 | `sdlc_plan`, `sdlc_approve` | no | no | yes — re-running rewrites the same document | no |
 | `sdlc_run_status`, `sdlc_run_result` | yes | no | yes | yes — they read Temporal |
+| `registry_runs`, `registry_approvals`, `registry_trace` | yes | no | yes | yes — they read the registry |
+| `registry_decide` | no | yes | no | yes |
 | `sdlc_feature`, `sdlc_start_run`, `sdlc_decide_gate` | no | yes | no | yes |
 
 Deciding a gate is destructive because a rejection ends a run. `_TIER` is total by construction:
@@ -79,6 +82,8 @@ Numbered, because §5 retires them by number.
 
 1. **No operator-ops tools.** Nothing lists registry runs or pending approvals generically;
    `sdlc_decide_gate` covers only an sdlc run's own gates. This is what the removed TUI did.
+   *(Closed in Phase 1 step 4: `registry_runs`, `registry_approvals`, `registry_trace`,
+   `registry_decide` — §2, operator tools.)*
 2. **`__all__` drifted from `_TOOLS`.** Four registered tools were not exported. *(Closed in
    Phase 1, with a test.)*
 3. **The tiers were prose only.** A host could not tell a read-only tool from a money-spending
@@ -99,9 +104,14 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
 - **4.1 Annotations and typed output.** Annotations: Phase 1. Typed output schemas (a model per
   tool instead of `dict[str, Any]`) are deferred to their own PR: the SDK already advertises an
   open-object schema, and real models touch twenty return shapes and their tests.
-- **4.2 Operator-ops tools.** `runs_list`, `run_trace`, `approvals_list`, `approval_decide` over
-  the registry `/v1` API with `X-API-Key`, reinstating the removed 52-line registry client as
-  `plugin/registry_client.py`. Config via `ORCHESTRATOR_API_URL` / `ORCHESTRATOR_API_KEY`.
+- **4.2 Operator-ops tools.** *(Shipped.)* `registry_runs`, `registry_approvals`,
+  `registry_trace`, `registry_decide` over the registry `/v1` API with `X-API-Key`, through
+  `plugin/registry_client.py` (the removed TUI client, reinstated and extended). Config via
+  `ORCHESTRATOR_API_URL` / `ORCHESTRATOR_API_KEY`. The `registry_` prefix mirrors `sdlc_`: it
+  names the surface, and says the tool needs the server up. Over HTTP rather than in-process
+  because the plugin process then needs no database or Temporal credentials, the registry
+  enforces tenant scoping, and the audit log records the key's principal as the actor.
+  `registry_trace` is bounded — the newest `tail` entries plus a `truncated` count.
 - **4.3 Per-tier scopes on HTTP.** `spine:read`, `spine:plan`, `spine:run`, checked per tool at
   registration; `sdlc` accepted as an alias for one release.
 - **4.4 `understand_repo` and `current_state` as tools.** Both deterministic by invariant, so
@@ -130,8 +140,8 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
 | 1 | 6 | Fix the stale install; ship 4.9. | **this PR** |
 | 2 | 2 | Sync `__all__`; a test holds it. | **this PR** |
 | 3 | 3 | 4.1 annotations (typed output deferred). | **this PR** |
-| 4 | 1 | 4.2 operator-ops tools. | next |
-| 5 | 4 | 4.3 scopes — before step 4 is served over HTTP to anyone else. | after 4 |
+| 4 | 1 | 4.2 operator-ops tools. | **shipped** |
+| 5 | 4 | 4.3 scopes — before step 4 is served over HTTP to anyone else. | next |
 | 6 | 5 | 4.4, then 4.5. | after 5 |
 
 ### Phase 2 — extensions, once §3 is empty

--- a/src/orchestrator/plugin/registry_client.py
+++ b/src/orchestrator/plugin/registry_client.py
@@ -1,0 +1,139 @@
+"""HTTP client for the registry ``/v1`` API, used by the plugin's operator tools.
+
+The ``registry_*`` tools are the successor to the terminal UI removed in #316: an
+assistant asks "what is running, what is waiting on me", and decides a gate. They
+go **over HTTP to the registry** rather than in-process through Temporal like the
+``sdlc_*`` run tools, and that is a choice, not an accident: the plugin process
+then needs only ``ORCHESTRATOR_API_URL`` and ``ORCHESTRATOR_API_KEY`` — no database,
+no Temporal — the registry enforces tenant scoping, and the audit log records the
+API-key principal as the actor, exactly as it does for the web inbox.
+
+A thin async wrapper over httpx, unit-testable with an httpx ``MockTransport``.
+Tools obtain one through :func:`registry_client` so a test can swap the factory
+without a server.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+from orchestrator.core.secrets import get_secret
+
+DEFAULT_URL = "http://localhost:8000"
+DEFAULT_KEY = "dev-key"
+
+#: What a failed call tells the assistant to do about it.
+UNREACHABLE_HINT = (
+    "The registry did not answer. Start it with `orchestrator up`, or point "
+    "ORCHESTRATOR_API_URL at a running one (and ORCHESTRATOR_API_KEY at its key)."
+)
+
+
+class RegistryError(RuntimeError):
+    """A registry call that did not succeed, with a hint the tool can pass on."""
+
+    def __init__(self, message: str, *, hint: str = UNREACHABLE_HINT) -> None:
+        super().__init__(message)
+        self.hint = hint
+
+
+class RegistryClient:
+    """Talks to the registry API as the operator (``X-API-Key`` auth)."""
+
+    def __init__(
+        self, base_url: str, api_key: str, *, transport: httpx.AsyncBaseTransport | None = None
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            base_url=self.base_url,
+            headers={"X-API-Key": api_key},
+            transport=transport,
+            timeout=15.0,
+        )
+
+    async def runs(self, *, limit: int = 20) -> list[dict[str, Any]]:
+        return await self._items("/v1/runs", params={"limit": limit})
+
+    async def approvals(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        return await self._items("/v1/approvals", params={"limit": limit})
+
+    async def approval(self, approval_id: str) -> dict[str, Any]:
+        return await self._json("GET", f"/v1/approvals/{approval_id}")
+
+    async def decide(
+        self,
+        approval_id: str,
+        action: str,
+        *,
+        rationale: str | None = None,
+        modified_input: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if rationale:
+            body["rationale"] = rationale
+        if modified_input is not None:
+            body["modified_input"] = modified_input
+        return await self._json("POST", f"/v1/approvals/{approval_id}/{action}", json=body)
+
+    async def trace(self, task_id: str) -> dict[str, Any]:
+        return await self._json("GET", f"/v1/tasks/{task_id}/trace")
+
+    async def _items(self, path: str, *, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        data = await self._json("GET", path, params=params)
+        return list(data.get("items", []))
+
+    async def _json(self, method: str, path: str, **kw: Any) -> dict[str, Any]:
+        try:
+            resp = await self._client.request(method, path, **kw)
+        except httpx.HTTPError as exc:  # connect refused, timeout, DNS — the server is not there
+            raise RegistryError(f"{method} {self.base_url}{path}: {exc.__class__.__name__}: {exc}") from exc
+        if resp.status_code >= 400:
+            hint = UNREACHABLE_HINT
+            if resp.status_code in (401, 403):
+                hint = "The registry refused the key. Check ORCHESTRATOR_API_KEY matches the server's."
+            elif resp.status_code == 404:
+                hint = "No such id at this registry — list first (registry_runs / registry_approvals)."
+            elif resp.status_code < 500:
+                hint = "The registry rejected the request; the detail says what it wanted."
+            raise RegistryError(f"{method} {path} → {resp.status_code}: {_detail(resp)}", hint=hint)
+        return dict(resp.json())
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+def _detail(resp: httpx.Response) -> str:
+    try:
+        data = resp.json()
+    except ValueError:
+        return resp.text[:200]
+    return str(data.get("detail", data))[:200] if isinstance(data, dict) else str(data)[:200]
+
+
+def registry_client() -> RegistryClient:
+    """The client the tools use, from the same env every other Spine client reads.
+
+    Module-level and looked up at call time (``registry_client()``, not a bound
+    default) so ``tests/plugin`` can replace it with one over a ``MockTransport``.
+    """
+    return RegistryClient(
+        os.getenv("ORCHESTRATOR_API_URL", DEFAULT_URL),
+        get_secret("ORCHESTRATOR_API_KEY") or DEFAULT_KEY,
+    )
+
+
+ClientFactory = Callable[[], RegistryClient]
+
+__all__ = [
+    "DEFAULT_KEY",
+    "DEFAULT_URL",
+    "UNREACHABLE_HINT",
+    "ClientFactory",
+    "RegistryClient",
+    "RegistryError",
+    "registry_client",
+]

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -38,6 +38,11 @@ open PR — which is why ``live`` additionally requires ``confirm=true``, an exp
 authorization on top of whatever confirmation the host already asks for. Safe mode
 (``live=false``) still costs tokens; it just keeps every write local.
 
+**Operator tools** — ``registry_runs`` / ``registry_approvals`` / ``registry_decide`` /
+``registry_trace``. "What is running, what is waiting on me", over HTTP to the registry
+(``orchestrator up``) — the successor to the removed terminal UI. Observing is read-only;
+deciding a gate is destructive, because a rejection ends a run.
+
 An assistant should work down the tiers, not up: comprehend, then plan and get the plan
 approved, then build. A run that starts at tier 3 is one nobody reviewed.
 
@@ -924,6 +929,156 @@ async def sdlc_run_result(sdlc_id: str) -> dict[str, Any]:
     return await run_result(sdlc_id)
 
 
+# ---- operator tools: what is running, what is waiting on me — over the registry -------
+#
+# The successor to the terminal UI removed in #316. These go over HTTP to the registry
+# (``plugin/registry_client.py`` says why), so they need ``orchestrator up`` — or a
+# ``ORCHESTRATOR_API_URL`` pointing at a running one — and nothing else.
+
+
+async def _registry(fn: Callable[[Any], Any]) -> dict[str, Any]:
+    """Run ``fn(client)`` against the registry; an unreachable or refusing registry returns
+    ``{"error": …, "hint": …}`` rather than raising, like a bad ``repo_path`` does."""
+    from orchestrator.plugin.registry_client import RegistryError, registry_client
+
+    client = registry_client()
+    try:
+        out = await fn(client)
+        return dict(out)
+    except RegistryError as exc:
+        return {"error": str(exc), "hint": exc.hint, "registry": client.base_url}
+    finally:
+        await client.aclose()
+
+
+async def registry_runs(limit: int = 20) -> dict[str, Any]:
+    """Recent SDLC runs at the registry, most recently active first: id, state
+    (``running`` / ``merged`` / ``failed`` / ``denied`` / ``cancelled``), last action and
+    timestamps. Read-only; scoped to the API key's tenant. Needs the registry up
+    (``orchestrator up``). ``limit`` is capped at 200 by the server."""
+
+    async def go(client: Any) -> dict[str, Any]:
+        items = await client.runs(limit=limit)
+        return {"count": len(items), "items": items, "markdown": _runs_markdown(items)}
+
+    return await _registry(go)
+
+
+async def registry_approvals(limit: int = 50) -> dict[str, Any]:
+    """Pending approvals at the registry — the gates waiting on a human — latest first,
+    each with its id, title, risk classification and the run it belongs to. Read-only.
+    Decide one with ``registry_decide``. Needs the registry up."""
+
+    async def go(client: Any) -> dict[str, Any]:
+        items = await client.approvals(limit=limit)
+        return {"count": len(items), "items": items, "markdown": _approvals_markdown(items)}
+
+    return await _registry(go)
+
+
+async def registry_decide(
+    approval_id: str,
+    action: str,
+    rationale: str = "",
+    modified_input: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Decide a pending approval at the registry so its run continues (or stops).
+
+    ``action`` is ``approve``, ``reject`` or ``modify_input`` (which requires
+    ``modified_input``, the patch the run should continue with). A rejection ends the
+    run, which is why a host treats this as destructive. The registry records the API-key
+    principal as the actor and signals the workflow — the same path as the web inbox.
+    ``sdlc_decide_gate`` does the same in-process for a run this plugin started; use that
+    when there is no registry, and this when there is."""
+    if action not in ("approve", "reject", "modify_input"):
+        return {"error": f"action must be approve, reject or modify_input, not {action!r}"}
+    if action == "modify_input" and not modified_input:
+        return {"error": "modify_input needs a non-empty modified_input patch"}
+
+    async def go(client: Any) -> dict[str, Any]:
+        record = await client.decide(
+            approval_id, action, rationale=rationale or None, modified_input=modified_input
+        )
+        return {"approval_id": approval_id, "action": action, "approval": record}
+
+    return await _registry(go)
+
+
+async def registry_trace(sdlc_id: str, tail: int = 50) -> dict[str, Any]:
+    """A run's trace at the registry: the newest ``tail`` audit entries and tool
+    invocations, the verifier outcome, and the replan count against its budget. Bounded —
+    ``truncated`` says how many older entries were left out. Read-only. Pass the run id as
+    ``registry_runs`` lists it — the same id the web console links its trace with."""
+
+    async def go(client: Any) -> dict[str, Any]:
+        # The audit rows of an SDLC run carry the run id itself (`trace_id == resource_id ==
+        # sdlc_id`); `task-<id>` is the *Temporal workflow* id, and the trace endpoint does
+        # not know it. The console fetches `/v1/tasks/<sdlc_id>/trace`, so do the same.
+        task_id = sdlc_id
+        trace = await client.trace(task_id)
+        audit = list(trace.get("audit") or [])
+        tools = list(trace.get("tool_invocations") or [])
+        kept_audit, kept_tools = audit[-tail:] if tail > 0 else [], tools[-tail:] if tail > 0 else []
+        return {
+            "sdlc_id": sdlc_id,
+            "task_id": task_id,
+            "verifier_outcome": trace.get("verifier_outcome"),
+            "workflow_pattern": trace.get("workflow_pattern"),
+            "replan_count": trace.get("replan_count", 0),
+            "replan_budget": trace.get("replan_budget", 0),
+            "audit": kept_audit,
+            "tool_invocations": kept_tools,
+            "truncated": {
+                "audit": max(len(audit) - len(kept_audit), 0),
+                "tool_invocations": max(len(tools) - len(kept_tools), 0),
+            },
+            "markdown": _trace_markdown(task_id, trace, kept_audit, len(audit)),
+        }
+
+    return await _registry(go)
+
+
+def _runs_markdown(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return "_No runs recorded at this registry._"
+    lines = ["| run | state | last action | updated |", "|---|---|---|---|"]
+    for r in items:
+        lines.append(
+            f"| `{r.get('sdlc_id', '')}` | {r.get('state', '')} | {r.get('last_action', '')} | "
+            f"{r.get('updated_at', '')} |"
+        )
+    return "\n".join(lines)
+
+
+def _approvals_markdown(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return "_Nothing is waiting on a decision._"
+    lines = ["| approval | risk | run | title |", "|---|---|---|---|"]
+    for a in items:
+        lines.append(
+            f"| `{a.get('id', '')}` | {a.get('risk_classification', '')} | `{a.get('task_id', '')}` | "
+            f"{a.get('title', '')} |"
+        )
+    return "\n".join(lines)
+
+
+def _trace_markdown(task_id: str, trace: dict[str, Any], audit: list[dict[str, Any]], total: int) -> str:
+    head = [
+        f"**{task_id}** — verifier: {trace.get('verifier_outcome') or '—'} · "
+        f"replans: {trace.get('replan_count', 0)}/{trace.get('replan_budget', 0)}",
+    ]
+    if not audit:
+        return head[0] + "\n\n_No audit entries._"
+    shown = f"last {len(audit)} of {total}" if total > len(audit) else f"all {total}"
+    lines = [*head, "", f"Audit ({shown}):", "", "| when | actor | action | resource |", "|---|---|---|---|"]
+    for e in audit:
+        lines.append(
+            f"| {e.get('timestamp', '')} | {e.get('actor', '')} | {e.get('action', '')} | "
+            f"{e.get('resource_type', '')}:{e.get('resource_id', '')} |"
+        )
+    return "\n".join(lines)
+
+
 _TOOLS = (
     doctor,
     ingest_preview,
@@ -948,6 +1103,11 @@ _TOOLS = (
     sdlc_run_status,
     sdlc_decide_gate,
     sdlc_run_result,
+    # operator: what is running, what is waiting on me — over the registry
+    registry_runs,
+    registry_approvals,
+    registry_decide,
+    registry_trace,
 )
 
 
@@ -998,6 +1158,10 @@ _TIER: dict[str, Tier] = {
     "sdlc_run_status": RUN_OBSERVE,
     "sdlc_decide_gate": RUN,
     "sdlc_run_result": RUN_OBSERVE,
+    "registry_runs": RUN_OBSERVE,
+    "registry_approvals": RUN_OBSERVE,
+    "registry_decide": RUN,  # a rejection ends a run
+    "registry_trace": RUN_OBSERVE,
 }
 
 
@@ -1134,6 +1298,10 @@ __all__ = [
     "pkg_grounding",
     "pkg_joins",
     "read_memory_bank",
+    "registry_approvals",
+    "registry_decide",
+    "registry_runs",
+    "registry_trace",
     "regression_gaps",
     "root_cause",
     "sdlc_approve",

--- a/tests/plugin/test_registry_client.py
+++ b/tests/plugin/test_registry_client.py
@@ -1,0 +1,96 @@
+"""The plugin's registry client — over an httpx MockTransport (no server)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from orchestrator.plugin.registry_client import RegistryClient, RegistryError, registry_client
+
+
+def _client(handler: object) -> RegistryClient:
+    return RegistryClient("http://test/", "k", transport=httpx.MockTransport(handler))  # type: ignore[arg-type]
+
+
+async def test_runs_and_approvals_unwrap_items_send_the_key_and_the_limit() -> None:
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["key"] = request.headers.get("x-api-key", "")
+        seen[request.url.path] = request.url.params.get("limit", "")
+        body = {"items": [{"sdlc_id": "R1"}]} if "runs" in request.url.path else {"items": [{"id": "g1"}]}
+        return httpx.Response(200, json=body)
+
+    client = _client(handler)
+    assert (await client.runs(limit=7))[0]["sdlc_id"] == "R1"
+    assert (await client.approvals(limit=9))[0]["id"] == "g1"
+    assert seen["key"] == "k"  # X-API-Key auth
+    assert seen["/v1/runs"] == "7" and seen["/v1/approvals"] == "9"
+    await client.aclose()
+
+
+async def test_decide_posts_to_the_action_path_with_only_what_was_given() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content or b"{}")
+        return httpx.Response(200, json={"id": "g1", "status": "approved"})
+
+    client = _client(handler)
+    out = await client.decide("g1", "approve")
+    assert out["status"] == "approved"
+    assert seen["path"] == "/v1/approvals/g1/approve"
+    assert seen["body"] == {}  # the API's ApprovalDecision forbids extras; send nothing spurious
+
+    await client.decide("g1", "modify_input", rationale="why", modified_input={"k": 1})
+    assert seen["body"] == {"rationale": "why", "modified_input": {"k": 1}}
+    await client.aclose()
+
+
+async def test_trace_reads_the_task_endpoint() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/tasks/R1/trace"
+        return httpx.Response(200, json={"task_id": "R1", "audit": []})
+
+    client = _client(handler)
+    assert (await client.trace("R1"))["task_id"] == "R1"
+    await client.aclose()
+
+
+async def test_a_server_that_is_not_there_is_a_registry_error_with_a_hint() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    client = _client(handler)
+    with pytest.raises(RegistryError) as info:
+        await client.runs()
+    assert "ConnectError" in str(info.value)
+    assert "orchestrator up" in info.value.hint
+    await client.aclose()
+
+
+@pytest.mark.parametrize(
+    ("status", "fragment"),
+    [(401, "ORCHESTRATOR_API_KEY"), (404, "list first"), (422, "rejected"), (500, "orchestrator up")],
+)
+async def test_http_failures_carry_a_hint_matched_to_the_status(status: int, fragment: str) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, json={"detail": "nope"})
+
+    client = _client(handler)
+    with pytest.raises(RegistryError) as info:
+        await client.approval("g1")
+    assert f"{status}" in str(info.value) and "nope" in str(info.value)
+    assert fragment in info.value.hint
+    await client.aclose()
+
+
+def test_the_factory_reads_the_same_env_as_every_other_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCHESTRATOR_API_URL", "http://registry:9000/")
+    monkeypatch.setenv("ORCHESTRATOR_API_KEY", "sekrit")
+    client = registry_client()
+    assert client.base_url == "http://registry:9000"
+    assert client._client.headers["x-api-key"] == "sekrit"

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -417,6 +417,151 @@ def test_http_server_wires_static_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     assert built.transport["port"] == 8080 and built.transport["host"] == "0.0.0.0"
 
 
+# ---- operator tools: over the registry, with a mock transport ----------------------
+
+
+def _registry_with(handler: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the tools at a RegistryClient over a MockTransport — no server."""
+    import httpx
+
+    import orchestrator.plugin.registry_client as rc
+
+    monkeypatch.setattr(
+        rc,
+        "registry_client",
+        lambda: rc.RegistryClient("http://test", "k", transport=httpx.MockTransport(handler)),  # type: ignore[arg-type]
+    )
+
+
+async def test_registry_runs_lists_with_a_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    from orchestrator.plugin.server import registry_runs
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/runs" and request.url.params["limit"] == "5"
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {"sdlc_id": "R1", "state": "running", "last_action": "sdlc.plan", "updated_at": "t"}
+                ]
+            },
+        )
+
+    _registry_with(handler, monkeypatch)
+    out = await registry_runs(limit=5)
+    assert out["count"] == 1 and out["items"][0]["sdlc_id"] == "R1"
+    assert "| `R1` | running |" in out["markdown"]
+
+
+async def test_registry_approvals_lists_what_waits(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    from orchestrator.plugin.server import registry_approvals
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "id": "sdlc-R1-0",
+                        "title": "Approve intents",
+                        "risk_classification": "medium",
+                        "task_id": "task-R1",
+                    }
+                ]
+            },
+        )
+
+    _registry_with(handler, monkeypatch)
+    out = await registry_approvals()
+    assert out["count"] == 1
+    assert "`sdlc-R1-0`" in out["markdown"] and "Approve intents" in out["markdown"]
+
+
+async def test_registry_decide_posts_the_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json as _json
+
+    import httpx
+
+    from orchestrator.plugin.server import registry_decide
+
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"], seen["body"] = request.url.path, _json.loads(request.content)
+        return httpx.Response(200, json={"id": "g1", "status": "rejected"})
+
+    _registry_with(handler, monkeypatch)
+    out = await registry_decide("g1", "reject", rationale="scope creep")
+    assert out["action"] == "reject" and out["approval"]["status"] == "rejected"
+    assert seen["path"] == "/v1/approvals/g1/reject" and seen["body"] == {"rationale": "scope creep"}
+
+
+async def test_registry_decide_refuses_a_bad_action_before_any_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.plugin.server import registry_decide
+
+    def handler(request: object) -> None:
+        raise AssertionError("must not reach the registry")
+
+    _registry_with(handler, monkeypatch)
+    assert "error" in await registry_decide("g1", "shrug")
+    assert "modified_input" in (await registry_decide("g1", "modify_input"))["error"]
+
+
+async def test_registry_trace_is_bounded_and_says_so(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    from orchestrator.plugin.server import registry_trace
+
+    audit = [
+        {
+            "timestamp": f"t{i}",
+            "actor": "a",
+            "action": f"step.{i}",
+            "resource_type": "sdlc",
+            "resource_id": "R1",
+        }
+        for i in range(120)
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/tasks/R1/trace"  # the run id as listed — what the console uses
+        return httpx.Response(
+            200,
+            json={
+                "task_id": "R1",
+                "audit": audit,
+                "tool_invocations": [],
+                "verifier_outcome": "pass",
+                "replan_count": 1,
+                "replan_budget": 3,
+            },
+        )
+
+    _registry_with(handler, monkeypatch)
+    out = await registry_trace("R1", tail=50)
+    assert len(out["audit"]) == 50 and out["audit"][-1]["action"] == "step.119"  # the newest, kept
+    assert out["truncated"] == {"audit": 70, "tool_invocations": 0}
+    assert "last 50 of 120" in out["markdown"] and "replans: 1/3" in out["markdown"]
+
+
+async def test_a_registry_that_is_down_is_an_error_with_a_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    from orchestrator.plugin.server import registry_approvals, registry_runs
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    _registry_with(handler, monkeypatch)
+    for tool in (registry_runs, registry_approvals):
+        out = await tool()
+        assert "error" in out and "orchestrator up" in out["hint"] and out["registry"] == "http://test"
+
+
 # ---- the tiers are metadata: annotations a host can act on -------------------------
 
 
@@ -432,9 +577,15 @@ def test_tiers_say_what_a_tool_can_cost() -> None:
     from orchestrator.plugin.server import _TOOLS, tool_annotations
 
     hints = {fn.__name__: tool_annotations(fn.__name__) for fn in _TOOLS}
-    spends_and_writes = {"sdlc_feature", "sdlc_start_run", "sdlc_decide_gate"}
+    spends_and_writes = {"sdlc_feature", "sdlc_start_run", "sdlc_decide_gate", "registry_decide"}
     plans = {"sdlc_plan", "sdlc_approve"}
-    observes_a_run = {"sdlc_run_status", "sdlc_run_result"}
+    observes_a_run = {
+        "sdlc_run_status",
+        "sdlc_run_result",
+        "registry_runs",
+        "registry_approvals",
+        "registry_trace",
+    }
     comprehension = set(hints) - spends_and_writes - plans - observes_a_run
 
     for name in comprehension | observes_a_run:


### PR DESCRIPTION
## Summary

MCP phase 1 step 4 of [`docs/specs/mcp-plugin-surface.md`](docs/specs/mcp-plugin-surface.md) — closes gap 1, the operator hole the terminal UI removal (#316) left.

Four tools answer "what is running, what is waiting on me" and decide a gate:

| Tool | Signature | Tier |
|---|---|---|
| `registry_runs` | `(limit=20)` | read-only |
| `registry_approvals` | `(limit=50)` | read-only |
| `registry_trace` | `(sdlc_id, tail=50)` | read-only, bounded (`truncated` says what was left out) |
| `registry_decide` | `(approval_id, action, rationale="", modified_input=None)` | destructive — a rejection ends the run |

**Over HTTP to the registry, not in-process.** Same `ORCHESTRATOR_API_URL` / `ORCHESTRATOR_API_KEY` every other client reads, so the plugin process needs no database or Temporal access; the registry scopes results to the key's tenant and records the key as the actor, as it does for the web inbox. A registry that is down returns `error` + `hint` rather than failing the call. `sdlc_decide_gate` stays for the in-process path.

`registry_trace` fetches by the run id as listed — the console does the same; `task-<id>` is Temporal's workflow id, which the trace endpoint does not know. (Caught in self-review; the first draft prefixed it.)

## Files

- `plugin/registry_client.py` (new): the client deleted with the TUI, reinstated and extended — trace, one approval, decision bodies, status-matched hints. `registry_client()` factory reads the env; tests swap it.
- `plugin/server.py`: the four tools, `_TIER` entries, `__all__`, markdown renderings.
- Tests: 9 in `tests/plugin/test_registry_client.py`, 6 in `tests/plugin/test_server.py` (mock transport, no server), tier assertions extended.
- Docs: CLAUDE_GUIDE §6 rows and an "Operating runs" subsection; the spec (gap 1 closed, 4.2 shipped, tiers table); SPEC-INDEX; CHANGELOG; STATE-OF-SPINE counts.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`, `matrix-count --check`, `state-numbers --check`: pass
- Full pytest: 3340 passed, 3 skipped
- Live: `build_server().list_tools()` shows the four with read-only / destructive hints as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)
