### PR TITLE
feat(plugin): per-principal audit on HTTP, and every tool advertises what it returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Added
 
+- **Every MCP tool advertises what it returns.** A type per tool
+  (`plugin/outputs.py`) with no required key, attached to the registered function
+  so the SDK derives an output schema and validates the result while the tool
+  keeps returning a plain dict. A host reads `found`, `matches[].where`,
+  `uncovered_elsewhere` before it calls. The types allow extras — pydantic would
+  otherwise drop an undeclared key from the structured result silently — and the
+  test suite's drift guard wraps every tool and fails on any returned key its type
+  does not declare. A tool without a type does not register.
+- **Per-principal audit on the MCP server's HTTP transport.** Every run-scope call
+  and every scope denial is recorded against the token's principal in the
+  registry's audit log through a new `POST /v1/audit` (the actor and tenant come
+  from the authenticated principal, never from the body): the principal, tool,
+  scope, the argument *names* and a digest of the values — never the values — and
+  the outcome. An unreachable registry degrades to a log line; the audit never
+  fails the call. Stdio records nothing: a local subprocess acts for one user.
+
 - **Every comprehension tool that can answer across repositories now does.**
   `explain_symbol`, `regression_gaps`, `localize` and `docs_for` take `repos=` (a
   `.spine/repos.yaml`) like `blast_radius` and `investigate`, with the same

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -276,6 +276,27 @@ run after a refine does not move it backwards — and a line the stage table doe
 on the current step as its message. Nothing changes in the tools' schemas, and a client that sends
 no token sees exactly what it saw before.
 
+### What each tool returns, as a schema
+
+Every tool advertises an **output schema** — a type per tool, with no required key, because
+every tool has an error path (`error` + `hint`) and most have several shapes (found / not
+found; single‑repo / multi‑repo). A host reads the fields — `found`, `matches[].where`,
+`uncovered_elsewhere` — before it calls, and the structured result validates against them. A key
+the type happens to miss still reaches the host (the types allow extras); the test suite's drift
+guard is what keeps the declarations honest. Open shapes — the twelve‑section build document, a
+run's Temporal status, the engine's design dict — stay untyped objects on purpose.
+
+### Who did what, over HTTP
+
+Over stdio a local subprocess acts for one user; nothing to attribute. Over HTTP several people
+may share one server, so every **run‑scope** call (`sdlc_feature`, `sdlc_start_run`,
+`sdlc_decide_gate`, `registry_decide`, `sdlc_address_review`, `sdlc_complete`, `sdlc_remediate`,
+`audit_repo`) and every **scope denial** is recorded against the token's principal in the
+registry's audit log (`POST /v1/audit`, with the plugin's own `ORCHESTRATOR_API_KEY` as the
+writer): the principal, the tool, its scope, the argument *names* and a digest of the values —
+never the values — and the outcome. `registry_trace` and `GET /v1/audit?resource_type=mcp_tool`
+read it back. A registry that is down degrades to a log line; the audit never fails the call.
+
 > **The tiers are metadata your host can act on.** Every tool is registered with MCP tool
 > annotations derived from its tier — *read‑only*, *destructive*, *idempotent*, *open‑world* — so a
 > host that asks before destructive calls asks before `sdlc_feature`, `sdlc_start_run` and

--- a/CODEX_GUIDE.md
+++ b/CODEX_GUIDE.md
@@ -241,6 +241,27 @@ run after a refine does not move it backwards — and a line the stage table doe
 on the current step as its message. Nothing changes in the tools' schemas, and a client that sends
 no token sees exactly what it saw before.
 
+### What each tool returns, as a schema
+
+Every tool advertises an **output schema** — a type per tool, with no required key, because
+every tool has an error path (`error` + `hint`) and most have several shapes (found / not
+found; single‑repo / multi‑repo). A host reads the fields — `found`, `matches[].where`,
+`uncovered_elsewhere` — before it calls, and the structured result validates against them. A key
+the type happens to miss still reaches the host (the types allow extras); the test suite's drift
+guard is what keeps the declarations honest. Open shapes — the twelve‑section build document, a
+run's Temporal status, the engine's design dict — stay untyped objects on purpose.
+
+### Who did what, over HTTP
+
+Over stdio a local subprocess acts for one user; nothing to attribute. Over HTTP several people
+may share one server, so every **run‑scope** call (`sdlc_feature`, `sdlc_start_run`,
+`sdlc_decide_gate`, `registry_decide`, `sdlc_address_review`, `sdlc_complete`, `sdlc_remediate`,
+`audit_repo`) and every **scope denial** is recorded against the token's principal in the
+registry's audit log (`POST /v1/audit`, with the plugin's own `ORCHESTRATOR_API_KEY` as the
+writer): the principal, the tool, its scope, the argument *names* and a digest of the values —
+never the values — and the outcome. `registry_trace` and `GET /v1/audit?resource_type=mcp_tool`
+read it back. A registry that is down degrades to a log line; the audit never fails the call.
+
 ### Asking across several repositories
 
 The comprehension tools take **one** repository by default, and for a service that is called

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1231,6 +1231,8 @@ a run), `spine:plan` (`sdlc_plan`, `sdlc_approve`), `spine:run` (anything that s
 writes where it cannot be taken back). An IdP-issued token needs the scope of the tier it calls;
 a shared-secret token carries all three unless `ORCHESTRATOR_MCP_REQUIRED_SCOPES` narrows it —
 `spine:read` makes it read-only. The legacy `sdlc` scope reads as all three for one release.
+Every run-scope call and every scope denial over HTTP is recorded against the token's principal
+in the registry's audit log (`POST /v1/audit`; read it back with `resource_type=mcp_tool`).
 
 Destructive tools stay gated regardless of auth: `sdlc_feature(live=true)` and
 `sdlc_start_run(create_jira=true)` both need an explicit `confirm=true`.

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -93,7 +93,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [gap6-benchmarks-roadmap](gap6-benchmarks-roadmap.md) | ✅ **Complete 2026-09-01** | All three phases: harness, 38-label gold set, ratchet gate. top-1 0.32 / top-10 0.71 against 0.085 chance; published as [BENCHMARK.md](../../BENCHMARK.md). This row read *Not started* for a day after the spec said COMPLETE |
 | [codegen-benchmark-roadmap](codegen-benchmark-roadmap.md) | Not started | **New 2026-08-15.** SWE-bench comparability → `resolved`-vs-`mergeable` delta |
 | [codex-plugin-keyless-roadmap](codex-plugin-keyless-roadmap.md) | Not started | **New 2026-08-15.** Phase 0 is a blocking spike |
-| [mcp-plugin-surface](mcp-plugin-surface.md) | ✅ **Phase 1 complete 2026-09-04** (3.31.0); Phase 2 steps 1–3 shipped | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
+| [mcp-plugin-surface](mcp-plugin-surface.md) | ✅ **Phase 1 complete 2026-09-04** (3.31.0); ✅ **Phase 2 complete 2026-09-04** | **New 2026-09-04.** The MCP server's 20 tools, the tier model as machine-readable annotations, six gaps, and the extension order — gaps first |
 | [phase5-agentic-codegen-loop](phase5-agentic-codegen-loop.md) | Proposed, under review | "The hinge phase" |
 | [autonomous-run-agent](autonomous-run-agent.md) | Proposed, no branch | 9 phases; 0–3 strictly serial |
 | [catalog-then-compose-roadmap](catalog-then-compose-roadmap.md) | Proposed, under review | Scope confirmed: Phases 0–3 |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -27,8 +27,8 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Version | **3.31.0** | cutting now; 3.30.0 is the last on PyPI until this ships |
 | Languages extracted | **8** front-ends | Python, Java, TypeScript, C#, C, C++, Go, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
