### PR TITLE
chore(review): the maintainer PR-review checklist as a skill and a subagent

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,29 @@
+---
+name: pr-reviewer
+description: >-
+  Maintainer-grade review of a pull request or branch into synaptixs/spine, producing a
+  merge/promotion verdict. Use when asked to review a PR or MR, to say whether a change is
+  ready to merge or promote, or to audit that a change updated every user-facing document
+  it obliges. Runs the repo's own quality gate with CI's extras, fans out deep code review,
+  smoke-tests front-end changes on a real repository, and applies the documentation matrix.
+  Read-only on the repository: it never edits the PR branch, never commits, never posts a
+  comment unless the caller passes --comment.
+tools: Bash, Read, Grep, Glob, Agent, WebFetch
+model: inherit
+---
+
+You are the pull-request reviewer for this repository. Follow the procedure in
+`.claude/skills/review-pr/SKILL.md` exactly, with its two reference files
+`docs-matrix.md` and `language-frontend-checklist.md`, and `CLAUDE.md` for the invariants.
+Read all four before doing anything else.
+
+Non-negotiables:
+- Every finding carries `file:line` and a concrete failure scenario, and says which command or
+  subagent produced it.
+- Use `uv run --frozen` for every command. Sync the extras `ci.yml` syncs, not a guess.
+- Report test results from the pytest summary line, never from an exit code; distinguish
+  environmental failures (Postgres on 5433) from real ones.
+- The documentation audit is mandatory on every PR: run the audit script, then walk the matrix,
+  and include the trigger/document/updated?/line table.
+- Do not edit files in the repository under review. Scratch work goes in the scratchpad.
+- Lead the report with the verdict; end with one ordered recommendation, not a menu.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: review-pr
+description: >-
+  Maintainer review of a pull request into this repo — the repeatable checklist a
+  merge/promotion decision needs: process and governance, the local quality gate with CI's
+  exact extras, deep code review fanned out to subagents (precision-first, no invented facts,
+  determinism, import cycles), the accuracy corpus rule, a real-repository smoke test when a
+  front-end changed, and a mechanical audit that every user-facing document a change touches
+  was actually updated. Use for "review PR 334", "is this MR ready to merge / promote",
+  "review this branch before release". Verdict at the end, findings ranked, docs table.
+argument-hint: "<pr-number | branch> [--promote] [--comment]"
+---
+
+# Review a pull request into Spine
+
+`$ARGUMENTS` — a PR number (preferred), or a branch name. `--promote` means the question is
+"is `develop` ready to become a release on `main`", which adds the release-cut checks in §7.
+`--comment` means post the finished review as one PR comment; never post without it.
+
+**Rules that override everything below**
+- Findings must carry `file:line` and a concrete failure scenario. No finding without one.
+- Run commands with `uv run --frozen`. A bare `uv run` re-syncs the environment to the
+  lockfile's default extras and can **uninstall a language grammar mid-review**, which
+  silently changes what the extractor emits and the persistence cache key.
+- Never write a validation repository's name into `src/` or `tests/`; `docs/` only.
+- Never commit `episteme/`, and never edit the PR branch during a review. Findings go in the
+  report; fixes go in a separate PR when asked.
+- Read [docs-matrix.md](docs-matrix.md) before §5 and
+  [language-frontend-checklist.md](language-frontend-checklist.md) when a front-end changed.
+
+## 0. Identify what you are reviewing
+
+```bash
+gh pr view <N> --json number,title,author,baseRefName,headRefName,state,isDraft,mergedAt,mergedBy,reviewDecision,statusCheckRollup,commits,files,body
+gh api repos/synaptixs/spine/collaborators/<login>/permission --jq '{permission,role_name}'
+gh api repos/synaptixs/spine/pulls/<N>/reviews --jq '.[]|{user:.user.login,state}'
+gh api graphql -f query='{repository(owner:"synaptixs",name:"spine"){pullRequest(number:<N>){reviewThreads(first:50){nodes{isResolved path comments(first:1){nodes{author{login} body}}}}}}}'
+gh api "repos/synaptixs/spine/code-scanning/alerts?state=open&ref=refs/heads/<head-or-base>&per_page=100"
+gh pr diff <N> > <scratchpad>/pr<N>.diff
+```
+
+Record, in the report's first lines: open or **already merged** (and by whom — an author
+self-merge with no maintainer review is a finding on its own), base/head, the contributor's
+permission level, whether the PR body's template placeholders (`<!-- … -->`) were left in and
+the "How it was tested" section is empty, unresolved review threads, and open code-scanning
+alerts on the changed files. CONTRIBUTING says an **unresolved review thread blocks the
+promotion PR even at Note severity**, and code scanning re-comments on the release PR for
+anything new relative to `main` — so an unresolved CodeQL note on `develop` is a promotion
+blocker, not cosmetics.
+
+Classify every changed file: `src/`, `tests/`, `corpus/`, `docs/specs/`, root user docs,
+generated artifacts (`assets/*.svg`, `scoreboard.json`, `uv.lock`), CI, and **forbidden**
+(`episteme/` anywhere in the diff fails the review outright).
+
+## 1. Get the code locally without disturbing the working tree
+
+Prefer a worktree: `git worktree add <scratchpad>/pr<N> <head-ref>` (for a merged PR review
+the merge commit on `develop`). If you must use the main checkout, move any untracked files
+that would collide out to the scratchpad first, and put them back at the end. Note that an
+**untracked `docs/specs/*.md` of your own changes the spec-file count** and will fail
+`state-numbers.py --check` for reasons unrelated to the PR — check `git status` before
+blaming the PR for a count.
+
+Sync exactly what CI syncs (read the list from `.github/workflows/ci.yml`, do not assume):
+
+```bash
+uv sync $(grep -A3 'uv sync --extra' .github/workflows/ci.yml | grep -oE -- '--extra [a-z-]+' | tr '\n' ' ')
+```
+
+## 2. The gate, as CI runs it
+
+All of these, and report each result verbatim, green or not:
+
+```bash
+uv run --frozen ruff check .
+uv run --frozen ruff format --check .
+uv run --frozen mypy src tests
+uv run --frozen python scripts/render_architecture_svg.py --check
+uv run --frozen python scripts/render_knowledge_foundation_svg.py --check
+uv run --frozen python scripts/matrix-count.py --check
+uv run --frozen python scripts/state-numbers.py --check
+uv run --frozen orchestrator pkg accuracy --check
+uv run --frozen orchestrator pkg verify .
+uv run --frozen pytest -q -p no:cacheprovider -o addopts=""
+```
+
+Run pytest **without `-x`** and read the summary line, not the exit code: a `-x` run stops at
+the first error and can still exit 0. `tests/integration/` needs Postgres on `127.0.0.1:5433`;
+a `psycopg.OperationalError` there is environmental — say so and cite the CI check instead,
+do not report the suite as passing. Language-extra tests `importorskip`, so a skip count that
+jumped is a missing extra, not a pass.
+
+When `scoreboard.json` changed: the per-language corpus blocks of **other** languages must be
+byte-identical; the repo-self numbers (provenance, drift, parity, invention totals) move with
+ordinary code and are not findings, but a PR claiming "the repo's own graph is unchanged"
+while they moved is misstating its evidence.
+
+## 3. Deep review — fan out, do not read 3,000 lines serially
+
+Launch subagents in parallel (`general-purpose`, background, READ-ONLY), one per new or
+heavily changed module, and one for tests-plus-corpus. Each prompt must name: the files, the
+spec in `docs/specs/` the PR claims to implement, the shipped template it should mirror, the
+invariants from `CLAUDE.md`, and the exact questions below. Ask for ranked findings with
+`file:line`, a "what is good" paragraph, and a one-line verdict.
+
+Questions every code-review agent answers:
+1. **Fabrication.** Any path that emits a node or edge the source does not prove: guessed
+   namespaces, dynamic names (`$obj->$m()`, reflection, string callables), `self`/`static`/
+   `parent` treated as class names, computed paths or prefixes emitted as literal, group
+   prefixes dropped. The `invention` gate is strict at zero per language; a single invented
+   edge is a high finding.
+2. **Spec conformance.** Each decision (D-rows) as built vs as written; any deviation the
+   spec's "as built" notes do not record.
+3. **Determinism.** Randomness, timestamps, set/dict iteration order, filesystem order.
+4. **Import cycles** (CodeQL `py/cyclic-import`): module-level vs function-local imports;
+   whether the precedent (`go_routes.py` imports nothing from its extractor) was followed.
+5. **Error tolerance**: an ERROR-laden parse still yields what parsed and never raises; no bare
+   `except`.
+6. **Provenance** on every grounded node; `end_line` where the template gives one.
+7. **Tests**: what each stated rule lacks a test for; magic counts; tests that pass by accident.
+8. **mypy --strict** hygiene and `# type: ignore` counts; repo style (why-docstrings, no
+   TODO/print/dead code).
+
+Questions the tests-and-corpus agent answers (read `corpus/README.md` first):
+- Labels written **from source**, not from extractor output: derive the true fact set from the
+  fixture by hand and diff it against `expected.json`; a case whose omissions coincide exactly
+  with what the extractor skips is the self-agreeing corpus the README forbids.
+- `known_gaps` predicted, with reasons that match the spec; `open_questions` empty;
+  `excluded` records builtins and other deliberate non-labels the way sibling cases do.
+- Each case exercises the finding the spec says it exists to catch (a "false positive" case
+  must contain the shape whose wrong answer would score).
+- Id vocabulary per the README table.
+
+You may also run `/code-review <N> high` for an independent correctness pass; it does not
+replace the questions above.
+
+## 4. Real-repository smoke test (any change to a front-end, a routes/ORM pass, a post-pass)
+
+Shallow-clone one public repository the relevant spec names into the scratchpad. Run against
+a **copy with `.git` removed** so no commit-keyed cache can be trusted, then delete both:
+
+```bash
+uv run --frozen orchestrator pkg extract <copy> --json   # node kinds by language; Endpoint/Entity present?
+uv run --frozen orchestrator pkg verify <copy>            # errors are findings; say which are pre-existing
+uv run --frozen orchestrator state <copy> --lens developer | grep -E "^- Stack|^- Size|Call graph"
+```
+
+Compare against a targeted extract of one or two files. A whole-repo result that contradicts
+a single-file result is a cache or ordering problem — locate it, do not average it away.
+Check `~/.cache/orchestrator/pkg` entries for the clone (repo-key = sha256 of the resolved
+path) and whether `persistence._GRAMMAR_MODULES` lists the new grammar; if it does not, a
+warm cache serves a graph without that language forever, silently.
+
+## 5. User-facing documentation audit — mandatory, every PR
+
+Run the mechanical half first, then the judgement half.
+
+```bash
+uv run --frozen python .claude/skills/review-pr/scripts/docs_audit.py --base <base-ref> --head <head-ref>
+```
+
+It reports: stale "N front-ends" counts against the registry, language enumerations that omit
+a registered language (informational — codegen lists legitimately exclude comprehension-only
+languages), CLI commands missing from `CLI_REFERENCE.md`, MCP tools missing from the two guides
+and the plugin skill, and every optional extra missing from any of its registration sites
+(`USER_GUIDE.md`, the `languages` meta-extra, `ci.yml`, `doctor.EXTRA_PROBES`,
+`persistence._GRAMMAR_MODULES`, the mypy override).
+
+Then walk [docs-matrix.md](docs-matrix.md): for each trigger the diff matches, confirm the
+named document changed **and says the right thing** — a language added to one list and
+missing from the same document's second list is a finding with both line numbers. Include a
+table in the report: trigger · document · updated? · line.
+
+Also check internal consistency across specs: a status line in one spec ("all four phases
+done") that another spec or `SPEC-INDEX.md` contradicts ("P1+P2") is a finding.
+
+## 6. Repo invariants to check by hand (from `CLAUDE.md`)
+
+PKG is the only source of truth (renderers never re-derive facts from paths); `understand` /
+`state` have no LLM call, randomness, or timestamp; any layout is seeded and computed;
+the web UI gained no build step or graph library; shared artifacts inline their CSS;
+grouping is by owning module, never by symbol id; aggregations record what they elided;
+caches are commit-keyed **and keyed on the extractor fingerprint**; a changed Protocol updated
+its test fakes; fixture source lives under a dot-prefixed root; `--language` stays validated
+(a comprehension-only language must **not** be added to `SUPPORTED_LANGUAGES`).
+
+## 7. Promotion (`--promote`) — the release cut
+
+- Version bumped in `pyproject.toml`; `CHANGELOG.md` has a dated header, not just
+  "Unreleased"; `README.md` "What's new" names the release; both SVGs re-rendered (they stamp
+  the version); `STATE-OF-SPINE.md` version row and the numbers `state-numbers.py` derives.
+- `grep -rn "<previous version>" *.md docs/specs/*.md` — stale version strings.
+- Every open code-scanning alert on the changed files resolved or fixed (they re-comment on
+  the release PR and block it).
+- `develop` is fast-forwardable from the reviewed merge commit; nothing landed since.
+
+## 8. The report
+
+Lead with the verdict on the first line — one of: **Ready to merge** / **Mergeable with
+fixes (listed)** / **Not mergeable**, and for `--promote`: **Ready to promote** / **Not ready
+to promote: fix-forward PR required**. Then:
+
+1. Process facts (§0) in three or four lines.
+2. Findings ranked most severe first, each `file:line` + scenario; group as
+   blocking / should-fix / nits. Attribute which agent or command produced each.
+3. Gate table: command → result (verbatim summary line).
+4. Docs audit table (§5).
+5. What is good — one paragraph, specific.
+6. Ordered next steps, ending with a single recommendation. No menus.
+
+Say what you could not verify and why. Say what was environmental. Never report a suite as
+passing from an exit code.

--- a/.claude/skills/review-pr/docs-matrix.md
+++ b/.claude/skills/review-pr/docs-matrix.md
@@ -1,0 +1,34 @@
+# User-facing documentation matrix — what a change obliges you to update
+
+Read across: if the diff matches the trigger, every document in the row must change in this
+PR, and say the right thing. "Says the right thing" means the reviewer opens the line, not
+just sees the file in the diff. Root-level `*.md` files are the user documentation; `docs/specs/`
+are design records and count separately.
+
+| Trigger in the diff | Must update | What to check on the line |
+|---|---|---|
+| Any user-visible behaviour change | `CHANGELOG.md` (Unreleased / this version) | one entry, names the command or surface, links the spec |
+| New language front-end (`pkg/*_extractor.py`) | `README.md` (**every** language list — there are at least three: the intro paragraph, the "Works across" line, the "Add a language" table row with its count), `FEATURES.md` (capability row **and** the "all N front-ends" accuracy row), `USER_GUIDE.md` (**both** passages: the extras list near the top and the "Multi-language" blockquote, plus the corpus-results line), `KNOWLEDGE_GRAPH.md` (node matrix, edge matrix, language table, "Parser coverage" paragraph, fact-mapping notes), `CLAUDE_GUIDE.md` and `CODEX_GUIDE.md` (language sentence, "N front-ends", toolchain table if codegen), `CLI_REFERENCE.md` (corpus results count), `EXAMPLE.md`, `BENCHMARK.md` ("other N front-ends"), `SETUP.md` if an extra is documented there, `plugins/spine/skills/*/SKILL.md` language line, `corpus/README.md` id-vocabulary row, `docs/specs/STATE-OF-SPINE.md` (front-end row **and** the precision row that says "all N front-ends"), `docs/specs/language-expansion-roadmap.md` status, `assets/spine-architecture.svg` via its script | run `scripts/docs_audit.py`; then grep the number word ("eight", "nine") as well as the digit |
+| New optional extra in `pyproject.toml` | `USER_GUIDE.md` extras list, `SETUP.md`, the `languages`/`all` meta-extras, `.github/workflows/ci.yml` sync line, `doctor.EXTRA_PROBES`, `persistence._GRAMMAR_MODULES` (grammar extras), mypy `ignore_missing_imports` override | the audit script checks all six sites |
+| New or changed CLI command / flag (`src/orchestrator/cli/*.py`) | `CLI_REFERENCE.md` (section + command map), `USER_GUIDE.md` if it is a user workflow, `CLAUDE_GUIDE.md`/`CODEX_GUIDE.md` if the guides walk through it, `docs/specs/STATE-OF-SPINE.md` CLI-commands count | the audit script checks presence; you check the flags are described |
+| New or changed MCP tool (`src/orchestrator/plugin/server.py`) | `CLAUDE_GUIDE.md` and `CODEX_GUIDE.md` tool tables, `plugins/spine/skills/*/SKILL.md` tool lists, `docs/specs/mcp-plugin-surface.md`, `plugin/outputs.py` output type | name, one-line purpose, read-only column |
+| New node or edge kind in `pkg/facts.py` | `KNOWLEDGE_GRAPH.md` matrices, `corpus/README.md` decided rules, `FEATURES.md`, `docs/specs/PRODUCT-KNOWLEDGE-GRAPH.md`, `assets/spine-architecture.svg` (it states "N node kinds · M edge kinds") | the SVG check script fails if not re-rendered |
+| New `docs/specs/*.md` | `docs/specs/SPEC-INDEX.md` (row **and** the count in prose **and** the `ls … wc -l` line), `docs/specs/README.md`, `docs/specs/STATE-OF-SPINE.md` spec-file count | `state-numbers.py --check` gates all three counts |
+| Any spec whose status changed | that spec's status line, `SPEC-INDEX.md` row, `STATE-OF-SPINE.md` progress table, any sibling spec that restates it (e.g. the expansion roadmap restating a language roadmap) | statuses must agree with each other and with the code |
+| Registry / web UI change (`registry/`) | `OPERATIONS.md`, `USER_GUIDE.md` operator section, `docs/specs/unified-ui.md` | no build step introduced |
+| Deploy / env / config change | `OPERATIONS.md`, `SETUP.md`, `.env.example` if present | variable name and default |
+| Contribution process change | `CONTRIBUTING.md`, `.github/pull_request_template.md` | |
+| Release cut | `pyproject.toml` version, `CHANGELOG.md` header, `README.md` "What's new", both SVGs, `STATE-OF-SPINE.md` version row, `grep` for the previous version string across `*.md` | see SKILL.md §7 |
+| New maintainer tooling (`.claude/skills`, `.claude/agents`, `scripts/`) | `CONTRIBUTING.md` (how to run it) | one line is enough |
+
+## Counts that rot
+
+These appear as prose and rot silently. After any change to what they count, grep for the
+digit **and** the word:
+
+- number of language front-ends (`FRONT_ENDS` in `pkg/capabilities.py`)
+- number of corpus fixture cases (`ls corpus/*/*/expected.json | wc -l`)
+- number of MCP tools; number of CLI commands; number of specs; test counts
+- "N node kinds · M edge kinds" in the architecture SVG
+
+`scripts/state-numbers.py --check` gates some of these; the audit script covers the rest.

--- a/.claude/skills/review-pr/language-frontend-checklist.md
+++ b/.claude/skills/review-pr/language-frontend-checklist.md
@@ -1,0 +1,60 @@
+# Adding or changing a language front-end — every site that must move together
+
+A front-end is "one module", but registering it touches all of these. A PR that misses one
+ships a language that works on the author's machine and nowhere else, or a cache that never
+notices the language exists. Check each with `file:line` in the report.
+
+## Registration (src)
+
+| Site | What | Failure if missed |
+|---|---|---|
+| `pkg/<lang>_extractor.py` | `language`, `suffixes`, `module_name`, `extract`, optional `finalize`; lazy `_<lang>_parser()`; `TYPE_CHECKING`-guarded `TSNode` | — |
+| `pkg/extractor.py` `default_extractors()` | gated append: `find_spec` **before** a function-local import | base install imports the grammar |
+| `pkg/capabilities.py` `FRONT_ENDS` | entry in registry order | capability matrix omits the language; `test_capabilities` fixtures |
+| `doctor.py` `EXTRA_PROBES` | extra → probe module | `doctor` cannot report the extra |
+| `pkg/persistence.py` `_GRAMMAR_MODULES` | the grammar module | **cache key ignores the extra: a warm cache serves a graph without the language forever** |
+| `catalog/profile.py` | suffix → language; manifest marker file; framework needles; test runner | repo profiles as no language; `state` "Stack" line wrong |
+| `pkg/scope.py` | `WALKERS[lang]` or `NOT_APPLICABLE[lang]` with a reason | invention oracle reports an unmeasured zero as clean; `test_scope` roster test |
+| `pkg/import_link.py` | a matcher, or a documented reason none is needed | orphan-rate / external-ratio errors in `pkg verify` |
+| `pkg/docs.py`, `pkg/doc_link.py` | source extension in the drift/ident sets | doc binder treats `Foo.php` as a symbol |
+| `knowledge/insights.py` | visibility rule or explicit `None` | public/private split guesses |
+| `sdlc/feature_runner.py` `SUPPORTED_LANGUAGES` | **only** with layout/scaffold/testenv/testrunner/prompts | `--language x` silently scaffolds Python |
+
+## Packaging and CI
+
+| Site | What |
+|---|---|
+| `pyproject.toml` | `<lang> = [...]` extra; `languages` meta-extra; mypy `ignore_missing_imports` module |
+| `uv.lock` | relocked |
+| `.github/workflows/ci.yml` | `--extra <lang>` on the sync line (else the biconditional test proves nothing) |
+
+## Tests
+
+`tests/pkg/test_<lang>_extractor.py` (module-level `importorskip`); `test_default_extractors.py`
+biconditional + end-to-end; `test_capabilities.py` `_FIXTURES`; `test_verifier.py` per-front-end
+freshness; `tests/catalog/test_profile.py`; `test_scope.py` roster; `test_doctor.py` if probes are
+enumerated; a persistence test that the fingerprint changes with the grammar present.
+
+## Corpus
+
+`corpus/<lang>/<case>/{expected.json,.repo/…}` — the dot on `.repo/` is load-bearing; labels
+from source; `known_gaps` predicted; a case per invention shape the spec forbids, containing the
+shape whose wrong answer would score; `corpus/README.md` vocabulary row; `scoreboard.json`
+regenerated with `--scoreboard` and the PR saying so.
+
+## Docs
+
+See `docs-matrix.md`, row "New language front-end".
+
+## Precision rules every front-end must honour (findings if violated)
+
+- Emit nothing for a computed path, prefix, name, or target. A wrong grounded fact is worse
+  than a missing one.
+- Never treat `self` / `static` / `parent` / `this` / `__PACKAGE__` as a class name.
+- Never emit a `CALLS` edge whose method name came from a variable.
+- No `ANY`-verb endpoints (`endpoints-typescript-go.md` D2).
+- A closure handler yields an `Endpoint` and no `EXPOSES`.
+- A guessed namespace is repointed or dropped in `finalize`; a guessed **method** id has no
+  backstop and must not be emitted unverified.
+- Templates, vendored trees, generated code, and build output are skipped by name, not
+  parsed and hoped for.

--- a/.claude/skills/review-pr/scripts/docs_audit.py
+++ b/.claude/skills/review-pr/scripts/docs_audit.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""The mechanical half of the user-facing documentation audit (`/review-pr` §5).
+
+Cross-checks what the code *registers* against what the documents *say*, so a reviewer does
+not have to remember which of nine documents carries a language list. Stdlib only, regex over
+source — no imports of the package, so it runs on any ref, with or without extras installed.
+
+    python .claude/skills/review-pr/scripts/docs_audit.py [--base REF --head REF] [--strict]
+
+Checks (each prints `[STALE]`, `[MISSING]`, or `[INFO]` lines; `--strict` exits non-zero on
+STALE/MISSING):
+
+1. front-end count — every "N front-ends" / "N language front-ends" claim (digit or word) in
+   the user documents vs the length of `FRONT_ENDS` in `pkg/capabilities.py`. A line that
+   carries a date or a `**x.y.z**` release stamp is history and reported as INFO; the rest as
+   STALE.
+2. language enumerations — a line naming four or more registered languages and omitting one.
+   INFO only: codegen lists legitimately exclude comprehension-only languages; a reviewer
+   decides.
+3. optional extras — every language extra in `pyproject.toml` (a `tree-sitter-<grammar>` or
+   `sqlglot` extra) must appear at all of its registration sites: `USER_GUIDE.md`, the
+   `languages` meta-extra, `ci.yml`'s sync line (or the `dev` extra CI installs),
+   `doctor.EXTRA_PROBES`, `persistence._GRAMMAR_MODULES` (grammar extras), and the mypy
+   `ignore_missing_imports` override.
+4. CLI commands — every `.command("name")` under `cli/` is mentioned in `CLI_REFERENCE.md`.
+5. MCP tools — every key of `plugin/outputs.py:OUTPUTS` is mentioned in `CLAUDE_GUIDE.md`,
+   `CODEX_GUIDE.md`, and at least one `plugins/spine/skills/*/SKILL.md`.
+6. with `--base/--head`: which user documents the diff touched, for the report's table.
+
+A finding here is a pointer for the reviewer, not a verdict: a stale count in a paragraph
+describing a dated measurement may be correct history. The reviewer opens the line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+SRC = ROOT / "src" / "orchestrator"
+
+USER_DOCS = [
+    "README.md",
+    "FEATURES.md",
+    "USER_GUIDE.md",
+    "KNOWLEDGE_GRAPH.md",
+    "CLAUDE_GUIDE.md",
+    "CODEX_GUIDE.md",
+    "CLI_REFERENCE.md",
+    "SETUP.md",
+    "EXAMPLE.md",
+    "BENCHMARK.md",
+    "OPERATIONS.md",
+    "CONTRIBUTING.md",
+    "docs/specs/STATE-OF-SPINE.md",
+    "docs/specs/SPEC-INDEX.md",
+    "corpus/README.md",
+]
+USER_DOC_GLOBS = ["plugins/spine/**/*.md"]
+
+DISPLAY = {
+    "python": "Python",
+    "java": "Java",
+    "typescript": "TypeScript",
+    "csharp": "C#",
+    "c": "C",
+    "cpp": "C++",
+    "go": "Go",
+    "php": "PHP",
+    "sql": "SQL",
+    "perl": "Perl",
+    "ruby": "Ruby",
+    "rust": "Rust",
+    "kotlin": "Kotlin",
+}
+WORDS = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+    "eleven": 11,
+    "twelve": 12,
+}
+# Lines that describe a moment rather than the present: a date, or a release stamp.
+_HISTORY = re.compile(r"20\d\d-\d\d-\d\d|\*\*\d+\.\d+\.\d+\*\*")
+_COUNT = re.compile(r"\b(?:all |the other |other )?(\d+|[a-z]+) (?:language )?front-ends\b", re.I)
+# Extras that bundle others or are tooling, never a language.
+_NOT_LANGUAGE_EXTRAS = frozenset({"dev", "languages", "all"})
+
+
+def _read(rel: str) -> str:
+    try:
+        return (ROOT / rel).read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def user_docs() -> list[str]:
+    out = [d for d in USER_DOCS if (ROOT / d).is_file()]
+    for pattern in USER_DOC_GLOBS:
+        out.extend(sorted(p.relative_to(ROOT).as_posix() for p in ROOT.glob(pattern)))
+    return out
+
+
+def front_ends() -> list[str]:
+    text = _read("src/orchestrator/pkg/capabilities.py")
+    if "FRONT_ENDS" not in text:
+        return []
+    block = text.split("FRONT_ENDS", 1)[1].split(")\n\n", 1)[0]
+    return re.findall(r'FrontEnd\("([a-z]+)"', block)
+
+
+def check_counts(n: int) -> list[str]:
+    out: list[str] = []
+    for doc in user_docs():
+        for i, line in enumerate(_read(doc).splitlines(), 1):
+            for m in _COUNT.finditer(line):
+                tok = m.group(1).lower()
+                val = int(tok) if tok.isdigit() else WORDS.get(tok)
+                if val is None:
+                    continue
+                other = "other" in m.group(0).lower()
+                expected = n - 1 if other else n
+                if val == expected:
+                    continue
+                tag = "INFO" if _HISTORY.search(line) else "STALE"
+                note = f" (other → {expected})" if other else ""
+                out.append(
+                    f"[{tag}] front-end count: {doc}:{i} says {tok!r}, registry has {n}{note}: "
+                    f"{line.strip()[:100]}"
+                )
+    return out
+
+
+def check_enumerations(langs: list[str]) -> list[str]:
+    out: list[str] = []
+    names = {lang: DISPLAY.get(lang, lang) for lang in langs}
+    for doc in user_docs():
+        for i, line in enumerate(_read(doc).splitlines(), 1):
+            present = {
+                lang
+                for lang, name in names.items()
+                if re.search(rf"(?<![\w#+]){re.escape(name)}(?![\w#+])", line)
+            }
+            if len(present) >= 4:
+                missing = [names[lang] for lang in langs if lang not in present]
+                if missing:
+                    out.append(
+                        f"[INFO] enumeration omits {', '.join(missing)}: {doc}:{i}: {line.strip()[:100]}"
+                    )
+    return out
+
+
+def _optional_extras() -> dict[str, str]:
+    py = _read("pyproject.toml")
+    if "[project.optional-dependencies]" not in py:
+        return {}
+    opt = py.split("[project.optional-dependencies]", 1)[1].split("\n[", 1)[0]
+    return {m.group(1): m.group(2) for m in re.finditer(r"^([a-z-]+) = \[(.*?)\]", opt, re.S | re.M)}
+
+
+def check_extras() -> list[str]:
+    out: list[str] = []
+    extras = _optional_extras()
+    lang_extras = {
+        k: v
+        for k, v in extras.items()
+        if k not in _NOT_LANGUAGE_EXTRAS and (re.search(r"tree-sitter-[a-z]", v) or "sqlglot" in v)
+    }
+    languages_meta = extras.get("languages", "")
+    dev_body = extras.get("dev", "")
+    sync = " ".join(re.findall(r"--extra [a-z-]+", _read(".github/workflows/ci.yml")))
+    doctor = _read("src/orchestrator/doctor.py")
+    persist = _read("src/orchestrator/pkg/persistence.py")
+    grammar_block = ""
+    if "_GRAMMAR_MODULES = (" in persist:
+        grammar_block = persist.split("_GRAMMAR_MODULES = (", 1)[1].split(")", 1)[0]
+    py = _read("pyproject.toml")
+    mypy = re.search(r"\[\[tool\.mypy\.overrides\]\]\nmodule = \[(.*?)\]", py, re.S)
+    mypy_mods = mypy.group(1) if mypy else ""
+    guide = _read("USER_GUIDE.md")
+    meta_names = re.findall(r"[a-z-]+", languages_meta.split("[", 1)[-1])
+    for extra, body in sorted(lang_extras.items()):
+        grammar = re.search(r'"(tree-sitter-[a-z-]+)', body)
+        module = grammar.group(1).replace("-", "_") if grammar else None
+        packages = re.findall(r'"([a-z-]+)', body)
+        if f"[{extra}]" not in guide:
+            out.append(f"[MISSING] extra {extra!r}: not mentioned as `[{extra}]` in USER_GUIDE.md")
+        if extra not in meta_names:
+            out.append(f"[MISSING] extra {extra!r}: absent from the `languages` meta-extra in pyproject.toml")
+        in_dev = all(f'"{p}' in dev_body for p in packages)
+        if f"--extra {extra}" not in sync and not in_dev:
+            out.append(
+                f"[MISSING] extra {extra!r}: absent from ci.yml's `uv sync` line (its tests skip in CI)"
+            )
+        if f'"{extra}":' not in doctor:
+            out.append(f"[MISSING] extra {extra!r}: absent from doctor.EXTRA_PROBES")
+        if module and module not in grammar_block:
+            out.append(
+                f"[MISSING] extra {extra!r}: {module} absent from persistence._GRAMMAR_MODULES — "
+                "a warm cache ignores whether it is installed"
+            )
+        if module and module not in mypy_mods:
+            out.append(
+                f"[MISSING] extra {extra!r}: {module} absent from the mypy ignore_missing_imports override"
+            )
+    return out
+
+
+def check_cli() -> list[str]:
+    out: list[str] = []
+    ref = _read("CLI_REFERENCE.md")
+    for path in sorted((SRC / "cli").glob("*.py")):
+        for m in re.finditer(r'@(\w+)\.command\("([a-z-]+)"', path.read_text(encoding="utf-8")):
+            app, cmd = m.group(1), m.group(2)
+            group = app.removesuffix("_app").replace("_", " ")
+            if not re.search(rf"\b{re.escape(cmd)}\b", ref):
+                out.append(f"[MISSING] CLI command `{group} {cmd}` ({path.name}) not in CLI_REFERENCE.md")
+    return out
+
+
+def check_mcp() -> list[str]:
+    out: list[str] = []
+    outputs = _read("src/orchestrator/plugin/outputs.py")
+    marker = "OUTPUTS: dict[str, type] = {"
+    block = outputs.split(marker, 1)[1].split("}", 1)[0] if marker in outputs else ""
+    tools = re.findall(r'^\s+"([a-z_]+)":', block, re.M)
+    guides = {g: _read(g) for g in ("CLAUDE_GUIDE.md", "CODEX_GUIDE.md")}
+    skills = "\n".join(p.read_text(encoding="utf-8") for p in ROOT.glob("plugins/spine/skills/*/SKILL.md"))
+    for tool in tools:
+        for g, text in guides.items():
+            if tool not in text:
+                out.append(f"[MISSING] MCP tool `{tool}` not mentioned in {g}")
+        if tool not in skills:
+            out.append(f"[INFO] MCP tool `{tool}` not named in any plugins/spine/skills/*/SKILL.md")
+    return out
+
+
+def touched_docs(base: str, head: str) -> list[str]:
+    try:
+        names = subprocess.run(
+            ["git", "-C", str(ROOT), "diff", "--name-only", f"{base}..{head}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.split()
+    except (subprocess.CalledProcessError, OSError) as exc:
+        return [f"[INFO] could not diff {base}..{head}: {exc}"]
+    docs = [n for n in names if n.endswith((".md", ".svg"))]
+    return [f"[INFO] docs touched by the diff ({len(docs)}): " + ", ".join(docs)]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base")
+    ap.add_argument("--head")
+    ap.add_argument("--strict", action="store_true")
+    args = ap.parse_args()
+
+    langs = front_ends()
+    lines: list[str] = [f"[INFO] registered front-ends ({len(langs)}): {', '.join(langs)}"]
+    lines += check_counts(len(langs))
+    lines += check_enumerations(langs)
+    lines += check_extras()
+    lines += check_cli()
+    lines += check_mcp()
+    if args.base and args.head:
+        lines += touched_docs(args.base, args.head)
+    for line in lines:
+        print(line)
+    bad = sum(1 for line in lines if line.startswith(("[STALE]", "[MISSING]")))
+    info = sum(1 for line in lines if line.startswith("[INFO]"))
+    print(f"\ndocs_audit: {bad} STALE/MISSING, {info} INFO")
+    return 1 if (args.strict and bad) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,11 @@ build/
 /BACKLOG.md
 
 # Claude Code session lockfiles
-.claude/
+# Per-user Claude Code state stays local; the shared maintainer skills and agents
+# (`/review-pr`, `pr-reviewer`) are tracked so every reviewer runs the same checklist.
+.claude/*
+!.claude/skills/
+!.claude/agents/
 
 # Secrets / local credentials (live integration testing)
 .env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,13 @@ published release notes.
 For larger features, the core team often develops them ahead of time and publishes
 them on a release cadence — so opening an issue first avoids duplicated effort.
 
+**Reviewing a pull request as a maintainer.** From Claude Code in this checkout, run
+`/review-pr <number>` (add `--promote` for a release-cut check). It is the checklist a merge
+decision needs — the gate with CI's extras, fan-out code review, a real-repository smoke test
+for front-end changes, and a mechanical audit that every user-facing document the change
+obliges was updated (`.claude/skills/review-pr/`). The same procedure is available as the
+`pr-reviewer` subagent.
+
 ## Opening a pull request
 
 1. Fork the repo and create a branch from `main` (e.g. `fix/email-validator-edge-case`).


### PR DESCRIPTION
## What & why

The maintainer PR-review checklist, as a project skill and a subagent, so every reviewer runs the same procedure the #334 review ran by hand — and so the documentation half of that review is mechanical rather than remembered.

- **`.claude/skills/review-pr/SKILL.md`** — `/review-pr <number> [--promote] [--comment]`: process facts (who merged, permission level, unresolved threads, open code-scanning alerts), the gate with CI's exact extras (`uv run --frozen` throughout — a bare `uv run` re-syncs and can uninstall a grammar mid-review), fan-out deep review with the fabrication questions, the corpus rule, a real-repository smoke test on a `.git`-less copy for front-end changes, the mandatory docs audit, the `CLAUDE.md` invariants, and the release-cut checks behind `--promote`. Verdict first, findings ranked with `file:line`, one recommendation at the end.
- **`docs-matrix.md`** — which user-facing documents each kind of change obliges, and what to check on the line (a new language touches at least three lists in `README.md` alone).
- **`language-frontend-checklist.md`** — every registration site a front-end must move together, including the persistence cache key #334 missed.
- **`scripts/docs_audit.py`** — the mechanical half, stdlib only: stale "N front-ends" counts against the registry, language enumerations that omit a registered language, every optional extra checked at all six of its registration sites, CLI commands missing from `CLI_REFERENCE.md`, MCP tools missing from the two guides. On #334 it flagged the fifteen stale counts and the `_GRAMMAR_MODULES` omission on its first run, plus two pre-existing gaps (`pkg fix-sites` absent from `CLI_REFERENCE.md`; four MCP tools absent from `CODEX_GUIDE.md`).
- **`.claude/agents/pr-reviewer.md`** — the same procedure as a subagent.
- **`.gitignore`** — `.claude/` was ignored wholesale; now only per-user state is, and `skills/` and `agents/` are tracked.
- **`CONTRIBUTING.md`** — one paragraph on how to run it.

No package code changes; `state-numbers.py --check` is unaffected (nothing under `src/`, `tests/`, or `docs/specs/`).

## How it was tested

```
uv run --frozen python .claude/skills/review-pr/scripts/docs_audit.py --base 0520ee9 --head 9ef91ca
  → 20 STALE/MISSING on the #334 range (all confirmed by hand), 42 INFO
uv run --frozen ruff check . / ruff format --check .        green (the script included)
```

The procedure itself was exercised end to end on #334; its findings became #335 and #336.

## Checklist
- [x] Quality gate green locally (`mypy src tests`, `ruff format --check .`)
- [x] Tests added/updated where it matters — n/a, no package code
- [x] No secrets committed
- [x] Docs updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
