### PR TITLE
chore(review): the documentation audit follows links and hunts removed surfaces

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -162,9 +162,19 @@ uv run --frozen python .claude/skills/review-pr/scripts/docs_audit.py --base <ba
 It reports: stale "N front-ends" counts against the registry, language enumerations that omit
 a registered language (informational — codegen lists legitimately exclude comprehension-only
 languages), CLI commands missing from `CLI_REFERENCE.md`, MCP tools missing from the two guides
-and the plugin skill, and every optional extra missing from any of its registration sites
+and the plugin skill, every optional extra missing from any of its registration sites
 (`USER_GUIDE.md`, the `languages` meta-extra, `ci.yml`, `doctor.EXTRA_PROBES`,
-`persistence._GRAMMAR_MODULES`, the mypy override).
+`persistence._GRAMMAR_MODULES`, the mypy override), **every relative link that does not
+resolve** (file or anchor, under GitHub's slug rules), and — with `--base/--head` — **every
+mention of a surface the diff removed** (a CLI command, an MCP tool, an extra). A removed
+feature often has no registry entry, so name it and its synonyms yourself:
+
+```bash
+uv run --frozen python .claude/skills/review-pr/scripts/docs_audit.py --base <base> --head <head> --removed "terminal UI,TUI,Textual"
+```
+
+A mention inside a version-stamped or dated paragraph is reported as INFO — it is history and
+may stay; a mention in present-tense prose is STALE.
 
 Then walk [docs-matrix.md](docs-matrix.md): for each trigger the diff matches, confirm the
 named document changed **and says the right thing** — a language added to one list and
@@ -186,10 +196,19 @@ its test fakes; fixture source lives under a dot-prefixed root; `--language` sta
 
 ## 7. Promotion (`--promote`) — the release cut
 
-- Version bumped in `pyproject.toml`; `CHANGELOG.md` has a dated header, not just
-  "Unreleased"; `README.md` "What's new" names the release; both SVGs re-rendered (they stamp
-  the version); `STATE-OF-SPINE.md` version row and the numbers `state-numbers.py` derives.
-- `grep -rn "<previous version>" *.md docs/specs/*.md` — stale version strings.
+- Version bumped in `pyproject.toml` **and the lockfile's own package entry only** (a full
+  `uv lock` on a developer machine rewrites unrelated markers and can downgrade the lock
+  revision — revert that, change the one line, as every prior cut did); `CHANGELOG.md` has a
+  dated header, not just "Unreleased"; `README.md` "What's new" names the release; both SVGs
+  re-rendered (they stamp the version); `STATE-OF-SPINE.md` version row and the numbers
+  `state-numbers.py` derives.
+- **Every plugin manifest** — the list is `_MANIFESTS` in `tests/plugin/test_manifests.py`
+  (three today, including the root `.claude-plugin/marketplace.json`, which a `find` for
+  `plugin.json` does not return). Run that test file; the 3.33.0 cut failed CI on the one
+  the grep below cannot see.
+- `grep -rn "<previous version>" *.md docs/specs/*.md` for stale version strings in prose,
+  and `grep -rn '"version": "<previous version>"' .claude-plugin plugins codex-marketplace`
+  for the JSON the Markdown grep misses.
 - Every open code-scanning alert on the changed files resolved or fixed (they re-comment on
   the release PR and block it).
 - `develop` is fast-forwardable from the reviewed merge commit; nothing landed since.

--- a/.claude/skills/review-pr/docs-matrix.md
+++ b/.claude/skills/review-pr/docs-matrix.md
@@ -18,8 +18,9 @@ are design records and count separately.
 | Registry / web UI change (`registry/`) | `OPERATIONS.md`, `USER_GUIDE.md` operator section, `docs/specs/unified-ui.md` | no build step introduced |
 | Deploy / env / config change | `OPERATIONS.md`, `SETUP.md`, `.env.example` if present | variable name and default |
 | Contribution process change | `CONTRIBUTING.md`, `.github/pull_request_template.md` | |