-| Source modules | **347** | `find src/orchestrator -name '*.py'` |
-| Test functions | **2,980** across 306 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Source modules | **349** | `find src/orchestrator -name '*.py'` |
+| Test functions | **2,996** across 309 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/mcp-plugin-surface.md
+++ b/docs/specs/mcp-plugin-surface.md
@@ -1,6 +1,6 @@
 # The MCP plugin surface — what it is, what it lacks, and the order to extend it
 
-**Status:** **Phase 1 COMPLETE** — all six steps shipped, all six gaps closed. Phase 2 in progress — steps 1 (prompts + resources), 2 (progress) and 3 (multi-repo parity) shipped. **Written 2026-09-04 against 3.30.0**,
+**Status:** **Phase 1 COMPLETE** — all six steps shipped, all six gaps closed. **Phase 2 COMPLETE** — prompts + resources, progress, multi-repo parity, per-principal audit, typed output all shipped. Only the `sdlc` scope alias retirement remains, for the next cut. **Written 2026-09-04 against 3.30.0**,
 after #316 removed the terminal UI and left the plugin as the only non-browser operator face.
 **Owner:** _unassigned_
 
@@ -121,9 +121,15 @@ Numbered, because §5 retires them by number.
 
 Each is scoped to one PR. The number is a name, not an order — §5 is the order.
 
-- **4.1 Annotations and typed output.** Annotations: Phase 1. Typed output schemas (a model per
-  tool instead of `dict[str, Any]`) are deferred to their own PR: the SDK already advertises an
-  open-object schema, and real models touch twenty return shapes and their tests.
+- **4.1 Annotations and typed output.** Annotations: Phase 1. Typed output: *(shipped in Phase 2
+  step 5)* — a `TypedDict` per tool in `plugin/outputs.py` with no required key (every tool has
+  an error path; most have several shapes), attached to the registered function's signature so
+  the SDK derives an output schema and validates the result while the tool keeps its plain
+  `dict`. Pydantic drops a key a `TypedDict` does not declare from the structured result
+  *silently*, so the types allow extras and the test suite's drift guard
+  (`tests/plugin/conftest.py`) wraps every tool and fails on any returned key its type does not
+  declare. Open shapes (the build document, Temporal status, the design dict) stay
+  `dict[str, Any]` on purpose. A tool without a type does not register.
 - **4.2 Operator-ops tools.** *(Shipped.)* `registry_runs`, `registry_approvals`,
   `registry_trace`, `registry_decide` over the registry `/v1` API with `X-API-Key`, through
   `plugin/registry_client.py` (the removed TUI client, reinstated and extended). Config via
@@ -172,8 +178,13 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
   fans out per repository instead of merging — a document describes the repository it lives
   in, and binding one repo's docs to another's symbols by name would be a false edge — each
   entry carrying its own `reproducible` flag.
-- **4.11 Per-principal audit on HTTP.** Tier-3 invocations recorded against the token principal,
-  in the registry's existing audit log.
+- **4.11 Per-principal audit on HTTP.** *(Shipped in Phase 2 step 4.)* Every `spine:run` call
+  and every scope denial is recorded against the token's principal in the registry's audit log
+  through a new `POST /v1/audit` — the actor and tenant come from the authenticated principal,
+  never from the body — with the principal, tool, scope, the argument *names* and a digest of the
+  values (never the values), and the outcome. The scope guard records it; the plugin keeps no
+  database credentials, so the registry is the one writer; an unreachable registry degrades to a
+  structured log line and never fails the call. Read-scope calls are not recorded.
 
 ## 5. Order — gaps first
 
@@ -196,8 +207,8 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
 | 1 | 4.7 prompts + 4.6 resources — protocol parity for non-Claude hosts | **shipped** |
 | 2 | 4.8 progress notifications from the long tools | **shipped** |
 | 3 | 4.10 multi-repo parity for `explain_symbol`, `regression_gaps`, `localize`, `docs_for` | **shipped** |
-| 4 | 4.11 per-principal audit on HTTP | next |
-| 5 | typed output (the deferred half of 4.1) | last — every return shape |
+| 4 | 4.11 per-principal audit on HTTP | **shipped** |
+| 5 | typed output (the deferred half of 4.1) | **shipped** |
 | — | retire the `sdlc` scope alias | the release after 3.31.0 |
 
 ## Invariants

--- a/src/orchestrator/plugin/audit.py
+++ b/src/orchestrator/plugin/audit.py
@@ -1,0 +1,83 @@
+"""Per-principal audit of the HTTP transport: who called what, recorded where the registry
+already keeps history.
+
+Over stdio a local subprocess acts for one user with that user's ``.env``; nothing to
+attribute. Over HTTP several people may share one server, and the run-scope tools spend
+money and write where it cannot be taken back — so every ``spine:run`` call, and every
+scope denial, is recorded **against the token's principal**, in the registry's audit log,
+through ``POST /v1/audit``. The plugin process keeps no database credentials (#321), so the
+registry is the one writer, and the actor is whatever principal the registry resolves for
+the API key the plugin holds — with the *token's* principal in the row's payload.
+
+What is recorded: the principal (client id, subject when the IdP issued one), the tool, its
+scope, the argument **names** and a digest of the argument values — never the values, which
+may carry a spec, a trace, or a secret — and the outcome (``ok``, ``error``, or the denied
+scope). A registry that is unreachable or unconfigured degrades to a structured log line
+with the same fields; the audit must never be the thing that fails a call.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger("orchestrator.plugin.audit")
+
+#: Scopes whose calls are recorded. Read-scope calls are cheap and numerous; the run tier is
+#: where money is spent and external state changes.
+AUDITED_SCOPES: frozenset[str] = frozenset({"spine:run"})
+
+
+def arguments_digest(arguments: dict[str, Any]) -> dict[str, Any]:
+    """``{"keys": [...], "sha256": "..."}`` — the shape of a call, not its contents."""
+    canonical = json.dumps(arguments, sort_keys=True, default=str, separators=(",", ":"))
+    return {"keys": sorted(arguments), "sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest()}
+
+
+def principal_of(token: Any) -> dict[str, Any]:
+    """The identity a verified bearer token carries, as the row's payload shows it."""
+    return {
+        "client_id": getattr(token, "client_id", None),
+        "subject": getattr(token, "subject", None),
+        "scopes": sorted(getattr(token, "scopes", None) or []),
+    }
+
+
+async def record_invocation(
+    *,
+    token: Any,
+    tool: str,
+    scope: str,
+    arguments: dict[str, Any],
+    outcome: str,
+    denied_scope: str | None = None,
+) -> bool:
+    """Record one call (or denial) against the token's principal. Returns whether the registry
+    took it; ``False`` means it went to the log instead. Never raises."""
+    payload: dict[str, Any] = {
+        "principal": principal_of(token),
+        "tool": tool,
+        "scope": scope,
+        "arguments": arguments_digest(arguments),
+        "outcome": outcome,
+    }
+    if denied_scope:
+        payload["denied_scope"] = denied_scope
+    action = "mcp_scope_denied" if denied_scope else "mcp_tool_invoked"
+    try:
+        from orchestrator.plugin.registry_client import registry_client
+
+        client = registry_client()
+        try:
+            await client.audit(action=action, resource_type="mcp_tool", resource_id=tool, after=payload)
+            return True
+        finally:
+            await client.aclose()
+    except Exception as exc:  # unreachable, unconfigured, refused — the log keeps the row
+        logger.warning("plugin.audit.%s", action, extra={**payload, "registry_error": str(exc)[:200]})
+        return False
+
+
+__all__ = ["AUDITED_SCOPES", "arguments_digest", "principal_of", "record_invocation"]

