### PR TITLE
feat(plugin): every comprehension tool that can answer across repositories now does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Added
 
+- **Every comprehension tool that can answer across repositories now does.**
+  `explain_symbol`, `regression_gaps`, `localize` and `docs_for` take `repos=` (a
+  `.spine/repos.yaml`) like `blast_radius` and `investigate`, with the same
+  contract and `standing` block. `regression_gaps` reports `uncovered_elsewhere` —
+  a change reaching a *different* service nothing tests — which needed the plan
+  to follow the one hop that crosses a service boundary (handler → endpoint →
+  consumer); the endpoint itself is the wire, not an item. `localize` says which
+  repository each frame landed in, and a frame two services could own is reported
+  as ambiguous with its candidates instead of the first match winning silently.
+  `docs_for` answers each repository on its own rather than merging, because a
+  document describes the repository it lives in.
+
 - **The long MCP tools report progress.** `sdlc_feature` per stage in the runner's
   own order (spec, layout, design, implement, tests, refine, judge, PR),
   `sdlc_remediate` per task, `sdlc_address_review` at checkout / respond / done,

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -291,8 +291,8 @@ over HTTP that is a trap rather than a limitation. `blast_radius` on a route han
 **`0 caller(s)`** — which is *true*, nothing in its own source calls it — and reads as safe to
 change.
 
-Declare your services in a **`.spine/repos.yaml`** and pass it as `repos=` to `blast_radius`
-or `investigate` instead of `repo_path`:
+Declare your services in a **`.spine/repos.yaml`** and pass it as `repos=` — to `blast_radius`,
+`investigate`, `explain_symbol`, `regression_gaps`, `localize` or `docs_for` — instead of `repo_path`:
 
 ```yaml
 repos:

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -248,8 +248,8 @@ over HTTP that is a trap rather than a limitation. `blast_radius` on a route han
 **`0 caller(s)`** — which is *true*, nothing in its own source calls it — and reads as safe to
 change.
 
-Declare your services in a **`.spine/repos.yaml`** and pass it as `repos=` to `blast_radius`
-or `investigate` instead of `repo_path`:
+Declare your services in a **`.spine/repos.yaml`** and pass it as `repos=` — to `blast_radius`,
+`investigate`, `explain_symbol`, `regression_gaps`, `localize` or `docs_for` — instead of `repo_path`:
 
 ```yaml
 repos:

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -93,7 +93,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [gap6-benchmarks-roadmap](gap6-benchmarks-roadmap.md) | ✅ **Complete 2026-09-01** | All three phases: harness, 38-label gold set, ratchet gate. top-1 0.32 / top-10 0.71 against 0.085 chance; published as [BENCHMARK.md](../../BENCHMARK.md). This row read *Not started* for a day after the spec said COMPLETE |
 | [codegen-benchmark-roadmap](codegen-benchmark-roadmap.md) | Not started | **New 2026-08-15.** SWE-bench comparability → `resolved`-vs-`mergeable` delta |
 | [codex-plugin-keyless-roadmap](codex-plugin-keyless-roadmap.md) | Not started | **New 2026-08-15.** Phase 0 is a blocking spike |
-| [mcp-plugin-surface](mcp-plugin-surface.md) | ✅ **Phase 1 complete 2026-09-04** (3.31.0); Phase 2 steps 1–2 shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
+| [mcp-plugin-surface](mcp-plugin-surface.md) | ✅ **Phase 1 complete 2026-09-04** (3.31.0); Phase 2 steps 1–3 shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
 | [phase5-agentic-codegen-loop](phase5-agentic-codegen-loop.md) | Proposed, under review | "The hinge phase" |
 | [autonomous-run-agent](autonomous-run-agent.md) | Proposed, no branch | 9 phases; 0–3 strictly serial |
 | [catalog-then-compose-roadmap](catalog-then-compose-roadmap.md) | Proposed, under review | Scope confirmed: Phases 0–3 |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
 | Source modules | **347** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,974** across 306 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **2,980** across 306 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/mcp-plugin-surface.md
+++ b/docs/specs/mcp-plugin-surface.md
@@ -1,6 +1,6 @@
 # The MCP plugin surface — what it is, what it lacks, and the order to extend it
 
