### PR TITLE
feat(plugin): prompts and resources — the workflow and the documents, for hosts that are not Claude Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## Unreleased
+
+### Added
+
+- **MCP prompts and resources — the workflow and the documents, for hosts that are
+  not Claude Code.** Five prompts carry the `understand-codebase` skill's "which
+  tool, in which order" through the protocol (`orient`, `investigate-ticket`,
+  `triage-bug`, `plan-then-approve`, `whats-waiting-on-me`), so Codex, Claude
+  Desktop and claude.ai get the same ordered guidance a Claude Code skill gives; the
+  prompts module is the source, because the skill directory is not in the wheel,
+  and a test holds the skill to the same tools. Five `spine://` resources make the
+  committed `episteme/` bank, the build documents under `.spine/plans` (with their
+  approval state) and the current-state report readable by URI and attachable as
+  context. Resources address the default repository — the working directory, or
+  `SPINE_REPO_ROOT` — because a URI segment cannot carry a path; the tools keep
+  taking `repo_path`.
+
 ## 3.31.0 — the plugin grows from twenty tools to thirty-two, and every one says what it can cost
 
 ### Added

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -232,6 +232,38 @@ At a glance:
 > `ORCHESTRATOR_MCP_REQUIRED_SCOPES` narrows it (`spine:read` = a read-only token); the legacy
 > `sdlc` scope still reads as all three for one release. Over stdio there is no token and no check.
 
+### Prompts and resources — the workflow and the documents, through the protocol
+
+Two things the plugin exposes besides tools, for any MCP host:
+
+**Prompts** carry the *which tool, in which order* workflow the `understand-codebase` skill
+describes, so a host that has no skills (Codex, Claude Desktop, claude.ai) gets the same ordered
+guidance. A host lists them and fills the arguments in its own UI.
+
+| Prompt | Arguments | Walks the host through |
+|---|---|---|
+| `orient` | `repo_path` (optional) | `map_repo` → `read_memory_bank` |
+| `investigate-ticket` | `title`, `problem` | `investigate` → `blast_radius` → `regression_gaps` — change nothing |
+| `triage-bug` | `bug` | `localize` → `regression_gaps` → `root_cause` — analysis only |
+| `plan-then-approve` | `title`, `summary`, `criteria` | `sdlc_plan` → a **human** reads → `sdlc_approve` → only then `sdlc_feature` |
+| `whats-waiting-on-me` | — | `registry_approvals` → `registry_trace` → `registry_decide` (a rejection ends the run) |
+
+**Resources** are the documents Spine has already written, readable by URI and attachable as
+context — a tool result scrolls away; a resource can be read again.
+
+| URI | Content |
+|---|---|
+| `spine://bank` | The committed `episteme/` index and section list — or a note that `understand_repo` builds one |
+| `spine://bank/{section}` | One page: `architecture`, `domain-model`, `conventions`, … |
+| `spine://plans` | The build documents under `.spine/plans`, each with its approval state |
+| `spine://plan/{intent_id}` | One build document, approval state on top |
+| `spine://state` | The current‑state report (developer lens), from the commit‑keyed cache |
+
+Resources describe the **default repository**: the process working directory, or
+`SPINE_REPO_ROOT` when set — a stdio plugin is launched per project, so that is the repo the host
+is in. The tools keep taking `repo_path` as before. All read‑only; over HTTP the `spine:read` floor
+covers them.
+
 > **The tiers are metadata your host can act on.** Every tool is registered with MCP tool
 > annotations derived from its tier — *read‑only*, *destructive*, *idempotent*, *open‑world* — so a
 > host that asks before destructive calls asks before `sdlc_feature`, `sdlc_start_run` and

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -197,6 +197,38 @@ At a glance:
 > streamable‑HTTP server (`orchestrator-mcp --http`, bearer/OAuth auth from env — see §3b); it
 > registers the exact same tools.
 
+### Prompts and resources — the workflow and the documents, through the protocol
+
+Two things the plugin exposes besides tools, for any MCP host:
+
+**Prompts** carry the *which tool, in which order* workflow the `understand-codebase` skill
+describes, so a host that has no skills (Codex among them) gets the same ordered
+guidance. A host lists them and fills the arguments in its own UI.
+
+| Prompt | Arguments | Walks the host through |
+|---|---|---|
+| `orient` | `repo_path` (optional) | `map_repo` → `read_memory_bank` |
+| `investigate-ticket` | `title`, `problem` | `investigate` → `blast_radius` → `regression_gaps` — change nothing |
+| `triage-bug` | `bug` | `localize` → `regression_gaps` → `root_cause` — analysis only |
+| `plan-then-approve` | `title`, `summary`, `criteria` | `sdlc_plan` → a **human** reads → `sdlc_approve` → only then `sdlc_feature` |
+| `whats-waiting-on-me` | — | `registry_approvals` → `registry_trace` → `registry_decide` (a rejection ends the run) |
+
+**Resources** are the documents Spine has already written, readable by URI and attachable as
+context — a tool result scrolls away; a resource can be read again.
+
+| URI | Content |
+|---|---|
+| `spine://bank` | The committed `episteme/` index and section list — or a note that `understand_repo` builds one |
+| `spine://bank/{section}` | One page: `architecture`, `domain-model`, `conventions`, … |
+| `spine://plans` | The build documents under `.spine/plans`, each with its approval state |
+| `spine://plan/{intent_id}` | One build document, approval state on top |
+| `spine://state` | The current‑state report (developer lens), from the commit‑keyed cache |
+
+Resources describe the **default repository**: the process working directory, or
+`SPINE_REPO_ROOT` when set — a stdio plugin is launched per project, so that is the repo the host
+is in. The tools keep taking `repo_path` as before. All read‑only; over HTTP the `spine:read` floor
+covers them.
+
 ### Asking across several repositories
 
 The comprehension tools take **one** repository by default, and for a service that is called

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -93,7 +93,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [gap6-benchmarks-roadmap](gap6-benchmarks-roadmap.md) | ✅ **Complete 2026-09-01** | All three phases: harness, 38-label gold set, ratchet gate. top-1 0.32 / top-10 0.71 against 0.085 chance; published as [BENCHMARK.md](../../BENCHMARK.md). This row read *Not started* for a day after the spec said COMPLETE |
 | [codegen-benchmark-roadmap](codegen-benchmark-roadmap.md) | Not started | **New 2026-08-15.** SWE-bench comparability → `resolved`-vs-`mergeable` delta |
 | [codex-plugin-keyless-roadmap](codex-plugin-keyless-roadmap.md) | Not started | **New 2026-08-15.** Phase 0 is a blocking spike |
