### PR TITLE
fix(pkg): key the cache on the PHP grammar, and make the PHP modules a tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Fixed
 
+- **The persistence cache could not tell whether the PHP extra was installed.** The
+  cache key's grammar list (`persistence._GRAMMAR_MODULES`) named every grammar except
+  `tree_sitter_php`, so a graph cached before the extra was installed — with no PHP facts
+  in it — kept being served after, for as long as the commit did not move. Listed now, and
+  a test cross-checks the list against `doctor.EXTRA_PROBES` so the next grammar cannot be
+  forgotten the same way.
+- **The PHP front-end's static import cycle** (CodeQL `py/cyclic-import`, six alerts):
+  `php_routes.py` and `php_orm.py` imported the name resolver and the type record from
+  `php_extractor.py`, which imports them back. The shared pieces now live in a leaf module,
+  `php_names.py`, that imports nothing from the other three — the shape `go_routes.py`
+  has always had. No behaviour change; every PHP fact is emitted exactly as before.
 - **Five ways the PHP front-end asserted a fact the source does not contain**, found
   reviewing #334 and each a wrong *grounded* fact rather than a missing one:
   `new self()` / `new static()` were resolved as classes named `self` and `static`, which

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -27,8 +27,8 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Version | **3.32.0** | cutting now; 3.31.0 is the last on PyPI until this ships |
 | Languages extracted | **9** front-ends | Python, Java, TypeScript, C#, C, C++, Go, PHP, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
-| Source modules | **352** | `find src/orchestrator -name '*.py'` |
-| Test functions | **3,034** across 312 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Source modules | **353** | `find src/orchestrator -name '*.py'` |
+| Test functions | **3,035** across 312 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 8 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) · **0.50** (PHP, on 8 labelled edges — the misses are P3's typed-receiver rule and the global-namespace fallback, both predicted `known_gaps`, not surprises) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/src/orchestrator/pkg/persistence.py
+++ b/src/orchestrator/pkg/persistence.py
@@ -168,6 +168,7 @@ _GRAMMAR_MODULES = (
     "tree_sitter_c",
     "tree_sitter_cpp",
     "tree_sitter_go",
+    "tree_sitter_php",
     "sqlglot",
 )
 

--- a/src/orchestrator/pkg/php_extractor.py
+++ b/src/orchestrator/pkg/php_extractor.py
@@ -42,12 +42,23 @@ PHP source.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from orchestrator.pkg.extractor import rel_module_name
 from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
+
+# The name resolver and the collected-type record are shared with php_routes.py and
+# php_orm.py, so they live in a leaf module neither side imports the other for.
+from orchestrator.pkg.php_names import (
+    _join,
+    _resolve_type_name,
+    _text,
+    _to_dotted,
+    _TypeRec,
+    _use_declaration_targets,
+)
 
 if TYPE_CHECKING:
     from tree_sitter import Node as TSNode
@@ -77,42 +88,6 @@ _REQUIRE_KINDS = frozenset(
         "include_once_expression",
     }
 )