-**Status:** **Phase 1 COMPLETE** — all six steps shipped, all six gaps closed. Phase 2 in progress — steps 1 (prompts + resources) and 2 (progress) shipped. **Written 2026-09-04 against 3.30.0**,
+**Status:** **Phase 1 COMPLETE** — all six steps shipped, all six gaps closed. Phase 2 in progress — steps 1 (prompts + resources), 2 (progress) and 3 (multi-repo parity) shipped. **Written 2026-09-04 against 3.30.0**,
 after #316 removed the terminal UI and left the plugin as the only non-browser operator face.
 **Owner:** _unassigned_
 
@@ -160,8 +160,18 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
   per-step hook. `root_cause(use_llm)` and `design_change(use_llm)` are single model calls and
   stay as they are.
 - **4.9 Self-describing `doctor`.** Phase 1.
-- **4.10 Multi-repo parity.** `explain_symbol`, `regression_gaps`, `localize`, `docs_for` take
-  `repos` like `blast_radius` and `investigate` do.
+- **4.10 Multi-repo parity.** *(Shipped in Phase 2 step 3.)* `explain_symbol`,
+  `regression_gaps`, `localize` and `docs_for` take `repos` like `blast_radius` and `investigate`
+  do, with the same "exactly one of `repo_path` or `repos`" contract and a `standing` block.
+  `explain_symbol` names each match's repo and its cross-repo reach. `regression_gaps` names
+  each impacted symbol's repo and reports `uncovered_elsewhere` — a change reaching a different
+  service nothing tests — which needed the plan to follow the one hop that crosses a service
+  boundary (EXPOSES + CONSUMES through the endpoint node; the endpoint itself is the wire, not
+  an item). `localize` reports each frame's repo, and a frame two services could own is
+  `ambiguous` with its candidates rather than the first match winning silently. `docs_for`
+  fans out per repository instead of merging — a document describes the repository it lives
+  in, and binding one repo's docs to another's symbols by name would be a false edge — each
+  entry carrying its own `reproducible` flag.
 - **4.11 Per-principal audit on HTTP.** Tier-3 invocations recorded against the token principal,
   in the registry's existing audit log.
 
@@ -185,8 +195,8 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
 |---|---|---|
 | 1 | 4.7 prompts + 4.6 resources — protocol parity for non-Claude hosts | **shipped** |
 | 2 | 4.8 progress notifications from the long tools | **shipped** |
-| 3 | 4.10 multi-repo parity for `explain_symbol`, `regression_gaps`, `localize`, `docs_for` | next |
-| 4 | 4.11 per-principal audit on HTTP | |
+| 3 | 4.10 multi-repo parity for `explain_symbol`, `regression_gaps`, `localize`, `docs_for` | **shipped** |
+| 4 | 4.11 per-principal audit on HTTP | next |
 | 5 | typed output (the deferred half of 4.1) | last — every return shape |
 | — | retire the `sdlc` scope alias | the release after 3.31.0 |
 

--- a/plugins/spine/skills/understand-codebase/SKILL.md
+++ b/plugins/spine/skills/understand-codebase/SKILL.md
@@ -36,7 +36,7 @@ and they cite their sources.
 | see what a change could break silently | **`regression_gaps(symbol=… or trace=…)`** — blast-radius symbols with **no covering test** |
 | root-cause a bug (hypotheses + fix approach) | **`root_cause(bug=…)`** — fault site, ranked hypotheses with evidence, regression surface, fix approach; deterministic (add `use_llm=true` for richer hypotheses) |
 | find which docs describe code (or how documented it is) | **`docs_for(symbol=…)`** — the doc pages that mention a symbol; call with no symbol for a doc-coverage summary + top drift. Ingests `.md`/`.rst`/`.txt`/PDF |
-| ask any of the above **across several repositories** | **`blast_radius(repos=…)`** / **`investigate(repos=…)`** — pass a `.spine/repos.yaml` instead of `repo_path` |
+| ask any of the above **across several repositories** | **`blast_radius`**, **`investigate`**, **`explain_symbol`**, **`regression_gaps`**, **`localize`**, **`docs_for`** all take **`repos=…`** — pass a `.spine/repos.yaml` instead of `repo_path`. `regression_gaps` then reports `uncovered_elsewhere` (a change reaching a *different* service nothing tests); `localize` says which repo each frame landed in and lists `ambiguous_frames`; `docs_for` answers each repo on its own |
 | see or sanity-check the cross-repo topology | **`pkg_joins(config=…, mode="propose"\|"check")`** — read-only; it never writes a config |
 
 Read a repo's committed knowledge base with **`read_memory_bank`** when one exists (built by