-| [mcp-plugin-surface](mcp-plugin-surface.md) | ✅ **Phase 1 complete 2026-09-04**; Phase 2 not started | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
+| [mcp-plugin-surface](mcp-plugin-surface.md) | ✅ **Phase 1 complete 2026-09-04** (3.31.0); Phase 2 step 1 shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
 | [phase5-agentic-codegen-loop](phase5-agentic-codegen-loop.md) | Proposed, under review | "The hinge phase" |
 | [autonomous-run-agent](autonomous-run-agent.md) | Proposed, no branch | 9 phases; 0–3 strictly serial |
 | [catalog-then-compose-roadmap](catalog-then-compose-roadmap.md) | Proposed, under review | Scope confirmed: Phases 0–3 |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -27,8 +27,8 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Version | **3.31.0** | cutting now; 3.30.0 is the last on PyPI until this ships |
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
-| Source modules | **344** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,949** across 303 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Source modules | **346** | `find src/orchestrator -name '*.py'` |
+| Test functions | **2,964** across 305 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/mcp-plugin-surface.md
+++ b/docs/specs/mcp-plugin-surface.md
@@ -1,6 +1,6 @@
 # The MCP plugin surface — what it is, what it lacks, and the order to extend it
 
-**Status:** **Phase 1 COMPLETE** — all six steps shipped, all six gaps closed. Phase 2 (extensions) not started. **Written 2026-09-04 against 3.30.0**,
+**Status:** **Phase 1 COMPLETE** — all six steps shipped, all six gaps closed. Phase 2 in progress — step 1 (prompts + resources) shipped. **Written 2026-09-04 against 3.30.0**,
 after #316 removed the terminal UI and left the plugin as the only non-browser operator face.
 **Owner:** _unassigned_
 
@@ -146,9 +146,9 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
   `sdlc_remediate` as tier-3 tools under the same `confirm` gate as `sdlc_feature(live=true)`
   (the first two on every call — they have no local mode), and `audit_repo`, which spends
   tokens on a persona loop — read-only in annotations, run scope, its own tier row.
-- **4.6 Resources.** `spine://episteme/{repo}/{section}`, `spine://plan/{repo}/{intent}`,
+- **4.6 Resources.** *(Shipped in Phase 2 step 1 — for the default repository, `SPINE_REPO_ROOT` or the cwd, because a URI segment cannot carry a path; `spine://bank`, `spine://bank/{section}`, `spine://plans`, `spine://plan/{intent_id}`, `spine://state`.)* Originally sketched as `spine://episteme/{repo}/{section}`, `spine://plan/{repo}/{intent}`,
   `spine://state/{repo}` as MCP resources — listable, subscribable, attachable as context.
-- **4.7 Prompts.** The `understand-codebase` skill's guidance registered as MCP prompts so Codex,
+- **4.7 Prompts.** *(Shipped in Phase 2 step 1 — five prompts in `plugin/prompts.py`, the source of the workflow because the skill is not in the wheel; a test holds the skill to the same tools.)* The `understand-codebase` skill's guidance registered as MCP prompts so Codex,
   Desktop and claude.ai get the "which tool, in which order" workflow through the protocol.
 - **4.8 Progress.** Per-phase progress notifications from `sdlc_feature` and
   `root_cause(use_llm=true)`, which run for minutes with no signal today.
@@ -172,10 +172,16 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
 | 6a | 5 | The free half: `understand_repo`, `profile_repo`, `design_change`, `sdlc_baseline`. | **shipped** |
 | 6b | 5 | The gated half: `sdlc_address_review`, `sdlc_complete`, `sdlc_remediate`, `audit_repo`. | **shipped** |
 
-### Phase 2 — extensions (§3 is empty as of 6b; none started)
+### Phase 2 — extensions (§3 is empty as of 6b)
 
