### PR TITLE
chore(plugin): retire the sdlc scope alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## Unreleased
 
+### Removed
+
+- **The `sdlc` scope alias.** 3.31.0 accepted the pre-tier `sdlc` scope as all three
+  tier scopes for one release, with a warning. That release has shipped. A bearer
+  token carrying only `sdlc` now has no tier scope and fails the server's
+  `spine:read` floor; grant `spine:read spine:plan spine:run` (or the subset the
+  token should have). `ORCHESTRATOR_MCP_REQUIRED_SCOPES` is taken verbatim.
+
 ### Added
 
 - **Every MCP tool advertises what it returns.** A type per tool

--- a/CLAUDE_GUIDE.md
+++ b/CLAUDE_GUIDE.md
@@ -230,7 +230,7 @@ At a glance:
 > `sdlc_decide_gate`, `registry_decide`). A token missing the tier's scope gets `error` + `needs`
 > + `has` back, not a 403. A static token carries all three unless
 > `ORCHESTRATOR_MCP_REQUIRED_SCOPES` narrows it (`spine:read` = a read-only token); the legacy
-> `sdlc` scope still reads as all three for one release. Over stdio there is no token and no check.
+> `sdlc` scope is retired — grant the three. Over stdio there is no token and no check.
 
 ### Prompts and resources — the workflow and the documents, through the protocol
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1230,7 +1230,7 @@ Scopes follow the tool tiers and are checked **per call**: `spine:read` (compreh
 a run), `spine:plan` (`sdlc_plan`, `sdlc_approve`), `spine:run` (anything that spends money or
 writes where it cannot be taken back). An IdP-issued token needs the scope of the tier it calls;
 a shared-secret token carries all three unless `ORCHESTRATOR_MCP_REQUIRED_SCOPES` narrows it —
-`spine:read` makes it read-only. The legacy `sdlc` scope reads as all three for one release.
+`spine:read` makes it read-only. (The pre-3.31 `sdlc` scope is retired; grant the three scopes.)
 Every run-scope call and every scope denial over HTTP is recorded against the token's principal
 in the registry's audit log (`POST /v1/audit`; read it back with `resource_type=mcp_tool`).
 

--- a/docs/specs/mcp-plugin-surface.md
+++ b/docs/specs/mcp-plugin-surface.md
@@ -1,6 +1,6 @@
 # The MCP plugin surface — what it is, what it lacks, and the order to extend it
 
-**Status:** **Phase 1 COMPLETE** — all six steps shipped, all six gaps closed. **Phase 2 COMPLETE** — prompts + resources, progress, multi-repo parity, per-principal audit, typed output all shipped. Only the `sdlc` scope alias retirement remains, for the next cut. **Written 2026-09-04 against 3.30.0**,
+**Status:** **Phase 1 COMPLETE** — all six steps shipped, all six gaps closed. **Phase 2 COMPLETE** — prompts + resources, progress, multi-repo parity, per-principal audit, typed output all shipped. The `sdlc` scope alias is retired. Nothing remains open. **Written 2026-09-04 against 3.30.0**,
 after #316 removed the terminal UI and left the plugin as the only non-browser operator face.
 **Owner:** _unassigned_
 
@@ -48,8 +48,8 @@ for the floor (`spine:read`); each registered tool is wrapped in a guard that re
 token at call time and refuses — naming the scope it needed and the scopes the token has — when
 the tier's scope is missing. Over stdio there is no token and the guard passes.
 `ORCHESTRATOR_MCP_REQUIRED_SCOPES` is what the **static token carries** (default: all three), so
-a read-only token is that variable set to `spine:read`. The legacy `sdlc` scope expands to all
-three for one release.
+a read-only token is that variable set to `spine:read`. The pre-3.31 `sdlc` scope was accepted
+as an alias for all three through 3.31.x and is retired.
 
 **Packaging.** A Claude Code plugin at `plugins/spine/` bundling the `understand-codebase` skill;
 marketplace entry in `.claude-plugin/marketplace.json`; `pip install 'synaptixs-spine[all]'`.
@@ -141,8 +141,8 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
 - **4.3 Per-tier scopes on HTTP.** *(Shipped.)* `spine:read`, `spine:plan`, `spine:run`, each
   tier naming its scope beside its annotations, enforced by a call-time guard around every
   registered tool — the SDK only checks scopes server-wide, and a request does not name its tool
-  until the protocol layer has parsed it. Stdio is untouched. `sdlc` expands to all three for one
-  release, then goes.
+  until the protocol layer has parsed it. Stdio is untouched. `sdlc` was accepted as all three for one
+  release (3.31.x) and is retired.
 - **4.4 `understand_repo` and `current_state` as tools.** *(Shipped in 6a — `understand_repo`
   builds or checks the bank; `current_state` was already `map_repo`.)* `understand_repo` refuses
   a build on a git URL unless `out` is absolute: the clone vanishes, and a bank written into it
