### PR TITLE
feat(plugin): the long tools report progress — the engine's own phases, to the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Added
 
+- **The long MCP tools report progress.** `sdlc_feature` per stage in the runner's
+  own order (spec, layout, design, implement, tests, refine, judge, PR),
+  `sdlc_remediate` per task, `sdlc_address_review` at checkout / respond / done,
+  `understand_repo` at extract / write, `audit_repo` at start / done — whenever the
+  host sends a progress token; a client that sends none sees what it saw before.
+  The phases are the engines' existing log prefixes mapped to ordered steps
+  (`plugin/progress.py`), so the CLI and the plugin describe the same stages; the
+  bar is monotonic, and an unknown line rides on the current step as its message.
+  The tools' schemas are unchanged: the SDK context arrives through an optional
+  parameter the scope wrapper passes through and the schema never shows.
+
 - **MCP prompts and resources — the workflow and the documents, for hosts that are
   not Claude Code.** Five prompts carry the `understand-codebase` skill's "which
   tool, in which order" through the protocol (`orient`, `investigate-ticket`,

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -264,6 +264,18 @@ Resources describe the **default repository**: the process working directory, or
 is in. The tools keep taking `repo_path` as before. All read‑only; over HTTP the `spine:read` floor
 covers them.
 
+### Progress from the long tools
+
+`sdlc_feature`, `understand_repo`, `sdlc_remediate`, `sdlc_address_review` and `audit_repo` run for
+seconds to minutes. When the host asks for progress (an MCP progress token on the call — most
+hosts send one), each reports it as it goes: `sdlc_feature` per stage in the runner's own order
+(spec, layout, design, implement, tests, refine, judge, PR), `sdlc_remediate` per task,
+`sdlc_address_review` at checkout / respond / done, `understand_repo` at extract / write, and
+`audit_repo` at start / done (its loop has no per‑step hook). The bar is monotonic — a second test
+run after a refine does not move it backwards — and a line the stage table does not know rides
+on the current step as its message. Nothing changes in the tools' schemas, and a client that sends
+no token sees exactly what it saw before.
+
 > **The tiers are metadata your host can act on.** Every tool is registered with MCP tool
 > annotations derived from its tier — *read‑only*, *destructive*, *idempotent*, *open‑world* — so a
 > host that asks before destructive calls asks before `sdlc_feature`, `sdlc_start_run` and

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -229,6 +229,18 @@ Resources describe the **default repository**: the process working directory, or
 is in. The tools keep taking `repo_path` as before. All read‑only; over HTTP the `spine:read` floor
 covers them.
 
+### Progress from the long tools
+
+`sdlc_feature`, `understand_repo`, `sdlc_remediate`, `sdlc_address_review` and `audit_repo` run for
+seconds to minutes. When the host asks for progress (an MCP progress token on the call — most
+hosts send one), each reports it as it goes: `sdlc_feature` per stage in the runner's own order
+(spec, layout, design, implement, tests, refine, judge, PR), `sdlc_remediate` per task,
+`sdlc_address_review` at checkout / respond / done, `understand_repo` at extract / write, and
+`audit_repo` at start / done (its loop has no per‑step hook). The bar is monotonic — a second test
+run after a refine does not move it backwards — and a line the stage table does not know rides
+on the current step as its message. Nothing changes in the tools' schemas, and a client that sends
+no token sees exactly what it saw before.
+
 ### Asking across several repositories
 
 The comprehension tools take **one** repository by default, and for a service that is called

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -93,7 +93,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [gap6-benchmarks-roadmap](gap6-benchmarks-roadmap.md) | ✅ **Complete 2026-09-01** | All three phases: harness, 38-label gold set, ratchet gate. top-1 0.32 / top-10 0.71 against 0.085 chance; published as [BENCHMARK.md](../../BENCHMARK.md). This row read *Not started* for a day after the spec said COMPLETE |
 | [codegen-benchmark-roadmap](codegen-benchmark-roadmap.md) | Not started | **New 2026-08-15.** SWE-bench comparability → `resolved`-vs-`mergeable` delta |
 | [codex-plugin-keyless-roadmap](codex-plugin-keyless-roadmap.md) | Not started | **New 2026-08-15.** Phase 0 is a blocking spike |