@@ -51,7 +51,8 @@ When a change's real blast radius leaves the repo, a single-repo answer is worse
 An HTTP handler reports **`0 caller(s)`** — which is *true*, nothing in its own source calls it —
 and reads as safe to change.
 
-If the project declares its services in a **`.spine/repos.yaml`**, pass it as `repos=` to
+If the project declares its services in a **`.spine/repos.yaml`**, pass it as `repos=` to any of
+`blast_radius`, `investigate`, `explain_symbol`, `regression_gaps`, `localize` or `docs_for` — e.g. to
 `blast_radius` or `investigate` instead of `repo_path`. Every match then also reports the
 dependents it has **in other repositories**:
 

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -474,16 +474,26 @@ def blast_radius(repo_path: str = "", symbol: str = "", repos: str | None = None
     return _in_repo_store(repo_path, run)
 
 
-def explain_symbol(repo_path: str, symbol: str) -> dict[str, Any]:
+def explain_symbol(repo_path: str = "", symbol: str = "", repos: str | None = None) -> dict[str, Any]:
     """What a symbol is and how it connects: kind, location, who calls it, what it calls, and
-    what it contains. Deterministic (no LLM)."""
+    what it contains. Deterministic (no LLM).
+
+    Pass ``repos`` (a ``.spine/repos.yaml``) instead of ``repo_path`` to explain it across every
+    declared repository: each match then says which repository it lives in and lists the
+    symbols in *other* repositories a change to it reaches — the callers a single-repo graph
+    cannot see."""
+    if not symbol:
+        return {"error": "provide a symbol"}
+    if bool(repo_path) == bool(repos):
+        return {"error": "provide exactly one of repo_path or repos"}
 
     def run(store: Any, _repo: Any) -> dict[str, Any]:
         matches = store.find(symbol)
         if not matches:
             return {"symbol": symbol, "found": False, "matches": []}
-        out = [
-            {
+        out: list[dict[str, Any]] = []
+        for node in matches[:5]:
+            entry: dict[str, Any] = {
                 "id": node.id,
                 "kind": node.kind.value,
                 "name": node.name,
@@ -493,11 +503,24 @@ def explain_symbol(repo_path: str, symbol: str) -> dict[str, Any]:
                 "calls": [n.id for n in store.callees_of(node.id)[:15]],
                 "contains": [n.id for n in store.children_of(node.id)[:25]],
             }
-            for node in matches[:5]
-        ]
+            if repos:
+                entry["repo"] = _repo_of_node(node)
+                reach = _cross_repo_reach(store, node.id)
+                entry["cross_repo_count"] = len(reach)
+                entry["cross_repo"] = reach[:25]
+            out.append(entry)
         return {"symbol": symbol, "found": True, "matches": out}
 
+    if repos:
+        return _in_repos_store(repos, run)
     return _in_repo_store(repo_path, run)
+
+
+def _repo_of_node(node: Any) -> str:
+    """Which repository a merged-graph node belongs to: its provenance, else its scoped id."""
+    from orchestrator.pkg.scoping import unscope_id
+
+    return (node.provenance.repo if node.provenance else "") or unscope_id(node.id)[0]
 
 
 def investigate(
@@ -613,11 +636,18 @@ def _joins_report(merged: Any) -> dict[str, Any]:
     }
 
 
-def localize(repo_path: str, trace: str) -> dict[str, Any]:
+def localize(repo_path: str = "", trace: str = "", repos: str | None = None) -> dict[str, Any]:
     """Resolve a stack trace / traceback to the repo symbols it names, pointing at the likely
-    fault site and its callers. Deterministic (no LLM)."""
+    fault site and its callers. Deterministic (no LLM).
+
+    Pass ``repos`` (a ``.spine/repos.yaml``) instead of ``repo_path`` for a trace that crosses
+    services: each resolved frame then says which repository it landed in, and a frame whose
+    path exists in more than one repository is reported as **ambiguous** with the candidates —
+    the first match does not win silently."""
     if not trace.strip():
         return {"error": "provide a stack trace / traceback text"}
+    if bool(repo_path) == bool(repos):
+        return {"error": "provide exactly one of repo_path or repos"}
 
     def run(store: Any, _repo: Any) -> dict[str, Any]:
         from orchestrator.sdlc.localize import localize_trace, render_localization_md
@@ -638,21 +668,43 @@ def localize(repo_path: str, trace: str) -> dict[str, Any]:
                     "resolved": f.resolved,
                     "id": f.node_id,
                     "where": f.where,
+                    **({"repo": f.repo, "candidates": f.candidates} if repos else {}),
                 }
                 for f in loc.frames
             ],
             "callers": loc.callers,