-4.7 and 4.6 (protocol parity), then 4.8, 4.10, 4.11 as the run tier sees real use, and the
-typed-output half of 4.1 on its own.
+| Step | Proposals | State |
+|---|---|---|
+| 1 | 4.7 prompts + 4.6 resources — protocol parity for non-Claude hosts | **shipped** |
+| 2 | 4.8 progress notifications from the long tools | next |
+| 3 | 4.10 multi-repo parity for `explain_symbol`, `regression_gaps`, `localize`, `docs_for` | |
+| 4 | 4.11 per-principal audit on HTTP | |
+| 5 | typed output (the deferred half of 4.1) | last — every return shape |
+| — | retire the `sdlc` scope alias | the release after 3.31.0 |
 
 ## Invariants
 

--- a/src/orchestrator/plugin/prompts.py
+++ b/src/orchestrator/plugin/prompts.py
@@ -1,0 +1,179 @@
+"""MCP prompts: the "which tool, in which order" workflow, through the protocol.
+
+The ``understand-codebase`` skill tells a Claude Code host *when* to reach for each tool and
+in what sequence. A skill is a Claude Code construct; Codex, Claude Desktop and claude.ai
+never see it. MCP **prompts** are the protocol's own way to ship that guidance: a host lists
+them, fills the arguments in its own UI, and the user gets the same ordered workflow the
+skill describes.
+
+The text lives here rather than in the skill file because the skill directory is not in the
+wheel — a PyPI install has no skill to read. ``tests/plugin/test_manifests.py`` holds the two
+to the same tools, so they cannot drift apart.
+
+Each prompt is a plain function returning the user-turn text, registered by
+``plugin.server.build_server`` through ``_PROMPTS``. Plain so it is testable without the
+``mcp`` extra. The tools a prompt sequences are listed in ``PROMPT_TOOLS`` for the parity
+test, next to the prompt, so adding a step means adding it in both places on one screen.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+#: The tools each prompt walks a host through, in order. Read by the parity test.
+PROMPT_TOOLS: dict[str, tuple[str, ...]] = {
+    "orient": ("map_repo", "read_memory_bank"),
+    "investigate-ticket": ("investigate", "blast_radius", "regression_gaps"),
+    "triage-bug": ("localize", "regression_gaps", "root_cause"),
+    "plan-then-approve": ("sdlc_plan", "sdlc_approve", "sdlc_feature"),
+    "whats-waiting-on-me": ("registry_approvals", "registry_trace", "registry_decide"),
+}
+
+_CITE = (
+    "Every tool returns `file:line` provenance and a `markdown` field — ground the answer in "
+    "those and show them, rather than paraphrasing."
+)
+
+
+def _repo_clause(repo_path: str | None) -> str:
+    return f"repo_path=`{repo_path}`" if repo_path else "the current repository (omit `repo_path`)"
+
+
+def orient(repo_path: str | None = None) -> str:
+    """Get oriented in a repository you don't know — before answering structural questions
+    or planning a change. One `map_repo` call beats many greps."""
+    return "\n".join(
+        [
+            f"Orient me in {_repo_clause(repo_path)} using Spine's read-only tools.",
+            "",
+            "1. Call `map_repo` first: languages, components, call hotspots, test-coverage gaps and "
+            "prioritized recommendations. Do not grep or guess before it answers.",
+            "2. Then call `read_memory_bank` with no section. If a committed `episteme/` bank exists, "
+            "read its `architecture` and `conventions` sections; if it does not, say so — "
+            "`understand_repo` can build one — and continue from the map.",
+            "3. Summarize: what the system is, its biggest areas, where the risk sits (untested areas, "
+            "hotspots), and the two or three things a newcomer should read first.",
+            "",
+            _CITE,
+        ]
+    )
+
+
+def investigate_ticket(title: str, problem: str = "", repo_path: str | None = None) -> str:
+    """Find where a ticket lands in the code and what changing it would affect — the
+    research an engineer does before touching anything."""
+    return "\n".join(
+        [
+            f"Research this ticket against {_repo_clause(repo_path)} before any code is written.",
+            "",
+            f"Title: {title}",
+            f"Problem: {problem or '(none given — work from the title)'}",
+            "",
+            "1. Call `investigate` with the title and problem: the real symbols to start from, with "
+            "caller counts and owning areas. If the answer carries `multi_repo_available`, stop and "
+            "re-run with the `repos=` path it names — the change may land in more than one service.",
+            "2. For each landing symbol worth touching, call `blast_radius` — direct callers plus the "
+            "cross-layer set a change ripples into.",
+            "3. Call `regression_gaps` for the same symbols: the production code a change reaches that "
+            "no test covers is what could break silently.",
+            "4. Report: where the work lands, what depends on it, what is untested, and a scoped "
+            "approach. Say what you did not find. Change nothing.",
+            "",
+            _CITE,
+        ]
+    )
+
+
+def triage_bug(bug: str, repo_path: str | None = None) -> str:
+    """Trace → fault site → coverage → hypotheses. Stops at analysis; never edits."""
+    return "\n".join(
+        [
+            f"Triage this bug against {_repo_clause(repo_path)}. Analysis only — do not change code.",
+            "",
+            "Bug report / trace:",
+            bug,
+            "",
+            "1. If the report contains a stack trace or traceback, call `localize` with it: each frame "
+            "resolved to a repo symbol, and the likely fault site with its callers. If it is a plain "
+            "description, skip to step 3.",
+            "2. Call `regression_gaps` with the same trace: the coverage around the fault site, so the "
+            "fix's blast radius is known before it is written.",
+            "3. Call `root_cause` with the report: ranked hypotheses with evidence, the regression "
+            "surface a fix must cover, and a scoped fix approach. Add `use_llm=true` only if the "
+            "deterministic hypotheses are thin and a model is configured.",
+            "4. Report the fault site, the leading hypothesis and what would confirm it, and the tests "
+            "a fix must add.",
+            "",
+            _CITE,
+        ]
+    )
+
+
+def plan_then_approve(title: str, summary: str = "", criteria: str = "", repo_path: str | None = None) -> str:
+    """The tiers, in order: a build document (no model, no credentials), a human decision on
+    it, and only then the gated build."""
+    return "\n".join(
+        [
+            f"Plan this change against {_repo_clause(repo_path)}, get the plan approved, and only "
+            "then build it. Work down the tiers; never start at the build.",
+            "",
+            f"Title: {title}",
+            f"Summary: {summary or '(none given)'}",
+            "Acceptance criteria: "
+            + (criteria or "(none given — draft them from the title and summary, and say so)"),
+            "",
+            "1. Draft the spec object: `intent_id`, `title`, `summary`, `acceptance_criteria` (a list, "
+            "at least one). Call `sdlc_plan` with it. This spends nothing and needs no credentials: "
+            "the twelve-section build document is rendered from the graph, git and the tree. Show "
+            "the human the document — the blast radius, the files, the cost and confidence sections "
+            "in particular.",
+            "2. Do not approve it yourself. When the human has read it and decided, call "
+            "`sdlc_approve` with their name in `decided_by` (or `reject=true`). The approval binds "
+            "to a digest of the document, so a plan edited afterwards reads as stale.",
+            "3. Only with a current approval, call `sdlc_feature` for the intent. Keep `live=false` "
+            "unless the human has explicitly authorized external writes — then, and only then, "
+            "pass `live=true` together with `confirm=true`.",
+            "",
+            _CITE,
+        ]
+    )
+
+
+def whats_waiting_on_me() -> str:
+    """The operator's question, answered from the registry: what is running, what is
+    waiting on a decision, and deciding it."""
+    return "\n".join(
+        [
+            "Tell me what is waiting on me at the Spine registry, and help me decide.",
+            "",
+            "1. Call `registry_approvals`: the gates waiting on a human, latest first, with risk and "
+            "the run each belongs to. If the registry is down the tool says so with a hint — relay "
+            "it and stop.",
+            "2. For each approval I want to look at, call `registry_trace` with its run id: the newest "
+            "audit entries, the verifier outcome, and the replan count. Summarize what the run did "
+            "to reach this gate.",
+            "3. Only when I say approve, reject or modify, call `registry_decide` with the approval id, "
+            "the action and my rationale. A rejection ends the run — confirm that with me first.",
+            "",
+            "Use `registry_runs` if I ask what is running overall.",
+        ]
+    )
+
+
+#: What ``build_server`` registers, with the name a host sees.
+_PROMPTS: tuple[tuple[str, Callable[..., str]], ...] = (
+    ("orient", orient),
+    ("investigate-ticket", investigate_ticket),
+    ("triage-bug", triage_bug),
+    ("plan-then-approve", plan_then_approve),
+    ("whats-waiting-on-me", whats_waiting_on_me),
+)
+
+__all__ = [
+    "PROMPT_TOOLS",
+    "investigate_ticket",
+    "orient",
+    "plan_then_approve",
+    "triage_bug",
+    "whats_waiting_on_me",
+]

--- a/src/orchestrator/plugin/resources.py
+++ b/src/orchestrator/plugin/resources.py
@@ -1,0 +1,177 @@
+"""MCP resources: the knowledge a repo has already committed, readable as documents.
+
+A tool result scrolls out of a host's context; a **resource** is listable, addressable by
+URI, and attachable as context whenever the host wants it back. Three things Spine
+produces are documents by nature and belong here rather than behind a tool call:
+
+- ``spine://bank`` and ``spine://bank/{section}`` — the committed ``episteme/`` knowledge
+  base ``understand`` writes (``README.md`` index, ``architecture``, ``domain-model``,
+  ``conventions``, …).
+- ``spine://plans`` and ``spine://plan/{intent_id}`` — the build documents ``sdlc_plan``
+  persists under ``.spine/plans/``, each with its approval state.
+- ``spine://state`` — the current-state report (developer lens), from the commit-keyed
+  cache.
+
+**They address the default repository.** A URI segment matches one path element, so an
+absolute repo path cannot ride inside a URI without encoding no host renders well. A stdio
+plugin is launched per project, so the process working directory is the repo — and
+``SPINE_REPO_ROOT`` overrides it for a host that launches from elsewhere. The tools keep
+taking ``repo_path`` as before; only the resources are per-process.
+
+Every resource returns markdown, and a missing thing returns a short note saying what
+would create it rather than an error — a host renders a note; it hides an error.
+
+Read-only by construction. Over HTTP the server-wide scope floor (``spine:read``) covers
+resource reads; there is nothing to guard per resource.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT_ENV = "SPINE_REPO_ROOT"
+
+
+def default_repo_root() -> Path:
+    """The repository the resources describe: ``SPINE_REPO_ROOT``, else the working directory."""
+    return Path(os.getenv(REPO_ROOT_ENV) or os.getcwd()).resolve()
+
+
+def bank_index() -> str:
+    """The committed knowledge base's index and section list, or how to build one."""
+    from orchestrator.knowledge.access import read_memory_bank
+
+    root = default_repo_root()
+    bank = read_memory_bank(root)
+    if not bank["exists"]:
+        return (
+            f"_No knowledge base at `{bank['dir']}`._\n\n"
+            f"Build one with the `understand_repo` tool (or `orchestrator understand .`) — "
+            f"deterministic, no model — then read `spine://bank/architecture` and friends."
+        )
+    sections = "\n".join(f"- `spine://bank/{name[:-3]}`" for name in bank["sections"])
+    return f"{bank['index']}\n\n---\n\nSections:\n\n{sections}\n"
+
+
+def bank_section(section: str) -> str:
+    """One committed page of the knowledge base, e.g. ``architecture`` or ``conventions``."""
+    from orchestrator.knowledge.access import read_memory_bank
+
+    bank = read_memory_bank(default_repo_root(), section)
+    if not bank["exists"]:
+        return bank_index()
+    content = bank.get("content")
+    if content is None:
+        return f"_No section `{section}` in the knowledge base._ See `spine://bank` for the list."
+    return str(content)
+
+
+def plans_index() -> str:
+    """The build documents under ``.spine/plans/``, each with its approval state."""
+    from orchestrator.sdlc.builddoc import load_approval, plan_dir
+
+    root = default_repo_root()
+    plans = plan_dir(root)
+    docs = sorted(plans.glob("*-build.md")) if plans.is_dir() else []
+    if not docs:
+        return (
+            f"_No build documents under `{plans}`._\n\n"
+            "`sdlc_plan` writes one per ticket — the twelve-section document, no model, no "
+            "credentials — and `sdlc_approve` records the decision on it."
+        )
+    lines = ["| intent | decision | decided by | document |", "|---|---|---|---|"]
+    for doc in docs:
+        intent = doc.name[: -len("-build.md")]
+        approval = load_approval(intent, root=root)
+        decision = approval.decision if approval else "not decided"
+        who = approval.decided_by if approval else ""
+        lines.append(f"| `{intent}` | {decision} | {who} | `spine://plan/{intent}` |")
+    return "\n".join(lines) + "\n"
+
+
+def plan_document(intent_id: str) -> str:
+    """One build document, as ``sdlc_plan`` wrote it, with its approval state on top."""
+    from orchestrator.sdlc.builddoc import load_approval, plan_dir
+
+    root = default_repo_root()
+    plans = plan_dir(root).resolve()
+    # ``intent_id`` arrives from a host: confine the read to the plans dir, the way the bank
+    # reader does, so "../../secrets" reaches nothing.
+    path = (plans / f"{intent_id}-build.md").resolve()
+    if not path.is_relative_to(plans) or not path.is_file():
+        return f"_No build document for `{intent_id}`._ See `spine://plans` for the list."
+    approval = load_approval(intent_id, root=root)
+    head = (
+        f"> **{approval.decision}** by {approval.decided_by} on {approval.decided_at}"
+        + (f" — {approval.note}" if approval.note else "")
+        if approval
+        else "> **Not decided.** A human reads this, then `sdlc_approve` records the decision."
+    )
+    return f"{head}\n\n{path.read_text(encoding='utf-8')}"
+
+
+def state_report() -> str:
+    """The current-state report for the repository — the same document ``map_repo``
+    renders, developer lens, from the commit-keyed cache."""
+    from orchestrator.knowledge.current_state import load_current_state, render_current_state
+
+    state, _batch = load_current_state(default_repo_root())
+    return render_current_state(state, lens="developer")
+
+
+@dataclass(frozen=True)
+class ResourceSpec:
+    uri: str
+    name: str
+    description: str
+    fn: Callable[..., str]
+
+
+#: What ``build_server`` registers. A ``{param}`` in the URI makes it a template the host
+#: can list and fill; the rest are direct resources.
+_RESOURCES: tuple[ResourceSpec, ...] = (
+    ResourceSpec(
+        "spine://bank",
+        "knowledge-base",
+        "The committed episteme/ knowledge base: index and section list.",
+        bank_index,
+    ),
+    ResourceSpec(
+        "spine://bank/{section}",
+        "knowledge-base-section",
+        "One page of the knowledge base (architecture, domain-model, conventions, …).",
+        bank_section,
+    ),
+    ResourceSpec(
+        "spine://plans",
+        "build-documents",
+        "The build documents under .spine/plans, with their approval state.",
+        plans_index,
+    ),
+    ResourceSpec(
+        "spine://plan/{intent_id}",
+        "build-document",
+        "One build document, with its approval state on top.",
+        plan_document,
+    ),
+    ResourceSpec(
+        "spine://state",
+        "current-state",
+        "The current-state report (developer lens), from the commit-keyed cache.",
+        state_report,
+    ),
+)
+
+__all__ = [
+    "REPO_ROOT_ENV",
+    "ResourceSpec",
+    "bank_index",
+    "bank_section",
+    "default_repo_root",
+    "plan_document",
+    "plans_index",
+    "state_report",
+]

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -72,6 +72,11 @@ The SDK only checks scopes server-wide, so the per-tool check has to live here. 
 there is no token, and the guard passes: a local subprocess a host launched already holds
 the user's ``.env``.
 