-| Release cut | `pyproject.toml` version, `CHANGELOG.md` header, `README.md` "What's new", both SVGs, `STATE-OF-SPINE.md` version row, `grep` for the previous version string across `*.md` | see SKILL.md §7 |
+| Release cut | `pyproject.toml` version and the lockfile's own entry, **every plugin manifest** (`_MANIFESTS` in `tests/plugin/test_manifests.py` — three, one at the repo root), `CHANGELOG.md` header, `README.md` "What's new", both SVGs, `STATE-OF-SPINE.md` version row, `CLI_REFERENCE.md` banner, `capability-matrix.md` header, the reusable-workflow tag in `gap4-adoption-distribution-roadmap.md`, `SPEC-INDEX.md` recount line; `grep` for the previous version string across `*.md` **and** `*.json` | see SKILL.md §7 |
 | New maintainer tooling (`.claude/skills`, `.claude/agents`, `scripts/`) | `CONTRIBUTING.md` (how to run it) | one line is enough |
+| **Removed feature or surface** (a CLI command, an MCP tool, an extra, a UI, a workflow) | every root document that named it — the audit lists them: `docs_audit.py --base <base> --head <head> --removed "<name>,<synonym>,<synonym>"`; the skill; any spec whose status restates it; `CHANGELOG.md` Removed | the name **and its synonyms** ("terminal UI" outlived "tui" by two releases); a mention inside a version-stamped paragraph is history and may stay |
 
 ## Counts that rot
 
@@ -32,3 +33,10 @@ digit **and** the word:
 - "N node kinds · M edge kinds" in the architecture SVG
 
 `scripts/state-numbers.py --check` gates some of these; the audit script covers the rest.
+
+## Links
+
+The audit follows every relative link in the user documents: the file must exist and an anchor
+must match a heading under GitHub's slug rules (an em dash yields a double hyphen —
+`step-1--install` — so do not "fix" those). Six dead links sat in `SETUP.md` for months before
+this check existed.

--- a/.claude/skills/review-pr/scripts/docs_audit.py
+++ b/.claude/skills/review-pr/scripts/docs_audit.py
@@ -26,6 +26,17 @@ STALE/MISSING):
 5. MCP tools — every key of `plugin/outputs.py:OUTPUTS` is mentioned in `CLAUDE_GUIDE.md`,
    `CODEX_GUIDE.md`, and at least one `plugins/spine/skills/*/SKILL.md`.
 6. with `--base/--head`: which user documents the diff touched, for the report's table.
+7. links — every relative link in the user documents resolves: the file exists and, when
+   there is an anchor, it matches a heading under GitHub's slug rules (an em dash in a
+   heading yields a double hyphen: "Step 1 — Install" → `step-1--install`). MISSING.
+8. removed surfaces — with `--base/--head`, whatever the diff removed from the registries
+   (a CLI command, an MCP tool, an optional extra), plus anything passed as
+   `--removed "terminal UI,TUI,Textual"`, is grepped for in the user documents at head.
+   A mention is STALE; inside a version-stamped or dated paragraph it is INFO (history).
+   The manual list exists because a removed feature often has no registry entry — the
+   terminal UI had none, and two README sentences outlived it by two releases.
+
+`--root DIR` points every check at another tree (the tests use a fixture tree).
 
 A finding here is a pointer for the reviewer, not a verdict: a stale count in a paragraph
 describing a dated measurement may be correct history. The reviewer opens the line.
@@ -41,6 +52,14 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[4]
 SRC = ROOT / "src" / "orchestrator"
