### PR TITLE
feat(plugin): scopes follow the tiers on the HTTP transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,4 +200,6 @@ JIRA_DRY_RUN=true                      # false to write real issues
 # ORCHESTRATOR_MCP_INTROSPECTION_URL=https://idp.yourorg.com/oauth2/introspect
 # ORCHESTRATOR_MCP_INTROSPECTION_CLIENT_ID=orchestrator-rs
 # ORCHESTRATOR_MCP_INTROSPECTION_CLIENT_SECRET=replace-me
-# ORCHESTRATOR_MCP_REQUIRED_SCOPES=sdlc
+# Scopes the STATIC token carries (default: all three tiers). spine:read = a read-only token.
+# Tokens from the IdP carry whatever it issued; each tool checks its tier's scope per call.
+# ORCHESTRATOR_MCP_REQUIRED_SCOPES=spine:read spine:plan spine:run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Added
 
+- **Scopes follow the tiers on the MCP server's HTTP transport.** `spine:read`
+  (comprehension, observing a run), `spine:plan` (`sdlc_plan`, `sdlc_approve`),
+  `spine:run` (anything that spends money or writes where it cannot be taken
+  back). Every registered tool is wrapped in a guard that reads the verified
+  bearer token at call time and refuses — naming the scope it needed and the
+  scopes the token has — when the tier's scope is missing; the SDK only checks
+  scopes server-wide, so the per-tool check lives in the plugin. Over stdio there
+  is no token and no check. `ORCHESTRATOR_MCP_REQUIRED_SCOPES` now means what the
+  static token *carries* (default: all three, so a self-host behaves as before),
+  and `spine:read` alone makes it a read-only token. The legacy `sdlc` scope
+  expands to all three for one release, with a logged warning, then goes.
+
 - **Operator tools in the MCP plugin — the terminal UI's successor.** `registry_runs`,
   `registry_approvals`, `registry_trace` and `registry_decide` answer "what is
   running, what is waiting on me" and decide a gate, over HTTP to the registry

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -214,7 +214,13 @@ At a glance:
 > `create_app`?"* `repo_path` is a **local path or a git URL** (shallow‑cloned behind the CLI's host
 > allow‑list); each returns structured fields **plus** a `markdown` rendering, bounded (top‑N +
 > `file:line`). To serve them to a **remote** host over HTTP, run the streamable‑HTTP server