+**Prompts and resources, for hosts that are not Claude Code** (``plugin/prompts.py``,
+``plugin/resources.py``). The ``understand-codebase`` skill's "which tool, in which order"
+ships as five MCP prompts; the committed ``episteme/`` bank, the build documents and the
+state report are readable as ``spine://`` resources. Both register beside the tools.
+
 Tool *implementations* are module-level functions (unit-testable without the ``mcp``
 extra); ``build_server`` lazy-imports the SDK's server class and registers them.
 """
@@ -1733,13 +1738,40 @@ def _register_tools(server: Any) -> Any:
     return server
 
 
+def _register_prompts(server: Any) -> Any:
+    """The skill's workflow as MCP prompts — ``plugin.prompts`` says why they live there."""
+    from orchestrator.plugin.prompts import _PROMPTS
+
+    for name, fn in _PROMPTS:
+        first_line = (fn.__doc__ or "").strip().splitlines()[0] if fn.__doc__ else None
+        server.prompt(name=name, description=first_line)(fn)
+    return server
+
+
+def _register_resources(server: Any) -> Any:
+    """The committed bank, the build documents and the state report as MCP resources —
+    ``plugin.resources`` says why they address the default repository."""
+    from orchestrator.plugin.resources import _RESOURCES
+
+    for spec in _RESOURCES:
+        server.resource(spec.uri, name=spec.name, description=spec.description, mime_type="text/markdown")(
+            spec.fn
+        )
+    return server
+
+
+def _register_all(server: Any) -> Any:
+    return _register_resources(_register_prompts(_register_tools(server)))
+
+
 def build_server() -> Any:
-    """Build the FastMCP server with the orchestrator's plugin tools registered.
+    """Build the FastMCP server with the orchestrator's plugin tools, prompts and
+    resources registered.
 
     Stdio transport (Phase A): the local plugin a desktop host launches as a
     subprocess. For the remote HTTP transport see ``build_http_server``.
     """
-    return _register_tools(_import_server_class()("synaptixs-spine"))
+    return _register_all(_import_server_class()("synaptixs-spine"))
 
 
 @dataclass(frozen=True)
@@ -1791,7 +1823,7 @@ def build_http_server(
     # here (where the refusal above lives) rather than at the call site.
     server = server_cls("synaptixs-spine", auth=auth_settings, token_verifier=verifier)
     return HttpServer(
-        server=_register_tools(server),
+        server=_register_all(server),
         transport={
             "host": host,
             "port": port,

--- a/tests/plugin/test_manifests.py
+++ b/tests/plugin/test_manifests.py
@@ -147,3 +147,18 @@ def test_the_skill_tells_an_assistant_how_to_cross_a_repo_boundary() -> None:
     assert "repos=" in body
     # The standing block is what separates a reproducible answer from one that only looks it.
     assert "standing" in body and "reproducible" in body
+
+
+def test_the_skill_and_the_prompts_sequence_the_same_tools() -> None:
+    """The skill (Claude Code) and the MCP prompts (every other host) carry the same
+    workflow. The prompts module is the source, because the skill is not in the wheel; this
+    holds the skill to it. Only the comprehension and plan tools are the skill's remit — the
+    operator prompt's `registry_*` tools are documented in the guides instead."""
+    from orchestrator.plugin.prompts import PROMPT_TOOLS
+
+    body = _SKILL.read_text(encoding="utf-8")
+    for name, tools in PROMPT_TOOLS.items():
+        if name == "whats-waiting-on-me":
+            continue
+        for tool in tools:
+            assert tool in body, f"prompt {name!r} sequences {tool}, which the skill never mentions"