--- a/src/orchestrator/plugin/outputs.py
+++ b/src/orchestrator/plugin/outputs.py
@@ -1,0 +1,715 @@
+"""What each tool returns, as a type a host can read before it calls.
+
+Every tool returns a plain ``dict``; that does not change here. What changes is that the
+server advertises an **output schema** per tool, derived from these ``TypedDict``s, so a host
+knows the fields — ``found``, ``matches[].where``, ``uncovered_elsewhere`` — without parsing
+markdown or guessing. The SDK builds the schema from the type and validates a result
+against it.
+
+**Two properties the types are built around.**
+
+- *No key is required.* Every tool has an error path (``{"error": …, "hint": …}``) and most
+  have several shapes (found / not found; single-repo / multi-repo). ``total=False`` lets one
+  type describe them all, and the shared :class:`Failure` keys sit on every type.
+- *An undeclared key would be dropped silently.* Pydantic validates a ``TypedDict`` by
+  keeping the declared keys and discarding the rest — the text copy of the result keeps
+  them, the structured copy does not. So the types carry ``extra="allow"`` (nothing is
+  lost at runtime even if a key is missing here), and ``tests/plugin/conftest.py`` wraps
+  every tool during the test run and fails on any returned key the type does not declare —
+  the drift guard. Adding a key to a tool means adding it here, on one screen.
+
+Open shapes — the twelve-section build document, a run's Temporal status, the engine's
+design dict — stay ``dict[str, Any]``: typing them would mean re-declaring another
+module's contract here and letting the two drift.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from pydantic import ConfigDict, with_config
+
+#: Every type carries this so an undeclared-but-present key survives into the structured
+#: result; the drift guard, not the runtime, is what keeps the declarations honest.
+_OPEN = ConfigDict(extra="allow")
+
+
+@with_config(_OPEN)
+class Failure(TypedDict, total=False):
+    """The keys any tool may return instead of a result."""
+
+    error: str
+    hint: str
+    registry: str  # registry_* tools: which base URL did not answer
+    code: int  # sdlc_complete / sdlc_remediate: the engine's exit code
+    step: str  # sdlc_address_review: which checkout step failed
+    needs: str  # scope guard: the scope the token lacked
+    has: list[str]  # scope guard: the scopes the token has
+    valid_fields: list[str]  # sdlc_plan / design_change: the spec's valid fields
+
+
+@with_config(_OPEN)
+class Standing(TypedDict, total=False):
+    repos: list[str]
+    reproducible: bool
+    untrusted: list[str]
+
+
+@with_config(_OPEN)
+class ReposNote(TypedDict, total=False):
+    config: str
+    declares: list[str]
+    note: str
+
+
+# ---- doctor ---------------------------------------------------------------------------
+
+
+@with_config(_OPEN)
+class Check(TypedDict, total=False):
+    name: str
+    passed: bool
+    detail: str
+
+
+@with_config(_OPEN)
+class ServerIdentity(TypedDict, total=False):
+    package: str
+    version: str | None
+    python: str
+    interpreter: str
+    mcp_sdk: str | None
+    extras: dict[str, bool]
+
+
+@with_config(_OPEN)
+class DoctorOut(Failure, total=False):
+    all_passed: bool
+    server: ServerIdentity
+    checks: list[Check]
+
+
+# ---- intake -----------------------------------------------------------------------------
+
+
+@with_config(_OPEN)
+class IntentSummary(TypedDict, total=False):
+    id: str
+    title: str
+
+
+@with_config(_OPEN)
+class IngestPreviewOut(Failure, total=False):
+    documents: int
+    intent_count: int
+    intents: list[IntentSummary]
+    gap_count: int
+    blocked: bool
+
+
+# ---- codegen --------------------------------------------------------------------------
+
+
+@with_config(_OPEN)
+class SdlcFeatureOut(Failure, total=False):
+    passed: bool
+    intent_id: str
+    issue_key: str
+    branch: str
+    files: list[str]
+    iterations: int
+    grounding_chars: int
+    live: bool
+    pr_url: str | None
+
+
+@with_config(_OPEN)
+class PkgGroundingOut(Failure, total=False):
+    chars: int
+    context: str
+    summary: dict[str, Any]
+    title: str
+
+
+@with_config(_OPEN)
+class ReadMemoryBankOut(Failure, total=False):
+    exists: bool
+    dir: str
+    sections: list[str]
+    index: str
+    section: str
+    content: str | None
+
+
+# ---- comprehension --------------------------------------------------------------------
+
+
+@with_config(_OPEN)
+class Hotspot(TypedDict, total=False):
+    function: str
+    call_sites: int
+
+
+@with_config(_OPEN)
+class UntestedArea(TypedDict, total=False):
+    area: str
+    types: int
+
+
+@with_config(_OPEN)
+class Coverage(TypedDict, total=False):
+    tested_areas: int
+    total_areas: int
+    largest_untested: list[UntestedArea]
+
+
+@with_config(_OPEN)
+class Recommendation(TypedDict, total=False):
+    priority: str
+    action: str
+
+
+@with_config(_OPEN)
+class MapRepoOut(Failure, total=False):
+    languages: list[str]
+    counts: dict[str, int]
+    areas: int
+    files: int
+    has_call_graph: bool
+    call_hotspots: list[Hotspot]
+    coverage: Coverage
+    recommendations: list[Recommendation]
+    markdown: str
+    multi_repo_available: ReposNote
+
+
+@with_config(_OPEN)
+class CallSite(TypedDict, total=False):
+    id: str
+    at: str
+
+
+@with_config(_OPEN)
+class Touched(TypedDict, total=False):
+    id: str
+    where: str | None
+
+
+@with_config(_OPEN)
+class CrossRepoReach(TypedDict, total=False):
+    id: str
+    repo: str
+    hops: int
+    where: str | None
+
+
+@with_config(_OPEN)
+class BlastMatch(TypedDict, total=False):
+    id: str
+    kind: str
+    where: str | None
+    caller_count: int
+    callers: list[CallSite]
+    touch_count: int
+    touches: list[Touched]
+    cross_repo_count: int
+    cross_repo: list[CrossRepoReach]
+
+
+@with_config(_OPEN)
+class BlastRadiusOut(Failure, total=False):
+    symbol: str
+    found: bool
+    matches: list[BlastMatch]
+    markdown: str
+    standing: Standing
+    multi_repo_available: ReposNote
+
+
+@with_config(_OPEN)
+class SymbolMatch(TypedDict, total=False):
+    id: str
+    kind: str
+    name: str
+    language: str
+    where: str | None
+    called_by: list[str]
+    calls: list[str]
+    contains: list[str]
+    repo: str
+    cross_repo_count: int
+    cross_repo: list[CrossRepoReach]
+
+
+@with_config(_OPEN)
+class ExplainSymbolOut(Failure, total=False):
+    symbol: str
+    found: bool
+    matches: list[SymbolMatch]
+    standing: Standing
+    multi_repo_available: ReposNote
+
+
+@with_config(_OPEN)
+class Landing(TypedDict, total=False):
+    name: str
+    kind: str
+    where: str | None
+    module: str
+    callers: int
+    repo: str
+    cross_repo: list[CrossRepoReach]
+
+
+@with_config(_OPEN)
+class InvestigateOut(Failure, total=False):
+    title: str
+    landing: list[Landing]
+    areas: list[str]
+    has_knowledge: bool
+    knowledge: dict[str, Any]
+    markdown: str
+    standing: Standing
+    multi_repo_available: ReposNote
+
+
+@with_config(_OPEN)
+class PkgJoinsOut(Failure, total=False):
+    mode: str
+    config: str
+    candidates: list[dict[str, Any]]
+    declared: list[dict[str, Any]]
+    already_declared: list[dict[str, Any]]
+    joined: int
+    unjoined: list[dict[str, Any]]
+    per_join: list[dict[str, Any]]
+    examined: int
+    recall: float | None
+    note: str
+    markdown: str
+    standing: Standing
+
+
+@with_config(_OPEN)
+class Fault(TypedDict, total=False):
+    func: str
+    where: str
+    id: str
+
+
+@with_config(_OPEN)
+class TraceFrame(TypedDict, total=False):
+    func: str
+    trace_at: str
+    resolved: bool
+    id: str
+    where: str
+    repo: str
+    candidates: list[str]
+
+
+@with_config(_OPEN)
+class AmbiguousFrame(TypedDict, total=False):
+    trace_at: str
+    resolved: str
+    also: list[str]
+
+
+@with_config(_OPEN)
+class LocalizeOut(Failure, total=False):
+    exception: str
+    grounded: bool
+    fault: Fault | None
+    frames: list[TraceFrame]
+    callers: list[str]
+    ambiguous_frames: list[AmbiguousFrame]
+    markdown: str
+    standing: Standing
+    multi_repo_available: ReposNote
+
+
+@with_config(_OPEN)
+class Uncovered(TypedDict, total=False):
+    name: str
+    where: str
+    repo: str
+
+
+@with_config(_OPEN)
+class RegressionGapsOut(Failure, total=False):
+    target: str
+    found: bool
+    target_covered: bool
+    call_graph_available: bool
+    impacted_count: int
+    uncovered: list[Uncovered]
+    covering_tests: list[str]
+    truncated: bool
+    target_repo: str
+    uncovered_elsewhere: list[Uncovered]
+    markdown: str
+    standing: Standing
+    multi_repo_available: ReposNote
+
+
+@with_config(_OPEN)
+class HypothesisOut(TypedDict, total=False):
+    claim: str
+    evidence: list[str]
+    confidence: str
+
+
+@with_config(_OPEN)
+class RootCauseOut(Failure, total=False):
+    problem: str
+    exception: str
+    fault_site: str
+    hypotheses: list[HypothesisOut]
+    regression_surface: list[str]
+    fix_approach: str
+    used_llm: bool
+    markdown: str
+    multi_repo_available: ReposNote
+
+
+@with_config(_OPEN)
+class DocMatch(TypedDict, total=False):
+    id: str
+    kind: str
+    where: str | None
+    docs: list[str]
+
+
+@with_config(_OPEN)
+class Drift(TypedDict, total=False):
+    claim: str
+    doc: str
+
+
+@with_config(_OPEN)
+class DocsForOut(Failure, total=False):
+    repo: str
+    symbol: str | None
+    found: bool
+    matches: list[DocMatch]
+    docs: int
+    note: str
+    documented_symbols: int
+    coverable_symbols: int
+    coverage_pct: int
+    drift_total: int
+    drift_top: list[Drift]
+    reproducible: bool
+    repos: dict[str, Any]  # the per-repository fan-out: each value is a DocsForOut
+    standing: Standing
+    markdown: str
+    multi_repo_available: ReposNote
+
+
+# ---- plan and decide ------------------------------------------------------------------
+
+
+@with_config(_OPEN)
+class SdlcPlanOut(Failure, total=False):
+    intent_id: str
+    document: dict[str, Any]
+    path: str
+    superseded: str
+
+
+@with_config(_OPEN)
+class SdlcApproveOut(Failure, total=False):
+    intent_id: str
+    decision: str
+    decided_by: str
+    decided_at: str
+    path: str
+
+
+# ---- the run ----------------------------------------------------------------------------
+
+
+@with_config(_OPEN)
+class SdlcStartRunOut(Failure, total=False):
+    sdlc_id: str
+    workflow_id: str
+    task_queue: str
+    gates: dict[str, str]
+    status: str
+
+
+@with_config(_OPEN)
+class SdlcRunStatusOut(Failure, total=False):
+    sdlc_id: str
+    status: str
+    awaiting_gate: str | None
+    gate_title: str | None
+    gate_description: str | None
+
+
+@with_config(_OPEN)
+class SdlcDecideGateOut(Failure, total=False):
+    sdlc_id: str
+    gate: str
+    approval_id: str
+    action: str
+    state: str
+    status: str
+
+
+@with_config(_OPEN)
+class SdlcRunResultOut(Failure, total=False):
+    sdlc_id: str
+    status: str
+    result: dict[str, Any] | None
+
+
+# ---- the back half ----------------------------------------------------------------------
+
+
+@with_config(_OPEN)
+class BankCheck(TypedDict, total=False):
+    ok: bool
+    absent: bool
+    bank_dir: str
+    missing: list[str]
+    stale: list[str]
+    orphaned: list[str]
+    commit: str | None
+    dirty: bool
+    summary: str
+
+
+@with_config(_OPEN)
+class UnderstandRepoOut(BankCheck, Failure, total=False):
+    dir: str
+    greenfield: bool
+    entry_pages: list[str]
+    files_written: int
+    profile: dict[str, Any]
+    markdown: str
+
+
+@with_config(_OPEN)
+class ProfileRepoOut(Failure, total=False):
+    languages: list[str]
+    framework: str | None
+    has_db: bool
+    has_migrations: bool
+    test_runner: str | None
+    task_type: str
+    markdown: str
+
+
+@with_config(_OPEN)
+class DesignChangeOut(Failure, total=False):
+    title: str
+    design: dict[str, Any]
+    unverified_references: list[str]
+    used_llm: bool
+    markdown: str
+
+
+@with_config(_OPEN)
+class GateScoreOut(TypedDict, total=False):
+    accuracy: float
+    cases: int
+    false_refusals: int
+    missed_refusals: int
+
+
+@with_config(_OPEN)
+class RunMetricsOut(TypedDict, total=False):
+    runs: int
+    completed: int
+    parked: int
+    failed: int
+    completion_rate: float
+    intervention_rate: float
+    mean_cost_usd: float
+
+
+@with_config(_OPEN)
+class SdlcBaselineOut(Failure, total=False):
+    gate: GateScoreOut
+    runs: RunMetricsOut
+    markdown: str
+
+
+@with_config(_OPEN)
+class SdlcAddressReviewOut(Failure, total=False):
+    pr: str
+    branch: str
+    comments: int
+    addressed: bool
+    green: bool
+    refines: int
+    detail: str
+
+
+@with_config(_OPEN)
+class SdlcCompleteOut(Failure, total=False):
+    issue: str
+    pr: str
+    merged: bool
+    status: str
+    backlog_done: bool
+
+
+@with_config(_OPEN)
+class RemediationOutcome(TypedDict, total=False):
+    entity: str
+    title: str
+    ok: bool
+    detail: str
+    result: str | None
+
+
+@with_config(_OPEN)
+class SdlcRemediateOut(Failure, total=False):
+    live: bool
+    tasks: int
+    ok: int
+    outcomes: list[RemediationOutcome]
+    markdown: str
+
+
+@with_config(_OPEN)
+class Finding(TypedDict, total=False):
+    title: str
+    file: str
+    line: int
+    severity: str
+    detail: str
+
+
+@with_config(_OPEN)
+class AuditRepoOut(Failure, total=False):
+    summary: str
+    findings: list[Finding]
+    unresolved: list[Finding]
+    steps: int
+    stopped_reason: str
+    markdown: str
+
+
+# ---- operate ------------------------------------------------------------------------------
+
+
+@with_config(_OPEN)
+class RegistryRunsOut(Failure, total=False):
+    count: int
+    items: list[dict[str, Any]]  # the registry's RunSummary rows
+    markdown: str
+
+
+@with_config(_OPEN)
+class RegistryApprovalsOut(Failure, total=False):
+    count: int
+    items: list[dict[str, Any]]  # the registry's ApprovalRequest rows
+    markdown: str
+
+
+@with_config(_OPEN)
+class RegistryDecideOut(Failure, total=False):
+    approval_id: str
+    action: str
+    approval: dict[str, Any]
+
+
+@with_config(_OPEN)
+class Truncation(TypedDict, total=False):
+    audit: int
+    tool_invocations: int
+
+
+@with_config(_OPEN)
+class RegistryTraceOut(Failure, total=False):
+    sdlc_id: str
+    task_id: str
+    verifier_outcome: str | None
+    workflow_pattern: str | None
+    replan_count: int
+    replan_budget: int
+    audit: list[dict[str, Any]]
+    tool_invocations: list[dict[str, Any]]
+    truncated: Truncation
+    markdown: str
+
+
+#: The type each registered tool returns, by name. Total by construction: registration
+#: refuses a tool it does not list, the way ``_TIER`` does for tiers.
+OUTPUTS: dict[str, type] = {
+    "doctor": DoctorOut,
+    "ingest_preview": IngestPreviewOut,
+    "sdlc_feature": SdlcFeatureOut,
+    "pkg_grounding": PkgGroundingOut,
+    "read_memory_bank": ReadMemoryBankOut,
+    "map_repo": MapRepoOut,
+    "blast_radius": BlastRadiusOut,
+    "explain_symbol": ExplainSymbolOut,
+    "investigate": InvestigateOut,
+    "pkg_joins": PkgJoinsOut,
+    "localize": LocalizeOut,
+    "regression_gaps": RegressionGapsOut,
+    "root_cause": RootCauseOut,
+    "sdlc_plan": SdlcPlanOut,
+    "sdlc_approve": SdlcApproveOut,
+    "docs_for": DocsForOut,
+    "sdlc_start_run": SdlcStartRunOut,
+    "sdlc_run_status": SdlcRunStatusOut,
+    "sdlc_decide_gate": SdlcDecideGateOut,
+    "sdlc_run_result": SdlcRunResultOut,
+    "understand_repo": UnderstandRepoOut,
+    "profile_repo": ProfileRepoOut,
+    "design_change": DesignChangeOut,
+    "sdlc_baseline": SdlcBaselineOut,
+    "sdlc_address_review": SdlcAddressReviewOut,
+    "sdlc_complete": SdlcCompleteOut,
+    "sdlc_remediate": SdlcRemediateOut,
+    "audit_repo": AuditRepoOut,
+    "registry_runs": RegistryRunsOut,
+    "registry_approvals": RegistryApprovalsOut,
+    "registry_decide": RegistryDecideOut,
+    "registry_trace": RegistryTraceOut,
+}
+
+
+def undeclared_keys(value: Any, declared: type, path: str = "") -> list[str]:
+    """Every key in ``value`` (a tool result) that ``declared`` (its TypedDict) does not
+    name, recursing into declared nested TypedDicts and lists of them. The drift guard."""
+    import typing
+
+    if not isinstance(value, dict):
+        return []
+    try:
+        hints = typing.get_type_hints(declared)
+    except Exception:  # pragma: no cover - a hint we cannot resolve is not a drift
+        return []
+    out: list[str] = []
+    for key, item in value.items():
+        here = f"{path}.{key}" if path else key
+        if key not in hints:
+            out.append(here)
+            continue
+        out.extend(_undeclared_in(item, hints[key], here))
+    return out
+
+
+def _undeclared_in(item: Any, hint: Any, path: str) -> list[str]:
+    import typing
+
+    origin = typing.get_origin(hint)
+    if origin is None and isinstance(hint, type) and hasattr(hint, "__required_keys__"):
+        return undeclared_keys(item, hint, path)
+    if origin in (list, tuple) and isinstance(item, list):
+        (inner,) = typing.get_args(hint)[:1] or (Any,)
+        return [k for i, el in enumerate(item) for k in _undeclared_in(el, inner, f"{path}[{i}]")]
+    if origin is typing.Union or str(origin) == "types.UnionType":
+        for arg in typing.get_args(hint):
+            if isinstance(arg, type) and hasattr(arg, "__required_keys__"):
+                return undeclared_keys(item, arg, path)
+    return []
+
+
+__all__ = ["OUTPUTS", "Failure", "Standing", "undeclared_keys"]

--- a/src/orchestrator/plugin/registry_client.py
+++ b/src/orchestrator/plugin/registry_client.py
@@ -82,6 +82,22 @@ class RegistryClient:
     async def trace(self, task_id: str) -> dict[str, Any]:
         return await self._json("GET", f"/v1/tasks/{task_id}/trace")
 
+    async def audit(
+        self,
+        *,
+        action: str,
+        resource_type: str,
+        resource_id: str,
+        after: dict[str, Any] | None = None,
+        timeout: float = 5.0,
+    ) -> dict[str, Any]:
+        """Record one row as this key's principal (``POST /v1/audit``). Short timeout: an audit
+        write must not add a registry's worth of latency to the tool it describes."""
+        body: dict[str, Any] = {"action": action, "resource_type": resource_type, "resource_id": resource_id}
+        if after is not None:
+            body["after"] = after
+        return await self._json("POST", "/v1/audit", json=body, timeout=timeout)
+
     async def _items(self, path: str, *, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
         data = await self._json("GET", path, params=params)
         return list(data.get("items", []))

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -1815,17 +1815,23 @@ def tool_scope(name: str) -> str:
     return _TIER[name].scope
 
 
-def scope_denial(name: str, scope: str) -> dict[str, Any] | None:
-    """``None`` when the current caller may call ``name``; otherwise the error to return.
-
-    The caller is the verified bearer token the SDK put in its auth context for this
-    request. No token — stdio, or an unauthenticated loopback bind — means no check.
-    """
+def current_token() -> Any:
+    """The verified bearer token the SDK put in its auth context for this request, or
+    ``None`` — stdio, an unauthenticated loopback bind, or no ``mcp`` extra at all."""
     try:
         from mcp.server.auth.middleware.auth_context import get_access_token
     except ImportError:  # pragma: no cover - without the `mcp` extra nothing is served
         return None
-    token = get_access_token()
+    return get_access_token()
+
+
+def scope_denial(name: str, scope: str, token: Any = None) -> dict[str, Any] | None:
+    """``None`` when the current caller may call ``name``; otherwise the error to return.
+
+    The caller is the verified bearer token for this request (looked up when not given).
+    No token — stdio, or an unauthenticated loopback bind — means no check.
+    """
+    token = token if token is not None else current_token()
     if token is None or scope in token.scopes:
         return None
     return {
@@ -1843,11 +1849,29 @@ def _scoped(fn: Callable[..., Any], scope: str) -> Callable[..., Any]:
 
     @functools.wraps(fn)
     async def guarded(*args: Any, **kwargs: Any) -> Any:
-        denied = scope_denial(fn.__name__, scope)
+        from orchestrator.plugin.audit import AUDITED_SCOPES, record_invocation
+
+        token = current_token()
+        denied = scope_denial(fn.__name__, scope, token)
         if denied is not None:
+            # Every denial is recorded: a token probing above its tier is worth knowing about.
+            await record_invocation(
+                token=token,
+                tool=fn.__name__,
+                scope=scope,
+                arguments=kwargs,
+                outcome="denied",
+                denied_scope=scope,
+            )
             return denied
         out = fn(*args, **kwargs)
-        return await out if inspect.isawaitable(out) else out
+        result = await out if inspect.isawaitable(out) else out
+        if token is not None and scope in AUDITED_SCOPES:
+            outcome = "error" if isinstance(result, dict) and "error" in result else "ok"
+            await record_invocation(
+                token=token, tool=fn.__name__, scope=scope, arguments=kwargs, outcome=outcome
+            )
+        return result
 
     return guarded
 

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -72,6 +72,11 @@ The SDK only checks scopes server-wide, so the per-tool check has to live here. 
 there is no token, and the guard passes: a local subprocess a host launched already holds
 the user's ``.env``.
 
+**Every tool advertises what it returns** (``plugin/outputs.py``): a ``TypedDict`` per tool,
+attached to the registered function so the SDK derives an output schema and validates the
+result, while the tool keeps returning a plain ``dict``. The test suite's drift guard fails
+on any returned key the type does not declare.
+
 **Prompts and resources, for hosts that are not Claude Code** (``plugin/prompts.py``,
 ``plugin/resources.py``). The ``understand-codebase`` skill's "which tool, in which order"
 ships as five MCP prompts; the committed ``episteme/`` bank, the build documents and the
@@ -1847,6 +1852,8 @@ def _scoped(fn: Callable[..., Any], scope: str) -> Callable[..., Any]:
     signature, annotations and docstring across, which is what the SDK builds the input
     schema and description from — a guarded tool advertises exactly what the bare one did."""
 
+    from orchestrator.plugin.outputs import OUTPUTS
+
     @functools.wraps(fn)
     async def guarded(*args: Any, **kwargs: Any) -> Any:
         from orchestrator.plugin.audit import AUDITED_SCOPES, record_invocation
@@ -1873,6 +1880,19 @@ def _scoped(fn: Callable[..., Any], scope: str) -> Callable[..., Any]:
             )
         return result
 
+    # The tool's declared output type rides on the registered function, so the SDK derives
+    # an output schema from it and validates the result — while the tool itself keeps its
+    # plain `dict` signature. A tool without a type does not register, like one without a tier.
+    try:
+        out_type = OUTPUTS[fn.__name__]
+    except KeyError as exc:
+        raise RuntimeError(
+            f"tool {fn.__name__!r} has no output type in OUTPUTS — say what it returns"
+        ) from exc
+    guarded.__annotations__ = {**fn.__annotations__, "return": out_type}
+    # The SDK takes the return type from `inspect.signature`, which follows `__wrapped__` to
+    # the tool's own `dict[str, Any]` — so the wrapper carries an explicit signature.
+    guarded.__signature__ = inspect.signature(fn).replace(return_annotation=out_type)  # type: ignore[attr-defined]
     return guarded
 
 

--- a/src/orchestrator/registry/api/audit.py
+++ b/src/orchestrator/registry/api/audit.py
@@ -5,6 +5,8 @@ All three read the append-only ``audit_log`` — the single source of truth:
 - ``GET /v1/audit``                    — C1: filterable audit-log query.
 - ``GET /v1/audit/{run_id}/governance`` — C2: per-run spend vs cap + policy/approval decisions.
 - ``GET /v1/audit/{run_id}/export``     — C3: the run's full timeline as a downloadable bundle.
+- ``POST /v1/audit``                   — an authenticated caller records its own action (the MCP
+  plugin's per-principal invocation audit; the actor is the principal, never the body).
 
 Honesty notes baked into the responses: the *agentic tool-call* allow/deny policy
 is trace/OTel-only (never persisted), so governance surfaces only what the audit
@@ -19,11 +21,12 @@ import os
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Response, status
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import or_, select
 
-from orchestrator.registry.api.deps import PrincipalDep, SessionDep
+from orchestrator.registry.api.deps import PrincipalDep, SessionDep, TraceIdDep
 from orchestrator.registry.db.models import AuditLogRow
+from orchestrator.registry.repositories import AuditLogRepo
 
 router = APIRouter(prefix="/v1/audit", tags=["audit"])
 
@@ -78,6 +81,42 @@ class AuditPage(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     items: list[AuditRow]
+
+
+class AuditWrite(BaseModel):
+    """What a caller may record about its own action. ``actor`` and the tenant are not here on
+    purpose: they come from the authenticated principal, so a caller cannot write history as
+    someone else."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    action: str = Field(min_length=1, max_length=128)
+    resource_type: str = Field(min_length=1, max_length=64)
+    resource_id: str = Field(min_length=1, max_length=256)
+    before: dict[str, Any] | None = None
+    after: dict[str, Any] | None = None
+    trace_id: str | None = Field(default=None, max_length=128)
+
+
+@router.post("", response_model=AuditRow, status_code=status.HTTP_201_CREATED)
+async def record_audit(
+    body: AuditWrite, session: SessionDep, principal: PrincipalDep, request_trace: TraceIdDep
+) -> AuditRow:
+    """Append one row as the caller. The MCP plugin uses this to record, per principal, every
+    run-scope tool invocation and every scope denial on its HTTP transport — the plugin
+    process keeps no database credentials, so the registry is the one writer."""
+    row = await AuditLogRepo(session).write(
+        actor=principal.id,
+        action=body.action,
+        resource_type=body.resource_type,
+        resource_id=body.resource_id,
+        before=body.before,
+        after=body.after,
+        trace_id=body.trace_id or request_trace,
+        tenant_id=principal.tenant_id,
+    )
+    await session.commit()
+    return _to_row(row)
 
 
 def _to_row(r: AuditLogRow) -> AuditRow:

--- a/tests/plugin/conftest.py
+++ b/tests/plugin/conftest.py
@@ -1,0 +1,55 @@
+"""The output drift guard.
+
+Every tool's declared output type (``plugin/outputs.py``) is what a host reads before it
+calls; a key a tool returns that the type does not declare is a field the host never learns
+about — and pydantic would drop it from the structured result silently if the types were
+strict. So every tool is wrapped for the whole test session: after each call, any returned
+key the type does not declare fails the test that made the call, naming the tool and the
+key path. The existing tests then exercise the declared shapes for free.
+
+The wrapping happens at conftest import, before the test modules bind the names with
+``from orchestrator.plugin.server import blast_radius``.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any
+
+import orchestrator.plugin.server as server
+from orchestrator.plugin.outputs import OUTPUTS, undeclared_keys
+
+
+def _check(name: str, result: Any) -> Any:
+    if isinstance(result, dict):
+        extra = undeclared_keys(result, OUTPUTS[name])
+        assert not extra, (
+            f"{name} returned keys its output type does not declare: {extra} — add them to plugin/outputs.py"
+        )
+    return result
+
+
+def _guarded(fn: Any) -> Any:
+    name = fn.__name__
+    if inspect.iscoroutinefunction(fn):
+
+        @functools.wraps(fn)
+        async def async_wrapper(*a: Any, **k: Any) -> Any:
+            return _check(name, await fn(*a, **k))
+
+        return async_wrapper
+
+    @functools.wraps(fn)
+    def wrapper(*a: Any, **k: Any) -> Any:
+        return _check(name, fn(*a, **k))
+
+    return wrapper
+
+
+_wrapped = tuple(_guarded(_fn) for _fn in server._TOOLS)
+for _fn in _wrapped:
+    setattr(server, _fn.__name__, _fn)
+# The tuple too, so `tool in _TOOLS` identity checks hold and registration wraps the guarded
+# functions (which carry the originals' names, signatures and annotations).
+server._TOOLS = _wrapped

--- a/tests/plugin/test_audit.py
+++ b/tests/plugin/test_audit.py
@@ -1,0 +1,176 @@
+"""Per-principal audit on the HTTP transport: run-scope calls and denials, against the token."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import httpx
+import pytest
+
+from orchestrator.plugin.audit import AUDITED_SCOPES, arguments_digest, principal_of, record_invocation
+
+
+class _Token:
+    def __init__(self, scopes: list[str], *, client_id: str = "app-1", subject: str | None = "ana") -> None:
+        self.scopes, self.client_id, self.subject = scopes, client_id, subject
+
+
+def _registry_with(handler: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    import orchestrator.plugin.registry_client as rc
+
+    monkeypatch.setattr(
+        rc,
+        "registry_client",
+        lambda: rc.RegistryClient("http://test", "k", transport=httpx.MockTransport(handler)),  # type: ignore[arg-type]
+    )
+
+
+def test_the_digest_is_the_shape_of_a_call_not_its_contents() -> None:
+    d = arguments_digest({"source": "file://./spec.md", "live": True, "confirm": True})
+    assert d["keys"] == ["confirm", "live", "source"]
+    assert len(d["sha256"]) == 64 and "spec.md" not in json.dumps(d)
+    assert arguments_digest({"a": 1}) != arguments_digest({"a": 2})  # a different call, a different digest
+
+
+def test_the_principal_is_what_the_token_carries() -> None:
+    assert principal_of(_Token(["spine:run", "spine:read"])) == {
+        "client_id": "app-1",
+        "subject": "ana",
+        "scopes": ["spine:read", "spine:run"],
+    }
+
+
+async def test_a_run_scope_call_is_recorded_against_the_principal(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"], seen["body"] = request.url.path, json.loads(request.content)
+        return httpx.Response(201, json={"actor": "key-1", "action": seen["body"]["action"]})
+
+    _registry_with(handler, monkeypatch)
+    ok = await record_invocation(
+        token=_Token(["spine:run"]),
+        tool="sdlc_feature",
+        scope="spine:run",
+        arguments={"source": "file://./secret-spec.md"},
+        outcome="ok",
+    )
+    assert ok is True and seen["path"] == "/v1/audit"
+    body = seen["body"]
+    assert (
+        body["action"] == "mcp_tool_invoked"
+        and body["resource_type"] == "mcp_tool"
+        and body["resource_id"] == "sdlc_feature"
+    )
+    after = body["after"]
+    assert (
+        after["principal"]["client_id"] == "app-1"
+        and after["outcome"] == "ok"
+        and after["scope"] == "spine:run"
+    )
+    assert after["arguments"]["keys"] == ["source"] and "secret-spec" not in json.dumps(after)
+
+
+async def test_a_denial_is_recorded_with_the_scope_it_needed(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(201, json={})
+
+    _registry_with(handler, monkeypatch)
+    await record_invocation(
+        token=_Token(["spine:read"]),
+        tool="registry_decide",
+        scope="spine:run",
+        arguments={},
+        outcome="denied",
+        denied_scope="spine:run",
+    )
+    assert (
+        seen["body"]["action"] == "mcp_scope_denied" and seen["body"]["after"]["denied_scope"] == "spine:run"
+    )
+
+
+async def test_an_unreachable_registry_degrades_to_a_log_line_and_never_raises(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    _registry_with(handler, monkeypatch)
+    with caplog.at_level(logging.WARNING, logger="orchestrator.plugin.audit"):
+        ok = await record_invocation(
+            token=_Token(["spine:run"]),
+            tool="sdlc_feature",
+            scope="spine:run",
+            arguments={"a": 1},
+            outcome="ok",
+        )
+    assert ok is False
+    record = next(r for r in caplog.records if r.name == "orchestrator.plugin.audit")
+    assert "mcp_tool_invoked" in record.getMessage()
+    assert record.tool == "sdlc_feature" and record.outcome == "ok" and "refused" in record.registry_error  # type: ignore[attr-defined]
+
+
+def test_only_the_run_tier_is_audited() -> None:
+    assert {"spine:run"} == AUDITED_SCOPES
+
+
+# ---- through the guard ------------------------------------------------------------------
+
+
+@pytest.fixture
+def _as_token(monkeypatch: pytest.MonkeyPatch) -> Any:
+    pytest.importorskip("mcp")
+    from mcp.server.auth.middleware.auth_context import (  # type: ignore[attr-defined]
+        AuthenticatedUser,
+        auth_context_var,
+    )
+    from mcp.server.auth.provider import AccessToken
+
+    def as_token(scopes: list[str] | None) -> None:
+        if scopes is None:
+            auth_context_var.set(None)
+            return
+        auth_context_var.set(
+            AuthenticatedUser(AccessToken(token="t", client_id="app-1", scopes=scopes, expires_at=None))
+        )
+
+    yield as_token
+    auth_context_var.set(None)
+
+
+async def test_the_guard_records_a_run_call_and_a_denial_but_not_a_read_call(
+    _as_token: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from orchestrator.plugin.auth import SCOPE_READ, SCOPE_RUN
+    from orchestrator.plugin.server import _scoped, doctor, registry_decide
+
+    recorded: list[dict[str, Any]] = []
+
+    async def fake_record(**kw: Any) -> bool:
+        recorded.append(kw)
+        return True
+
+    monkeypatch.setattr("orchestrator.plugin.audit.record_invocation", fake_record)
+
+    _as_token([SCOPE_READ])
+    out = await _scoped(registry_decide, SCOPE_RUN)("g1", "approve")
+    assert out["needs"] == SCOPE_RUN
+    assert recorded[-1]["outcome"] == "denied" and recorded[-1]["denied_scope"] == SCOPE_RUN
+    assert recorded[-1]["tool"] == "registry_decide"
+
+    await _scoped(doctor, SCOPE_READ)()  # read tier: nothing recorded
+    assert len(recorded) == 1
+
+    _as_token([SCOPE_RUN])
+    out = await _scoped(registry_decide, SCOPE_RUN)("g1", "shrug")  # the tool's own validation answers
+    assert "error" in out
+    assert recorded[-1]["outcome"] == "error" and recorded[-1]["token"].client_id == "app-1"
+
+    _as_token(None)  # stdio: no token, nothing recorded
+    await _scoped(registry_decide, SCOPE_RUN)("g1", "shrug")
+    assert len(recorded) == 2

--- a/tests/plugin/test_outputs.py
+++ b/tests/plugin/test_outputs.py
@@ -1,0 +1,71 @@
+"""Typed output: every tool advertises what it returns, and the types cannot drift from it."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from orchestrator.plugin.outputs import OUTPUTS, Failure, undeclared_keys
+
+
+def test_every_registered_tool_has_an_output_type_and_nothing_else_does() -> None:
+    from orchestrator.plugin.server import _TOOLS
+
+    assert set(OUTPUTS) == {fn.__name__ for fn in _TOOLS}
+
+
+def test_every_output_type_carries_the_failure_keys() -> None:
+    """A tool's error path must fit its own type, or the SDK would reject the error."""
+    import typing
+
+    failure = set(typing.get_type_hints(Failure))
+    for name, td in OUTPUTS.items():
+        assert failure <= set(typing.get_type_hints(td)), name
+
+
+def test_undeclared_keys_finds_drift_at_any_depth() -> None:
+    from orchestrator.plugin.outputs import BlastRadiusOut
+
+    ok = {"symbol": "x", "found": True, "matches": [{"id": "a", "callers": [{"id": "b", "at": "f:1"}]}]}
+    assert undeclared_keys(ok, BlastRadiusOut) == []
+    drift = {"symbol": "x", "novel": 1, "matches": [{"id": "a", "callers": [{"id": "b", "since": 2}]}]}
+    assert undeclared_keys(drift, BlastRadiusOut) == ["novel", "matches[0].callers[0].since"]
+    assert undeclared_keys("not a dict", BlastRadiusOut) == []
+
+
+def test_an_untyped_tool_is_refused_at_registration(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("mcp")
+    import orchestrator.plugin.server as mod
+
+    def orphan() -> dict[str, int]:
+        return {}
+
+    monkeypatch.setitem(mod._TIER, "orphan", mod.COMPREHEND_LOCAL)
+    monkeypatch.setattr(mod, "_TOOLS", (*mod._TOOLS, orphan))
+    with pytest.raises(RuntimeError, match="no output type"):
+        mod.build_server()
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="needs the 'mcp' extra")
+async def test_every_tool_advertises_its_output_schema_to_the_host() -> None:
+    from orchestrator.plugin.server import build_server
+
+    tools = {t.name: t for t in await build_server().list_tools()}
+    for name, td in OUTPUTS.items():
+        schema = tools[name].output_schema
+        assert schema and schema.get("type") == "object", name
+        assert schema.get("title") == td.__name__, name
+        assert "error" in schema["properties"] and "required" not in schema, name  # no key is required
+        assert "ctx" not in tools[name].input_schema["properties"], name  # unchanged by typing
+
+
+@pytest.mark.skipif(importlib.util.find_spec("mcp") is None, reason="needs the 'mcp' extra")
+async def test_a_result_reaches_the_host_structured_with_every_key_kept() -> None:
+    """`extra="allow"`: a key the type happened to miss still reaches the host; the drift
+    guard, not the runtime, is what enforces the declarations."""
+    from orchestrator.plugin.server import build_server
+
+    r = await build_server().call_tool("doctor", {})
+    assert r.structured_content and "all_passed" in r.structured_content and "server" in r.structured_content
+    assert r.structured_content["server"]["package"] == "synaptixs-spine"

--- a/tests/registry/test_audit_write.py
+++ b/tests/registry/test_audit_write.py
@@ -1,0 +1,74 @@
+"""POST /v1/audit — a caller records its own action; the actor is the principal, never the body."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import cast
+
+import httpx
+import pytest
+from sqlalchemy import Table
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from orchestrator.registry.api.app import create_app
+from orchestrator.registry.api.config import Settings
+from orchestrator.registry.db.models import AuditLogRow
+
+_AUTH = {"X-API-Key": "dev-key"}
+
+
+@pytest.fixture
+async def app() -> AsyncIterator[SimpleNamespace]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(cast(Table, AuditLogRow.__table__).create)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    application = create_app(Settings())
+    application.router.lifespan_context = None  # type: ignore[assignment]
+    application.state.session_factory = factory
+    yield SimpleNamespace(app=application)
+    await engine.dispose()
+
+
+def _client(app: object) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test", headers=_AUTH)  # type: ignore[arg-type]
+
+
+async def test_a_caller_records_its_own_action_and_reads_it_back(app: SimpleNamespace) -> None:
+    async with _client(app.app) as c:
+        r = await c.post(
+            "/v1/audit",
+            json={
+                "action": "mcp_tool_invoked",
+                "resource_type": "mcp_tool",
+                "resource_id": "sdlc_feature",
+                "after": {"principal": {"client_id": "static"}, "outcome": "ok"},
+            },
+        )
+        assert r.status_code == 201, r.text
+        row = r.json()
+        assert row["action"] == "mcp_tool_invoked" and row["resource_id"] == "sdlc_feature"
+        assert row["actor"]  # the principal the key resolves to — not something the body said
+        assert row["after"]["outcome"] == "ok"
+        listed = (await c.get("/v1/audit?resource_type=mcp_tool")).json()["items"]
+        assert [x["resource_id"] for x in listed] == ["sdlc_feature"]
+
+
+async def test_the_body_cannot_name_an_actor_or_a_tenant(app: SimpleNamespace) -> None:
+    async with _client(app.app) as c:
+        for extra in ({"actor": "someone-else"}, {"tenant_id": "other"}):
+            r = await c.post(
+                "/v1/audit",
+                json={"action": "a", "resource_type": "t", "resource_id": "r", **extra},
+            )
+            assert r.status_code == 422, r.text  # extra="forbid"
+
+
+async def test_an_unauthenticated_write_is_refused(app: SimpleNamespace) -> None:
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app.app), base_url="http://test") as c:
+        r = await c.post("/v1/audit", json={"action": "a", "resource_type": "t", "resource_id": "r"})
+        assert r.status_code in (401, 403)


### PR DESCRIPTION
## Summary

MCP phase 2 steps 4 and 5 of [`docs/specs/mcp-plugin-surface.md`](docs/specs/mcp-plugin-surface.md), as two commits. **With them phase 2 is complete**; only the `sdlc` scope-alias retirement remains, for the next cut.

### Commit 1 — per-principal audit on the HTTP transport (4.11)

Every **run-scope** call and every **scope denial** over HTTP is recorded against the token's principal in the registry's audit log.

- **`POST /v1/audit`** (new): an authenticated caller records its own action. The actor and tenant come from the principal, never from the body — `extra="forbid"` refuses an `actor` in the body (tested). Committed on write.
- **`plugin/audit.py`**: the recorder posts the principal (client id, subject, scopes), the tool, its scope, the argument **names** and a **digest** of the values — never the values, which may carry a spec, a trace or a secret — and the outcome. An unreachable or unconfigured registry degrades to a structured log line with the same fields; the audit never fails the call.
- **The scope guard** does the recording: after a `spine:run` call (`ok` / `error`) and on every denial (`mcp_scope_denied`). Read-scope calls are not recorded; stdio (no token) records nothing.

### Commit 2 — typed output (the deferred half of 4.1)

- **`plugin/outputs.py`**: a `TypedDict` per tool (32), **no required key** — every tool has an error path and most have several shapes. Nested item types where the shape is stable (matches, frames, uncovered symbols, outcomes, findings). Open shapes (the build document, Temporal status, the design dict) stay `dict[str, Any]` on purpose.
- Attached to the **registered function's signature** (the SDK reads the return type from `inspect.signature`, which follows `__wrapped__` to the tool's own `dict[str, Any]`), so the SDK derives an output schema and validates the result while the tool keeps returning a plain dict. A tool without a type does not register.
- **The drift guard.** Pydantic drops a key a `TypedDict` does not declare from the structured result *silently*. So the types allow extras (nothing lost at runtime) and `tests/plugin/conftest.py` wraps every tool for the session and fails on any returned key its type does not declare — the existing plugin tests then exercise the declared shapes for free. It caught one on its first run (`sdlc_decide_gate` returned `state`).

Verified over the SDK: 32 tools, 32 output schemas, titles matching the types, no key required.

## Files

- Registry: `api/audit.py` (route), `tests/registry/test_audit_write.py` (3).
- Plugin: `audit.py` (new), `outputs.py` (new), `registry_client.py` (`audit()`), `server.py` (guard, registration).
- Tests: `test_audit.py` (7), `test_outputs.py` (6), `conftest.py` (the guard).
- Docs: "What each tool returns, as a schema" and "Who did what, over HTTP" in CLAUDE_GUIDE and CODEX_GUIDE; USER_GUIDE §10.2; the spec (4.11 and 4.1 shipped, phase 2 complete); SPEC-INDEX; CHANGELOG; STATE-OF-SPINE counts.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`, `matrix-count --check`, `state-numbers --check`, `check-mermaid`: pass
- Full pytest: 3421 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