-
-
-def _to_dotted(name: str) -> str:
-    """``App\\Http\\Controllers`` -> ``App.Http.Controllers`` (D2)."""
-    return name.replace("\\", ".").strip(".")
-
-
-def _join(namespace: str, name: str) -> str:
-    if namespace and name:
-        return f"{namespace}.{name}"
-    return name or namespace
-
-
-@dataclass
-class _TypeRec:
-    """A collected class/interface/trait/enum — the working set the CALLS pass (P2)
-    reasons over, once every declaration in the file is known."""
-
-    type_id: str
-    name: str
-    namespace: str
-    use_map: dict[str, str]
-    use_func_map: dict[str, str]
-    node: TSNode  # the declaration node itself — php_routes.py reads its attributes (P3)
-    # The single `extends` target's raw name (classes only — D3's trait/interface
-    # `use`/`implements` never feed `parent::`), for CALLS row 3.
-    base_name: str | None = None
-    methods: list[tuple[str, str, TSNode]] = field(default_factory=list)  # (name, id, node)
-    # Trait names this type `use`s (D3) — resolved lazily in the CALLS pass so a
-    # same-file trait's methods count as this type's own for `$this->`/`self::` calls
-    # it doesn't override (the `traits` corpus case's whole point).
-    trait_names: list[str] = field(default_factory=list)
-    # name -> raw type text, for every TYPED property and TYPED promoted ctor param
-    # (both become properties reachable via `$this->prop->m()`) — P3's typed-receiver
-    # rule (§3.2 rows 7-8). An untyped property/param is simply absent here.
-    typed_props: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -797,76 +772,6 @@ def _emit_receiver_call(
         batch.add_edge(Edge(caller_id, target, EdgeKind.CALLS, Provenance(rel, line)))
 
 
-# --- use-declaration parsing -------------------------------------------------
-
-
-def _use_clause(clause: TSNode, source: bytes) -> tuple[str, str, str]:
-    """``(fqn, bind_name, kind)`` for one ``namespace_use_clause``.
-
-    ``kind`` is ``class`` unless a ``function``/``const`` marker is present. ``fqn`` is
-    left backslash-separated (the caller joins group prefixes before converting to dots
-    once). ``bind_name`` is the alias if aliased, else the FQN's own last segment.
-    """
-    kind = "class"
-    type_tok = clause.child_by_field_name("type")
-    if type_tok is not None and _text(type_tok, source) in ("function", "const"):
-        kind = _text(type_tok, source)
-    name_node = next((c for c in clause.named_children if c.type in ("qualified_name", "name")), None)
-    fqn = _text(name_node, source) if name_node is not None else ""
-    alias_node = clause.child_by_field_name("alias")
-    bind = _text(alias_node, source) if alias_node is not None else fqn.rsplit("\\", 1)[-1]
-    return fqn, bind, kind
-
-
-def _use_declaration_targets(decl: TSNode, source: bytes) -> list[tuple[str, str, str]]:
-    """``(fqn_dotted, bind_name, kind)`` for every clause in a ``namespace_use_declaration``,
-    grouped (``use App\\Models\\{Customer, Invoice as Inv};``) or not."""
-    out: list[tuple[str, str, str]] = []
-    prefix = ""
-    group: TSNode | None = None
-    for child in decl.named_children:
-        if child.type == "namespace_name":
-            prefix = _text(child, source)
-        elif child.type == "namespace_use_group":
-            group = child
-        elif child.type == "namespace_use_clause":
-            fqn, bind, kind = _use_clause(child, source)
-            out.append((_to_dotted(fqn), bind, kind))
-    if group is not None:
-        for clause in group.named_children:
-            if clause.type != "namespace_use_clause":
-                continue
-            fqn, bind, kind = _use_clause(clause, source)
-            full = f"{prefix}\\{fqn}" if prefix else fqn
-            out.append((_to_dotted(full), bind, kind))
-    return out
-
-
-# --- PHP's class-name resolution (D0/§2) -------------------------------------
-
-
-def _resolve_type_name(name: str, namespace: str, use_map: dict[str, str]) -> tuple[str, bool]:
-    """Fully-qualified, qualified, or unqualified -> current namespace unless `use`d
-    (the PHP RFC rule). Returns ``(dotted_id, is_guess)``: ``is_guess`` is True only
-    for the same-namespace assumption made when nothing resolves the name — the one
-    case `finalize` may need to correct. Every other shape (a leading `\\`, or a hit
-    in the `use` map) is a claim read directly off the source and must never be
-    treated as provisional, even though it is very often *external* — see the
-    `finalize` docstring for why the distinction matters."""
-    name = name.strip()
-    if name.startswith("\\"):
-        return _to_dotted(name), False  # fully qualified — already absolute
-    if "\\" in name:  # qualified: resolve the first segment, keep the rest
-        head, _, rest = name.partition("\\")
-        if head in use_map:
-            base = use_map[head]
-            return (f"{base}.{_to_dotted(rest)}" if rest else base), False
-        return _join(namespace, _to_dotted(name)), True
-    if name in use_map:  # unqualified, explicitly `use`d
-        return use_map[name], False
-    return _join(namespace, name), True  # unqualified, not `use`d — assume current namespace
-
-
 # --- require/include literal detection (D7) ----------------------------------
 
 
@@ -1046,12 +951,6 @@ def _string_content(node: TSNode, source: bytes) -> str:
 def _field_text(node: TSNode, field: str, source: bytes) -> str:
     child = node.child_by_field_name(field)
     return _text(child, source) if child is not None else ""
-
-
-def _text(node: TSNode | None, source: bytes) -> str:
-    if node is None:
-        return ""
-    return source[node.start_byte : node.end_byte].decode("utf-8", "replace").strip()
 
 
 def _php_parser() -> Any:

--- a/src/orchestrator/pkg/php_names.py
+++ b/src/orchestrator/pkg/php_names.py
@@ -1,0 +1,145 @@
+"""What the three PHP modules share — names, and the record they all read.
+
+``php_extractor.py`` emits declarations and calls; ``php_routes.py`` and ``php_orm.py``
+emit the framework facts on top. All three resolve a class name the same way (D2 of
+``php-support-roadmap.md``: the PHP RFC's fully-qualified / qualified / unqualified rule,
+converted to dots once) and all three read the same collected ``_TypeRec``. When those
+lived in ``php_extractor.py`` the two framework modules imported them from it while it
+imported them back — a cycle CodeQL flagged six times. It never failed at import time,
+because the extractor's side was function-local, but a dependency that only works because
+of *where* an import statement sits is one refactor from an ``ImportError``.
+
+So this module is a leaf: it imports ``tree_sitter`` types for annotation only and nothing
+from its three siblings, the shape ``go_routes.py`` has always had. Everything here is
+private to the PHP front-end; the public surface stays ``PhpExtractor``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tree_sitter import Node as TSNode
+
+
+def _text(node: TSNode | None, source: bytes) -> str:
+    if node is None:
+        return ""
+    return source[node.start_byte : node.end_byte].decode("utf-8", "replace").strip()
+
+
+def _to_dotted(name: str) -> str:
+    """``App\\Http\\Controllers`` -> ``App.Http.Controllers`` (D2)."""
+    return name.replace("\\", ".").strip(".")
+
+
+def _join(namespace: str, name: str) -> str:
+    if namespace and name:
+        return f"{namespace}.{name}"
+    return name or namespace
+
+
+@dataclass
+class _TypeRec:
+    """A collected class/interface/trait/enum — the working set the CALLS pass (P2)
+    reasons over, once every declaration in the file is known."""
+
+    type_id: str
+    name: str
+    namespace: str
+    use_map: dict[str, str]
+    use_func_map: dict[str, str]
+    node: TSNode  # the declaration node itself — php_routes.py reads its attributes (P3)
+    # The single `extends` target's raw name (classes only — D3's trait/interface
+    # `use`/`implements` never feed `parent::`), for CALLS row 3.
+    base_name: str | None = None
+    methods: list[tuple[str, str, TSNode]] = field(default_factory=list)  # (name, id, node)
+    # Trait names this type `use`s (D3) — resolved lazily in the CALLS pass so a
+    # same-file trait's methods count as this type's own for `$this->`/`self::` calls
+    # it doesn't override (the `traits` corpus case's whole point).
+    trait_names: list[str] = field(default_factory=list)
+    # name -> raw type text, for every TYPED property and TYPED promoted ctor param
+    # (both become properties reachable via `$this->prop->m()`) — P3's typed-receiver
+    # rule (§3.2 rows 7-8). An untyped property/param is simply absent here.
+    typed_props: dict[str, str] = field(default_factory=dict)
+
+
+# --- use-declaration parsing -------------------------------------------------
+
+
+def _use_clause(clause: TSNode, source: bytes) -> tuple[str, str, str]:
+    """``(fqn, bind_name, kind)`` for one ``namespace_use_clause``.
+
+    ``kind`` is ``class`` unless a ``function``/``const`` marker is present. ``fqn`` is
+    left backslash-separated (the caller joins group prefixes before converting to dots
+    once). ``bind_name`` is the alias if aliased, else the FQN's own last segment.
+    """
+    kind = "class"
+    type_tok = clause.child_by_field_name("type")
+    if type_tok is not None and _text(type_tok, source) in ("function", "const"):
+        kind = _text(type_tok, source)
+    name_node = next((c for c in clause.named_children if c.type in ("qualified_name", "name")), None)
+    fqn = _text(name_node, source) if name_node is not None else ""
+    alias_node = clause.child_by_field_name("alias")
+    bind = _text(alias_node, source) if alias_node is not None else fqn.rsplit("\\", 1)[-1]
+    return fqn, bind, kind
+
+
+def _use_declaration_targets(decl: TSNode, source: bytes) -> list[tuple[str, str, str]]:
+    """``(fqn_dotted, bind_name, kind)`` for every clause in a ``namespace_use_declaration``,
+    grouped (``use App\\Models\\{Customer, Invoice as Inv};``) or not."""
+    out: list[tuple[str, str, str]] = []
+    prefix = ""
+    group: TSNode | None = None
+    for child in decl.named_children:
+        if child.type == "namespace_name":
+            prefix = _text(child, source)
+        elif child.type == "namespace_use_group":
+            group = child
+        elif child.type == "namespace_use_clause":
+            fqn, bind, kind = _use_clause(child, source)
+            out.append((_to_dotted(fqn), bind, kind))
+    if group is not None:
+        for clause in group.named_children:
+            if clause.type != "namespace_use_clause":
+                continue
+            fqn, bind, kind = _use_clause(clause, source)
+            full = f"{prefix}\\{fqn}" if prefix else fqn
+            out.append((_to_dotted(full), bind, kind))
+    return out
+
+
+# --- PHP's class-name resolution (D0/§2) -------------------------------------
+
+
+def _resolve_type_name(name: str, namespace: str, use_map: dict[str, str]) -> tuple[str, bool]:
+    """Fully-qualified, qualified, or unqualified -> current namespace unless `use`d
+    (the PHP RFC rule). Returns ``(dotted_id, is_guess)``: ``is_guess`` is True only
+    for the same-namespace assumption made when nothing resolves the name — the one
+    case `finalize` may need to correct. Every other shape (a leading `\\`, or a hit
+    in the `use` map) is a claim read directly off the source and must never be
+    treated as provisional, even though it is very often *external* — see the
+    `finalize` docstring in ``php_extractor.py`` for why the distinction matters."""
+    name = name.strip()
+    if name.startswith("\\"):
+        return _to_dotted(name), False  # fully qualified — already absolute
+    if "\\" in name:  # qualified: resolve the first segment, keep the rest
+        head, _, rest = name.partition("\\")
+        if head in use_map:
+            base = use_map[head]
+            return (f"{base}.{_to_dotted(rest)}" if rest else base), False
+        return _join(namespace, _to_dotted(name)), True
+    if name in use_map:  # unqualified, explicitly `use`d
+        return use_map[name], False
+    return _join(namespace, name), True  # unqualified, not `use`d — assume current namespace
+
+
+__all__ = [
+    "_TypeRec",
+    "_join",
+    "_resolve_type_name",
+    "_text",
+    "_to_dotted",
+    "_use_declaration_targets",
+]

--- a/src/orchestrator/pkg/php_orm.py
+++ b/src/orchestrator/pkg/php_orm.py
@@ -21,7 +21,7 @@ model, a dataclass and an ORM model are indistinguishable at field level, so the
   X::class)]`` (``OneToMany``/``ManyToMany``/``OneToOne`` likewise) names the relation.
 
 A relation's target resolves through the same namespace-rule resolver
-(:func:`orchestrator.pkg.php_extractor._resolve_type_name`) every other PHP fact uses. It
+(:func:`orchestrator.pkg.php_names._resolve_type_name`) every other PHP fact uses. It
 always gets a node — grounded when the target is itself a detected entity in this file,
 external otherwise ("the third-party target stays external", the `eloquent` corpus case's
 own wording) — so a `REFERENCES` edge is never left dangling.
@@ -32,12 +32,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
-from orchestrator.pkg.php_extractor import _resolve_type_name
+from orchestrator.pkg.php_names import _resolve_type_name
 
 if TYPE_CHECKING:
     from tree_sitter import Node as TSNode
 
-    from orchestrator.pkg.php_extractor import _TypeRec
+    from orchestrator.pkg.php_names import _TypeRec
 
 _ELOQUENT_RELATIONS = frozenset({"belongsTo", "hasMany", "hasOne", "belongsToMany"})
 _DOCTRINE_RELATIONS = frozenset({"ManyToOne", "OneToMany", "ManyToMany", "OneToOne"})

--- a/src/orchestrator/pkg/php_routes.py
+++ b/src/orchestrator/pkg/php_routes.py
@@ -25,7 +25,7 @@ yields no edge, never a guess:
   resolved FQN, matching that precedent). A `#[Route]` with no `methods:` is verb-less →
   nothing (same D2).
 
-Handler class names resolve through :func:`orchestrator.pkg.php_extractor._resolve_type_name`
+Handler class names resolve through :func:`orchestrator.pkg.php_names._resolve_type_name`
 — the same namespace-rule resolver every other PHP fact uses, so a route handler lands on
 the exact id its own class declaration would produce.
 """
@@ -36,12 +36,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from orchestrator.pkg.facts import Edge, EdgeKind, FactBatch, Node, NodeKind, Provenance
-from orchestrator.pkg.php_extractor import _resolve_type_name, _to_dotted, _use_declaration_targets
+from orchestrator.pkg.php_names import _resolve_type_name, _to_dotted, _use_declaration_targets
 
 if TYPE_CHECKING:
     from tree_sitter import Node as TSNode
 
-    from orchestrator.pkg.php_extractor import _TypeRec
+    from orchestrator.pkg.php_names import _TypeRec
 
 _LARAVEL_VERBS = frozenset({"get", "post", "put", "patch", "delete", "options"})
 _SLIM_RECEIVER = "$app"

--- a/tests/pkg/test_persistence.py
+++ b/tests/pkg/test_persistence.py
@@ -239,3 +239,16 @@ def test_the_fingerprint_is_in_the_cache_filename(tmp_path: Path) -> None:
     load_or_extract(repo, cache_dir=cache)
     (cache_file,) = list(cache.glob("*.json"))
     assert extractor_fingerprint() in cache_file.name
+
+
+def test_every_grammar_extra_is_in_the_cache_key() -> None:
+    """Review of #334 found `tree_sitter_php` missing from `_GRAMMAR_MODULES`: a graph
+    cached before the extra was installed — with no PHP facts — was served after it,
+    for as long as the commit did not move. `doctor.EXTRA_PROBES` is the one place every
+    extra is enumerated, so the cache key is checked against it here rather than
+    remembered per language."""
+    from orchestrator.doctor import EXTRA_PROBES
+    from orchestrator.pkg.persistence import _GRAMMAR_MODULES
+
+    grammars = {m for m in EXTRA_PROBES.values() if m.startswith("tree_sitter_") or m == "sqlglot"}
+    assert grammars <= set(_GRAMMAR_MODULES), sorted(grammars - set(_GRAMMAR_MODULES))


### PR DESCRIPTION
## What & why

The two remaining **promotion blockers** from the maintainer review of #334, after #335 fixed the five fabrication findings.

**1. The persistence cache could not tell whether the PHP extra was installed.** `persistence._GRAMMAR_MODULES` — the "available grammars" half of the extractor fingerprint that keys the commit-scoped cache — named every grammar except `tree_sitter_php`. So a graph cached before the extra was installed, with no PHP facts in it, kept being served after, for as long as the commit did not move. Exactly the failure the fingerprint's own docstring was written to prevent. Listed now, and `test_every_grammar_extra_is_in_the_cache_key` cross-checks the list against `doctor.EXTRA_PROBES` (the one place every extra is enumerated) so the next grammar cannot be forgotten the same way.

**2. The PHP front-end's static import cycle** (CodeQL `py/cyclic-import`, alerts 209–214, six unresolved review threads on #334). `php_routes.py` and `php_orm.py` imported `_resolve_type_name` / `_to_dotted` / `_use_declaration_targets` / `_TypeRec` from `php_extractor.py`, which imports them back. It never failed at import time because the extractor's side was function-local, but a dependency that only works because of *where* an import statement sits is one refactor from an `ImportError`. The shared pieces now live in **`php_names.py`**, a leaf that imports nothing from its three siblings — the shape `go_routes.py` has always had.

```
php_names  ◄──  php_extractor  ──(function-local, pass ordering)──►  php_routes, php_orm
    ▲                                                                       │
    └───────────────────────────────────────────────────────────────────────┘
```

No behaviour change: same private names, same ids, same facts, same `pkg capabilities` column (the delegate-module detector still finds `php_routes`/`php_orm` through the function-local imports).

Also: `CHANGELOG.md` (two **Unreleased → Fixed** entries), `STATE-OF-SPINE.md`'s gated source-module (352 → 353) and test-function (3,034 → 3,035) counts.

Still open from the review, not in this PR: the `eloquent` / `global_fallback` corpus-label gaps, braced multi-namespace files, and fifteen stale "eight front-ends" doc lines. With this merged, CodeQL's six alerts on `develop` should close on the next analysis, which clears the last thread-resolution blocker for the release PR.

## How it was tested

```
uv run --frozen ruff check . / ruff format --check .        green
uv run --frozen mypy src tests                              green (697 files)
pytest tests/pkg (php, persistence, capabilities, default_extractors, verifier) + test_doctor   143 passed
pytest --ignore=tests/integration (full suite)              see the checks below
uv run --frozen orchestrator pkg accuracy --check           0 gated regressions
scripts/state-numbers.py --check, pkg verify .              green
```

## Checklist
- [x] Quality gate green locally (`mypy src tests`, `ruff format --check .`)
- [x] Tests added/updated where it matters
- [x] No secrets committed
- [x] Docs updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