--- a/tests/plugin/test_prompts.py
+++ b/tests/plugin/test_prompts.py
@@ -1,0 +1,90 @@
+"""MCP prompts: the skill's workflow, through the protocol."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+
+import pytest
+
+from orchestrator.plugin.prompts import (
+    _PROMPTS,
+    PROMPT_TOOLS,
+    investigate_ticket,
+    orient,
+    plan_then_approve,
+    triage_bug,
+    whats_waiting_on_me,
+)
+
+
+def test_every_prompt_names_its_tools_in_order() -> None:
+    """The text and the parity table cannot disagree: each tool the table lists appears in
+    the rendered prompt, in that order — the order is the point of a prompt."""
+    rendered = {
+        "orient": orient(),
+        "investigate-ticket": investigate_ticket("t"),
+        "triage-bug": triage_bug("b"),
+        "plan-then-approve": plan_then_approve("t"),
+        "whats-waiting-on-me": whats_waiting_on_me(),
+    }
+    assert set(rendered) == set(PROMPT_TOOLS) == {name for name, _ in _PROMPTS}
+    for name, tools in PROMPT_TOOLS.items():
+        positions = [rendered[name].find(f"`{tool}`") for tool in tools]
+        assert all(p >= 0 for p in positions), (name, tools)
+        assert positions == sorted(positions), (name, "tools out of order")
+
+
+def test_every_tool_a_prompt_names_is_registered() -> None:
+    from orchestrator.plugin.server import _TOOLS
+
+    registered = {fn.__name__ for fn in _TOOLS}
+    for name, tools in PROMPT_TOOLS.items():
+        assert set(tools) <= registered, (name, set(tools) - registered)
+
+
+def test_prompts_carry_their_arguments_into_the_text() -> None:
+    assert "repo_path=`/x`" in orient("/x") and "current repository" in orient()
+    text = investigate_ticket("Add refunds", "Customers cannot refund", repo_path="/r")
+    assert "Add refunds" in text and "Customers cannot refund" in text and "repo_path=`/r`" in text
+    assert "Traceback" in triage_bug("Traceback (most recent call last) …")
+    text = plan_then_approve("Persist ledger", "to disk", "survives restart")
+    assert "Persist ledger" in text and "survives restart" in text
+
+
+def test_the_gated_prompts_say_who_decides() -> None:
+    """The prompts are where a host's model learns the gates; they must not read as
+    'approve it and build'."""
+    plan = plan_then_approve("t")
+    assert "Do not approve it yourself" in plan
+    assert "`confirm=true`" in plan and "`live=false`" in plan
+    waiting = whats_waiting_on_me()
+    assert "Only when I say" in waiting and "rejection ends the run" in waiting
+
+
+def test_prompts_stop_at_analysis_where_they_should() -> None:
+    assert "Change nothing" in investigate_ticket("t")
+    assert "do not change code" in triage_bug("b")
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="needs the 'mcp' extra")
+async def test_prompts_reach_the_host_with_their_arguments() -> None:
+    from orchestrator.plugin.server import build_server
+
+    server = build_server()
+    prompts = {p.name: p for p in await server.list_prompts()}
+    assert set(prompts) == set(PROMPT_TOOLS)
+    ticket = prompts["investigate-ticket"]
+    args = {a.name: a.required for a in ticket.arguments or []}
+    assert args == {"title": True, "problem": False, "repo_path": False}
+    assert ticket.description and "ticket" in ticket.description.lower()
+    got = await server.get_prompt("investigate-ticket", {"title": "Add refunds"})
+    assert got.messages[0].role == "user"
+    text = got.messages[0].content.text
+    assert "Add refunds" in text and "`investigate`" in text
+    # No prompt renders a stray Python repr — e.g. `None` for an omitted optional.
+    for name in PROMPT_TOOLS:
+        p = prompts[name]
+        required = {a.name for a in p.arguments or [] if a.required}
+        got = await server.get_prompt(name, dict.fromkeys(required, "x"))
+        assert not re.search(r"\bNone\b", got.messages[0].content.text)

--- a/tests/plugin/test_resources.py
+++ b/tests/plugin/test_resources.py
@@ -1,0 +1,132 @@
+"""MCP resources: the committed bank, the build documents and the state, as documents."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from orchestrator.plugin.resources import (
+    _RESOURCES,
+    REPO_ROOT_ENV,
+    bank_index,
+    bank_section,
+    default_repo_root,
+    plan_document,
+    plans_index,
+    state_report,
+)
+
+LEDGER = '''\
+class TokenLedger:
+    """Tracks per-stage token usage."""
+
+    def record(self, stage, result):
+        return None
+'''
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    (tmp_path / "ledger.py").write_text(LEDGER, encoding="utf-8")
+    monkeypatch.setenv(REPO_ROOT_ENV, str(tmp_path))
+    return tmp_path
+
+
+def test_the_default_repo_is_the_env_override_else_the_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(REPO_ROOT_ENV, raising=False)
+    monkeypatch.chdir(tmp_path)
+    assert default_repo_root() == tmp_path.resolve()
+    monkeypatch.setenv(REPO_ROOT_ENV, str(tmp_path / "elsewhere"))
+    assert default_repo_root() == (tmp_path / "elsewhere").resolve()
+
+
+def test_a_missing_bank_is_a_note_naming_what_builds_it(repo: Path) -> None:
+    text = bank_index()
+    assert "No knowledge base" in text and "understand_repo" in text
+    assert "No knowledge base" in bank_section("architecture")  # same note, not an error
+
+
+def test_a_built_bank_is_readable_by_index_and_by_section(repo: Path) -> None:
+    from orchestrator.plugin.server import understand_repo
+
+    assert "error" not in understand_repo(str(repo))
+    index = bank_index()
+    assert "spine://bank/architecture" in index and "spine://bank/conventions" in index
+    page = bank_section("architecture")
+    assert page.startswith("#") or "rchitecture" in page
+    assert "No section" in bank_section("no-such-page")
+
+
+def test_a_section_cannot_escape_the_bank(repo: Path) -> None:
+    from orchestrator.plugin.server import understand_repo
+
+    (repo.parent / "secret.md").write_text("SECRET", encoding="utf-8")
+    understand_repo(str(repo))
+    assert "SECRET" not in bank_section("../../secret")
+    assert "SECRET" not in bank_section("../secret")
+
+
+def test_plans_index_and_document_with_and_without_an_approval(repo: Path) -> None:
+    from orchestrator.sdlc.builddoc import PlanApproval, plan_dir, save_approval
+
+    assert "No build documents" in plans_index() and "sdlc_plan" in plans_index()
+    plans = plan_dir(repo)
+    plans.mkdir(parents=True)
+    (plans / "TCK-1-build.md").write_text("# Build TCK-1\n\nthe document\n", encoding="utf-8")
+    (plans / "TCK-2-build.md").write_text("# Build TCK-2\n", encoding="utf-8")
+    save_approval(
+        PlanApproval(
+            intent_id="TCK-2",
+            decision="APPROVED",
+            decided_by="ana",
+            decided_at="2026-09-04",
+            digest="d",
+            commit="c",
+            note="ok",
+        ),
+        root=repo,
+    )
+    index = plans_index()
+    assert "| `TCK-1` | not decided |" in index and "| `TCK-2` | APPROVED | ana |" in index
+    assert "spine://plan/TCK-1" in index
+    doc = plan_document("TCK-1")
+    assert doc.startswith("> **Not decided.**") and "the document" in doc
+    doc = plan_document("TCK-2")
+    assert doc.startswith("> **APPROVED** by ana on 2026-09-04 — ok")
+    assert "No build document" in plan_document("TCK-9")
+
+
+def test_a_plan_id_cannot_escape_the_plans_dir(repo: Path) -> None:
+    from orchestrator.sdlc.builddoc import plan_dir
+
+    plan_dir(repo).mkdir(parents=True)
+    (repo / ".spine" / "leak-build.md").write_text("LEAK", encoding="utf-8")
+    assert "LEAK" not in plan_document("../leak")
+
+
+def test_state_report_renders_the_repo(repo: Path) -> None:
+    text = state_report()
+    assert "TokenLedger" in text or "ledger" in text.lower()
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="needs the 'mcp' extra")
+async def test_resources_reach_the_host_and_read_back(repo: Path) -> None:
+    from orchestrator.plugin.server import build_server, understand_repo
+
+    understand_repo(str(repo))
+    server = build_server()
+    direct = {str(r.uri): r for r in await server.list_resources()}
+    templates = {t.uri_template: t for t in await server.list_resource_templates()}
+    assert set(direct) == {"spine://bank", "spine://plans", "spine://state"}
+    assert set(templates) == {"spine://bank/{section}", "spine://plan/{intent_id}"}
+    assert {s.uri for s in _RESOURCES} == set(direct) | set(templates)
+    assert all(r.mime_type == "text/markdown" for r in direct.values())
+    contents = list(await server.read_resource("spine://bank/architecture"))
+    assert contents and contents[0].mime_type == "text/markdown"
+    assert "rchitecture" in str(contents[0].content)
+    contents = list(await server.read_resource("spine://plans"))
+    assert "No build documents" in str(contents[0].content)