@@ -209,7 +209,7 @@ Each is scoped to one PR. The number is a name, not an order — §5 is the orde
 | 3 | 4.10 multi-repo parity for `explain_symbol`, `regression_gaps`, `localize`, `docs_for` | **shipped** |
 | 4 | 4.11 per-principal audit on HTTP | **shipped** |
 | 5 | typed output (the deferred half of 4.1) | **shipped** |
-| — | retire the `sdlc` scope alias | the release after 3.31.0 |
+| — | retire the `sdlc` scope alias | **shipped** (for the release after 3.31.0) |
 
 ## Invariants
 

--- a/src/orchestrator/plugin/auth.py
+++ b/src/orchestrator/plugin/auth.py
@@ -23,8 +23,8 @@ only ever on loopback).
 spends money or writes where it cannot be taken back). The SDK checks scopes once,
 server-wide, and only for the floor (``spine:read``); the per-tool check is
 ``plugin.server``'s scope guard, which reads the verified token at call time and
-refuses with the scope it needed. A token carrying the legacy ``sdlc`` scope is
-treated as carrying all three for one release (``expand_scopes``).
+refuses with the scope it needed. (The pre-3.31 ``sdlc`` scope was accepted as an alias for
+all three through 3.31.x and is retired: a token carrying only ``sdlc`` now fails the floor.)
 """
 
 from __future__ import annotations
@@ -47,9 +47,6 @@ SCOPE_READ = "spine:read"
 SCOPE_PLAN = "spine:plan"
 SCOPE_RUN = "spine:run"
 ALL_SCOPES = [SCOPE_READ, SCOPE_PLAN, SCOPE_RUN]
-#: The scope every token had before the tiers had scopes. Expands to all three for one
-#: release so an existing static token or IdP grant keeps working; remove after.
-LEGACY_SCOPE = "sdlc"
 
 #: What the static token carries when ``ORCHESTRATOR_MCP_REQUIRED_SCOPES`` is unset: every
 #: tier, so a single-tenant self-host behaves as it did with the one ``sdlc`` scope.
@@ -57,23 +54,6 @@ _DEFAULT_SCOPES = list(ALL_SCOPES)
 #: What the SDK requires of every token before any request reaches a tool. The floor is
 #: read: a token that cannot comprehend has no business at any tier.
 _SERVER_FLOOR = [SCOPE_READ]
-
-_legacy_warned = False
-
-
-def expand_scopes(scopes: list[str]) -> list[str]:
-    """``sdlc`` → all three tier scopes (once-warned); everything else passes through."""
-    global _legacy_warned
-    if LEGACY_SCOPE not in scopes:
-        return list(scopes)
-    if not _legacy_warned:
-        logger.warning(
-            "plugin.auth.legacy_scope",
-            extra={"detail": f"scope {LEGACY_SCOPE!r} is deprecated; grant {' '.join(ALL_SCOPES)} instead"},
-        )
-        _legacy_warned = True
-    out = [s for s in scopes if s != LEGACY_SCOPE]
-    return out + [s for s in ALL_SCOPES if s not in out]
 
 
 def _scopes_from_env(value: str | None) -> list[str]:
@@ -95,7 +75,7 @@ class StaticTokenVerifier:
         if not secret:
             raise ValueError("StaticTokenVerifier needs a non-empty secret")
         self._secret = secret
-        self._scopes = expand_scopes(scopes or list(_DEFAULT_SCOPES))
+        self._scopes = scopes or list(_DEFAULT_SCOPES)
 
     async def verify_token(self, token: str) -> AccessToken | None:
         from mcp.server.auth.provider import AccessToken
@@ -149,7 +129,7 @@ class IntrospectionTokenVerifier:
         exp = data.get("exp")
         if isinstance(exp, (int, float)) and exp < time.time():
             return None
-        scopes = expand_scopes(_scopes_from_env(data.get("scope"))) if data.get("scope") else []
+        scopes = _scopes_from_env(data.get("scope")) if data.get("scope") else []
         return AccessToken(
             token=token,
             client_id=str(data.get("client_id", "introspected")),
@@ -214,12 +194,10 @@ def build_auth_from_env() -> tuple[AuthSettings | None, TokenVerifier | None]:
 
 __all__ = [
     "ALL_SCOPES",
-    "LEGACY_SCOPE",
     "SCOPE_PLAN",
     "SCOPE_READ",
     "SCOPE_RUN",
     "IntrospectionTokenVerifier",
     "StaticTokenVerifier",
     "build_auth_from_env",
-    "expand_scopes",
 ]

--- a/tests/plugin/test_auth.py
+++ b/tests/plugin/test_auth.py
@@ -16,7 +16,6 @@ from orchestrator.plugin.auth import (
     IntrospectionTokenVerifier,
     StaticTokenVerifier,
     build_auth_from_env,
-    expand_scopes,  # noqa: E402
 )
 
 _MCP_ENV = (
@@ -80,8 +79,9 @@ async def test_introspection_active_token_maps_scopes(monkeypatch: pytest.Monkey
     v = IntrospectionTokenVerifier("https://idp.example/introspect")
     tok = await v.verify_token("opaque")
     assert tok is not None and tok.client_id == "app-1"
-    # The IdP's scopes as issued — with the legacy `sdlc` expanded to the three tier scopes.
-    assert set(tok.scopes) == {"admin", *ALL_SCOPES}
+    # The IdP's scopes exactly as issued. `sdlc` is no longer an alias for the tiers: a token
+    # that carries only it has no tier scope, and the floor refuses it.
+    assert set(tok.scopes) == {"admin", "sdlc"}
 
 
 async def test_introspection_inactive_token_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -125,11 +125,13 @@ async def test_env_static_token_builds_resource_server(monkeypatch: pytest.Monke
     monkeypatch.setenv("ORCHESTRATOR_MCP_REQUIRED_SCOPES", "sdlc, admin")
     settings, verifier = build_auth_from_env()
     assert isinstance(verifier, StaticTokenVerifier)
-    # The env var is what the static token *carries* (legacy `sdlc` expanded); what the SDK
-    # requires of every token is the floor, `spine:read` — the tiers above are per tool.
+    # The env var is what the static token *carries*, verbatim; what the SDK requires of every
+    # token is the floor, `spine:read` — the tiers above are per tool. A static token set to
+    # the retired `sdlc` scope therefore fails the floor: the deprecation #322 announced.
     assert settings is not None and settings.required_scopes == [SCOPE_READ]
     tok = await verifier.verify_token("s3cret")
-    assert tok is not None and set(tok.scopes) == {"admin", *ALL_SCOPES}
+    assert tok is not None and set(tok.scopes) == {"admin", "sdlc"}
+    assert SCOPE_READ not in tok.scopes
     # issuer defaults to the resource URL for the static (no real AS) path.
     assert str(settings.issuer_url).startswith("https://mcp.example.com")
 
@@ -152,13 +154,13 @@ def test_env_verifier_without_any_url_errors(monkeypatch: pytest.MonkeyPatch) ->
 # ---- scopes follow the tiers -------------------------------------------------------
 
 
-def test_the_legacy_scope_expands_to_every_tier_once() -> None:
-    """A token minted for the one `sdlc` scope keeps working for a release: it reads as all
-    three tier scopes. Anything else passes through untouched, order kept."""
-    assert expand_scopes(["sdlc"]) == ALL_SCOPES
-    assert expand_scopes(["admin", "sdlc"]) == ["admin", *ALL_SCOPES]
-    assert expand_scopes([SCOPE_READ]) == [SCOPE_READ]
-    assert expand_scopes([SCOPE_RUN, "sdlc"]) == [SCOPE_RUN, SCOPE_READ, SCOPE_PLAN]  # no duplicate
+def test_the_retired_sdlc_scope_is_not_an_alias_any_more() -> None:
+    """3.31.0 accepted `sdlc` as all three tiers for one release, with a warning. That release
+    has shipped; a token carrying only `sdlc` now has no tier scope at all."""
+    import orchestrator.plugin.auth as auth
+
+    assert not hasattr(auth, "expand_scopes") and not hasattr(auth, "LEGACY_SCOPE")
+    assert "sdlc" not in {SCOPE_READ, SCOPE_PLAN, SCOPE_RUN}
 
 
 async def test_a_static_token_carries_every_tier_by_default() -> None:


### PR DESCRIPTION
## Summary

The deprecation #322 announced: 3.31.0 accepted the pre-tier `sdlc` scope as an alias for `spine:read spine:plan spine:run` for one release, with a once-logged warning. That release has shipped, so the alias goes.

- `expand_scopes` and `LEGACY_SCOPE` removed from `plugin/auth.py`. A static token's `ORCHESTRATOR_MCP_REQUIRED_SCOPES` and an IdP's scope claim are taken **verbatim**.
- A bearer token carrying only `sdlc` now has no tier scope and fails the server's `spine:read` floor (tested for both the static and the introspection path).
- The default for an **unset** variable is unchanged — all three scopes — so a self-host that never set it is unaffected.
- Docs: CLAUDE_GUIDE §6, USER_GUIDE §10.2, the spec (§1, 4.3, the phase 2 table — nothing remains open), CHANGELOG Removed.

The last item before the 3.32.0 cut.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`, `state-numbers --check`: pass
- Full pytest: 3421 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