+            **(
+                {
+                    "ambiguous_frames": [
+                        {"trace_at": f"{f.file}:{f.line}", "resolved": f.node_id, "also": f.candidates}
+                        for f in loc.frames
+                        if f.candidates
+                    ]
+                }
+                if repos
+                else {}
+            ),
             "markdown": render_localization_md(loc),
         }
 
+    if repos:
+        return _in_repos_store(repos, run)
     return _in_repo_store(repo_path, run)
 
 
-def regression_gaps(repo_path: str, symbol: str = "", trace: str = "") -> dict[str, Any]:
+def regression_gaps(
+    repo_path: str = "", symbol: str = "", trace: str = "", repos: str | None = None
+) -> dict[str, Any]:
     """Blast-radius test-coverage gaps for a change: the production symbols a change to
-    ``symbol`` (or the fault site in ``trace``) reaches that **no test covers**. Deterministic."""
+    ``symbol`` (or the fault site in ``trace``) reaches that **no test covers**. Deterministic.
+
+    Pass ``repos`` (a ``.spine/repos.yaml``) instead of ``repo_path`` to answer across every
+    declared repository: each impacted symbol then names its repository, and ``uncovered_elsewhere``
+    is the headline — a change reaching a *different* service that has no test for it."""
     if not symbol and not trace.strip():
         return {"error": "provide a symbol name or a stack trace"}
+    if bool(repo_path) == bool(repos):
+        return {"error": "provide exactly one of repo_path or repos"}
 
     def run(store: Any, _repo: Any) -> dict[str, Any]:
         from orchestrator.sdlc.coverage import (
@@ -671,18 +723,33 @@ def regression_gaps(repo_path: str, symbol: str = "", trace: str = "") -> dict[s
         if not target_id:
             return {"target": symbol or "(trace)", "found": False}
         plan = build_regression_plan(store, target_id)
-        return {
+        out: dict[str, Any] = {
             "target": plan.target,
             "found": True,
             "target_covered": plan.target_covered,
             "call_graph_available": plan.call_graph_available,
             "impacted_count": len(plan.impacted),
-            "uncovered": [{"name": i.name, "where": i.where} for i in plan.impacted if not i.covered],
+            "uncovered": [
+                {"name": i.name, "where": i.where, **({"repo": i.repo} if repos else {})}
+                for i in plan.impacted
+                if not i.covered
+            ],
             "covering_tests": plan.covering_tests,
             "truncated": plan.truncated,
             "markdown": render_regression_plan_md(plan),
         }
+        if repos:
+            home = _repo_of_node(store.node(target_id)) if store.node(target_id) else ""
+            out["target_repo"] = home
+            out["uncovered_elsewhere"] = [
+                {"name": i.name, "where": i.where, "repo": i.repo}
+                for i in plan.impacted
+                if not i.covered and i.repo and i.repo != home
+            ]
+        return out
 
+    if repos:
+        return _in_repos_store(repos, run)
     return _in_repo_store(repo_path, run)
 
 
@@ -831,12 +898,19 @@ def sdlc_approve(
     return _in_repo(repo_path, run, hint=False)
 
 
-def docs_for(repo_path: str, symbol: str = "") -> dict[str, Any]:
+def docs_for(repo_path: str = "", symbol: str = "", repos: str | None = None) -> dict[str, Any]:
     """Which docs describe the code — the doc-ingestion surface. With a ``symbol``, the doc pages
     that **MENTION** it (grounded to the repo's docs). Without one, a doc-coverage summary: how many
     docs are ingested, how many symbols they name, and the top **potential drift** (doc claims the
     graph can't resolve — renamed/removed code). Deterministic (no LLM). ``repo_path`` is a local
-    path or a git URL."""
+    path or a git URL.
+
+    Pass ``repos`` (a ``.spine/repos.yaml``) instead of ``repo_path`` to ask every declared
+    repository — **each on its own**, keyed by repository. Docs are not merged across repos: a
+    document describes the repository it lives in, and binding one repo's docs to another's
+    symbols by name would be a false edge. Each entry carries its own ``reproducible`` flag."""
+    if bool(repo_path) == bool(repos):
+        return {"error": "provide exactly one of repo_path or repos"}
 
     def run(repo: Any) -> dict[str, Any]:
         from orchestrator.knowledge.current_state import load_current_state
@@ -888,7 +962,39 @@ def docs_for(repo_path: str, symbol: str = "") -> dict[str, Any]:
             "markdown": "\n".join(lines),
         }
 
+    if repos:
+        return _per_repo(repos, run)
     return _in_repo(repo_path, run)
+
+
+def _per_repo(repos: str, fn: Callable[[Any], dict[str, Any]]) -> dict[str, Any]:
+    """Run ``fn(root)`` for every repository a ``repos.yaml`` declares, keyed by repository —
+    for questions that do not merge (docs describe their own repo). Each entry says whether
+    that checkout is reproducible, the way a merged graph's ``standing`` does for all of them."""
+    from orchestrator.pkg.persistence import repo_state
+    from orchestrator.pkg.repos import RepoConfigError, load_repo_config
+
+    try:
+        repo_set = load_repo_config(repos)
+    except RepoConfigError as exc:
+        return {"error": str(exc)}
+    out: dict[str, Any] = {}
+    for key, root in repo_set.roots:
+        sha, dirty = repo_state(root)
+        entry = fn(root)
+        entry["reproducible"] = sha is not None and not dirty
+        out[key] = entry
+    return {
+        "repos": out,
+        "standing": {
+            "repos": [k for k, _ in repo_set.roots],
+            "reproducible": all(v["reproducible"] for v in out.values()),
+            "untrusted": [k for k, v in out.items() if not v["reproducible"]],
+        },
+        "markdown": "\n\n".join(
+            f"## {key}\n\n{v.get('markdown') or v.get('note') or ''}" for key, v in out.items()
+        ),
+    }
 
 
 def _blast_markdown(matches: list[dict[str, Any]]) -> str:

--- a/src/orchestrator/sdlc/coverage.py
+++ b/src/orchestrator/sdlc/coverage.py
@@ -43,6 +43,7 @@ class CoverageItem:
     name: str
     where: str  # "file:line"
     covered: bool  # reachable from a test through the call graph
+    repo: str = ""  # which repository, in a merged multi-repo graph; "" for a single repo
 
 
 @dataclass
@@ -143,16 +144,23 @@ def build_regression_plan(store: FactStore, target_id: str, *, max_impacted: int
         return RegressionPlan(grounded=grounded, call_graph_available=call_graph)
 
     where = str(node.provenance) if node.provenance else ""
-    impact = store.impact_across(target_id, kinds=(EdgeKind.CALLS,), max_depth=4)
+    # CALLS is the blast radius inside a process. EXPOSES + CONSUMES is the one hop that
+    # crosses a service boundary — a handler, its endpoint, the client that calls the
+    # endpoint — which is exactly the reach a merged multi-repo graph exists to show. The
+    # endpoint node itself is the wire, not a symbol a test covers, so it is not an item.
+    impact = store.impact_across(
+        target_id, kinds=(EdgeKind.CALLS, EdgeKind.EXPOSES, EdgeKind.CONSUMES), max_depth=4
+    )
     covering = [f"{n.name} @ {n.provenance}" for n, _ in impact if is_test_node(n)]
 
-    production = [n for n, _ in impact if not is_test_node(n)]
+    production = [n for n, _ in impact if not is_test_node(n) and n.kind is not NodeKind.ENDPOINT]
     clipped = production[:max_impacted]
     items = [
         CoverageItem(
             name=n.name,
             where=str(n.provenance) if n.provenance else "",
             covered=_is_reached_by_test(store, n.id),
+            repo=(n.provenance.repo if n.provenance else "") or _repo_of(n.id),
         )
         for n in clipped
     ]
@@ -165,6 +173,12 @@ def build_regression_plan(store: FactStore, target_id: str, *, max_impacted: int
         grounded=grounded,
         call_graph_available=call_graph,
     )
+
+
+def _repo_of(node_id: str) -> str:
+    from orchestrator.pkg.scoping import unscope_id
+
+    return unscope_id(node_id)[0]
 
 
 def resolve_target(store: FactStore, name: str) -> str | None:

--- a/src/orchestrator/sdlc/localize.py
+++ b/src/orchestrator/sdlc/localize.py
@@ -40,6 +40,14 @@ _PATH_RE = re.compile(r"(?<![\w/])(?P<path>[\w][\w./-]*\.[A-Za-z][A-Za-z0-9+#]{0
 
 @dataclass(frozen=True)
 class Frame:
+    """One trace frame, resolved against the graph when it can be.
+
+    ``repo`` and ``candidates`` matter only in a merged multi-repo graph: a path like
+    ``app/routes.py`` can exist in two services, and a trace does not say which. The best
+    match still wins (``node_id``), but ``candidates`` lists the ids that matched in *other*
+    repositories so the caller can say "ambiguous" instead of pointing at the wrong service.
+    """
+
     """One trace frame, and the PKG symbol it resolved to (if any)."""
 
     file: str  # as written in the trace
@@ -48,6 +56,8 @@ class Frame:
     node_id: str = ""  # resolved grounded node id, or ""
     where: str = ""  # resolved node provenance "file:line"
     module: str = ""  # owning module
+    repo: str = ""  # which repository the resolved node lives in (merged graphs only)
+    candidates: list[str] = field(default_factory=list)  # matching ids in *other* repositories
 
     @property
     def resolved(self) -> bool:
@@ -132,16 +142,24 @@ def _owning_module(store: FactStore, node_id: str, parents: dict[str, str]) -> s
     return (node.provenance.file if node and node.provenance else "") or ""
 
 
-def _resolve_frame(store: FactStore, file: str, line: int) -> Node | None:
-    """The smallest grounded symbol whose file matches ``file`` and span covers ``line``.
+def _repo_of(node: Node) -> str:
+    from orchestrator.pkg.scoping import unscope_id
 
-    Path match is lenient (suffix or basename) because a trace path is usually
-    absolute while provenance is repo-relative.
+    return (node.provenance.repo if node.provenance else "") or unscope_id(node.id)[0]
+
+
+def _resolve_frame_candidates(store: FactStore, file: str, line: int) -> list[Node]:
+    """The smallest grounded symbol whose file matches ``file`` and span covers ``line`` —
+    **one per repository**, best first.
+
+    Path match is lenient (suffix or basename) because a trace path is usually absolute while
+    provenance is repo-relative. In a single-repo graph the list has at most one entry; in a
+    merged graph it has one per repository whose file matched, so the caller can tell an
+    unambiguous frame from one that two services could own.
     """
     norm = file.replace("\\", "/")
     base = _basename(norm)
-    best: Node | None = None
-    best_size = 1 << 62
+    best_by_repo: dict[str, tuple[int, Node]] = {}
     for node in store.nodes:
         prov = node.provenance
         if not node.grounded or prov is None:
@@ -153,9 +171,16 @@ def _resolve_frame(store: FactStore, file: str, line: int) -> Node | None:
         end = prov.end_line if prov.end_line is not None else prov.line
         if prov.line <= line <= end:
             size = end - prov.line
-            if size < best_size:
-                best, best_size = node, size
-    return best
+            repo = _repo_of(node)
+            if repo not in best_by_repo or size < best_by_repo[repo][0]:
+                best_by_repo[repo] = (size, node)
+    return [node for _size, node in sorted(best_by_repo.values(), key=lambda t: (t[0], t[1].id))]
+
+
+def _resolve_frame(store: FactStore, file: str, line: int) -> Node | None:
+    """The single best match — the first of :func:`_resolve_frame_candidates`."""
+    found = _resolve_frame_candidates(store, file, line)
+    return found[0] if found else None
 
 
 def localize_trace(text: str, *, store: FactStore) -> Localization:
@@ -165,13 +190,16 @@ def localize_trace(text: str, *, store: FactStore) -> Localization:
 
     frames: list[Frame] = []
     for file, line, func in raw_frames:
-        node = _resolve_frame(store, file, line)
+        found = _resolve_frame_candidates(store, file, line)
+        node = found[0] if found else None
         if node is not None:
             # repo-relative file (from provenance) + the *trace* line (where it failed),
             # not the symbol's definition line — that's the actionable fault point.
             repo_file = node.provenance.file if node.provenance else file
             frames.append(
                 Frame(
+                    repo=_repo_of(node),
+                    candidates=[c.id for c in found[1:]],
                     file=file,
                     line=line,
                     func=func,

--- a/tests/plugin/test_server.py
+++ b/tests/plugin/test_server.py
@@ -1308,6 +1308,95 @@ def test_blast_radius_reports_dependents_in_another_repo(tmp_path: Path) -> None
     assert "Dependents in other repos" in out["markdown"]
 
 
+def test_explain_symbol_across_repos_names_the_repo_and_the_reach(tmp_path: Path) -> None:
+    out = explain_symbol(symbol="create_order", repos=_repos_config(tmp_path))
+    assert out["found"], out
+    match = out["matches"][0]
+    assert match["repo"] == "billing"
+    assert match["cross_repo_count"] >= 1 and any(c["repo"] == "web" for c in match["cross_repo"])
+    assert out["standing"]["repos"] == ["billing", "web"]
+    # Single-repo answers do not grow multi-repo keys.
+    single = explain_symbol(str(tmp_path / "billing"), "create_order")
+    assert "repo" not in single["matches"][0] and "standing" not in single
+
+
+def test_regression_gaps_across_repos_flags_the_uncovered_symbol_in_the_other_service(tmp_path: Path) -> None:
+    out = regression_gaps(symbol="create_order", repos=_repos_config(tmp_path))
+    assert out["found"], out
+    assert out["target_repo"] == "billing"
+    assert all("repo" in u for u in out["uncovered"])
+    # The headline: a change to billing's handler reaches web's caller, which nothing tests.
+    elsewhere = out["uncovered_elsewhere"]
+    assert elsewhere and all(u["repo"] == "web" for u in elsewhere)
+    assert any(u["name"] == "place_order" for u in elsewhere)
+    single = regression_gaps(str(tmp_path / "billing"), symbol="create_order")
+    assert "uncovered_elsewhere" not in single and all("repo" not in u for u in single["uncovered"])
+
+
+_TRACE_ROUTES = """\
+Traceback (most recent call last):
+  File "/srv/app/routes.py", line 8, in create_order
+    return {"id": 1}
+KeyError: 'id'
+"""
+
+
+def test_localize_across_repos_says_which_repo_a_frame_landed_in(tmp_path: Path) -> None:
+    out = localize(trace=_TRACE_ROUTES, repos=_repos_config(tmp_path))
+    resolved = [f for f in out["frames"] if f["resolved"]]
+    assert resolved and resolved[0]["repo"] == "billing" and resolved[0]["candidates"] == []
+    assert out["ambiguous_frames"] == []
+    assert out["standing"]["repos"] == ["billing", "web"]
+    single = localize(str(tmp_path / "billing"), _TRACE_ROUTES)
+    assert "repo" not in single["frames"][0] and "ambiguous_frames" not in single
+
+
+def test_localize_across_repos_reports_a_frame_two_services_could_own(tmp_path: Path) -> None:
+    """Both repos have app/routes.py with a function covering line 8: the first match must
+    not win silently."""
+    a = _repo_at(tmp_path / "svc-a", "routes.py", _BILLING)
+    b = _repo_at(tmp_path / "svc-b", "routes.py", _BILLING)
+    cfg = tmp_path / "repos.yaml"
+    cfg.write_text(f"repos:\n  svc-a: {a}\n  svc-b: {b}\n", encoding="utf-8")
+    out = localize(trace=_TRACE_ROUTES, repos=str(cfg))
+    frame = next(f for f in out["frames"] if f["resolved"])
+    assert frame["candidates"], frame  # the other repo's match is listed, not dropped
+    assert {frame["repo"], *(c.split("@")[0].split(":")[-1] for c in frame["candidates"])} == {
+        "svc-a",
+        "svc-b",
+    }
+    assert out["ambiguous_frames"] and out["ambiguous_frames"][0]["also"] == frame["candidates"]
+
+
+def test_docs_for_across_repos_answers_each_repo_on_its_own(tmp_path: Path) -> None:
+    cfg = _repos_config(tmp_path)
+    (tmp_path / "billing" / "README.md").write_text(
+        "# Billing\n\n`create_order` handles POST /v1/orders.\n", encoding="utf-8"
+    )
+    out = docs_for(symbol="create_order", repos=cfg)
+    assert set(out["repos"]) == {"billing", "web"}
+    assert out["repos"]["billing"]["found"] and out["repos"]["billing"]["matches"][0]["docs"]
+    assert out["repos"]["web"].get("found") is not True  # no docs there at all
+    # The README is uncommitted, so billing is not reproducible; web still is.
+    assert out["repos"]["billing"]["reproducible"] is False and out["repos"]["web"]["reproducible"] is True
+    assert out["standing"] == {"repos": ["billing", "web"], "reproducible": False, "untrusted": ["billing"]}
+    assert "## billing" in out["markdown"] and "## web" in out["markdown"]
+    coverage = docs_for(repos=cfg)
+    assert coverage["repos"]["billing"]["docs"] >= 1
+
+
+def test_every_multi_repo_tool_refuses_both_or_neither_of_repo_path_and_repos(tmp_path: Path) -> None:
+    cfg = _repos_config(tmp_path)
+    both = str(tmp_path / "billing")
+    assert "exactly one" in explain_symbol(repo_path=both, symbol="x", repos=cfg)["error"]
+    assert "exactly one" in explain_symbol(symbol="x")["error"]
+    assert "exactly one" in regression_gaps(repo_path=both, symbol="x", repos=cfg)["error"]
+    assert "exactly one" in localize(repo_path=both, trace="t\n", repos=cfg)["error"]
+    assert "exactly one" in docs_for(repo_path=both, repos=cfg)["error"]
+    assert "exactly one" in docs_for()["error"]
+    assert "error" in docs_for(repos=str(tmp_path / "missing.yaml"))
+
+
 def test_multi_repo_answers_carry_their_standing(tmp_path: Path) -> None:
     """A graph built over a dirty tree looks identical to one that is reproducible."""
     cfg = _repos_config(tmp_path)


### PR DESCRIPTION
## Summary

MCP phase 2 step 3 of [`docs/specs/mcp-plugin-surface.md`](docs/specs/mcp-plugin-surface.md): proposal 4.10, multi-repo parity.

`explain_symbol`, `regression_gaps`, `localize` and `docs_for` take `repos=` (a `.spine/repos.yaml`) like `blast_radius` and `investigate`, with the same "exactly one of `repo_path` or `repos`" contract and a `standing` block. **Single-repo answers are unchanged**: the multi-repo keys appear only with `repos=` (tested).

| Tool | With `repos=` |
|---|---|
| `explain_symbol` | `repo` on each match, plus `cross_repo` reach |
| `regression_gaps` | `repo` on each impacted symbol; **`uncovered_elsewhere`** — a change reaching a *different* service nothing tests |
| `localize` | `repo` on each frame; a frame two services could own is in **`ambiguous_frames`** with its candidates, instead of the first match winning silently |
| `docs_for` | per-repository fan-out, keyed by repo, each with its own `reproducible` flag — docs are not merged, because a document describes the repo it lives in |

**Two engine changes, both small and both single-repo-safe:**
- `sdlc/coverage.py`: the regression plan walked `CALLS` only, so the cross-service caller (handler → endpoint → consumer, which is `EXPOSES` + `CONSUMES`) never appeared. It now follows that hop; the endpoint node itself is the wire, not an item. `CoverageItem` gains `repo`.
- `sdlc/localize.py`: frame resolution returns one candidate per repository, best first; `Frame` gains `repo` and `candidates`. The single-repo resolver is the first candidate — unchanged.

## Files

- `plugin/server.py`: the four tools, `_repo_of_node`, `_per_repo` fan-out.
- `sdlc/coverage.py`, `sdlc/localize.py` as above.
- Tests: 6 new in `tests/plugin/test_server.py` over the existing two-repository fixture, including a second fixture where both repos own `app/routes.py` for the ambiguity case.
- Docs: the skill's multi-repo rows name all six tools; CLAUDE_GUIDE and CODEX_GUIDE "Asking across several repositories"; the spec (4.10 shipped, phase 2 table); SPEC-INDEX; CHANGELOG; STATE-OF-SPINE count.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`, `matrix-count --check`, `state-numbers --check`: pass
- Full pytest: 3405 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