### PR DESCRIPTION
## Summary

MCP phase 2 step 1 of [`docs/specs/mcp-plugin-surface.md`](docs/specs/mcp-plugin-surface.md): proposals 4.7 (prompts) and 4.6 (resources) — protocol parity for hosts that are not Claude Code.

**Prompts.** Five carry the `understand-codebase` skill's "which tool, in which order":

| Prompt | Arguments | Sequence |
|---|---|---|
| `orient` | `repo_path?` | `map_repo` → `read_memory_bank` |
| `investigate-ticket` | `title`, `problem?` | `investigate` → `blast_radius` → `regression_gaps` — change nothing |
| `triage-bug` | `bug` | `localize` → `regression_gaps` → `root_cause` — analysis only |
| `plan-then-approve` | `title`, `summary?`, `criteria?` | `sdlc_plan` → a **human** reads → `sdlc_approve` → only then `sdlc_feature` |
| `whats-waiting-on-me` | — | `registry_approvals` → `registry_trace` → `registry_decide` |

`plugin/prompts.py` is the source (the skill directory is not in the wheel). `PROMPT_TOOLS` lists each prompt's tools beside it; a test checks the rendered text names them **in that order**, another that every named tool is registered, and a manifests test holds the skill to the same tools so the two cannot drift.