+
+
+def set_root(path: Path | str) -> None:
+    """Point every check at ``path`` instead of the checkout this file lives in."""
+    global ROOT, SRC
+    ROOT = Path(path).resolve()
+    SRC = ROOT / "src" / "orchestrator"
+
 
 USER_DOCS = [
     "README.md",
@@ -90,8 +109,35 @@ WORDS = {
     "eleven": 11,
     "twelve": 12,
 }
-# Lines that describe a moment rather than the present: a date, or a release stamp.
-_HISTORY = re.compile(r"20\d\d-\d\d-\d\d|\*\*\d+\.\d+\.\d+\*\*")
+# A date, a bold release stamp (`**3.32.0**`, `**3.32.0 (current)**`), or prose that pins a
+# version ("removed in 3.31.0", "shipped 1.18.0", "since 3.29"). Present-tense prose has none.
+_HISTORY = re.compile(
+    r"20\d\d-\d\d-\d\d"
+    r"|\*\*\d+\.\d+\.\d+[^*\n]*\*\*"
+    r"|\b(?:removed|shipped|added|landed|since|until|before|after|in|at)(?: in)? v?\d+\.\d+(?:\.\d+)?\b",
+    re.I,
+)
+
+
+def history_lines(text: str) -> set[int]:
+    """1-based line numbers that are history: the line carries a date or release stamp, or
+    the paragraph it sits in opens with one ("What's new" stamps the paragraph, not every
+    line)."""
+    out: set[int] = set()
+    lines = text.splitlines()
+    para_start = 0
+    para_history = False
+    for i, line in enumerate(lines, 1):
+        if not line.strip():
+            para_start, para_history = 0, False
+            continue
+        if para_start == 0:
+            para_start, para_history = i, bool(_HISTORY.search(line))
+        if para_history or _HISTORY.search(line):
+            out.add(i)
+    return out
+
+
 _COUNT = re.compile(r"\b(?:all |the other |other )?(\d+|[a-z]+) (?:language )?front-ends\b", re.I)
 # Extras that bundle others or are tooling, never a language.
 _NOT_LANGUAGE_EXTRAS = frozenset({"dev", "languages", "all"})
@@ -122,7 +168,9 @@ def front_ends() -> list[str]:
 def check_counts(n: int) -> list[str]:
     out: list[str] = []
     for doc in user_docs():
-        for i, line in enumerate(_read(doc).splitlines(), 1):
+        text = _read(doc)
+        history = history_lines(text)
+        for i, line in enumerate(text.splitlines(), 1):
             for m in _COUNT.finditer(line):
                 tok = m.group(1).lower()
                 val = int(tok) if tok.isdigit() else WORDS.get(tok)
@@ -132,7 +180,7 @@ def check_counts(n: int) -> list[str]:
                 expected = n - 1 if other else n
                 if val == expected:
                     continue
-                tag = "INFO" if _HISTORY.search(line) else "STALE"
+                tag = "INFO" if i in history else "STALE"
                 note = f" (other → {expected})" if other else ""
                 out.append(
                     f"[{tag}] front-end count: {doc}:{i} says {tok!r}, registry has {n}{note}: "
@@ -245,6 +293,169 @@ def check_mcp() -> list[str]:
     return out
 
 
+# --------------------------------------------------------------------------- #
+# 7. links
+# --------------------------------------------------------------------------- #
+
+_LINK = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+_HEADING = re.compile(r"^(#{1,6})\s+(.*?)\s*#*\s*$")
+
+
+def github_slug(heading: str) -> str:
+    """GitHub's anchor for a heading: markdown stripped, lowercased, everything but letters,
+    digits, spaces, hyphens and underscores dropped, spaces to hyphens. Consecutive hyphens
+    are kept — that is where the double hyphen for an em dash comes from."""
+    text = re.sub(r"`([^`]*)`", r"\1", heading)
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)  # [text](link) → text
+    text = text.replace("**", "").replace("*", "").replace("_", "_")
+    text = text.lower()
+    text = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
+    text = text.replace(" ", "-")
+    return text
+
+
+def heading_anchors(text: str) -> set[str]:
+    """Every anchor a document offers, duplicates suffixed the way GitHub does (-1, -2, …).
+    Headings inside code fences are not headings."""
+    seen: dict[str, int] = {}
+    out: set[str] = set()
+    fenced = False
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        m = _HEADING.match(line)
+        if not m:
+            continue
+        slug = github_slug(m.group(2))
+        n = seen.get(slug, 0)
+        seen[slug] = n + 1
+        out.add(slug if n == 0 else f"{slug}-{n}")
+    return out
+
+
+def _links_in(text: str) -> list[tuple[int, str]]:
+    """``(line, target)`` for every link outside a code fence; inline code is skipped too."""
+    out: list[tuple[int, str]] = []
+    fenced = False
+    for i, line in enumerate(text.splitlines(), 1):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        bare = re.sub(r"`[^`]*`", "", line)
+        for m in _LINK.finditer(bare):
+            out.append((i, m.group(1)))
+    return out
+
+
+def check_links() -> list[str]:
+    out: list[str] = []
+    for doc in user_docs():
+        text = _read(doc)
+        for lineno, target in _links_in(text):
+            if re.match(r"[a-z][a-z0-9+.-]*:", target) or target.startswith("//"):
+                continue  # http(s), mailto:, and friends
+            path, _, anchor = target.partition("#")
+            if not path and not anchor:
+                continue
+            base = (ROOT / doc).parent
+            file = (base / path).resolve() if path else (ROOT / doc)
+            if not file.exists():
+                out.append(f"[MISSING] link: {doc}:{lineno} → {target} — file not found")
+                continue
+            if anchor and file.suffix == ".md":
+                anchors = heading_anchors(file.read_text(encoding="utf-8", errors="replace"))
+                if anchor not in anchors:
+                    stem = anchor.split("-")[0]
+                    near = sorted(a for a in anchors if a.startswith(stem))[:3]
+                    hint = f" (nearest: {', '.join(near)})" if near else ""
+                    out.append(f"[MISSING] link: {doc}:{lineno} → {target} — no such anchor{hint}")
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# 8. removed surfaces
+# --------------------------------------------------------------------------- #
+
+
+def cli_commands_in(text: str) -> set[str]:
+    return set(re.findall(r'@\w+\.command\("([a-z-]+)"', text))
+
+
+def mcp_tools_in(outputs_text: str) -> set[str]:
+    marker = "OUTPUTS: dict[str, type] = {"
+    block = outputs_text.split(marker, 1)[1].split("}", 1)[0] if marker in outputs_text else ""
+    return set(re.findall(r'^\s+"([a-z_]+)":', block, re.M))
+
+
+def extras_in(pyproject_text: str) -> set[str]:
+    if "[project.optional-dependencies]" not in pyproject_text:
+        return set()
+    opt = pyproject_text.split("[project.optional-dependencies]", 1)[1].split("\n[", 1)[0]
+    return set(re.findall(r"^([a-z-]+) = \[", opt, re.M)) - _NOT_LANGUAGE_EXTRAS
+
+
+def _at_ref(ref: str, rel: str) -> str:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(ROOT), "show", f"{ref}:{rel}"], capture_output=True, text=True, check=True
+        ).stdout
+    except (subprocess.CalledProcessError, OSError):
+        return ""
+
+
+def _cli_files_at(ref: str) -> list[str]:
+    try:
+        names = subprocess.run(
+            ["git", "-C", str(ROOT), "ls-tree", "--name-only", ref, "src/orchestrator/cli/"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.split()
+    except (subprocess.CalledProcessError, OSError):
+        return []
+    return [n for n in names if n.endswith(".py")]
+
+
+def removed_surfaces(base: str, head: str) -> dict[str, set[str]]:
+    """What ``head`` no longer registers that ``base`` did: CLI commands, MCP tools, extras."""
+
+    def registries(ref: str) -> dict[str, set[str]]:
+        cli = set()
+        for f in _cli_files_at(ref):
+            cli |= cli_commands_in(_at_ref(ref, f))
+        return {
+            "CLI command": cli,
+            "MCP tool": mcp_tools_in(_at_ref(ref, "src/orchestrator/plugin/outputs.py")),
+            "extra": extras_in(_at_ref(ref, "pyproject.toml")),
+        }
+
+    before, after = registries(base), registries(head)
+    return {kind: before[kind] - after[kind] for kind in before if before[kind] - after[kind]}
+
+
+def check_removed(terms: dict[str, str]) -> list[str]:
+    """``terms`` maps a phrase to what it is (``"tui": "CLI command"``, ``"terminal ui":
+    "removed surface"``). Every mention in the user documents is STALE, or INFO inside a
+    history paragraph."""
+    out: list[str] = []
+    for doc in user_docs():
+        text = _read(doc)
+        history = history_lines(text)
+        for i, line in enumerate(text.splitlines(), 1):
+            for term, kind in terms.items():
+                if re.search(rf"(?<![\w-]){re.escape(term)}(?![\w-])", line, re.I):
+                    tag = "INFO" if i in history else "STALE"
+                    out.append(
+                        f"[{tag}] removed {kind} {term!r} still mentioned: {doc}:{i}: {line.strip()[:100]}"
+                    )
+    return out
+
+
 def touched_docs(base: str, head: str) -> list[str]:
     try:
         names = subprocess.run(
@@ -264,7 +475,15 @@ def main() -> int:
     ap.add_argument("--base")
     ap.add_argument("--head")
     ap.add_argument("--strict", action="store_true")
+    ap.add_argument("--root", help="audit another tree (default: this checkout)")
+    ap.add_argument(
+        "--removed",
+        default="",
+        help='comma-separated names/synonyms of removed features to grep for, e.g. "terminal UI,TUI,Textual"',
+    )
     args = ap.parse_args()
+    if args.root:
+        set_root(args.root)
 
     langs = front_ends()
     lines: list[str] = [f"[INFO] registered front-ends ({len(langs)}): {', '.join(langs)}"]
@@ -273,8 +492,17 @@ def main() -> int:
     lines += check_extras()
     lines += check_cli()
     lines += check_mcp()
+    lines += check_links()
+    terms: dict[str, str] = {t.strip(): "surface" for t in args.removed.split(",") if t.strip()}
     if args.base and args.head:
         lines += touched_docs(args.base, args.head)
+        for kind, names in removed_surfaces(args.base, args.head).items():
+            lines.append(
+                f"[INFO] {kind}s removed between {args.base} and {args.head}: {', '.join(sorted(names))}"
+            )
+            terms.update({n: kind for n in names})
+    if terms:
+        lines += check_removed(terms)
     for line in lines:
         print(line)
     bad = sum(1 for line in lines if line.startswith(("[STALE]", "[MISSING]")))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); the package is `synaptixs-spine`
 (import/CLI stay `orchestrator`).
 
+## Unreleased
+
+### Added
+
+- **The documentation audit follows links and hunts removed surfaces.** The review
+  skill's `docs_audit.py` now fails on any relative link in a user document whose
+  file or anchor does not resolve (under GitHub's slug rules — an em dash yields a
+  double hyphen), and, given `--base/--head`, lists what the diff removed from the
+  CLI, MCP and extras registries and reports every remaining mention; `--removed
+  "terminal UI,TUI"` adds the names and synonyms of a feature that had no registry
+  entry. A mention inside a version-stamped paragraph is history, not a finding.
+  Six dead links in `SETUP.md` and two README sentences about a removed terminal
+  UI are what it would have caught. The docs matrix gains a "removed feature"
+  row; the script gains `--root` and its first tests. The release-cut guidance in
+  the skill now names the lockfile's own entry and every plugin manifest.
+
 ## 3.33.0 — a PHP codebase gets the whole graph
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,13 @@ published release notes.
 For larger features, the core team often develops them ahead of time and publishes
 them on a release cadence — so opening an issue first avoids duplicated effort.
 
+**Auditing the documentation a change obliges.** `uv run --frozen python
+.claude/skills/review-pr/scripts/docs_audit.py --base develop --head HEAD` cross-checks the
+user documents against what the code registers (front-end counts, extras, CLI commands, MCP
+tools), follows every relative link, and — add `--removed "<name>,<synonym>"` — finds mentions
+of a feature you took out. Stdlib only; runs on any ref. The reviewer runs it on every PR
+(`.claude/skills/review-pr/docs-matrix.md` says which document each kind of change obliges).
+
 **Reviewing a pull request as a maintainer.** From Claude Code in this checkout, run
 `/review-pr <number>` (add `--promote` for a release-cut check). It is the checklist a merge
 decision needs — the gate with CI's extras, fan-out code review, a real-repository smoke test

--- a/docs/specs/SPEC-INDEX.md
+++ b/docs/specs/SPEC-INDEX.md
@@ -81,7 +81,7 @@ Graphify-gap series only. This file is the complete inventory.
 | [java-codegen](java-codegen.md) | 2a (1.8.0), 2b + 2c (1.9.0) | Remaining slices |
 | [typescript-codegen](typescript-codegen.md) | Slice 1 comprehension (1.11.0) | Codegen slices |
 | [multi-language-java](multi-language-java.md) | Slice 1 comprehension (1.7.0) | Superseded in part by `java-codegen` |
-| [unified-ui](unified-ui.md) | P0–P3 — the buildable UI | P4 TUI, P5 SPA (**optional**) |
+| [unified-ui](unified-ui.md) | P0–P3 — the buildable UI; P4 TUI shipped 1.18.0, removed 3.31.0 | P5 SPA (**optional**) |
 | [cross-run-semantic-memory](cross-run-semantic-memory.md) | Phase 1 read path, `MemoryRow` | Write/distil path |
 | [project-comprehension-memory-bank](project-comprehension-memory-bank.md) | Phases 1 + 4 (1.5.0, 1.6.0) | Phases 2–3 |
 | [persona-skill-measurement](persona-skill-measurement.md) | P0–P3 implemented | The P2 A/B `--live` run |

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **9** front-ends | Python, Java, TypeScript, C#, C, C++, Go, PHP, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
 | Source modules | **353** | `find src/orchestrator -name '*.py'` |
-| Test functions | **3,035** across 312 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **3,042** across 313 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 9 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) · **0.50** (PHP, on 8 labelled edges — the misses are P3's typed-receiver rule and the global-namespace fallback, both predicted `known_gaps`, not surprises) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/tests/test_docs_audit.py
+++ b/tests/test_docs_audit.py
@@ -1,0 +1,152 @@
+"""The review skill's documentation audit: the two checks that would have caught this week's
+stale docs — dead links and mentions of removed surfaces — plus GitHub's slug rules."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1] / ".claude" / "skills" / "review-pr" / "scripts" / "docs_audit.py"
+)
+
+
+@pytest.fixture
+def audit(tmp_path: Path) -> ModuleType:
+    """The script as a module, pointed at a fixture tree (it is stdlib-only by design)."""
+    spec = importlib.util.spec_from_file_location("docs_audit", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.set_root(tmp_path)
+    return mod
+
+
+def test_github_slug_matches_what_github_renders(audit: ModuleType) -> None:
+    """Verified against github.com's rendering of USER_GUIDE.md: an em dash yields a double
+    hyphen, punctuation vanishes, backticks and bold are stripped."""
+    assert audit.github_slug("Step 1 — Install") == "step-1--install"
+    assert (
+        audit.github_slug("Step 7 — The full pipeline + web dashboard")
+        == "step-7--the-full-pipeline--web-dashboard"
+    )
+    assert audit.github_slug("What's new") == "whats-new"
+    assert audit.github_slug("`doctor` says **which** install") == "doctor-says-which-install"
+    assert audit.github_slug("Asking across several repositories") == "asking-across-several-repositories"
+
+
+def test_heading_anchors_number_duplicates_and_skip_fences(audit: ModuleType) -> None:
+    text = "# Title\n\n## Notes\n\n```\n## not a heading\n```\n\n## Notes\n"
+    assert audit.heading_anchors(text) == {"title", "notes", "notes-1"}
+
+
+def _tree(root: Path, files: dict[str, str]) -> None:
+    for rel, body in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+
+def test_check_links_reports_missing_files_and_anchors_but_not_urls_or_fenced_links(
+    audit: ModuleType, tmp_path: Path
+) -> None:
+    _tree(
+        tmp_path,
+        {
+            "README.md": "\n".join(
+                [
+                    "# Spine",
+                    "See [the guide](USER_GUIDE.md#step-1--install) and [ops](OPERATIONS.md).",
+                    "Broken: [gone](PROGRESS.md) and [bad anchor](USER_GUIDE.md#step-1-install).",
+                    "External: [site](https://example.com/x#frag) and [mail](mailto:a@b.c).",
+                    "In code: `[not a link](nope.md)`.",
+                    "```",
+                    "[fenced](also-nope.md)",
+                    "```",
+                    "Same file: [top](#spine) and [nowhere](#missing).",
+                    "![diagram](assets/arch.svg)",
+                ]
+            ),
+            "USER_GUIDE.md": "# Guide\n\n## Step 1 — Install\n\ntext\n",
+            "OPERATIONS.md": "# Ops\n",
+            "assets/arch.svg": "<svg/>",
+        },
+    )
+    findings = audit.check_links()
+    assert any("README.md:3 → PROGRESS.md — file not found" in f for f in findings)
+    assert any(
+        "README.md:3 → USER_GUIDE.md#step-1-install — no such anchor (nearest: step-1--install)" in f
+        for f in findings
+    )
+    assert any("README.md:9 → #missing — no such anchor" in f for f in findings)
+    assert len(findings) == 3, findings  # the good link, the URLs, the fenced/inline ones, the image: silent
+
+
+def test_check_removed_flags_live_mentions_and_reads_stamped_paragraphs_as_history(
+    audit: ModuleType, tmp_path: Path
+) -> None:
+    _tree(
+        tmp_path,
+        {
+            "README.md": "\n".join(
+                [
+                    "# Spine",
+                    "",
+                    "A **CLI**, a **web dashboard**, a **terminal UI**, and **MCP**.",
+                    "",
+                    "**3.32.0 (current)** — the plugin speaks the whole protocol. The operator tools",
+                    "are the terminal UI's successor — the TUI is gone.",
+                    "",
+                    "Use the web UI (or terminal UI) to approve gates. Intuition is not a TUI.",
+                ]
+            ),
+        },
+    )
+    findings = audit.check_removed({"terminal UI": "surface", "TUI": "surface"})
+    stale = [f for f in findings if f.startswith("[STALE]")]
+    info = [f for f in findings if f.startswith("[INFO]")]
+    assert [f.split(": README.md:")[1][:1] for f in stale] == [
+        "3",
+        "8",
+        "8",
+    ]  # line 3; line 8 twice (both terms)
+    assert all(":6:" in f for f in info) and len(info) == 2  # the stamped paragraph: history
+    assert not any(
+        "Intuition" in f and "'TUI'" in f and f.startswith("[STALE]") and ":3:" in f for f in findings
+    )
+
+
+def test_history_lines_cover_the_whole_stamped_paragraph(audit: ModuleType) -> None:
+    text = (
+        "**3.31.0** — first line\nsecond line of the same paragraph\n\nnot history\n2026-09-04 dated line\n"
+    )
+    assert audit.history_lines(text) == {1, 2, 5}
+    # Prose that pins a version is history too: a status row saying what shipped and when.
+    text = (
+        "| unified-ui | P4 TUI shipped 1.18.0, removed in 3.31.0 |\n"
+        "the TUI is gone since 3.31.0\n\nthe TUI is a surface\n"
+    )
+    assert audit.history_lines(text) == {1, 2}
+
+
+def test_registry_parsers_read_what_the_diff_check_compares(audit: ModuleType) -> None:
+    assert audit.cli_commands_in('@app.command("tui", rich_help_panel=X)\n@sdlc_app.command("run")\n') == {
+        "tui",
+        "run",
+    }
+    assert audit.mcp_tools_in(
+        'x\nOUTPUTS: dict[str, type] = {\n    "doctor": DoctorOut,\n    "map_repo": MapRepoOut,\n}\n'
+    ) == {
+        "doctor",
+        "map_repo",
+    }
+    py = '[project.optional-dependencies]\ntui = [\n  "textual",\n]\ndev = [\n]\nall = [\n]\n[tool.x]\n'
+    assert audit.extras_in(py) == {"tui"}
+
+
+def test_the_matrix_names_the_removed_surface_trigger() -> None:
+    matrix = (_SCRIPT.parents[1] / "docs-matrix.md").read_text(encoding="utf-8")
+    assert "Removed feature" in matrix and "--removed" in matrix


### PR DESCRIPTION
## Summary

Step 3 of the docs cleanup: the review skill's audit script gains the two checks that would have caught this week's failures — the six dead links in `SETUP.md` (#340) and the two README sentences that listed a terminal UI two releases after #316 removed it.

**Check 7 — links.** Every relative link in the user documents must resolve: the file exists, and an anchor matches a heading under GitHub's slug rules — an em dash yields a double hyphen (`step-1--install`), verified against github.com's rendering so nobody "fixes" those. Links inside code fences and inline code are ignored. `[MISSING]`.

**Check 8 — removed surfaces.** With `--base/--head` the script diffs the CLI, MCP and extras registries at both refs, lists what disappeared, and greps the user documents at head for every remaining mention. `--removed "terminal UI,TUI,Textual"` adds the names and synonyms of a feature that had no registry entry (the TUI had none — the removal sweep grepped for `tui` and "terminal UI" survived). A mention inside a version-stamped or dated paragraph, or prose that pins a version ("removed in 3.31.0", "shipped 1.18.0"), is `[INFO]` — history; present-tense prose is `[STALE]`.

Run against the tag before the TUI removal it finds the removed command and extra by itself and reads the three surviving mentions as history:

```
$ docs_audit.py --base v3.30.0 --head develop --removed "terminal UI,Textual"
[INFO] CLI commands removed between v3.30.0 and develop: tui
[INFO] extras removed between v3.30.0 and develop: tui
[INFO] removed surface 'terminal UI' still mentioned: README.md:139 …   ← the "What's new" paragraph
[INFO] removed extra 'tui' still mentioned: docs/specs/SPEC-INDEX.md:84 … ← "shipped 1.18.0, removed 3.31.0"
```

**Also.** `--root` points every check at another tree; `tests/test_docs_audit.py` (7) is the script's first test file — slug rules, duplicate headings, fenced links, the history paragraph, the registry parsers, and that the matrix names the trigger. The docs matrix gains a **"Removed feature or surface"** row and a links section; SKILL.md §5 and CONTRIBUTING name the checks; SPEC-INDEX's unified-ui row no longer lists the TUI as outstanding (the one genuine finding the new check made on develop). Folds in the release-cut guidance for the lockfile entry and every plugin manifest that was sitting uncommitted.

**What the audit reports on develop today, unrelated to this PR and left for a follow-up:** ten "8 front-ends" counts that predate PHP (FEATURES, USER_GUIDE, KNOWLEDGE_GRAPH, CLAUDE_GUIDE ×2, CLI_REFERENCE ×2, EXAMPLE, BENCHMARK ×2), `pkg fix-sites` absent from CLI_REFERENCE, and four MCP tools absent from CODEX_GUIDE (`profile_repo`, `design_change`, `sdlc_baseline`, `registry_runs`).

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`: pass
- `tests/test_docs_audit.py`: 7 passed; `state-numbers` test counts bumped (the spec count is unchanged in the committed tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