-| [mcp-plugin-surface](mcp-plugin-surface.md) | ✅ **Phase 1 complete 2026-09-04** (3.31.0); Phase 2 step 1 shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
+| [mcp-plugin-surface](mcp-plugin-surface.md) | ✅ **Phase 1 complete 2026-09-04** (3.31.0); Phase 2 steps 1–2 shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
 | [phase5-agentic-codegen-loop](phase5-agentic-codegen-loop.md) | Proposed, under review | "The hinge phase" |
 | [autonomous-run-agent](autonomous-run-agent.md) | Proposed, no branch | 9 phases; 0–3 strictly serial |
 | [catalog-then-compose-roadmap](catalog-then-compose-roadmap.md) | Proposed, under review | Scope confirmed: Phases 0–3 |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -27,8 +27,8 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Version | **3.31.0** | cutting now; 3.30.0 is the last on PyPI until this ships |
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
-| Source modules | **346** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,964** across 305 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Source modules | **347** | `find src/orchestrator -name '*.py'` |
+| Test functions | **2,974** across 306 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/mcp-plugin-surface.md
+++ b/docs/specs/mcp-plugin-surface.md
@@ -1,6 +1,6 @@
 # The MCP plugin surface — what it is, what it lacks, and the order to extend it
 
-**Status:** **Phase 1 COMPLETE** — all six steps shipped, all six gaps closed. Phase 2 in progress — step 1 (prompts + resources) shipped. **Written 2026-09-04 against 3.30.0**,
+**Status:** **Phase 1 COMPLETE** — all six steps shipped, all six gaps closed. Phase 2 in progress — steps 1 (prompts + resources) and 2 (progress) shipped. **Written 2026-09-04 against 3.30.0**,
 after #316 removed the terminal UI and left the plugin as the only non-browser operator face.
 **Owner:** _unassigned_
 
@@ -150,8 +150,15 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
   `spine://state/{repo}` as MCP resources — listable, subscribable, attachable as context.
 - **4.7 Prompts.** *(Shipped in Phase 2 step 1 — five prompts in `plugin/prompts.py`, the source of the workflow because the skill is not in the wheel; a test holds the skill to the same tools.)* The `understand-codebase` skill's guidance registered as MCP prompts so Codex,
   Desktop and claude.ai get the "which tool, in which order" workflow through the protocol.
-- **4.8 Progress.** Per-phase progress notifications from `sdlc_feature` and
-  `root_cause(use_llm=true)`, which run for minutes with no signal today.
+- **4.8 Progress.** *(Shipped in Phase 2 step 2.)* The five long tools receive the SDK
+  `Context` through an optional parameter the scope wrapper passes through untouched and the
+  schema never shows. The phases come from the engines' existing log hooks — the feature
+  runner's bracketed prefixes, mapped to ordered steps in `plugin/progress.py` — not from new
+  instrumentation, so the CLI and the plugin describe the same stages. Monotonic (a high-water
+  mark); an unknown line rides on the current step as its message, because MCP's separate
+  logging capability is deprecated (SEP-2577). `audit_repo` is start/done only: its loop has no
+  per-step hook. `root_cause(use_llm)` and `design_change(use_llm)` are single model calls and
+  stay as they are.
 - **4.9 Self-describing `doctor`.** Phase 1.
 - **4.10 Multi-repo parity.** `explain_symbol`, `regression_gaps`, `localize`, `docs_for` take
   `repos` like `blast_radius` and `investigate` do.
@@ -177,8 +184,8 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
 | Step | Proposals | State |
 |---|---|---|
 | 1 | 4.7 prompts + 4.6 resources — protocol parity for non-Claude hosts | **shipped** |
-| 2 | 4.8 progress notifications from the long tools | next |
-| 3 | 4.10 multi-repo parity for `explain_symbol`, `regression_gaps`, `localize`, `docs_for` | |
+| 2 | 4.8 progress notifications from the long tools | **shipped** |
+| 3 | 4.10 multi-repo parity for `explain_symbol`, `regression_gaps`, `localize`, `docs_for` | next |
 | 4 | 4.11 per-principal audit on HTTP | |
 | 5 | typed output (the deferred half of 4.1) | last — every return shape |
 | — | retire the `sdlc` scope alias | the release after 3.31.0 |