-> (`orchestrator-mcp --http`, bearer/OAuth auth from env) — it registers the same tools.
+> (`orchestrator-mcp --http`, bearer/OAuth auth from env) — it registers the same tools, and
+> **checks a scope per tier** on each call: `spine:read` (comprehension, observing a run),
+> `spine:plan` (`sdlc_plan`, `sdlc_approve`), `spine:run` (`sdlc_feature`, `sdlc_start_run`,
+> `sdlc_decide_gate`, `registry_decide`). A token missing the tier's scope gets `error` + `needs`
+> + `has` back, not a 403. A static token carries all three unless
+> `ORCHESTRATOR_MCP_REQUIRED_SCOPES` narrows it (`spine:read` = a read-only token); the legacy
+> `sdlc` scope still reads as all three for one release. Over stdio there is no token and no check.
 
 > **The tiers are metadata your host can act on.** Every tool is registered with MCP tool
 > annotations derived from its tier — *read‑only*, *destructive*, *idempotent*, *open‑world* — so a

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1224,7 +1224,13 @@ orchestrator-mcp --http --host 0.0.0.0 --port 8080     # behind TLS in productio
 ```
 Pick one auth mode (a public bind without either is refused):
 - **Shared secret** — set `ORCHESTRATOR_MCP_TOKEN` + `ORCHESTRATOR_MCP_RESOURCE_URL`; the client sends that token as its bearer.
-- **OAuth introspection** — set `ORCHESTRATOR_MCP_ISSUER_URL`, `…_INTROSPECTION_URL`, client id/secret, and `…_REQUIRED_SCOPES` to validate every token against your IdP.
+- **OAuth introspection** — set `ORCHESTRATOR_MCP_ISSUER_URL`, `…_INTROSPECTION_URL` and client id/secret to validate every token against your IdP.
+
+Scopes follow the tool tiers and are checked **per call**: `spine:read` (comprehension, observing
+a run), `spine:plan` (`sdlc_plan`, `sdlc_approve`), `spine:run` (anything that spends money or
+writes where it cannot be taken back). An IdP-issued token needs the scope of the tier it calls;
+a shared-secret token carries all three unless `ORCHESTRATOR_MCP_REQUIRED_SCOPES` narrows it —
+`spine:read` makes it read-only. The legacy `sdlc` scope reads as all three for one release.
 
 Destructive tools stay gated regardless of auth: `sdlc_feature(live=true)` and
 `sdlc_start_run(create_jira=true)` both need an explicit `confirm=true`.

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -93,7 +93,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [gap6-benchmarks-roadmap](gap6-benchmarks-roadmap.md) | ✅ **Complete 2026-09-01** | All three phases: harness, 38-label gold set, ratchet gate. top-1 0.32 / top-10 0.71 against 0.085 chance; published as [BENCHMARK.md](../../BENCHMARK.md). This row read *Not started* for a day after the spec said COMPLETE |
 | [codegen-benchmark-roadmap](codegen-benchmark-roadmap.md) | Not started | **New 2026-08-15.** SWE-bench comparability → `resolved`-vs-`mergeable` delta |
 | [codex-plugin-keyless-roadmap](codex-plugin-keyless-roadmap.md) | Not started | **New 2026-08-15.** Phase 0 is a blocking spike |
-| [mcp-plugin-surface](mcp-plugin-surface.md) | Phase 1: steps 1–4 shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
+| [mcp-plugin-surface](mcp-plugin-surface.md) | Phase 1: steps 1–5 shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
 | [phase5-agentic-codegen-loop](phase5-agentic-codegen-loop.md) | Proposed, under review | "The hinge phase" |
 | [autonomous-run-agent](autonomous-run-agent.md) | Proposed, no branch | 9 phases; 0–3 strictly serial |
 | [catalog-then-compose-roadmap](catalog-then-compose-roadmap.md) | Proposed, under review | Scope confirmed: Phases 0–3 |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
 | Source modules | **343** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,916** across 301 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,926** across 301 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/mcp-plugin-surface.md
+++ b/docs/specs/mcp-plugin-surface.md
@@ -1,6 +1,6 @@
 # The MCP plugin surface — what it is, what it lacks, and the order to extend it
 
-**Status:** Phase 1 in progress — steps 1–4 shipped, steps 5–6 open. **Written 2026-09-04 against 3.30.0**,
+**Status:** Phase 1 in progress — steps 1–5 shipped, step 6 open. **Written 2026-09-04 against 3.30.0**,
 after #316 removed the terminal UI and left the plugin as the only non-browser operator face.
 **Owner:** _unassigned_
 
@@ -38,9 +38,18 @@ because a host's cwd is not the repo.
 
 **Auth (HTTP only).** An OAuth 2.1 resource server: it verifies bearer tokens and never mints
 them. Introspection (`ORCHESTRATOR_MCP_INTROSPECTION_URL` + client id/secret, issuer and resource
-URLs) or a static shared secret (`ORCHESTRATOR_MCP_TOKEN`, constant-time compare). One scope list
-for the whole server (`ORCHESTRATOR_MCP_REQUIRED_SCOPES`, default `sdlc`). A non-loopback bind
-with neither configured is refused unless `--allow-unauthenticated`.
+URLs) or a static shared secret (`ORCHESTRATOR_MCP_TOKEN`, constant-time compare). A non-loopback
+bind with neither configured is refused unless `--allow-unauthenticated`.
+
+**Scopes follow the tiers (Phase 1 step 5).** `spine:read` for comprehension and observing a
+run, `spine:plan` for the build document and its approval, `spine:run` for anything that spends
+money or writes where it cannot be taken back. The SDK checks scopes once, server-wide, and only
+for the floor (`spine:read`); each registered tool is wrapped in a guard that reads the verified
+token at call time and refuses — naming the scope it needed and the scopes the token has — when
+the tier's scope is missing. Over stdio there is no token and the guard passes.
+`ORCHESTRATOR_MCP_REQUIRED_SCOPES` is what the **static token carries** (default: all three), so
+a read-only token is that variable set to `spine:read`. The legacy `sdlc` scope expands to all
+three for one release.
 
 **Packaging.** A Claude Code plugin at `plugins/spine/` bundling the `understand-codebase` skill;
 marketplace entry in `.claude-plugin/marketplace.json`; `pip install 'synaptixs-spine[all]'`.
@@ -89,6 +98,7 @@ Numbered, because §5 retires them by number.
 3. **The tiers were prose only.** A host could not tell a read-only tool from a money-spending
    one. *(Closed in Phase 1 — §2.)*
 4. **One scope for everything.** A token that may call `map_repo` may call `sdlc_feature`.
+   *(Closed in Phase 1 step 5: per-tier scopes, checked per call on HTTP — §1.)*
 5. **The back half of the pipeline is CLI-only.** `sdlc address-review`, `sdlc complete`,
    `sdlc remediate`, `sdlc baseline`, `design`, `audit`, `profile`, `understand`, `state` exist
    as commands and not as tools. An assistant can open the PR but cannot drive what follows.
@@ -112,8 +122,11 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
   because the plugin process then needs no database or Temporal credentials, the registry
   enforces tenant scoping, and the audit log records the key's principal as the actor.
   `registry_trace` is bounded — the newest `tail` entries plus a `truncated` count.
-- **4.3 Per-tier scopes on HTTP.** `spine:read`, `spine:plan`, `spine:run`, checked per tool at
-  registration; `sdlc` accepted as an alias for one release.
+- **4.3 Per-tier scopes on HTTP.** *(Shipped.)* `spine:read`, `spine:plan`, `spine:run`, each
+  tier naming its scope beside its annotations, enforced by a call-time guard around every
+  registered tool — the SDK only checks scopes server-wide, and a request does not name its tool
+  until the protocol layer has parsed it. Stdio is untouched. `sdlc` expands to all three for one
+  release, then goes.
 - **4.4 `understand_repo` and `current_state` as tools.** Both deterministic by invariant, so
   they fit tier 2 without new policy. Today `read_memory_bank` can only read a bank someone
   already committed.
@@ -141,8 +154,8 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
 | 2 | 2 | Sync `__all__`; a test holds it. | **this PR** |
 | 3 | 3 | 4.1 annotations (typed output deferred). | **this PR** |
 | 4 | 1 | 4.2 operator-ops tools. | **shipped** |
-| 5 | 4 | 4.3 scopes — before step 4 is served over HTTP to anyone else. | next |
-| 6 | 5 | 4.4, then 4.5. | after 5 |
+| 5 | 4 | 4.3 scopes — before step 4 is served over HTTP to anyone else. | **shipped** |
+| 6 | 5 | 4.4, then 4.5. | next |
 
 ### Phase 2 — extensions, once §3 is empty
 
@@ -153,6 +166,9 @@ typed-output half of 4.1 on its own.
 
 - **A tool without a tier does not register.** The refusal lives in `_register_tools`, not in a
   review checklist.
+- **A tool's scope is its tier's scope.** `tool_scope(name)` reads the same `_TIER` row as
+  `tool_annotations(name)`; the guard is applied at registration to every tool, so a tool cannot
+  be reachable on HTTP without a scope check any more than without a tier.
 - **Annotations are derived, never hand-copied.** `tool_annotations(name)` is the one source;
   the protocol-level test compares what a host sees against it field for field.
 - **Tier 1 and 2 stay model-free and credential-free.** That is the property the keyless

--- a/src/orchestrator/plugin/auth.py
+++ b/src/orchestrator/plugin/auth.py
@@ -17,6 +17,14 @@ Two verifier modes, selected by env (see ``build_auth_from_env``):
 
 Neither set → no auth settings (the caller decides whether to allow that, and
 only ever on loopback).
+
+**Scopes follow the tiers.** ``spine:read`` (comprehension and observing a run),
+``spine:plan`` (the build document and its approval), ``spine:run`` (anything that
+spends money or writes where it cannot be taken back). The SDK checks scopes once,
+server-wide, and only for the floor (``spine:read``); the per-tool check is
+``plugin.server``'s scope guard, which reads the verified token at call time and
+refuses with the scope it needed. A token carrying the legacy ``sdlc`` scope is
+treated as carrying all three for one release (``expand_scopes``).
 """
 
 from __future__ import annotations
@@ -35,7 +43,37 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("orchestrator.plugin.auth")
 
-_DEFAULT_SCOPES = ["sdlc"]
+SCOPE_READ = "spine:read"
+SCOPE_PLAN = "spine:plan"
+SCOPE_RUN = "spine:run"
+ALL_SCOPES = [SCOPE_READ, SCOPE_PLAN, SCOPE_RUN]
+#: The scope every token had before the tiers had scopes. Expands to all three for one
+#: release so an existing static token or IdP grant keeps working; remove after.
+LEGACY_SCOPE = "sdlc"
+
+#: What the static token carries when ``ORCHESTRATOR_MCP_REQUIRED_SCOPES`` is unset: every
+#: tier, so a single-tenant self-host behaves as it did with the one ``sdlc`` scope.
+_DEFAULT_SCOPES = list(ALL_SCOPES)
+#: What the SDK requires of every token before any request reaches a tool. The floor is
+#: read: a token that cannot comprehend has no business at any tier.
+_SERVER_FLOOR = [SCOPE_READ]
+
+_legacy_warned = False
+
+
+def expand_scopes(scopes: list[str]) -> list[str]:
+    """``sdlc`` → all three tier scopes (once-warned); everything else passes through."""
+    global _legacy_warned
+    if LEGACY_SCOPE not in scopes:
+        return list(scopes)
+    if not _legacy_warned:
+        logger.warning(
+            "plugin.auth.legacy_scope",
+            extra={"detail": f"scope {LEGACY_SCOPE!r} is deprecated; grant {' '.join(ALL_SCOPES)} instead"},
+        )
+        _legacy_warned = True
+    out = [s for s in scopes if s != LEGACY_SCOPE]
+    return out + [s for s in ALL_SCOPES if s not in out]
 
 
 def _scopes_from_env(value: str | None) -> list[str]:
@@ -57,7 +95,7 @@ class StaticTokenVerifier:
         if not secret:
             raise ValueError("StaticTokenVerifier needs a non-empty secret")
         self._secret = secret
-        self._scopes = scopes or list(_DEFAULT_SCOPES)
+        self._scopes = expand_scopes(scopes or list(_DEFAULT_SCOPES))
 
     async def verify_token(self, token: str) -> AccessToken | None:
         from mcp.server.auth.provider import AccessToken
@@ -111,7 +149,7 @@ class IntrospectionTokenVerifier:
         exp = data.get("exp")
         if isinstance(exp, (int, float)) and exp < time.time():
             return None
-        scopes = _scopes_from_env(data.get("scope")) if data.get("scope") else []
+        scopes = expand_scopes(_scopes_from_env(data.get("scope"))) if data.get("scope") else []
         return AccessToken(
             token=token,
             client_id=str(data.get("client_id", "introspected")),
@@ -129,6 +167,11 @@ def build_auth_from_env() -> tuple[AuthSettings | None, TokenVerifier | None]:
     resource URL when not given. Returns ``(None, None)`` when neither verifier
     is configured — an unauthenticated server (loopback only; the runner gates
     public binds).
+
+    ``ORCHESTRATOR_MCP_REQUIRED_SCOPES`` is what the **static token carries** (default:
+    all three tier scopes); a read-only token is that variable set to ``spine:read``.
+    The server-wide requirement the SDK enforces is the floor, ``spine:read``; the
+    tiers above it are checked per tool by the scope guard.
     """
     from mcp.server.auth.settings import AuthSettings
     from pydantic import AnyHttpUrl
@@ -164,13 +207,19 @@ def build_auth_from_env() -> tuple[AuthSettings | None, TokenVerifier | None]:
     settings = AuthSettings(
         issuer_url=AnyHttpUrl(effective_issuer),
         resource_server_url=AnyHttpUrl(resource_url) if resource_url else None,
-        required_scopes=scopes,
+        required_scopes=list(_SERVER_FLOOR),
     )
     return settings, verifier
 
 
 __all__ = [
+    "ALL_SCOPES",
+    "LEGACY_SCOPE",
+    "SCOPE_PLAN",
+    "SCOPE_READ",
+    "SCOPE_RUN",
     "IntrospectionTokenVerifier",
     "StaticTokenVerifier",
     "build_auth_from_env",
+    "expand_scopes",
 ]

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -53,16 +53,28 @@ tier model is enforced by the client rather than by a docstring a model may not 
 A tool without a tier does not register — ``_register_tools`` raises, and a test says so
 before a host does.
 
+**And the tiers are scopes, on HTTP.** Each tier names the OAuth scope a bearer token needs
+(``spine:read`` / ``spine:plan`` / ``spine:run``, in ``orchestrator.plugin.auth``), and every
+registered tool is wrapped in a guard that reads the verified token at call time and
+refuses — naming the scope it needed and the scopes the token has — when it is missing.
+The SDK only checks scopes server-wide, so the per-tool check has to live here. Over stdio
+there is no token, and the guard passes: a local subprocess a host launched already holds
+the user's ``.env``.
+
 Tool *implementations* are module-level functions (unit-testable without the ``mcp``
 extra); ``build_server`` lazy-imports the SDK's server class and registers them.
 """
 
 from __future__ import annotations
 
+import functools
+import inspect
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
+
+from orchestrator.plugin.auth import SCOPE_PLAN, SCOPE_READ, SCOPE_RUN
 
 
 def doctor() -> dict[str, Any]:
@@ -1113,27 +1125,35 @@ _TOOLS = (
 
 @dataclass(frozen=True)
 class Tier:
-    """What a tool can cost you if it is wrong, in the four hints MCP hosts understand."""
+    """What a tool can cost you if it is wrong — the four hints MCP hosts understand, and
+    the OAuth scope a bearer token needs on the HTTP transport."""
 
     name: str
     read_only: bool
     destructive: bool
     idempotent: bool
     open_world: bool
+    scope: str
 
 
 #: Read-only comprehension. ``open_world`` because ``repo_path`` may be a git URL (a
 #: shallow clone) and a requirements ``source`` may be Confluence or Notion.
-COMPREHEND = Tier("comprehend", read_only=True, destructive=False, idempotent=True, open_world=True)
+COMPREHEND = Tier(
+    "comprehend", read_only=True, destructive=False, idempotent=True, open_world=True, scope=SCOPE_READ
+)
 #: The same, for tools that only ever read this machine.
-COMPREHEND_LOCAL = Tier("comprehend", read_only=True, destructive=False, idempotent=True, open_world=False)
+COMPREHEND_LOCAL = Tier(
+    "comprehend", read_only=True, destructive=False, idempotent=True, open_world=False, scope=SCOPE_READ
+)
 #: Plan and decide: writes under ``.spine/`` only, re-running rewrites the same document.
-PLAN = Tier("plan", read_only=False, destructive=False, idempotent=True, open_world=False)
+PLAN = Tier("plan", read_only=False, destructive=False, idempotent=True, open_world=False, scope=SCOPE_PLAN)
 #: Observing a run: reads Temporal state, changes nothing.
-RUN_OBSERVE = Tier("run", read_only=True, destructive=False, idempotent=True, open_world=True)
+RUN_OBSERVE = Tier(
+    "run", read_only=True, destructive=False, idempotent=True, open_world=True, scope=SCOPE_READ
+)
 #: Driving a run: spends money, and with ``live``/``confirm`` writes where it cannot be
 #: taken back. A rejected gate ends a run, which is why deciding one is destructive too.
-RUN = Tier("run", read_only=False, destructive=True, idempotent=False, open_world=True)
+RUN = Tier("run", read_only=False, destructive=True, idempotent=False, open_world=True, scope=SCOPE_RUN)
 
 #: Every registered tool's tier, by function name. Keep it total: registration refuses a
 #: tool that is missing here, and ``tests/plugin`` asserts the two stay in step.
@@ -1181,6 +1201,49 @@ def tool_annotations(name: str) -> dict[str, bool]:
     }
 
 
+def tool_scope(name: str) -> str:
+    """The OAuth scope a bearer token needs to call ``name`` over HTTP. ``KeyError`` for a
+    tool with no tier — the same refusal as ``tool_annotations``."""
+    return _TIER[name].scope
+
+
+def scope_denial(name: str, scope: str) -> dict[str, Any] | None:
+    """``None`` when the current caller may call ``name``; otherwise the error to return.
+
+    The caller is the verified bearer token the SDK put in its auth context for this
+    request. No token — stdio, or an unauthenticated loopback bind — means no check.
+    """
+    try:
+        from mcp.server.auth.middleware.auth_context import get_access_token
+    except ImportError:  # pragma: no cover - without the `mcp` extra nothing is served
+        return None
+    token = get_access_token()
+    if token is None or scope in token.scopes:
+        return None
+    return {
+        "error": f"{name} needs scope {scope!r}; this token has {sorted(token.scopes)}",
+        "needs": scope,
+        "has": sorted(token.scopes),
+        "hint": "Ask for a token that carries the scope, or use a tier this token is allowed.",
+    }
+
+
+def _scoped(fn: Callable[..., Any], scope: str) -> Callable[..., Any]:
+    """Wrap a tool so the scope guard runs before it. ``functools.wraps`` carries the
+    signature, annotations and docstring across, which is what the SDK builds the input
+    schema and description from — a guarded tool advertises exactly what the bare one did."""
+
+    @functools.wraps(fn)
+    async def guarded(*args: Any, **kwargs: Any) -> Any:
+        denied = scope_denial(fn.__name__, scope)
+        if denied is not None:
+            return denied
+        out = fn(*args, **kwargs)
+        return await out if inspect.isawaitable(out) else out
+
+    return guarded
+
+
 def _import_server_class() -> Any:
     """The SDK's server class — ``MCPServer`` since v2 (was ``mcp.server.fastmcp.FastMCP``).
 
@@ -1211,7 +1274,7 @@ def _register_tools(server: Any) -> Any:
                 idempotent_hint=hints["idempotent_hint"],
                 open_world_hint=hints["open_world_hint"],
             )
-        )(fn)
+        )(_scoped(fn, tool_scope(fn.__name__)))
     return server
 
 
@@ -1304,6 +1367,7 @@ __all__ = [
     "registry_trace",
     "regression_gaps",
     "root_cause",
+    "scope_denial",
     "sdlc_approve",
     "sdlc_decide_gate",
     "sdlc_feature",
@@ -1313,4 +1377,5 @@ __all__ = [
     "sdlc_start_run",
     "Tier",
     "tool_annotations",
+    "tool_scope",
 ]

--- a/tests/plugin/test_auth.py
+++ b/tests/plugin/test_auth.py
@@ -8,10 +8,15 @@ import pytest
 
 pytest.importorskip("mcp", reason="needs the 'mcp' extra")
 
-from orchestrator.plugin.auth import (  # noqa: E402
+from orchestrator.plugin.auth import (
+    ALL_SCOPES,
+    SCOPE_PLAN,
+    SCOPE_READ,
+    SCOPE_RUN,
     IntrospectionTokenVerifier,
     StaticTokenVerifier,
     build_auth_from_env,
+    expand_scopes,  # noqa: E402
 )
 
 _MCP_ENV = (
@@ -35,9 +40,9 @@ def _clean_mcp_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 async def test_static_accepts_exact_secret() -> None:
-    v = StaticTokenVerifier("s3cret", scopes=["sdlc"])
+    v = StaticTokenVerifier("s3cret", scopes=[SCOPE_READ])
     tok = await v.verify_token("s3cret")
-    assert tok is not None and tok.scopes == ["sdlc"] and tok.client_id == "static"
+    assert tok is not None and tok.scopes == [SCOPE_READ] and tok.client_id == "static"
 
 
 async def test_static_rejects_wrong_or_empty_token() -> None:
@@ -75,7 +80,8 @@ async def test_introspection_active_token_maps_scopes(monkeypatch: pytest.Monkey
     v = IntrospectionTokenVerifier("https://idp.example/introspect")
     tok = await v.verify_token("opaque")
     assert tok is not None and tok.client_id == "app-1"
-    assert set(tok.scopes) == {"sdlc", "admin"}
+    # The IdP's scopes as issued — with the legacy `sdlc` expanded to the three tier scopes.
+    assert set(tok.scopes) == {"admin", *ALL_SCOPES}
 
 
 async def test_introspection_inactive_token_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -113,13 +119,17 @@ def test_env_no_verifier_returns_none() -> None:
     assert build_auth_from_env() == (None, None)
 
 
-def test_env_static_token_builds_resource_server(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_env_static_token_builds_resource_server(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ORCHESTRATOR_MCP_TOKEN", "s3cret")
     monkeypatch.setenv("ORCHESTRATOR_MCP_RESOURCE_URL", "https://mcp.example.com")
     monkeypatch.setenv("ORCHESTRATOR_MCP_REQUIRED_SCOPES", "sdlc, admin")
     settings, verifier = build_auth_from_env()
     assert isinstance(verifier, StaticTokenVerifier)
-    assert settings is not None and settings.required_scopes == ["sdlc", "admin"]
+    # The env var is what the static token *carries* (legacy `sdlc` expanded); what the SDK
+    # requires of every token is the floor, `spine:read` — the tiers above are per tool.
+    assert settings is not None and settings.required_scopes == [SCOPE_READ]
+    tok = await verifier.verify_token("s3cret")
+    assert tok is not None and set(tok.scopes) == {"admin", *ALL_SCOPES}
     # issuer defaults to the resource URL for the static (no real AS) path.
     assert str(settings.issuer_url).startswith("https://mcp.example.com")
 
@@ -137,3 +147,32 @@ def test_env_verifier_without_any_url_errors(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("ORCHESTRATOR_MCP_TOKEN", "s3cret")  # no issuer/resource URL
     with pytest.raises(ValueError, match="ISSUER_URL"):
         build_auth_from_env()
+
+
+# ---- scopes follow the tiers -------------------------------------------------------
+
+
+def test_the_legacy_scope_expands_to_every_tier_once() -> None:
+    """A token minted for the one `sdlc` scope keeps working for a release: it reads as all
+    three tier scopes. Anything else passes through untouched, order kept."""
+    assert expand_scopes(["sdlc"]) == ALL_SCOPES
+    assert expand_scopes(["admin", "sdlc"]) == ["admin", *ALL_SCOPES]
+    assert expand_scopes([SCOPE_READ]) == [SCOPE_READ]
+    assert expand_scopes([SCOPE_RUN, "sdlc"]) == [SCOPE_RUN, SCOPE_READ, SCOPE_PLAN]  # no duplicate
+
+
+async def test_a_static_token_carries_every_tier_by_default() -> None:
+    """Unset env → the single-tenant self-host behaves as before: one token, every tier."""
+    tok = await StaticTokenVerifier("s3cret").verify_token("s3cret")
+    assert tok is not None and tok.scopes == ALL_SCOPES
+
+
+async def test_a_read_only_static_token_is_one_env_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORCHESTRATOR_MCP_TOKEN", "s3cret")
+    monkeypatch.setenv("ORCHESTRATOR_MCP_RESOURCE_URL", "https://mcp.example.com")
+    monkeypatch.setenv("ORCHESTRATOR_MCP_REQUIRED_SCOPES", SCOPE_READ)
+    settings, verifier = build_auth_from_env()
+    assert settings is not None and verifier is not None
+    tok = await verifier.verify_token("s3cret")
+    assert tok is not None and tok.scopes == [SCOPE_READ]
+    assert settings.required_scopes == [SCOPE_READ]  # the floor lets it in; the guard keeps it to tier 1

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -649,6 +649,120 @@ def test_registration_refuses_a_tool_without_a_tier(monkeypatch: pytest.MonkeyPa
         mod.build_server()
 
 
+# ---- the tiers are scopes: the guard on the HTTP transport ---------------------------
+
+
+def test_every_tier_names_a_scope_and_it_follows_the_hints() -> None:
+    from orchestrator.plugin.auth import SCOPE_PLAN, SCOPE_READ, SCOPE_RUN
+    from orchestrator.plugin.server import _TOOLS, tool_annotations, tool_scope
+
+    for fn in _TOOLS:
+        name = fn.__name__
+        hints, scope = tool_annotations(name), tool_scope(name)
+        if hints["read_only_hint"]:
+            assert scope == SCOPE_READ, name
+        elif hints["destructive_hint"]:
+            assert scope == SCOPE_RUN, name
+        else:
+            assert scope == SCOPE_PLAN, name
+    assert tool_scope("registry_decide") == SCOPE_RUN and tool_scope("sdlc_plan") == SCOPE_PLAN
+
+
+def test_an_untiered_tool_has_no_scope_either() -> None:
+    from orchestrator.plugin.server import tool_scope
+
+    with pytest.raises(KeyError):
+        tool_scope("a_tool_nobody_classified")
+
+
+@pytest.fixture
+def _as_token(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Run the rest of the test as a caller whose verified bearer token carries `scopes`."""
+    pytest.importorskip("mcp")
+    from mcp.server.auth.middleware.auth_context import (  # type: ignore[attr-defined]
+        AuthenticatedUser,
+        auth_context_var,
+    )
+    from mcp.server.auth.provider import AccessToken
+
+    def as_token(scopes: list[str] | None) -> None:
+        if scopes is None:
+            auth_context_var.set(None)
+            return
+        user = AuthenticatedUser(AccessToken(token="t", client_id="c", scopes=scopes, expires_at=None))
+        auth_context_var.set(user)
+
+    yield as_token
+    auth_context_var.set(None)
+
+
+def test_the_guard_refuses_a_token_without_the_tools_scope(_as_token: Any) -> None:
+    from orchestrator.plugin.auth import SCOPE_READ, SCOPE_RUN
+    from orchestrator.plugin.server import scope_denial
+
+    _as_token([SCOPE_READ])
+    denied = scope_denial("registry_decide", SCOPE_RUN)
+    assert denied is not None
+    assert denied["needs"] == SCOPE_RUN and denied["has"] == [SCOPE_READ]
+    assert "registry_decide" in denied["error"] and SCOPE_RUN in denied["error"]
+
+
+def test_the_guard_passes_a_token_with_the_scope_and_no_token_at_all(_as_token: Any) -> None:
+    from orchestrator.plugin.auth import SCOPE_RUN
+    from orchestrator.plugin.server import scope_denial
+
+    _as_token([SCOPE_RUN])
+    assert scope_denial("registry_decide", SCOPE_RUN) is None
+    _as_token(None)  # stdio, or an unauthenticated loopback bind: nothing to check against
+    assert scope_denial("registry_decide", SCOPE_RUN) is None
+
+
+async def test_a_guarded_tool_returns_the_denial_instead_of_running(
+    _as_token: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End to end through the wrapper the server registers: a read-only token calling a
+    run-tier tool never reaches the registry."""
+    from orchestrator.plugin.auth import SCOPE_READ, SCOPE_RUN
+    from orchestrator.plugin.server import _scoped, registry_decide
+
+    def handler(request: object) -> None:
+        raise AssertionError("must not reach the registry")
+
+    _registry_with(handler, monkeypatch)
+    guarded = _scoped(registry_decide, SCOPE_RUN)
+    _as_token([SCOPE_READ])
+    out = await guarded("g1", "approve")
+    assert out["needs"] == SCOPE_RUN
+
+
+async def test_a_guarded_sync_tool_still_runs_when_allowed(_as_token: Any) -> None:
+    from orchestrator.plugin.auth import SCOPE_READ
+    from orchestrator.plugin.server import _scoped, doctor
+
+    _as_token([SCOPE_READ])
+    out = await _scoped(doctor, SCOPE_READ)()
+    assert "all_passed" in out  # the sync tool ran, through the async wrapper
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="needs the 'mcp' extra")
+async def test_the_guard_does_not_change_what_a_host_sees() -> None:
+    """The wrapper must be invisible in `list_tools`: same names, same input schema, same
+    annotations, same description — the SDK builds those from what `functools.wraps` carries."""
+    from orchestrator.plugin.server import _TOOLS, build_server, registry_decide, tool_annotations
+
+    tools = {t.name: t for t in await build_server().list_tools()}
+    assert set(tools) == {fn.__name__ for fn in _TOOLS}
+    decide = tools["registry_decide"]
+    assert set(decide.input_schema["properties"]) == {"approval_id", "action", "rationale", "modified_input"}
+    assert decide.input_schema["required"] == ["approval_id", "action"]
+    assert decide.description == registry_decide.__doc__
+    for name, tool in tools.items():
+        assert tool.annotations is not None
+        assert tool.annotations.model_dump(exclude_none=True, exclude={"title"}) == tool_annotations(name), (
+            name
+        )
+
+
 # ---- dogfood: drive the real stdio server (needs the `mcp` extra) -----------
 
 


### PR DESCRIPTION
## Summary

MCP phase 1 step 5 of [`docs/specs/mcp-plugin-surface.md`](docs/specs/mcp-plugin-surface.md) — closes gap 4: a token that may call `map_repo` could call `sdlc_feature`.

| Scope | Tools |
|---|---|
| `spine:read` | Tier 1 comprehension, `sdlc_run_status`, `sdlc_run_result`, `registry_runs`, `registry_approvals`, `registry_trace` |
| `spine:plan` | `sdlc_plan`, `sdlc_approve` |
| `spine:run` | `sdlc_feature`, `sdlc_start_run`, `sdlc_decide_gate`, `registry_decide` |

Each `Tier` names its scope beside its annotations, so a tool gets its scope the way it gets its hints, and the same total-table test covers both.

**Enforced at call time.** Every registered tool is wrapped in a guard that reads the verified bearer token from the SDK's auth context and refuses — returning `error` + `needs` + `has` — when the tier's scope is missing. The SDK only checks scopes server-wide, and a request does not name its tool until the protocol layer has parsed it, so the per-tool check lives in the plugin. `functools.wraps` carries signature, annotations and docstring across; a protocol-level test holds `list_tools` identical before and after. **Stdio is untouched**: no token, no check.

**Env semantics.** `ORCHESTRATOR_MCP_REQUIRED_SCOPES` now means what the static token *carries* (default: all three, so a self-host behaves as before); `spine:read` alone makes a read-only token. The SDK's server-wide requirement becomes the floor, `spine:read`. The legacy `sdlc` scope expands to all three for one release with a once-logged warning, then goes.

Verified live through the SDK server: a `spine:read` token calling `registry_decide` gets the denial naming `spine:run`; the same token calling `doctor` succeeds; with no token the guard passes and the tool's own validation answers.

## Files

- `plugin/auth.py`: scope constants, `expand_scopes` (alias), static default grant, the server floor.
- `plugin/server.py`: `Tier.scope`, `tool_scope`, `scope_denial`, `_scoped` wrapper at registration.
- Tests: 3 updated + 3 new in `test_auth.py`; 7 new in `test_server.py`.
- Docs: spec (§1 scopes, gap 4 closed, 4.3 shipped, invariant), SPEC-INDEX, CLAUDE_GUIDE §6, USER_GUIDE §10.2, `.env.example`, CHANGELOG, STATE-OF-SPINE count.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`, `matrix-count --check`, `state-numbers --check`, `check-mermaid`: pass
- Full pytest: 3350 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
