### PR TITLE
chore(cli): the cheap rungs say what supersedes them, and two duplications move into the engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project are documented here. Format loosely follows
 
 ### Changed
 
+- **The cheap rungs say what supersedes them.** `investigate`, `design` and
+  `localize` — the read-only first steps — now say in `--help` and in
+  CLI_REFERENCE that `sdlc plan` and `rca` are the composites that run them and
+  add the rest, and when to run the rung alone. The CLI review found no dead
+  command, only a ladder nobody had labelled.
+- **One reader, one summary.** The `episteme/` pages a design draws on were read
+  by two identical functions, one in the CLI and one in the plugin; they are
+  `sdlc.design.design_bank` now. The `sdlc baseline --json` object and the
+  plugin's `sdlc_baseline` result were assembled twice from the same scores;
+  they are `evals.agent_corpus.baseline_summary` now. Neither surface changed
+  its output.
+
 - **Thirteen commands leave the help screen.** The platform substrate — `task submit`
   and the ten `template` / `contract` commands — predates the comprehension and
   SDLC surfaces and is driven today by the integration tests, not by users; the

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -639,6 +639,10 @@ The KG-grounded engineering commands: design a change, research a ticket, and tr
 
 Grounded feature design: spec × knowledge graph → a design with blast radius.
 