--- a/src/orchestrator/plugin/progress.py
+++ b/src/orchestrator/plugin/progress.py
@@ -1,0 +1,136 @@
+"""Progress for the long tools: the engine's own phases, sent to the host as it goes.
+
+``sdlc_feature`` runs for minutes — spec, layout, design, implement, tests, refine, judge,
+PR — and a host saw a spinner until the whole run ended. MCP has progress notifications
+for exactly this: a tool that receives the SDK ``Context`` calls ``report_progress`` and
+the host renders it (when the client sent a progress token; it is a no-op otherwise).
+
+**The phases come from the engines' existing log hooks, not new instrumentation.** The
+feature runner already names its stages in bracketed log prefixes (``[spec] …``,
+``[implement] …``); :class:`Reporter` maps those to ordered steps, so the CLI and the
+plugin describe the same stages. Progress is a high-water mark — a second ``[run_tests]``
+after ``[refine]`` does not move it backwards — and a line whose prefix the table does not
+know rides on the *current* step as its message, so the host still sees the text and the
+bar stays monotonic. (MCP's separate logging capability is deprecated as of SEP-2577, so
+nothing here uses it.)
+
+The reporter is a no-op with no context (the tools stay callable as plain functions) and
+outside a real request (the SDK raises there), so nothing a test or a script does can be
+broken by progress.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger("orchestrator.plugin.progress")
+
+#: The feature runner's stages, in the order a run reaches them. A prefix's position is its
+#: step; ``len(FEATURE_PHASES)`` is the total. Kept in one place so a new stage in the
+#: runner is a one-line addition here.
+FEATURE_PHASES: tuple[str, ...] = (
+    "backlog",
+    "spec",
+    "jira",
+    "workspace",
+    "layout",
+    "testenv",
+    "persona",
+    "design",
+    "implement",
+    "author_tests",
+    "run_tests",
+    "cover",
+    "refine",
+    "judge",
+    "revise",
+    "repair",
+    "typecheck",
+    "proof",
+    "coverage",
+    "gate",
+    "pr",
+    "commit",
+)
+
+_PREFIX = re.compile(r"^\[([a-z_]+)")
+
+
+def phase_of(line: str) -> str | None:
+    """The bracketed prefix of a runner log line — ``[run_tests #2] …`` → ``run_tests``."""
+    m = _PREFIX.match(line.strip())
+    return m.group(1) if m else None
+
+
+class Reporter:
+    """Send ordered progress (and stray log lines) to the host through a tool's ``Context``.
+
+    ``ctx`` is the SDK context the tool received, or ``None``. Every method is safe to call
+    in either case: without a context, or outside a request, it does nothing and never
+    raises — a progress bar must not be able to fail the work it describes.
+    """
+
+    def __init__(self, ctx: Any = None, *, phases: tuple[str, ...] = FEATURE_PHASES) -> None:
+        self._ctx = ctx
+        self._phases = phases
+        self._high = 0
+
+    @property
+    def total(self) -> int:
+        return len(self._phases)
+
+    @property
+    def high_water(self) -> int:
+        return self._high
+
+    async def step(self, done: int, total: int, message: str) -> None:
+        """Report an explicit step. Monotonic: a lower ``done`` than seen before is skipped."""
+        if done < self._high:
+            return
+        self._high = done
+        await self._send("report_progress", done, total, message)
+
+    async def log(self, message: str) -> None:
+        """A line for the host without advancing the bar: the current step, re-sent with this
+        message. (Not MCP's logging capability — that is deprecated.)"""
+        await self._send("report_progress", self._high, self.total, message)
+
+    async def phase_line(self, line: str) -> None:
+        """Route a runner log line: a known prefix advances the bar, anything else is logged."""
+        name = phase_of(line)
+        if name in self._phases:
+            await self.step(self._phases.index(name) + 1, self.total, line.strip())
+        else:
+            await self.log(line.strip())
+
+    def as_log(self) -> Callable[[str], None]:
+        """A synchronous ``log`` callback for engines that take one (the feature runner,
+        the bank builder). The runner is sync-called from async code; the notification is
+        scheduled on the running loop rather than awaited."""
+        import asyncio
+
+        def emit(line: str) -> None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:  # no loop — a plain function call; nothing to send to
+                return
+            loop.create_task(self.phase_line(line))
+
+        return emit
+
+    async def _send(self, method: str, *args: Any) -> None:
+        if self._ctx is None:
+            return
+        fn = getattr(self._ctx, method, None)
+        if fn is None:
+            return
+        try:
+            await fn(*args)
+        except Exception as exc:  # outside a request, or a closed session: never the tool's problem
+            logger.debug("plugin.progress.dropped", extra={"method": method, "error": str(exc)[:120]})
+
+
+__all__ = ["FEATURE_PHASES", "Reporter", "phase_of"]

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -92,6 +92,16 @@ from pathlib import Path
 from typing import Any
 
 from orchestrator.plugin.auth import SCOPE_PLAN, SCOPE_READ, SCOPE_RUN
+from orchestrator.plugin.progress import Reporter
+
+# The SDK injects its ``Context`` into a parameter annotated with this class and keeps it
+# out of the input schema — but it resolves the annotation through this module's globals
+# at registration, so the name must exist at runtime. Without the ``mcp`` extra (the tool
+# implementations stay importable without it) it aliases to ``Any`` and nothing changes.
+try:
+    from mcp.server.mcpserver import Context
+except ImportError:  # pragma: no cover - only without the extra
+    Context = Any  # type: ignore[assignment,misc]
 
 
 def doctor() -> dict[str, Any]:
@@ -140,8 +150,11 @@ async def sdlc_feature(
     live: bool = False,
     confirm: bool = False,
     max_refine: int = 3,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
-    """Build ONE intent end to end: spec → grounded codegen → tests → branch.
+    """Build ONE intent end to end: spec → grounded codegen → tests → branch. Reports
+    progress per stage (spec, layout, design, implement, tests, refine, judge, PR) when the
+    host asks for it.
 
     Works for **greenfield and brownfield**:
     - ``repo`` — a git URL/owner-slug to branch from (e.g. ``https://github.com/me/app``
@@ -164,6 +177,7 @@ async def sdlc_feature(
         )
     from orchestrator.sdlc.feature_runner import FeatureRunError, run_feature
 
+    progress = Reporter(ctx)
     try:
         result = await run_feature(
             source,
@@ -174,6 +188,7 @@ async def sdlc_feature(
             package_name=package_name,
             live=live,
             max_refine=max_refine,
+            log=progress.as_log(),
         )
     except FeatureRunError as exc:
         return {"passed": False, "error": str(exc)}
@@ -970,8 +985,12 @@ async def sdlc_run_result(sdlc_id: str) -> dict[str, Any]:
 _BANK_ENTRY_PAGES = ("README.md", "architecture.md", "domain-model.md")
 
 
-def understand_repo(
-    repo_path: str, check: bool = False, refresh: bool = False, out: str | None = None
+async def understand_repo(
+    repo_path: str,
+    check: bool = False,
+    refresh: bool = False,
+    out: str | None = None,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Build a repo's ``episteme/`` knowledge base — or, with ``check=true``, verify the
     committed one still matches the code. **Deterministic, no LLM, no credentials**: the
@@ -998,9 +1017,12 @@ def understand_repo(
             "pass a local repo_path, or out=<absolute directory> to keep the bank.",
         }
 
+    progress = Reporter(ctx, phases=("extract", "understand"))
+    await progress.step(1, 2, "[extract] extracting the graph and rendering the pages")
+
     def run(repo: Any) -> dict[str, Any]:
         if check:
-            report = check_memory_bank(repo, out_dir=out_dir, refresh=refresh)
+            report = check_memory_bank(repo, out_dir=out_dir, refresh=refresh, log=progress.as_log())
             return {
                 "ok": report.ok,
                 "absent": report.absent,
@@ -1012,7 +1034,7 @@ def understand_repo(
                 "dirty": report.dirty,
                 "summary": report.summary_line(),
             }
-        result = build_memory_bank(repo, out_dir=out_dir, refresh=refresh)
+        result = build_memory_bank(repo, out_dir=out_dir, refresh=refresh, log=progress.as_log())
         files = list(result.get("files") or [])
         return {
             "dir": result["dir"],
@@ -1189,6 +1211,7 @@ async def sdlc_address_review(
     bot_login: str | None = None,
     max_refines: int = 3,
     confirm: bool = False,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Address the human review comments on an open PR and **push a fix to its branch**:
     clone the repo, check the PR out, feed the comments to codegen, re-drive the change to
@@ -1214,10 +1237,13 @@ async def sdlc_address_review(
     )
     from orchestrator.sdlc.worker import build_deps
 
+    progress = Reporter(ctx, phases=("checkout", "respond", "done"))
+    await progress.step(1, 3, f"[checkout] cloning and checking out {pr}")
     try:
         workdir, branch = await checkout_pr_worktree(repo_url, pr)
     except PRCheckoutError as exc:
         return {"error": str(exc), "step": exc.step}
+    await progress.step(2, 3, f"[respond] addressing review comments on {branch}")
     result = await respond_to_pr_feedback(
         build_deps(),
         pr_url=pr,
@@ -1225,6 +1251,9 @@ async def sdlc_address_review(
         path=str(workdir),
         bot_login=bot_login,
         max_refines=max_refines,
+    )
+    await progress.step(
+        3, 3, f"[done] {result.detail or ('pushed' if result.addressed else 'nothing to push')}"
     )
     return {"pr": pr, "branch": branch, **result.__dict__}
 
@@ -1262,6 +1291,7 @@ async def sdlc_remediate(
     min_severity: str = "warning",
     live: bool = False,
     confirm: bool = False,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Turn an infodrift drift report into remediation feature runs, one per material
     finding at or above ``min_severity`` (``warning`` | ``critical``). ``report_path`` is
@@ -1296,7 +1326,13 @@ async def sdlc_remediate(
         return {"error": f"could not read the mapping store at {mappings_path!r}: {exc}"}
     entity_iris = infer_entity_iris(report, mappings)
 
+    progress = Reporter(ctx)
+    done = 0
+
     async def runner(task: RemediationTask) -> str:
+        nonlocal done
+        done += 1
+        await progress.step(done, done, f"[remediate #{done}] {task.spec.get('title', task.entity_key)}")
         result = await run_feature(source="spine://remediation", spec=task.spec, repo=repo, live=live)
         return result.branch
 
@@ -1333,13 +1369,16 @@ def _finding_dict(f: Any) -> dict[str, Any]:
 
 
 async def audit_repo(
-    repo_path: str, focus: str = "general code quality, correctness risks, and security"
+    repo_path: str,
+    focus: str = "general code quality, correctness risks, and security",
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """A codebase-auditor persona reads the repo — the graph plus file reads, **no writes**
     — and reports findings anchored to a real ``file:line`` (claims that resolve to nothing
     are listed separately as ``unresolved``). **Spends tokens**: needs a tool-calling model
     (``ORCHESTRATOR_INTAKE_MODEL``). ``repo_path`` is a local path or a git URL; ``focus``
-    says what to look for."""
+    says what to look for. Progress is start and done only — the audit loop has no
+    per-step hook."""
     from orchestrator.core.env import load_local_env
     from orchestrator.sdlc.codegen import resolve_codegen_model
 
@@ -1355,7 +1394,10 @@ async def audit_repo(
         from orchestrator.core.llm import LiteLLMClient
         from orchestrator.personas import render_findings_markdown, run_audit
 
+        progress = Reporter(ctx, phases=("audit", "done"))
+        await progress.step(1, 2, f"[audit] reading the repo with focus: {focus}")
         result = await run_audit(repo, llm=LiteLLMClient(), model=model, focus=focus)
+        await progress.step(2, 2, f"[done] {len(result.findings)} finding(s); {result.stopped_reason}")
         return {
             "summary": result.summary,
             "findings": [_finding_dict(f) for f in result.findings],

--- a/tests/plugin/test_progress.py
+++ b/tests/plugin/test_progress.py
@@ -1,0 +1,196 @@
+"""Progress for the long tools: the engine's phases, to the host, never able to fail the work."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from orchestrator.plugin.progress import FEATURE_PHASES, Reporter, phase_of
+
+
+class _Ctx:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.progress: list[tuple[float, float | None, str | None]] = []
+        self.fail = fail
+
+    async def report_progress(
+        self, progress: float, total: float | None = None, message: str | None = None
+    ) -> None:
+        if self.fail:
+            raise ValueError("Context is not available outside of a request")
+        self.progress.append((progress, total, message))
+
+
+def test_phase_of_reads_the_bracketed_prefix() -> None:
+    assert phase_of("[run_tests #2] passed=False rc=1") == "run_tests"
+    assert phase_of("  [spec] wrote spec") == "spec"
+    assert phase_of("no prefix here") is None
+    assert phase_of("[Not-A-Phase] x") is None
+
+
+def test_the_phase_table_is_in_run_order_and_names_the_stages_the_runner_logs() -> None:
+    """The runner's own log prefixes, in the order a run reaches them — a new stage in the
+    runner is one line here. Sanity: the bookends are where they must be."""
+    assert FEATURE_PHASES[0] == "backlog" and FEATURE_PHASES[-1] == "commit"
+    assert (
+        FEATURE_PHASES.index("implement")
+        < FEATURE_PHASES.index("author_tests")
+        < FEATURE_PHASES.index("run_tests")
+    )
+    assert FEATURE_PHASES.index("refine") < FEATURE_PHASES.index("pr")
+    assert len(set(FEATURE_PHASES)) == len(FEATURE_PHASES)
+
+
+async def test_a_reporter_without_a_context_is_a_silent_no_op() -> None:
+    r = Reporter(None)
+    await r.step(1, 3, "x")
+    await r.log("y")
+    await r.phase_line("[spec] z")
+    assert r.high_water == FEATURE_PHASES.index("spec") + 1  # it still tracks the place
+
+
+async def test_known_prefixes_advance_the_bar_monotonically_and_unknown_lines_ride_the_current_step() -> None:
+    ctx = _Ctx()
+    r = Reporter(ctx)
+    for line in (
+        "[spec] s",
+        "[implement] i",
+        "[run_tests #1] t",
+        "[refine] r",
+        "[run_tests #2] t",
+        "[pr] p",
+        "plain note",
+    ):
+        await r.phase_line(line)
+    steps = [p for p, _t, _m in ctx.progress]
+    assert steps == sorted(steps)  # never backwards: run_tests #2 after refine is skipped
+    assert all(t == len(FEATURE_PHASES) for _p, t, _m in ctx.progress)
+    assert ctx.progress[0][2] == "[spec] s"
+    # The unknown line rides on the current step: same `done` as `[pr]`, its own message.
+    assert ctx.progress[-1] == (FEATURE_PHASES.index("pr") + 1, len(FEATURE_PHASES), "plain note")
+    assert r.high_water == FEATURE_PHASES.index("pr") + 1
+
+
+async def test_a_context_outside_a_request_cannot_fail_the_tool() -> None:
+    r = Reporter(_Ctx(fail=True))
+    await r.step(1, 2, "x")  # raises inside; swallowed
+    await r.phase_line("[spec] s")
+
+
+async def test_as_log_feeds_a_sync_engine_callback_into_the_bar() -> None:
+    ctx = _Ctx()
+    r = Reporter(ctx)
+    emit = r.as_log()
+    emit("[design] d")
+    emit("[implement] i")
+    await asyncio.sleep(0)  # let the scheduled notifications run
+    await asyncio.sleep(0)
+    assert [m for _p, _t, m in ctx.progress] == ["[design] d", "[implement] i"]
+
+
+def test_as_log_without_a_running_loop_drops_the_line_quietly() -> None:
+    emit = Reporter(_Ctx()).as_log()
+    emit("[spec] s")  # no loop: nothing to schedule on, nothing raised
+
+
+@pytest.mark.parametrize("phases", [("a", "b"), ("one",)])
+async def test_a_custom_phase_table_sets_the_total(phases: tuple[str, ...]) -> None:
+    ctx = _Ctx()
+    r = Reporter(ctx, phases=phases)
+    await r.phase_line(f"[{phases[-1]}] end")
+    assert ctx.progress == [(len(phases), len(phases), f"[{phases[-1]}] end")]
+
+
+# ---- end to end: a host sees the runner's phases while sdlc_feature runs ---------------
+
+
+@pytest.mark.skipif(__import__("importlib").util.find_spec("mcp") is None, reason="needs the 'mcp' extra")
+async def test_a_host_receives_the_runners_phases_in_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The real server over in-memory streams, a real client with a progress callback, and
+    the feature runner replaced by one that logs the stages a run logs. The wrapper from
+    the scope guard must pass the injected Context through untouched."""
+    import anyio
+    from mcp import ClientSession
+    from mcp.shared.memory import create_client_server_memory_streams
+
+    from orchestrator.plugin.server import build_server
+
+    class _Result:
+        passed, intent_id, issue_key, branch, files, iterations, grounding_chars, live, pr_url = (
+            True,
+            "I-1",
+            "K-1",
+            "feat/x",
+            ["a.py"],
+            1,
+            0,
+            False,
+            None,
+        )
+
+    async def fake_run_feature(source: str, **kw: Any) -> _Result:
+        log = kw["log"]
+        for line in (
+            "[spec] wrote spec",
+            "[implement] 1 file",
+            "[run_tests #1] passed=True",
+            "[pr] skipped (safe)",
+        ):
+            log(line)
+        await asyncio.sleep(0)  # let the scheduled notifications go out before we return
+        await asyncio.sleep(0)
+        return _Result()
+
+    monkeypatch.setattr("orchestrator.sdlc.feature_runner.run_feature", fake_run_feature)
+    server = build_server()
+    seen: list[tuple[float, float | None, str | None]] = []
+
+    async def on_progress(progress: float, total: float | None, message: str | None) -> None:
+        seen.append((progress, total, message))
+
+    async with create_client_server_memory_streams() as ((cr, cw), (sr, sw)), anyio.create_task_group() as tg:
+        low = server._lowlevel_server
+        tg.start_soon(low.run, sr, sw, low.create_initialization_options())
+        async with ClientSession(cr, cw) as client:
+            await client.initialize()
+            tool = next(t for t in (await client.list_tools()).tools if t.name == "sdlc_feature")
+            assert "ctx" not in tool.input_schema["properties"]  # the host never sees the context
+            result = await client.call_tool(
+                "sdlc_feature", {"source": "file://./spec.md"}, progress_callback=on_progress
+            )
+        tg.cancel_scope.cancel()
+
+    assert not result.is_error and (result.structured_content or {}).get("passed") is True
+    messages = [m for _p, _t, m in seen]
+    assert messages == [
+        "[spec] wrote spec",
+        "[implement] 1 file",
+        "[run_tests #1] passed=True",
+        "[pr] skipped (safe)",
+    ]
+    steps = [p for p, _t, _m in seen]
+    assert steps == sorted(steps) and all(t == len(FEATURE_PHASES) for _p, t, _m in seen)
+    assert steps[0] == FEATURE_PHASES.index("spec") + 1 and steps[-1] == FEATURE_PHASES.index("pr") + 1
+
+
+@pytest.mark.skipif(__import__("importlib").util.find_spec("mcp") is None, reason="needs the 'mcp' extra")
+async def test_the_progress_tools_advertise_the_same_schema_and_hints_as_before() -> None:
+    from orchestrator.plugin.server import _TOOLS, build_server, tool_annotations
+
+    with_ctx = {"sdlc_feature", "understand_repo", "sdlc_remediate", "sdlc_address_review", "audit_repo"}
+    tools = {t.name: t for t in await build_server().list_tools()}
+    assert set(tools) == {fn.__name__ for fn in _TOOLS}
+    for name in with_ctx:
+        assert "ctx" not in tools[name].input_schema["properties"], name
+        assert tools[name].annotations is not None
+        assert tools[name].annotations.model_dump(exclude_none=True, exclude={"title"}) == tool_annotations(
+            name
+        )
+    assert set(tools["understand_repo"].input_schema["properties"]) == {
+        "repo_path",
+        "check",
+        "refresh",
+        "out",
+    }

--- a/tests/plugin/test_resources.py
+++ b/tests/plugin/test_resources.py
@@ -50,10 +50,10 @@ def test_a_missing_bank_is_a_note_naming_what_builds_it(repo: Path) -> None:
     assert "No knowledge base" in bank_section("architecture")  # same note, not an error
 
 
-def test_a_built_bank_is_readable_by_index_and_by_section(repo: Path) -> None:
+async def test_a_built_bank_is_readable_by_index_and_by_section(repo: Path) -> None:
     from orchestrator.plugin.server import understand_repo
 
-    assert "error" not in understand_repo(str(repo))
+    assert "error" not in await understand_repo(str(repo))
     index = bank_index()
     assert "spine://bank/architecture" in index and "spine://bank/conventions" in index
     page = bank_section("architecture")
@@ -61,11 +61,11 @@ def test_a_built_bank_is_readable_by_index_and_by_section(repo: Path) -> None:
     assert "No section" in bank_section("no-such-page")
 
 
-def test_a_section_cannot_escape_the_bank(repo: Path) -> None:
+async def test_a_section_cannot_escape_the_bank(repo: Path) -> None:
     from orchestrator.plugin.server import understand_repo
 
     (repo.parent / "secret.md").write_text("SECRET", encoding="utf-8")
-    understand_repo(str(repo))
+    await understand_repo(str(repo))
     assert "SECRET" not in bank_section("../../secret")
     assert "SECRET" not in bank_section("../secret")
 
@@ -117,7 +117,7 @@ def test_state_report_renders_the_repo(repo: Path) -> None:
 async def test_resources_reach_the_host_and_read_back(repo: Path) -> None:
     from orchestrator.plugin.server import build_server, understand_repo
 
-    understand_repo(str(repo))
+    await understand_repo(str(repo))
     server = build_server()
     direct = {str(r.uri): r for r in await server.list_resources()}
     templates = {t.uri_template: t for t in await server.list_resource_templates()}

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -430,12 +430,12 @@ def _ledger_repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_understand_repo_builds_the_bank_and_names_where_to_start(tmp_path: Path) -> None:
+async def test_understand_repo_builds_the_bank_and_names_where_to_start(tmp_path: Path) -> None:
     from orchestrator.knowledge.understand import BANK_DIRNAME
     from orchestrator.plugin.server import read_memory_bank, understand_repo
 
     repo = _ledger_repo(tmp_path)
-    out = understand_repo(str(repo))
+    out = await understand_repo(str(repo))
     assert "error" not in out, out
     assert out["dir"] == str(repo / BANK_DIRNAME)
     assert out["files_written"] > 0 and (repo / BANK_DIRNAME / "README.md").exists()
@@ -446,37 +446,37 @@ def test_understand_repo_builds_the_bank_and_names_where_to_start(tmp_path: Path
     assert "error" not in bank
 
 
-def test_understand_repo_check_is_current_then_stale(tmp_path: Path) -> None:
+async def test_understand_repo_check_is_current_then_stale(tmp_path: Path) -> None:
     from orchestrator.plugin.server import understand_repo
 
     repo = _ledger_repo(tmp_path)
-    assert understand_repo(str(repo), check=True)["absent"] is True  # nothing built yet
-    understand_repo(str(repo))
-    current = understand_repo(str(repo), check=True)
+    assert (await understand_repo(str(repo), check=True))["absent"] is True  # nothing built yet
+    await understand_repo(str(repo))
+    current = await understand_repo(str(repo), check=True)
     assert current["ok"] is True and "current" in current["summary"]
     # The code moves on; the committed pages no longer describe it.
     (repo / "router.py").write_text("class WebhookRouter:\n    pass\n", encoding="utf-8")
-    stale = understand_repo(str(repo), check=True)
+    stale = await understand_repo(str(repo), check=True)
     assert stale["ok"] is False and (stale["stale"] or stale["missing"])
     assert "stale" in stale["summary"]
 
 
-def test_understand_repo_refuses_to_build_into_a_clone_that_vanishes(tmp_path: Path) -> None:
+async def test_understand_repo_refuses_to_build_into_a_clone_that_vanishes(tmp_path: Path) -> None:
     from orchestrator.plugin.server import understand_repo
 
-    out = understand_repo("https://github.com/example/repo.git")  # allow-listed host, never cloned
+    out = await understand_repo("https://github.com/example/repo.git")  # allow-listed host, never cloned
     assert "error" in out and "out=" in out["error"]
     # A relative `out` is the same trap in a subprocess whose cwd is not the repo.
-    assert "error" in understand_repo("https://github.com/example/repo.git", out="episteme")
+    assert "error" in await understand_repo("https://github.com/example/repo.git", out="episteme")
 
 
-def test_understand_repo_writes_where_out_says(tmp_path: Path) -> None:
+async def test_understand_repo_writes_where_out_says(tmp_path: Path) -> None:
     from orchestrator.plugin.server import understand_repo
 
     (tmp_path / "repo").mkdir()
     repo = _ledger_repo(tmp_path / "repo")
     target = tmp_path / "elsewhere"
-    out = understand_repo(str(repo), out=str(target))
+    out = await understand_repo(str(repo), out=str(target))
     assert out["dir"] == str(target) and (target / "README.md").exists()
 
 


### PR DESCRIPTION
## Summary

MCP phase 2 step 2 of [`docs/specs/mcp-plugin-surface.md`](docs/specs/mcp-plugin-surface.md): proposal 4.8, progress notifications from the long tools.

| Tool | Phases | Source |
|---|---|---|
| `sdlc_feature` | spec, layout, design, implement, author tests, run tests, refine, judge, PR … (22 stages, in the runner's order) | the feature runner's existing bracketed log prefixes |
| `understand_repo` | extract / write | the bank builder's log |
| `sdlc_remediate` | one step per task | the runner it drives |
| `sdlc_address_review` | checkout / respond / done | the tool's own stages |
| `audit_repo` | start / done | none available — its loop has no per-step hook |

**Mechanism.** Each tool gains an optional `ctx: Context | None` parameter. The SDK injects its context there, keeps it out of the input schema, and the scope wrapper from #322 passes it through untouched (verified). A runtime alias keeps the module importable without the `mcp` extra. `plugin/progress.py` holds the reporter: a high-water mark (a second `[run_tests]` after `[refine]` does not move the bar backwards), an unknown line rides on the current step as its message (MCP's logging capability is deprecated, SEP-2577), and it is a no-op with no context or outside a request and never raises — a progress bar must not be able to fail the work it describes.

`understand_repo` becomes async to report its steps; its callers `await` it.

**Verified end to end** (`tests/plugin/test_progress.py`): the real server over in-memory streams, a real `ClientSession` with a `progress_callback`, the feature runner replaced by one that logs the stages a run logs — the host receives them in order, with the same schema and annotations as before.

## Files

- `plugin/progress.py` (new): `FEATURE_PHASES`, `phase_of`, `Reporter`.
- `plugin/server.py`: the five tools, the `Context` alias.
- Tests: `test_progress.py` (11: reporter unit tests, the end-to-end session, schema/annotation parity); `test_server.py` / `test_resources.py` await `understand_repo`.
- Docs: "Progress from the long tools" in CLAUDE_GUIDE and CODEX_GUIDE §6; the spec (4.8 shipped, phase 2 table); SPEC-INDEX; CHANGELOG Unreleased; STATE-OF-SPINE counts.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`, `matrix-count --check`, `state-numbers --check`: pass
- Full pytest: 3399 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
