### PR TITLE
feat(plugin): the free half of the back half — understand, profile, design, baseline as tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Added
 
+- **The free half of the pipeline's back half, as MCP tools.** `understand_repo`
+  builds a repo's `episteme/` knowledge base — or, with `check=true`, verifies the
+  committed one still matches the code, naming the missing, stale and orphaned
+  pages — so an assistant can bootstrap a repo that has no bank and then
+  `read_memory_bank` it. It refuses a build on a git URL unless `out` is an
+  absolute directory, because the clone vanishes. `profile_repo` (languages,
+  framework, database, test runner, task type), `design_change` (a grounded
+  design with blast radius and unverified references, for the same `spec` object
+  `sdlc_plan` takes; `use_llm` opt-in) and `sdlc_baseline` (the agent-corpus
+  gate and run metrics) join it. All deterministic, no credentials. There is no
+  `state` tool because `map_repo` already is it.
+
 - **Scopes follow the tiers on the MCP server's HTTP transport.** `spine:read`
   (comprehension, observing a run), `spine:plan` (`sdlc_plan`, `sdlc_approve`),
   `spine:run` (anything that spends money or writes where it cannot be taken

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -196,6 +196,10 @@ At a glance:
 | [`read_memory_bank`](#read_memory_bank) | Read a repo's committed `episteme/` (code‑true project knowledge). | no |
 | [`pkg_grounding`](#pkg_grounding) | The existing‑code context a repo's Product Knowledge Graph surfaces for a spec — real APIs/types Spine would reuse, with `file:line`. | no |
 | [`ingest_preview`](#ingest_preview) | Preview the backlog (derived intents + gaps) for a requirements source — dry‑run. | no |
+| `understand_repo` | **Build the `episteme/` knowledge base** a repo has none of yet (then `read_memory_bank` it), or `check=true` to verify the committed one still matches the code — missing / stale / orphaned pages named. Deterministic, no model. Refuses a build on a git URL unless `out` is an absolute directory. | `episteme/` |
+| `profile_repo` | Languages, framework, database + migrations, test runner, and the task type for an `intent` — the profile the catalog picks skills from. | no |
+| `design_change` | A grounded design for one spec (the same `spec` object as `sdlc_plan`): approach, **blast radius**, **unverified references**. Deterministic; `use_llm=true` writes the prose. Never writes. | no |
+| `sdlc_baseline` | Score the run agent against a corpus of tickets with known answers, plus the durable run records — false and missed refusals counted separately. Free. | no |
 | **Plan it, then decide — before anything is built** | | |
 | [`sdlc_plan`](#sdlc_plan) | **The build document.** Twelve grounded sections for one ticket: requirement, intent, root cause, what the graph knows, blast radius, design, files, acceptance criteria, the codegen prompt, cost and confidence — each labelled with where it came from. **No model, no credentials, nothing spent.** | `.spine/` |
 | [`sdlc_approve`](#sdlc_approve) | Record that a **human** read that document and decided. Binds to a digest of it, so a plan that changes afterwards reads as *stale* rather than still approved. | `.spine/` |
@@ -208,7 +212,8 @@ At a glance:
 | [`registry_decide`](#operating-runs-registry_runs--friends) | Approve / reject / modify a pending approval so its run continues (or stops). | gated |
 
 > **The comprehension tools are read‑only, need no credentials, and are deterministic** (only
-> `root_cause`'s opt‑in `use_llm` uses a model). They ship with an **`understand-codebase` skill**
+> `root_cause`'s and `design_change`'s opt‑in `use_llm` use a model). There is no `state` tool
+> because `map_repo` *is* `orchestrator state` — same engine, same rendering. They ship with an **`understand-codebase` skill**
 > that tells Claude *when* to reach for each — so you can just ask in plain language and Claude picks
 > the tool. Try: *"Map this repo and tell me what's untested,"* or *"What breaks if I change
 > `create_app`?"* `repo_path` is a **local path or a git URL** (shallow‑cloned behind the CLI's host

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -93,7 +93,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [gap6-benchmarks-roadmap](gap6-benchmarks-roadmap.md) | ✅ **Complete 2026-09-01** | All three phases: harness, 38-label gold set, ratchet gate. top-1 0.32 / top-10 0.71 against 0.085 chance; published as [BENCHMARK.md](../../BENCHMARK.md). This row read *Not started* for a day after the spec said COMPLETE |
 | [codegen-benchmark-roadmap](codegen-benchmark-roadmap.md) | Not started | **New 2026-08-15.** SWE-bench comparability → `resolved`-vs-`mergeable` delta |
 | [codex-plugin-keyless-roadmap](codex-plugin-keyless-roadmap.md) | Not started | **New 2026-08-15.** Phase 0 is a blocking spike |
-| [mcp-plugin-surface](mcp-plugin-surface.md) | Phase 1: steps 1–5 shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
+| [mcp-plugin-surface](mcp-plugin-surface.md) | Phase 1: steps 1–6a shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
 | [phase5-agentic-codegen-loop](phase5-agentic-codegen-loop.md) | Proposed, under review | "The hinge phase" |
 | [autonomous-run-agent](autonomous-run-agent.md) | Proposed, no branch | 9 phases; 0–3 strictly serial |
 | [catalog-then-compose-roadmap](catalog-then-compose-roadmap.md) | Proposed, under review | Scope confirmed: Phases 0–3 |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
 | Source modules | **343** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,926** across 301 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,935** across 301 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/mcp-plugin-surface.md
+++ b/docs/specs/mcp-plugin-surface.md
@@ -1,6 +1,6 @@
 # The MCP plugin surface — what it is, what it lacks, and the order to extend it
 
-**Status:** Phase 1 in progress — steps 1–5 shipped, step 6 open. **Written 2026-09-04 against 3.30.0**,
+**Status:** Phase 1 in progress — steps 1–5 and 6a shipped, 6b open. **Written 2026-09-04 against 3.30.0**,
 after #316 removed the terminal UI and left the plugin as the only non-browser operator face.
 **Owner:** _unassigned_
 
@@ -54,7 +54,7 @@ three for one release.
 **Packaging.** A Claude Code plugin at `plugins/spine/` bundling the `understand-codebase` skill;
 marketplace entry in `.claude-plugin/marketplace.json`; `pip install 'synaptixs-spine[all]'`.
 
-## 2. The 24 tools, in three tiers plus an operator set
+## 2. The 28 tools, in three tiers plus an operator set
 
 The tiers are separated by what a tool can cost you if it is wrong. An assistant works **down**
 them: comprehend, then plan and get the plan approved, then build.
@@ -63,6 +63,7 @@ them: comprehend, then plan and get the plan approved, then build.
 |---|---|---|
 | **1 · comprehend** | `doctor`, `map_repo`, `blast_radius`, `explain_symbol`, `investigate`, `localize`, `regression_gaps`, `root_cause`, `docs_for`, `pkg_joins`, `read_memory_bank`, `pkg_grounding`, `ingest_preview` | No credentials, no model, deterministic. `root_cause(use_llm=true)` is the one opt-in model call, and it still never changes code. `repo_path` is a local path or a git URL; `blast_radius` and `investigate` answer across repositories via `repos` (`.spine/repos.yaml`). |
 | **2 · plan** | `sdlc_plan`, `sdlc_approve` | Writes only under `.spine/`. Still no model, no credentials — which is what lets a host with its own model drive Spine on a machine where Spine has neither. |
+| **the free back half** | `understand_repo`, `profile_repo`, `design_change`, `sdlc_baseline` | Deterministic, no credentials (`design_change(use_llm=true)` is the opt-in model call). `understand_repo` is the one write — under `episteme/` or `out` — so it carries plan scope; the rest are tier 1. |
 | **operate** | `registry_runs`, `registry_approvals`, `registry_trace`, `registry_decide` | Over HTTP to the registry (`orchestrator up`); needs only the API URL and key. Observing is read-only; `registry_decide` is destructive because a rejection ends a run. |
 | **3 · run** | `sdlc_feature`, `sdlc_start_run`, `sdlc_run_status`, `sdlc_decide_gate`, `sdlc_run_result` | Spends tokens. `live=true` (or `create_jira=true`) writes where it cannot be taken back and needs `confirm=true` on top of the host's own confirmation. The run set needs the Temporal backend. |
 
@@ -76,6 +77,7 @@ what to confirm. From Phase 1 every registration carries the four hints, derived
 | Tier 1 | yes | no | yes | yes — `repo_path` may be a URL, a `source` may be remote |
 | `doctor`, `pkg_joins` | yes | no | yes | no — local only |
 | `sdlc_plan`, `sdlc_approve` | no | no | yes — re-running rewrites the same document | no |
+| `understand_repo` | no | no | yes | yes — `repo_path` may be a URL; the write stays under `episteme/` |
 | `sdlc_run_status`, `sdlc_run_result` | yes | no | yes | yes — they read Temporal |
 | `registry_runs`, `registry_approvals`, `registry_trace` | yes | no | yes | yes — they read the registry |
 | `registry_decide` | no | yes | no | yes |
@@ -102,6 +104,9 @@ Numbered, because §5 retires them by number.
 5. **The back half of the pipeline is CLI-only.** `sdlc address-review`, `sdlc complete`,
    `sdlc remediate`, `sdlc baseline`, `design`, `audit`, `profile`, `understand`, `state` exist
    as commands and not as tools. An assistant can open the PR but cannot drive what follows.
+   *(Half closed in Phase 1 step 6a — the free, deterministic half: `understand_repo`,
+   `profile_repo`, `design_change`, `sdlc_baseline`; `state` turned out to be `map_repo`
+   already. The gated half — address-review, complete, remediate, audit — is step 6b.)*
 6. **A stale install was invisible.** The `orchestrator-mcp` on one machine's PATH pointed at
    another checkout's venv (Spine 3.9.3, no `mcp` module); the host saw "Connection closed" and
    nothing said why. *(Closed in Phase 1: `doctor` reports version, interpreter, SDK and extras,
@@ -127,11 +132,14 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
   registered tool — the SDK only checks scopes server-wide, and a request does not name its tool
   until the protocol layer has parsed it. Stdio is untouched. `sdlc` expands to all three for one
   release, then goes.
-- **4.4 `understand_repo` and `current_state` as tools.** Both deterministic by invariant, so
-  they fit tier 2 without new policy. Today `read_memory_bank` can only read a bank someone
-  already committed.
-- **4.5 The post-PR loop.** `sdlc_address_review`, `sdlc_complete`, `sdlc_remediate`,
-  `sdlc_baseline`, `design` as tier-3 tools under the same `live`/`confirm` gate.
+- **4.4 `understand_repo` and `current_state` as tools.** *(Shipped in 6a — `understand_repo`
+  builds or checks the bank; `current_state` was already `map_repo`.)* `understand_repo` refuses
+  a build on a git URL unless `out` is absolute: the clone vanishes, and a bank written into it
+  with it. It returns the three entry pages and the counts, not every path.
+- **4.5 The post-PR loop.** Split by cost. *6a (shipped):* `profile_repo`, `design_change`,
+  `sdlc_baseline` — deterministic, free, tier 1. *6b:* `sdlc_address_review`, `sdlc_complete`,
+  `sdlc_remediate` as tier-3 tools under the same `confirm` gate as `sdlc_feature(live=true)`,
+  and `audit`, which spends tokens on a persona loop — read-only in annotations, run scope.
 - **4.6 Resources.** `spine://episteme/{repo}/{section}`, `spine://plan/{repo}/{intent}`,
   `spine://state/{repo}` as MCP resources — listable, subscribable, attachable as context.
 - **4.7 Prompts.** The `understand-codebase` skill's guidance registered as MCP prompts so Codex,
@@ -155,7 +163,8 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
 | 3 | 3 | 4.1 annotations (typed output deferred). | **this PR** |
 | 4 | 1 | 4.2 operator-ops tools. | **shipped** |
 | 5 | 4 | 4.3 scopes — before step 4 is served over HTTP to anyone else. | **shipped** |
-| 6 | 5 | 4.4, then 4.5. | next |
+| 6a | 5 | The free half: `understand_repo`, `profile_repo`, `design_change`, `sdlc_baseline`. | **shipped** |
+| 6b | 5 | The gated half: `sdlc_address_review`, `sdlc_complete`, `sdlc_remediate`, `audit`. | next |
 
 ### Phase 2 — extensions, once §3 is empty
 

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -38,6 +38,11 @@ open PR — which is why ``live`` additionally requires ``confirm=true``, an exp
 authorization on top of whatever confirmation the host already asks for. Safe mode
 (``live=false``) still costs tokens; it just keeps every write local.
 
+**The free half of the back half** — ``understand_repo`` (build or check the ``episteme/``
+bank; the one write, under the repo), ``profile_repo``, ``design_change`` and
+``sdlc_baseline``. Deterministic, no credentials, apart from ``design_change``'s opt-in
+``use_llm``. ``state`` has no tool of its own because ``map_repo`` already is it.
+
 **Operator tools** — ``registry_runs`` / ``registry_approvals`` / ``registry_decide`` /
 ``registry_trace``. "What is running, what is waiting on me", over HTTP to the registry
 (``orchestrator up``) — the successor to the removed terminal UI. Observing is read-only;
@@ -72,6 +77,7 @@ import inspect
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from orchestrator.plugin.auth import SCOPE_PLAN, SCOPE_READ, SCOPE_RUN
@@ -941,6 +947,219 @@ async def sdlc_run_result(sdlc_id: str) -> dict[str, Any]:
     return await run_result(sdlc_id)
 
 
+# ---- the free half of the back half: understand, profile, design, baseline -----------
+#
+# Commands that existed only in the CLI (gap 5 of docs/specs/mcp-plugin-surface.md). These
+# four are deterministic and need no credentials; the gated half — address-review,
+# complete, remediate, audit — is its own step, because each of those spends money or
+# writes outside the repo. ``state`` is not here because ``map_repo`` already is it.
+
+#: The three pages a reader starts from. Named rather than "N files written", the way the
+#: CLI reports it — an index is not a place to start.
+_BANK_ENTRY_PAGES = ("README.md", "architecture.md", "domain-model.md")
+
+
+def understand_repo(
+    repo_path: str, check: bool = False, refresh: bool = False, out: str | None = None
+) -> dict[str, Any]:
+    """Build a repo's ``episteme/`` knowledge base — or, with ``check=true``, verify the
+    committed one still matches the code. **Deterministic, no LLM, no credentials**: the
+    same pages ``orchestrator understand`` writes, so an assistant can bootstrap a repo
+    that has no bank yet, then ``read_memory_bank`` it. Writes only under ``episteme/``
+    (or ``out``). ``check`` writes nothing and reports the pages that are missing, stale
+    (the code moved on) or orphaned (describing code that is gone). ``refresh`` re-extracts
+    the graph instead of using the commit cache. A **build on a git URL is refused** unless
+    ``out`` is an absolute directory — the clone vanishes, and a bank written into it with
+    it; ``check`` on a URL is fine. Returns the three entry pages and the counts, not every
+    path."""
+    from orchestrator.knowledge.understand import build_memory_bank, check_memory_bank
+    from orchestrator.registry.api.config import Settings
+    from orchestrator.registry.api.workspace import RepoSourceError, resolve_repo_source
+
+    try:
+        source = resolve_repo_source(repo_path, Settings(repo_allow_any_local=True))
+    except RepoSourceError as exc:
+        return {"error": str(exc)}
+    out_dir = Path(out).expanduser() if out else None
+    if source.kind == "git" and not check and (out_dir is None or not out_dir.is_absolute()):
+        return {
+            "error": "understand_repo writes into the repo, and a git URL is a clone that vanishes — "
+            "pass a local repo_path, or out=<absolute directory> to keep the bank.",
+        }
+
+    def run(repo: Any) -> dict[str, Any]:
+        if check:
+            report = check_memory_bank(repo, out_dir=out_dir, refresh=refresh)
+            return {
+                "ok": report.ok,
+                "absent": report.absent,
+                "bank_dir": str(report.bank_dir),
+                "missing": list(report.missing),
+                "stale": list(report.stale),
+                "orphaned": list(report.orphaned),
+                "commit": report.commit,
+                "dirty": report.dirty,
+                "summary": report.summary_line(),
+            }
+        result = build_memory_bank(repo, out_dir=out_dir, refresh=refresh)
+        files = list(result.get("files") or [])
+        return {
+            "dir": result["dir"],
+            "greenfield": result.get("greenfield", False),
+            "entry_pages": [f for f in _BANK_ENTRY_PAGES if f in files],
+            "files_written": len(files),
+            "summary": result.get("summary") or {},
+            "profile": result.get("profile") or {},
+            "markdown": f"Wrote {len(files)} pages to `{result['dir']}`. Start with "
+            + ", ".join(f"`{f}`" for f in _BANK_ENTRY_PAGES if f in files)
+            + ". Read them with `read_memory_bank`.",
+        }
+
+    return _in_repo(repo_path, run, hint=False)
+
+
+def profile_repo(repo_path: str, intent: str | None = None) -> dict[str, Any]:
+    """Profile a project: languages, framework, database and migrations, test runner, and
+    — given an ``intent`` title — the task type Spine would classify it as. Read-only,
+    deterministic; the same profile the catalog uses to pick skills. ``repo_path`` is a
+    local path or a git URL."""
+
+    def run(repo: Any) -> dict[str, Any]:
+        from orchestrator.catalog import ProjectProfile
+
+        prof = ProjectProfile.from_repo(repo, intent_title=intent)
+        data = prof.to_dict()
+        lines = [
+            f"languages: {', '.join(sorted(prof.languages)) or '(none detected)'}",
+            f"framework: {prof.framework or '-'}",
+            f"database: {'yes' if prof.has_db else 'no'} "
+            f"(migrations: {'yes' if prof.has_migrations else 'no'})",
+            f"test runner: {prof.test_runner or '-'}",
+            f"task type: {prof.task_type}",
+        ]
+        return {**data, "markdown": "\n".join(f"- {ln}" for ln in lines)}
+
+    return _in_repo(repo_path, run, hint=False)
+
+
+async def design_change(repo_path: str, spec: dict[str, Any], use_llm: bool = False) -> dict[str, Any]:
+    """A grounded design for one feature: the spec × the knowledge graph → an approach
+    anchored to the repo's real structure, its **blast radius** (modules touched, who
+    depends on them, call hotspots) and any **unverified references** (paths the spec names
+    that the graph does not have). Takes the same ``spec`` object as ``sdlc_plan``
+    (``intent_id``, ``title``, ``summary``, ``acceptance_criteria``), validated the same way.
+    **Deterministic by default**; ``use_llm=true`` lets a model write the prose (needs
+    ``ORCHESTRATOR_INTAKE_MODEL``). Returns the design and its markdown — it never writes.
+    For the full twelve-section build document, use ``sdlc_plan``."""
+    from orchestrator.intake.specs import FeatureSpec
+    from orchestrator.sdlc.spec_file import SpecFileError, validate_spec
+
+    if not isinstance(spec, dict):
+        return {"error": f"spec must be an object, got {type(spec).__name__}"}
+    try:
+        resolved = validate_spec(spec, where="spec")
+    except SpecFileError as exc:
+        return {"error": str(exc), "valid_fields": sorted(FeatureSpec.model_fields)}
+
+    client: Any = None
+    if use_llm:
+        from orchestrator.core.env import load_local_env
+        from orchestrator.sdlc.codegen import resolve_codegen_model
+
+        load_local_env()
+        if not resolve_codegen_model():
+            return {
+                "error": "use_llm=true needs a model — set ORCHESTRATOR_INTAKE_MODEL (or SDLC_CODEGEN_MODEL)."
+            }
+        from orchestrator.core.llm import LiteLLMClient
+
+        client = LiteLLMClient()
+
+    async def run(repo: Any) -> dict[str, Any]:
+        from orchestrator.pkg import FactStore, load_or_extract
+        from orchestrator.pkg.overview import build_overview
+        from orchestrator.sdlc.design import produce_design, render_design_md
+
+        batch = load_or_extract(repo)
+        design = await produce_design(
+            resolved,
+            overview=build_overview(batch),
+            memory_bank=_design_bank(repo),
+            store=FactStore(batch),
+            llm=client,
+            root=repo,
+        )
+        unverified = (design.get("blast_radius") or {}).get("unverified_references") or []
+        return {
+            "title": resolved.get("title"),
+            "design": design,
+            "unverified_references": unverified,
+            "used_llm": client is not None,
+            "markdown": render_design_md(resolved, design),
+        }
+
+    from orchestrator.registry.api.workspace import RepoPathError, RepoSourceError
+
+    try:
+        with _open_repo(repo_path) as repo:
+            return await run(repo)
+    except (RepoSourceError, RepoPathError) as exc:
+        return {"error": str(exc)}
+
+
+def _design_bank(repo: Path) -> dict[str, str]:
+    """The committed ``episteme/`` pages a design draws conventions from, when present —
+    the same three the CLI's ``design`` reads."""
+    import contextlib
+
+    from orchestrator.knowledge.understand import existing_bank_dir
+
+    out: dict[str, str] = {}
+    with contextlib.suppress(Exception):
+        bank = existing_bank_dir(repo)
+        for name in ("domain-model.md", "tech-context.md", "conventions.md"):
+            page = bank / name
+            if page.exists():
+                out[name] = page.read_text(encoding="utf-8")
+    return out
+
+
+def sdlc_baseline(repo_path: str) -> dict[str, Any]:
+    """Score the run agent against a corpus of tickets whose right answer is known, and
+    summarize the durable run records. **Deterministic and free**: the validity gate reads
+    each ticket and this repo's real graph; run metrics are observations of what ran.
+    False refusals and missed refusals are counted separately — one accuracy number would
+    let each hide behind the other. ``repo_path`` is a local path or a git URL."""
+
+    def run(repo: Any) -> dict[str, Any]:
+        from orchestrator.evals.agent_corpus import render_report, score_gate, score_runs
+        from orchestrator.pkg import FactStore, load_or_extract
+        from orchestrator.sdlc.runstate import RunStore
+
+        gate = score_gate(FactStore(load_or_extract(repo)))
+        runs = score_runs(RunStore().all())
+        return {
+            "gate": {
+                "accuracy": gate.accuracy,
+                "cases": len(gate.results),
+                "false_refusals": gate.false_refusals,
+                "missed_refusals": gate.missed_refusals,
+            },
+            "runs": {
+                "runs": runs.runs,
+                "completed": runs.completed,
+                "parked": runs.parked,
+                "failed": runs.failed,
+                "completion_rate": runs.completion_rate,
+                "intervention_rate": runs.intervention_rate,
+                "mean_cost_usd": runs.mean_cost_usd,
+            },
+            "markdown": render_report(gate, runs),
+        }
+
+    return _in_repo(repo_path, run, hint=False)
+
+
 # ---- operator tools: what is running, what is waiting on me — over the registry -------
 #
 # The successor to the terminal UI removed in #316. These go over HTTP to the registry
@@ -1115,6 +1334,11 @@ _TOOLS = (
     sdlc_run_status,
     sdlc_decide_gate,
     sdlc_run_result,
+    # the free half of the back half (gap 5): understand, profile, design, baseline
+    understand_repo,
+    profile_repo,
+    design_change,
+    sdlc_baseline,
     # operator: what is running, what is waiting on me — over the registry
     registry_runs,
     registry_approvals,
@@ -1147,6 +1371,12 @@ COMPREHEND_LOCAL = Tier(
 )
 #: Plan and decide: writes under ``.spine/`` only, re-running rewrites the same document.
 PLAN = Tier("plan", read_only=False, destructive=False, idempotent=True, open_world=False, scope=SCOPE_PLAN)
+#: Plan-tier semantics for a local write that may follow a clone: ``understand_repo``
+#: writes under ``episteme/`` (or ``out``) and nowhere else, but its ``repo_path`` may be a
+#: URL, so it is not local-only the way ``sdlc_plan`` is.
+PLAN_REMOTE = Tier(
+    "plan", read_only=False, destructive=False, idempotent=True, open_world=True, scope=SCOPE_PLAN
+)
 #: Observing a run: reads Temporal state, changes nothing.
 RUN_OBSERVE = Tier(
     "run", read_only=True, destructive=False, idempotent=True, open_world=True, scope=SCOPE_READ
@@ -1178,6 +1408,10 @@ _TIER: dict[str, Tier] = {
     "sdlc_run_status": RUN_OBSERVE,
     "sdlc_decide_gate": RUN,
     "sdlc_run_result": RUN_OBSERVE,
+    "understand_repo": PLAN_REMOTE,
+    "profile_repo": COMPREHEND,
+    "design_change": COMPREHEND,  # `use_llm` spends tokens; it still never writes
+    "sdlc_baseline": COMPREHEND,
     "registry_runs": RUN_OBSERVE,
     "registry_approvals": RUN_OBSERVE,
     "registry_decide": RUN,  # a rejection ends a run
@@ -1350,6 +1584,7 @@ __all__ = [
     "blast_radius",
     "build_http_server",
     "build_server",
+    "design_change",
     "docs_for",
     "doctor",
     "explain_symbol",
@@ -1360,6 +1595,7 @@ __all__ = [
     "map_repo",
     "pkg_grounding",
     "pkg_joins",
+    "profile_repo",
     "read_memory_bank",
     "registry_approvals",
     "registry_decide",
@@ -1369,6 +1605,7 @@ __all__ = [
     "root_cause",
     "scope_denial",
     "sdlc_approve",
+    "sdlc_baseline",
     "sdlc_decide_gate",
     "sdlc_feature",
     "sdlc_plan",
@@ -1378,4 +1615,5 @@ __all__ = [
     "Tier",
     "tool_annotations",
     "tool_scope",
+    "understand_repo",
 ]

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -417,6 +417,133 @@ def test_http_server_wires_static_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     assert built.transport["port"] == 8080 and built.transport["host"] == "0.0.0.0"
 
 
+# ---- the free half of the back half: understand, profile, design, baseline ----------
+
+
+def _ledger_repo(tmp_path: Path) -> Path:
+    (tmp_path / "ledger.py").write_text(LEDGER, encoding="utf-8")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_ledger.py").write_text(
+        "from ledger import TokenLedger\n\n\ndef test_record():\n    TokenLedger().record('s', None)\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_understand_repo_builds_the_bank_and_names_where_to_start(tmp_path: Path) -> None:
+    from orchestrator.knowledge.understand import BANK_DIRNAME
+    from orchestrator.plugin.server import read_memory_bank, understand_repo
+
+    repo = _ledger_repo(tmp_path)
+    out = understand_repo(str(repo))
+    assert "error" not in out, out
+    assert out["dir"] == str(repo / BANK_DIRNAME)
+    assert out["files_written"] > 0 and (repo / BANK_DIRNAME / "README.md").exists()
+    assert "README.md" in out["entry_pages"]
+    assert "read_memory_bank" in out["markdown"]
+    # The point of the tool: a bank an assistant can now read.
+    bank = read_memory_bank(str(repo))
+    assert "error" not in bank
+
+
+def test_understand_repo_check_is_current_then_stale(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import understand_repo
+
+    repo = _ledger_repo(tmp_path)
+    assert understand_repo(str(repo), check=True)["absent"] is True  # nothing built yet
+    understand_repo(str(repo))
+    current = understand_repo(str(repo), check=True)
+    assert current["ok"] is True and "current" in current["summary"]
+    # The code moves on; the committed pages no longer describe it.
+    (repo / "router.py").write_text("class WebhookRouter:\n    pass\n", encoding="utf-8")
+    stale = understand_repo(str(repo), check=True)
+    assert stale["ok"] is False and (stale["stale"] or stale["missing"])
+    assert "stale" in stale["summary"]
+
+
+def test_understand_repo_refuses_to_build_into_a_clone_that_vanishes(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import understand_repo
+
+    out = understand_repo("https://github.com/example/repo.git")  # allow-listed host, never cloned
+    assert "error" in out and "out=" in out["error"]
+    # A relative `out` is the same trap in a subprocess whose cwd is not the repo.
+    assert "error" in understand_repo("https://github.com/example/repo.git", out="episteme")
+
+
+def test_understand_repo_writes_where_out_says(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import understand_repo
+
+    (tmp_path / "repo").mkdir()
+    repo = _ledger_repo(tmp_path / "repo")
+    target = tmp_path / "elsewhere"
+    out = understand_repo(str(repo), out=str(target))
+    assert out["dir"] == str(target) and (target / "README.md").exists()
+
+
+def test_profile_repo_reads_the_project(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import profile_repo
+
+    out = profile_repo(str(_ledger_repo(tmp_path)), intent="Add a refund endpoint")
+    assert "python" in out["languages"]
+    assert out["task_type"] and "task type:" in out["markdown"]
+
+
+async def test_design_change_is_grounded_and_never_writes(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import design_change
+
+    repo = _ledger_repo(tmp_path)
+    before = sorted(p.name for p in repo.rglob("*") if p.is_file())
+    out = await design_change(
+        str(repo),
+        {
+            "intent_id": "LED-1",
+            "title": "Persist the ledger",
+            "summary": "Write it to disk",
+            "acceptance_criteria": ["survives restart"],
+        },
+    )
+    assert "error" not in out, out
+    assert out["title"] == "Persist the ledger" and out["used_llm"] is False
+    assert "Persist the ledger" in out["markdown"]
+    assert isinstance(out["unverified_references"], list)
+    assert sorted(p.name for p in repo.rglob("*") if p.is_file()) == before  # nothing written
+
+
+async def test_design_change_refuses_a_bad_spec_naming_the_valid_fields(tmp_path: Path) -> None:
+    from orchestrator.plugin.server import design_change
+
+    out = await design_change(str(_ledger_repo(tmp_path)), {"title": "x", "invented": True})
+    assert "error" in out and "title" in out["valid_fields"]
+    assert "error" in await design_change(str(tmp_path), "not an object")  # type: ignore[arg-type]
+
+
+async def test_design_change_with_llm_needs_a_model(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from orchestrator.plugin.server import design_change
+
+    # The catalog can resolve a default model from a real .env, and this test must never
+    # reach a provider — so make the model unresolvable the way the root_cause test does.
+    monkeypatch.setattr("orchestrator.sdlc.codegen.resolve_codegen_model", lambda *a, **k: None)
+    out = await design_change(
+        str(_ledger_repo(tmp_path)),
+        {"intent_id": "X-1", "title": "x", "acceptance_criteria": ["works"]},
+        use_llm=True,
+    )
+    assert "error" in out and "ORCHESTRATOR_INTAKE_MODEL" in out["error"]
+
+
+def test_sdlc_baseline_scores_the_gate_over_this_repos_graph(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from orchestrator.plugin.server import sdlc_baseline
+
+    monkeypatch.setenv("SPINE_RUN_STATE", str(tmp_path / "state"))  # an empty run store
+    out = sdlc_baseline(str(_ledger_repo(tmp_path)))
+    assert "error" not in out, out
+    assert out["gate"]["cases"] > 0 and 0.0 <= out["gate"]["accuracy"] <= 1.0
+    assert out["runs"]["runs"] == 0
+    assert "refus" in out["markdown"].lower()
+
+
 # ---- operator tools: over the registry, with a mock transport ----------------------
 
 
@@ -578,7 +705,7 @@ def test_tiers_say_what_a_tool_can_cost() -> None:
 
     hints = {fn.__name__: tool_annotations(fn.__name__) for fn in _TOOLS}
     spends_and_writes = {"sdlc_feature", "sdlc_start_run", "sdlc_decide_gate", "registry_decide"}
-    plans = {"sdlc_plan", "sdlc_approve"}
+    plans = {"sdlc_plan", "sdlc_approve", "understand_repo"}  # the last: a write under episteme/
     observes_a_run = {
         "sdlc_run_status",
         "sdlc_run_result",


### PR DESCRIPTION
## Summary

MCP phase 1 step 6a of [`docs/specs/mcp-plugin-surface.md`](docs/specs/mcp-plugin-surface.md) — the free, deterministic half of gap 5 (the back half of the pipeline was CLI-only).

| Tool | Signature | Tier / scope | What it does |
|---|---|---|---|
| `understand_repo` | `(repo_path, check=False, refresh=False, out=None)` | plan-tier write under `episteme/`, `spine:plan` | Build the knowledge base, or `check=true` to verify the committed one — missing / stale / orphaned pages named. Refuses a build on a git URL unless `out` is absolute (the clone vanishes). Returns the three entry pages and counts, not every path. |
| `profile_repo` | `(repo_path, intent=None)` | tier 1, `spine:read` | Languages, framework, database + migrations, test runner, task type. |
| `design_change` | `(repo_path, spec, use_llm=False)` | tier 1, `spine:read` | Grounded design with blast radius and unverified references, for the same `spec` object `sdlc_plan` takes, validated the same way. Never writes. |
| `sdlc_baseline` | `(repo_path)` | tier 1, `spine:read` | The agent-corpus gate and run metrics; false and missed refusals counted separately. |

**Two findings shaped it.** `map_repo` already *is* `orchestrator state` (same engine, same rendering), so no `state` tool is added — the guide says so. And the back half splits cleanly by cost: the gated half (`address-review`, `complete`, `remediate`, `audit`) is step 6b, since each spends money or writes outside the repo.

One new tier row (`PLAN_REMOTE`): plan-tier semantics for a local write whose `repo_path` may be a URL. Verified over the SDK: the four tools advertise the intended hints, scopes and input schemas.

## Files

- `plugin/server.py`: the four tools, `PLAN_REMOTE`, `_TIER` entries, `__all__`.
- `tests/plugin/test_server.py`: 9 new — build then read back the bank; check current → stale; URL refusal; `out` honoured; profile; design grounded and non-writing, bad spec named, `use_llm` without a model refused (model made unresolvable so the test never reaches a provider); baseline over an empty run store. Tier assertions extended.
- Docs: CLAUDE_GUIDE §6 rows + the `map_repo`-is-`state` note; the spec (gap 5 half closed, 4.4/4.5 updated, step 6 split, tiers table); SPEC-INDEX; CHANGELOG; STATE-OF-SPINE count.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`, `matrix-count --check`, `state-numbers --check`: pass
- Full pytest: 3359 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