**Resources.** Five `spine://` URIs, markdown, read-only:

| URI | Content |
|---|---|
| `spine://bank` | the committed `episteme/` index + section list, or a note that `understand_repo` builds one |
| `spine://bank/{section}` | one page |
| `spine://plans` | build documents under `.spine/plans`, each with its approval state |
| `spine://plan/{intent_id}` | one build document, approval state on top |
| `spine://state` | the current-state report (developer lens) |

They address the **default repository** — the working directory, or `SPINE_REPO_ROOT` — because a URI segment cannot carry a path; the tools keep taking `repo_path`. Section and intent ids arrive from a host and are confined to their directories (tested with `../` escapes). A missing thing returns a note naming what creates it, not an error.

Verified through the real stdio server as a host: 32 tools, 5 prompts, 3 resources + 2 templates, `spine://bank` reads this repo's bank.

## Files

- `plugin/prompts.py`, `plugin/resources.py` (new); `plugin/server.py` registers both beside the tools (stdio and HTTP).
- Tests: `test_prompts.py` (6), `test_resources.py` (8), `test_manifests.py` (+1).
- Docs: the same "Prompts and resources" section in CLAUDE_GUIDE §6 and CODEX_GUIDE §6; the spec (4.6/4.7 shipped, phase 2 table); SPEC-INDEX; CHANGELOG Unreleased; STATE-OF-SPINE counts.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`, `matrix-count --check`, `state-numbers --check`: pass
- Full pytest: 3388 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