+> One rung of a ladder: `sdlc plan` produces the same design as one of its twelve sections,
+> alongside the investigation, blast radius, files and cost. Run this alone for the design
+> without writing anything under `.spine/`.
+
 Produces the M2 design for one feature anchored to the repo's real structure,
 and annotates it with its **blast radius** (which modules it touches, who
 depends on them, the call hotspots) and any **unverified references** (named
@@ -667,6 +671,9 @@ orchestrator design [PATH] [OPTIONS]
 ### `orchestrator investigate`
 
 Investigation brief: a ticket × the codebase, before you design.
+
+> The read-only rung: `sdlc plan` carries this brief as its first sections and writes the
+> build document. Run this alone when nothing should be written yet.
 
 Researches where a ticket lands in the code (knowledge-graph retrieval, with
 `file:line` + caller counts), the relevant committed `episteme/` knowledge,
@@ -700,6 +707,9 @@ orchestrator investigate [PATH] [OPTIONS]
 ### `orchestrator localize`
 
 Fault localization: a stack trace → the repo symbols it names.
+
+> `rca` runs this same localization and adds ranked hypotheses, a regression surface and a fix
+> approach. Run this alone when the fault site is all you need, in a second.
 
 Parses a Python traceback / pytest failure, resolves each frame to a
 knowledge-graph symbol (`file:line`), and points at the likely fault site

--- a/src/orchestrator/cli/change.py
+++ b/src/orchestrator/cli/change.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import json
 from pathlib import Path
 from typing import Annotated, Any
@@ -48,12 +47,17 @@ def design(
     depends on them, the call hotspots) and any **unverified references** (named
     paths absent from the graph). Deterministic by default; `--llm` writes the
     prose. `path` may be a local path or a git URL cloned on demand.
+
+    This is one rung of a ladder: `sdlc plan` produces the same design as one of its
+    twelve sections, alongside the investigation, the blast radius, the files and the
+    cost — run this alone when you want the design without writing anything under
+    `.spine/`.
     """
     import asyncio
 
     from orchestrator.pkg import FactStore, RepoCodeExtractor, load_or_extract
     from orchestrator.pkg.overview import build_overview
-    from orchestrator.sdlc.design import produce_design, render_design_md
+    from orchestrator.sdlc.design import design_bank, produce_design, render_design_md
 
     spec = _load_design_spec(spec_file, title, summary, list(criterion or []))
     if not spec.get("title"):
@@ -77,7 +81,7 @@ def design(
         batch = extractor.extract(repo) if refresh else load_or_extract(repo, extractor=extractor)
         store = FactStore(batch)
         overview = build_overview(batch)
-        memory_bank = _read_design_bank(repo)
+        memory_bank = design_bank(repo)
         design_dict = asyncio.run(
             produce_design(spec, overview=overview, memory_bank=memory_bank, store=store, llm=client)
         )
@@ -108,20 +112,6 @@ def _load_design_spec(
         head = lines[0].lstrip("# ").strip() if lines else ""
         return {"title": head, "summary": "\n".join(lines[1:]), "acceptance_criteria": criteria}
     return {"title": title, "summary": summary, "acceptance_criteria": criteria}
-
-
-def _read_design_bank(repo: Path) -> dict[str, str]:
-    """Optional conventions/domain context from a committed `episteme/`, if present."""
-    from orchestrator.knowledge.understand import existing_bank_dir
-
-    out: dict[str, str] = {}
-    with contextlib.suppress(Exception):
-        bank = existing_bank_dir(repo)
-        for name in ("domain-model.md", "tech-context.md", "conventions.md"):
-            p = bank / name
-            if p.exists():
-                out[name] = p.read_text(encoding="utf-8")
-    return out
 
 
 @app.command("investigate", rich_help_panel=PANEL_CHANGE)
@@ -166,7 +156,9 @@ def investigate(
     `file:line` + caller counts), the relevant committed `episteme/` knowledge,
     and — when a registry DB is configured — prior-run notes. Deterministic, no
     LLM. Pass the ticket via `--source` (e.g. `jira://PROJ-123`) or inline with
-    `--title`/`--text`. Feed the result into `orchestrator design`.
+    `--title`/`--text`. Feed the result into `orchestrator design` — or skip both and run
+    `sdlc plan`, which carries this brief as its first sections and writes the build
+    document; this command is the read-only rung for when nothing should be written yet.
     """
     from orchestrator.pkg import FactStore, RepoCodeExtractor, load_or_extract
     from orchestrator.sdlc.investigate import build_investigation, render_investigation_md
@@ -281,7 +273,9 @@ def localize(
     Parses a Python traceback / pytest failure, resolves each frame to a
     knowledge-graph symbol (`file:line`), and points at the likely fault site
     plus who calls it. Reads the trace from `--trace <file>`, `--text`, or stdin.
-    Deterministic, no LLM — the first step of a root-cause investigation.
+    Deterministic, no LLM — the first step of a root-cause investigation. `rca` runs this
+    same localization and adds ranked hypotheses, a regression surface and a fix approach;
+    use this alone when the fault site is all you need, in a second.
     """
     import sys
 

--- a/src/orchestrator/cli/sdlc.py
+++ b/src/orchestrator/cli/sdlc.py
@@ -228,35 +228,14 @@ def sdlc_baseline(
     """
     import json as _json
 
-    from orchestrator.evals.agent_corpus import render_report, score_gate, score_runs
+    from orchestrator.evals.agent_corpus import baseline_summary, render_report, score_gate, score_runs
     from orchestrator.pkg import FactStore, load_or_extract
     from orchestrator.sdlc.runstate import RunStore
 
     gate = score_gate(FactStore(load_or_extract(path)))
     runs = score_runs(RunStore().all())
     if as_json:
-        typer.echo(
-            _json.dumps(
-                {
-                    "gate": {
-                        "accuracy": gate.accuracy,
-                        "cases": len(gate.results),
-                        "false_refusals": gate.false_refusals,
-                        "missed_refusals": gate.missed_refusals,
-                    },
-                    "runs": {
-                        "runs": runs.runs,
-                        "completed": runs.completed,
-                        "parked": runs.parked,
-                        "failed": runs.failed,
-                        "completion_rate": runs.completion_rate,
-                        "intervention_rate": runs.intervention_rate,
-                        "mean_cost_usd": runs.mean_cost_usd,
-                    },
-                },
-                indent=2,
-            )
-        )
+        typer.echo(_json.dumps(baseline_summary(gate, runs), indent=2))
         return
     typer.echo(render_report(gate, runs))
 

--- a/src/orchestrator/evals/agent_corpus.py
+++ b/src/orchestrator/evals/agent_corpus.py
@@ -297,11 +297,34 @@ def score_runs(records: list[Any]) -> RunMetrics:
     return metrics
 
 
+def baseline_summary(gate: GateScore, runs: RunMetrics) -> dict[str, Any]:
+    """The numbers as one JSON-shaped object — what ``sdlc baseline --json`` prints and the
+    plugin's ``sdlc_baseline`` returns, from one place so the two cannot disagree on a key."""
+    return {
+        "gate": {
+            "accuracy": gate.accuracy,
+            "cases": len(gate.results),
+            "false_refusals": gate.false_refusals,
+            "missed_refusals": gate.missed_refusals,
+        },
+        "runs": {
+            "runs": runs.runs,
+            "completed": runs.completed,
+            "parked": runs.parked,
+            "failed": runs.failed,
+            "completion_rate": runs.completion_rate,
+            "intervention_rate": runs.intervention_rate,
+            "mean_cost_usd": runs.mean_cost_usd,
+        },
+    }
+
+
 def render_report(gate: GateScore, runs: RunMetrics) -> str:
     return "\n\n".join(["# Agent baseline", gate.render(), runs.render()])
 
 
 __all__ = [
+    "baseline_summary",
     "CORPUS",
     "Case",
     "CaseResult",

--- a/src/orchestrator/plugin/server.py
+++ b/src/orchestrator/plugin/server.py
@@ -1222,13 +1222,13 @@ async def design_change(repo_path: str, spec: dict[str, Any], use_llm: bool = Fa
     async def run(repo: Any) -> dict[str, Any]:
         from orchestrator.pkg import FactStore, load_or_extract
         from orchestrator.pkg.overview import build_overview
-        from orchestrator.sdlc.design import produce_design, render_design_md
+        from orchestrator.sdlc.design import design_bank, produce_design, render_design_md
 
         batch = load_or_extract(repo)
         design = await produce_design(
             resolved,
             overview=build_overview(batch),
-            memory_bank=_design_bank(repo),
+            memory_bank=design_bank(repo),
             store=FactStore(batch),
             llm=client,
             root=repo,
@@ -1251,23 +1251,6 @@ async def design_change(repo_path: str, spec: dict[str, Any], use_llm: bool = Fa
         return {"error": str(exc)}
 
 
-def _design_bank(repo: Path) -> dict[str, str]:
-    """The committed ``episteme/`` pages a design draws conventions from, when present —
-    the same three the CLI's ``design`` reads."""
-    import contextlib
-
-    from orchestrator.knowledge.understand import existing_bank_dir
-
-    out: dict[str, str] = {}
-    with contextlib.suppress(Exception):
-        bank = existing_bank_dir(repo)
-        for name in ("domain-model.md", "tech-context.md", "conventions.md"):
-            page = bank / name
-            if page.exists():
-                out[name] = page.read_text(encoding="utf-8")
-    return out
-
-
 def sdlc_baseline(repo_path: str) -> dict[str, Any]:
     """Score the run agent against a corpus of tickets whose right answer is known, and
     summarize the durable run records. **Deterministic and free**: the validity gate reads
@@ -1276,30 +1259,13 @@ def sdlc_baseline(repo_path: str) -> dict[str, Any]:
     let each hide behind the other. ``repo_path`` is a local path or a git URL."""
 
     def run(repo: Any) -> dict[str, Any]:
-        from orchestrator.evals.agent_corpus import render_report, score_gate, score_runs
+        from orchestrator.evals.agent_corpus import baseline_summary, render_report, score_gate, score_runs
         from orchestrator.pkg import FactStore, load_or_extract
         from orchestrator.sdlc.runstate import RunStore
 
         gate = score_gate(FactStore(load_or_extract(repo)))
         runs = score_runs(RunStore().all())
-        return {
-            "gate": {
-                "accuracy": gate.accuracy,
-                "cases": len(gate.results),
-                "false_refusals": gate.false_refusals,
-                "missed_refusals": gate.missed_refusals,
-            },
-            "runs": {
-                "runs": runs.runs,
-                "completed": runs.completed,
-                "parked": runs.parked,
-                "failed": runs.failed,
-                "completion_rate": runs.completion_rate,
-                "intervention_rate": runs.intervention_rate,
-                "mean_cost_usd": runs.mean_cost_usd,
-            },
-            "markdown": render_report(gate, runs),
-        }
+        return {**baseline_summary(gate, runs), "markdown": render_report(gate, runs)}
 
     return _in_repo(repo_path, run, hint=False)
 

--- a/src/orchestrator/sdlc/design.py
+++ b/src/orchestrator/sdlc/design.py
@@ -378,4 +378,23 @@ async def design_feature(
     }
 
 
-__all__ = ["design_feature", "produce_design", "render_design_md"]
+def design_bank(repo: Path | str) -> dict[str, str]:
+    """The committed ``episteme/`` pages a design draws conventions and domain context from,
+    when present — ``domain-model``, ``tech-context``, ``conventions``. Empty when there is
+    no bank; never raises. One reader, shared by ``orchestrator design`` and the plugin's
+    ``design_change``, so the two cannot drift on which pages count."""
+    import contextlib
+
+    from orchestrator.knowledge.understand import existing_bank_dir
+
+    out: dict[str, str] = {}
+    with contextlib.suppress(Exception):
+        bank = existing_bank_dir(repo)
+        for name in ("domain-model.md", "tech-context.md", "conventions.md"):
+            page = bank / name
+            if page.exists():
+                out[name] = page.read_text(encoding="utf-8")
+    return out
+
+
+__all__ = ["design_bank", "design_feature", "produce_design", "render_design_md"]


### PR DESCRIPTION
## Summary

Recommendations 4 and 5 of the CLI command review, together as planned.

**5 — the cheap rungs say what supersedes them.** The review found no dead command; what looks like repetition is a ladder nobody had labelled. `investigate` and `design` are the read-only first rungs of `sdlc plan` (which runs both — `builddoc.py` calls `build_investigation` and `produce_design` — and adds the blast radius, files and cost); `localize` is the first step of `rca` (which runs `localize_trace` and adds hypotheses, a regression surface, a fix approach). The three commands' `--help` and their CLI_REFERENCE sections now name the composite and say when to run the rung alone.

**4 — two duplications move into the engine.** The CLI and the MCP plugin each carried an identical copy of:
- the reader for the three `episteme/` pages a design draws on → `sdlc.design.design_bank` (both `orchestrator design` and `design_change` call it);
- the baseline JSON assembled from `score_gate` / `score_runs` → `evals.agent_corpus.baseline_summary` (both `sdlc baseline --json` and `sdlc_baseline` call it).

Neither surface changed its output: the plugin's output-type drift guard and the CLI tests hold the shapes, and `docs_audit.py` reports 0 STALE/MISSING.

## Files

`sdlc/design.py`, `evals/agent_corpus.py` (the engine homes); `cli/change.py`, `cli/sdlc.py`, `plugin/server.py` (callers); `CLI_REFERENCE.md`, `CHANGELOG.md`.

## Gate

- `mypy src tests`, `ruff format --check`, `ruff check`: pass
- Full pytest: 3469 passed, 3 skipped (the one local failure is `test_state_numbers` tripping on an untracked spec on my machine, not in this PR)
- `docs_audit.py`: 0 STALE/MISSING

🤖 Generated with [Claude Code](https://claude.com/claude-code)
