### PR TITLE
feat(sdlc): the SDLC as a reusable CI pipeline; nested checkouts are a walker boundary

### DIFF
--- a/.github/sdlc/dogfood-spec.json
+++ b/.github/sdlc/dogfood-spec.json
@@ -1,0 +1,10 @@
+{
+  "intent_id": "DOGFOOD-1",
+  "title": "Name the nested-checkout boundary in the pkg extract help text",
+  "summary": "The repository walker stops at any nested git checkout (a submodule, a vendored clone). `orchestrator pkg extract --help` should say so, beside the ignored-directory list, so an operator reading the help learns why a submodule's symbols are absent from the superproject's graph.",
+  "acceptance_criteria": [
+    "`orchestrator pkg extract --help` mentions that nested git checkouts are not walked",
+    "The wording names the `.git` entry as the boundary marker",
+    "No extraction behaviour changes: the same commit produces the same facts"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,15 @@ jobs:
       - name: PKG invariants (orchestrator pkg verify)
         run: uv run orchestrator pkg verify .
 
+      # The reusable SDLC workflow promises to work on four repository shapes — single repo,
+      # monorepo package, multi-repo workspace, superproject with submodules. This builds all
+      # four from scratch (real git, a real `submodule add`) and runs the plan stage on each,
+      # asserting determinism and, for the submodule shape, that its symbols are scoped once:
+      # they were scoped twice until 2026-09-09 and nothing said so. No model, no network.
+      # The design is in the header of .github/workflows/spine-sdlc.yml.
+      - name: SDLC pipeline holds on all four repository shapes
+        run: uv run python scripts/sdlc_shapes.py
+
       # The architecture diagram carries live numbers — version, command count, node and edge
       # kinds — and it is generated from them rather than drawn. The PNG this replaced was
       # stamped 3.8.4 and claimed `7 node kinds · 9 edge kinds` two releases after

--- a/.github/workflows/sdlc-dogfood.yml
+++ b/.github/workflows/sdlc-dogfood.yml
@@ -1,0 +1,50 @@
+# Spine's own SDLC pipeline, run on Spine — the reusable workflow exercised on this checkout.
+#
+# Two triggers. A pull request that touches the reusable workflow runs its `plan` job here,
+# plan-only, so a change to the published interface is seen working before it is tagged: a
+# workflow nothing runs is the "number nobody re-checks" failure ci.yml already names.
+# `workflow_dispatch` runs the whole thing — plan, the `spine-build` environment gate, then
+# the build — against a spec you name, safe by default.
+#
+# `install-from: ./repo[languages]` installs the checkout under test, not a release: the
+# reusable workflow checks the caller out at `repo/`, and this caller is Spine.
+name: SDLC dogfood
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/spine-sdlc.yml"
+      - ".github/workflows/sdlc-dogfood.yml"
+      - ".github/sdlc/**"
+  workflow_dispatch:
+    inputs:
+      spec:
+        description: "Spec to plan and build (JSON, inside this repository)."
+        type: string
+        default: ".github/sdlc/dogfood-spec.json"
+      live:
+        description: "Open the pull request (default: build locally, push nothing)."
+        type: boolean
+        default: false
+      max-cost:
+        description: "Cap on model spend, USD."
+        type: string
+        default: "5"
+
+permissions:
+  contents: read
+
+jobs:
+  spine:
+    uses: ./.github/workflows/spine-sdlc.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      spec: ${{ inputs.spec || '.github/sdlc/dogfood-spec.json' }}
+      install-from: "./repo[languages]"
+      build: ${{ github.event_name == 'workflow_dispatch' }}
+      live: ${{ inputs.live || false }}
+      max-cost: ${{ inputs.max-cost || '5' }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/spine-sdlc.yml
+++ b/.github/workflows/spine-sdlc.yml
@@ -1,0 +1,339 @@
+# Reusable SDLC pipeline — the governed build path, as two jobs split where the model starts.
+#
+# A calling repository adds a few lines and gets Spine's SDLC stages as a pipeline:
+#
+#     jobs:
+#       spine:
+#         uses: synaptixs/spine/.github/workflows/spine-sdlc.yml@<tag>   # pin a release
+#         with:
+#           spec: .spine/specs/TICKET-1.json
+#         secrets:
+#           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+#
+# **`plan` costs nothing and needs nothing.** It runs intake → investigate → validity → design
+# from a hand-written spec — no model, no credentials, same commit in, same document out — and
+# publishes the build document as the job summary and an artifact. It runs on every trigger.
+#
+# **`build` is where a human decides.** It is bound to a GitHub Environment (`spine-build` by
+# default): configure required reviewers on it and the reviewer's click *is* the plan gate.
+# The job records that decision with `sdlc approve` — the approver's login, the run URL — and
+# only then runs `sdlc autorun`, which refuses to build a plan nobody approved. Default `--safe`
+# clones, generates, tests and commits locally and pushes nothing; `live: true` opens the PR.
+#
+# **Three locations, named separately**, because a single-package repository lets you conflate
+# them and the other shapes do not:
+#   * `path`        — the graph root Spine reads (a monorepo package, or `.`)
+#   * `target-dir`  — where generated code lands and tests run (defaults to `path`)
+#   * the git repo  — what is branched and gets the PR (always the caller)
+# Delivery into a subdirectory is not supported yet (`sdlc-target-layout-scaffold.md`, v1 is a
+# single package root), so `build` refuses when `target-dir` is not the repository root rather
+# than scaffolding at the wrong level. `plan` still works for that package.
+#
+# **Multirepo (option A):** the caller commits `.spine/repos.yaml` and lists the sibling
+# checkouts it needs in `checkouts`. Each is cloned beside `repo/` before `plan`, every declared
+# root is verified to be a populated, clean git checkout, and `investigate --repos` writes the
+# cross-repo brief next to the build document. Delivery stays one repository, one PR — a
+# ticket spanning repos is planned here and shipped as one run per repo.
+#
+# **Submodules** are checked out recursively. Spine treats a nested checkout as a boundary,
+# not a subdirectory, so a superproject's graph stops at each submodule and a `repos.yaml`
+# declaring both is scoped exactly once. Delivery *into* a submodule is a PR to that
+# repository plus a pin bump here, which is the multi-repo case again — `build` refuses it.
+#
+# This header is the design record.
+name: Spine SDLC
+
+on:
+  workflow_call:
+    inputs:
+      spec:
+        description: "Path, inside the calling repository, of the hand-written spec (JSON: title, summary, acceptance_criteria)."
+        type: string
+        required: true
+      path:
+        description: "Graph root Spine reads, relative to the repository root. A monorepo package, or `.`."
+        type: string
+        default: "."
+      target-dir:
+        description: "Where generated code lands and tests run, relative to the repository root. Defaults to `path`."
+        type: string
+        default: ""
+      repos:
+        description: "A `.spine/repos.yaml` inside the repository, for a multi-repo graph. Empty for one repository."
+        type: string
+        default: ""
+      checkouts:
+        description: >-
+          JSON list of sibling checkouts the multi-repo graph needs, each {repository, ref, path}
+          with `path` relative to the workspace (beside `repo/`). Empty for one repository.
+        type: string
+        default: "[]"
+      build:
+        description: "Run the gated build job after plan. Set false for plan-only pipelines."
+        type: boolean
+        default: true
+      live:
+        description: "Push the branch and open the pull request. Default false: clone, generate, test, commit locally, push nothing."
+        type: boolean
+        default: false
+      environment:
+        description: "GitHub Environment the build job deploys to. Put required reviewers on it — that review is the plan gate."
+        type: string
+        default: "spine-build"
+      max-cost:
+        description: "Cap on model spend for the build, in USD. Exhausting it parks the run."
+        type: string
+        default: "5"
+      version:
+        description: "Spine version to install. Pin it; an unpinned tool changes under you."
+        type: string
+        default: ""
+      install-from:
+        description: "A pip requirement that overrides `version` — used by Spine's own repository to run the workflow on the checkout under test."
+        type: string
+        default: ""
+      python-version:
+        description: "Python used to run Spine, not the version of the code being read."
+        type: string
+        default: "3.12"
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: "Model key for the build job's intake, implement and review stages. Plan needs none."
+        required: false
+      CHECKOUT_TOKEN:
+        description: "Token able to read the sibling repositories in `checkouts`. The job token cannot read other private repositories."
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    name: plan (deterministic, no model)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      intent: ${{ steps.doc.outputs.intent }}
+    env:
+      SPEC: ${{ inputs.spec }}
+      GRAPH_ROOT: ${{ inputs.path }}
+      TARGET_DIR: ${{ inputs.target-dir || inputs.path }}
+      REPOS_FILE: ${{ inputs.repos }}
+      CHECKOUTS: ${{ inputs.checkouts }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: repo
+          # Full history: the commit cache is keyed on HEAD and only trusted on a clean tree.
+          fetch-depth: 0
+          # A superproject's submodules are part of what is being read. Cheap when there are none.
+          submodules: recursive
+
+      - name: Check out the sibling repositories the multi-repo graph declares
+        if: ${{ inputs.checkouts != '[]' }}
+        env:
+          # The job token reads only this repository; siblings need one the caller supplies.
+          GH_TOKEN: ${{ secrets.CHECKOUT_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          echo "$CHECKOUTS" | python3 -c '
+          import json, subprocess, sys
+          for c in json.load(sys.stdin):
+              repo, ref, path = c["repository"], c.get("ref", ""), c["path"]
+              if not path or path.startswith(("/", "..")):
+                  sys.exit(f"checkouts: path {path!r} must be relative and inside the workspace")
+              cmd = ["gh", "repo", "clone", repo, path, "--", "--recurse-submodules"]
+              if ref:
+                  cmd += ["--branch", ref]
+              print(" ".join(cmd), flush=True)
+              subprocess.run(cmd, check=True)
+          '
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install Spine
+        env:
+          VERSION: ${{ inputs.version }}
+          INSTALL_FROM: ${{ inputs.install-from }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INSTALL_FROM" ]; then
+            pip install --quiet "$INSTALL_FROM"
+          elif [ -n "$VERSION" ]; then
+            pip install --quiet "synaptixs-spine[languages]==$VERSION"
+          else
+            pip install --quiet "synaptixs-spine[languages]"
+          fi
+          orchestrator --version
+
+      # Every root the multi-repo graph declares must be a populated, clean git checkout
+      # *before* anything reads it. An un-initialised submodule is an empty directory — it
+      # loads without error and contributes no facts, which is a graph that is quietly wrong.
+      # A dirty tree makes the whole merged graph untrusted, and a pipeline should not plan on
+      # an untrusted graph without saying so.
+      - name: Verify every declared repository is checked out and clean
+        if: ${{ inputs.repos != '' }}
+        working-directory: repo
+        run: |
+          set -euo pipefail
+          python3 - "$REPOS_FILE" <<'PY'
+          import subprocess, sys
+          from orchestrator.pkg.repos import load_repo_config
+          from orchestrator.pkg.persistence import repo_state
+          bad = []
+          for key, root in load_repo_config(sys.argv[1]):
+              sha, dirty = repo_state(root)
+              populated = any(root.iterdir())
+              state = "ok" if sha and not dirty and populated else "NOT OK"
+              print(f"{key:>16}  {root}  head={sha or '-'}  dirty={dirty}  populated={populated}  {state}")
+              if state != "ok":
+                  bad.append(key)
+          if bad:
+              sys.exit(f"::error::declared repositories not usable: {bad} — check `checkouts` and submodule init")
+          PY
+
+      - name: Where this change lands, across repositories
+        if: ${{ inputs.repos != '' }}
+        working-directory: repo
+        run: |
+          set -euo pipefail
+          # `investigate` takes a title and body; lift them from the spec. Through variables,
+          # never inline — the spec is caller-authored text.
+          title=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["title"])' "$SPEC")
+          text=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("summary", ""))' "$SPEC")
+          orchestrator investigate . --title "$title" --text "$text" --repos "$REPOS_FILE" --out ../brief-across-repos.md
+          {
+            echo "## Across repositories"
+            echo
+            cat ../brief-across-repos.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build document (sdlc plan)
+        id: doc
+        working-directory: repo
+        run: |
+          set -euo pipefail
+          intent=$(python3 -c 'import json,pathlib,sys; p=pathlib.Path(sys.argv[1]); print(json.loads(p.read_text()).get("intent_id") or p.stem)' "$SPEC")
+          echo "intent=$intent" >> "$GITHUB_OUTPUT"
+          orchestrator sdlc plan --spec "$SPEC" --path "$GRAPH_ROOT" --out ../plans --quiet
+          cp "../plans/$intent-build.md" ../build-document.md
+          if [ "$TARGET_DIR" != "." ]; then
+            echo "::notice::target-dir is '$TARGET_DIR' — plan is scoped to it, but delivery into a subdirectory is not supported yet; the build job will refuse."
+          fi
+          {
+            echo "## Build document — \`$intent\`"
+            echo
+            cat ../build-document.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: spine-plan
+          path: |
+            build-document.md
+            brief-across-repos.md
+          if-no-files-found: error
+
+  build:
+    name: build (gated)
+    needs: plan
+    if: ${{ inputs.build }}
+    runs-on: ubuntu-latest
+    # The environment's required reviewers are the plan gate. Nothing below runs until one of
+    # them approves this run, and the approval is recorded against the plan's digest.
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      SPEC: ${{ inputs.spec }}
+      GRAPH_ROOT: ${{ inputs.path }}
+      TARGET_DIR: ${{ inputs.target-dir || inputs.path }}
+      INTENT: ${{ needs.plan.outputs.intent }}
+      ENVIRONMENT: ${{ inputs.environment }}
+      MAX_COST: ${{ inputs.max-cost }}
+      LIVE: ${{ inputs.live }}
+      REPO_URL: https://github.com/${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Refuse delivery shapes Spine does not support yet
+        run: |
+          set -euo pipefail
+          if [ "$TARGET_DIR" != "." ]; then
+            echo "::error::Delivery into a subdirectory ('$TARGET_DIR') is not supported: codegen, the test environment and layout detection key off the repository root (docs/specs/sdlc-target-layout-scaffold.md, v1 is a single package root). Plan for that package succeeded; run the build with target-dir '.' or wait for target-dir delivery."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+        with:
+          path: repo
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install Spine
+        env:
+          VERSION: ${{ inputs.version }}
+          INSTALL_FROM: ${{ inputs.install-from }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INSTALL_FROM" ]; then
+            pip install --quiet "$INSTALL_FROM"
+          elif [ -n "$VERSION" ]; then
+            pip install --quiet "synaptixs-spine[languages]==$VERSION"
+          else
+            pip install --quiet "synaptixs-spine[languages]"
+          fi
+          orchestrator --version
+
+      # The plan is regenerated here rather than downloaded: it is deterministic for the
+      # commit, so the digest the approval binds to is the digest the reviewer read, and a
+      # plan that would differ is exactly the case the digest exists to catch.
+      - name: Record who approved, against the plan they approved
+        working-directory: repo
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          orchestrator sdlc plan --spec "$SPEC" --path "$GRAPH_ROOT" --quiet
+          approver=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" \
+            --jq '[.[] | select(.state == "approved")] | last | .user.login // empty' 2>/dev/null || true)
+          who="${approver:-$ACTOR}"
+          orchestrator sdlc approve "$INTENT" --path "$GRAPH_ROOT" --by "$who" \
+            --note "GitHub Environment '$ENVIRONMENT' approval on $RUN_URL"
+
+      - name: Build (sdlc autorun)
+        working-directory: repo
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Read by the clone and the push; `gh` opens the PR with it.
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
+          SDLC_WORKSPACE_ROOT: ${{ runner.temp }}/sdlc-workspaces
+        run: |
+          set -euo pipefail
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::ANTHROPIC_API_KEY is not set — the build job's intake, implement and review stages call a model. Pass it under secrets:."
+            exit 1
+          fi
+          mode=--safe
+          if [ "$LIVE" = "true" ]; then mode=--live; fi
+          orchestrator sdlc autorun \
+            --source "file://$SPEC" --spec "$SPEC" \
+            --path "$GRAPH_ROOT" --repo "$REPO_URL" \
+            "$mode" --max-cost "$MAX_COST" --no-review \
+            --out ../run-artifacts
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: spine-run
+          path: run-artifacts
+          if-no-files-found: warn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,12 @@ Keep new design records in here rather than in an untracked scratch directory.
   **`.repo/`** and the leading dot is load-bearing — see `corpus/README.md`. `pkg verify`
   does *not* catch this: fixture modules are perfectly self-consistent, so nothing will
   remind you. Same trap for any future on-disk fixture tree, not just this corpus.
+- **A nested git checkout is a boundary, not a subdirectory.** Both walkers also stop at any
+  child directory holding a `.git` entry — file *or* directory, because a submodule's is a
+  file (`is_nested_repo` in `extractor.py`). Before that rule a superproject's graph walked
+  into its submodules, and declaring both in `.spine/repos.yaml` scoped every symbol twice.
+  `from_mapping` now refuses a declared root nested inside another unless the inner one is a
+  checkout of its own. The reasoning is in the header of `.github/workflows/spine-sdlc.yml`.
 - **`--language` is not validated in `cli/`** — an unsupported language silently
   scaffolds a *Python* project (every dispatch chain falls through to the Python branch).
   Detection (`catalog/profile.py`) and extraction (`pkg/`) are independent systems; a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ the repository keeps the two reference documents and the script, which need no a
    python scripts/matrix-count.py --check
    python scripts/state-numbers.py --check                  # claims re-derived from source
    uv run orchestrator pkg accuracy --check
+   python scripts/sdlc_shapes.py                            # the SDLC pipeline on four repo shapes
    ```
    **The four `--check` scripts are generated-artifact gates and CI runs every one of them.**
    They are listed together because running only the first is how a release PR failed on a

--- a/docs/specs/STATE-OF-SPINE.md
+++ b/docs/specs/STATE-OF-SPINE.md
@@ -28,7 +28,7 @@ gates (before building, before merging). The product is **Spine**; it ships as
 | Languages extracted | **9** front-ends | Python, Java, TypeScript, C#, C, C++, Go, PHP, SQL |
 | CLI commands | **56** | `grep -c '\.command(' src/orchestrator/cli/*.py`, summed |
 | Source modules | **353** | `find src/orchestrator -name '*.py'` |
-| Test functions | **3,051** across 314 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
+| Test functions | **3,070** across 316 files | `grep -rh '^def test_\|^async def test_' tests`; files via the same pattern with `-rl` |
 | Graph precision | **1.00** on every node and edge kind, all 9 front-ends | `orchestrator pkg accuracy` against a hand-labelled corpus |
 | `CALLS` recall | **1.00** (C, SQL) → **0.86** (TypeScript, on 14 labelled edges) · **0.50** (PHP, on 8 labelled edges — the misses are P3's typed-receiver rule and the global-namespace fallback, both predicted `known_gaps`, not surprises) | same |
 | Grounding effect, `create` tickets | **29/50 grounded, 0/50 ungrounded** | 200-run controlled A/B, 2 frontier models, 5 passes |

--- a/docs/specs/gap4-adoption-distribution-roadmap.md
+++ b/docs/specs/gap4-adoption-distribution-roadmap.md
@@ -162,6 +162,16 @@ pull-request title is **attacker-controlled**, and interpolating `${{ github.eve
 inside a `run:` block lets a title containing `$(…)` execute. It is passed through `env:` and
 quoted, and a test asserts no step interpolates event data into a shell.
 
+**✅ 5c shipped 2026-09-09 — the governed half, without 5b.** [`.github/workflows/spine-sdlc.yml`](../../.github/workflows/spine-sdlc.yml)
+is 5a's shape applied to the write path: a `plan` job that runs intake → investigate →
+validity → design from a hand-written spec with **no credentials**, and a `build` job bound to
+a GitHub Environment whose required reviewers *are* the plan gate, recorded with `sdlc approve`
+before `sdlc autorun` runs. Single repo, monorepo package, multi-repo workspace and
+submodules, each proved by a fixture CI builds from scratch. It hosts the single-ticket path
+only — the Temporal batch still needs 5b's dependencies — and it refuses the two delivery
+shapes the runner does not support rather than building at the wrong level. The design is in
+the workflow's own header.
+
 **5b remains unscheduled: build it only against a named operator who wants to self-host.**
 An image nobody has asked to run is a maintenance burden with a version number.
 

--- a/docs/specs/multi-repo-roadmap.md
+++ b/docs/specs/multi-repo-roadmap.md
@@ -517,6 +517,29 @@ the risk.
 Building delivery on an unmeasured join would be blast radius computed from a proposal again —
 verification-shaped, and fiction.
 
+## Submodules — a multi-repo laid out inside one checkout (2026-09-09)
+
+A superproject with submodules is this roadmap's case with the checkouts nested rather than
+side by side, and it exposed one gap. Per-repo identity already worked: `repo_state` runs
+`git -C <dir>`, so a submodule reports its own HEAD and its own clean/dirty state, and a
+pin that drifted makes the superproject dirty — which is the right answer. But **neither
+walker knew a submodule existed**: a submodule's `.git` is a file, the walkers pruned only
+ignored names and dot-prefixed directories, so the superproject's extraction descended into
+it. Declaring both in `repos.yaml` then double-counted every symbol under two ids
+(`py:lib@lib.core.helper` and `py:super@libs.lib.lib.core.helper`), and `from_mapping`'s
+overlap check — identical directories only — did not see nesting.
+
+The rule now: **a nested checkout is a boundary.** `is_nested_repo()` stops both walks at
+any child with a `.git` entry; `from_mapping` refuses a root nested inside another unless
+the inner one is a checkout of its own; `WorkspaceManager` clones with
+`--recurse-submodules` and populates submodules in every worktree. Declaration stays
+explicit — the superproject lists its submodules in `repos.yaml` like any sibling; nothing
+reads `.gitmodules`, by the same *declared, not guessed* rule as D1.
+
+Delivery into a submodule is the non-goal above with an order: a PR to the submodule's
+repository, then a pin bump here. The CI pipeline refuses it and says so — see the header of
+[`.github/workflows/spine-sdlc.yml`](../../.github/workflows/spine-sdlc.yml).
+
 ## Invariants
 
 > **The one idea underneath the first three.** Single-repo extraction has precision 1.00 and a

--- a/docs/specs/php-support-roadmap.md
+++ b/docs/specs/php-support-roadmap.md
@@ -288,5 +288,5 @@ corpus method is for. BookStack/WordPress remain the larger-scale sanity check b
 2. P2 corpus + CALLS → corpus 1.00 precision, CALLS recall pinned — ✅ done (recall 0.50, all misses predicted)
 3. P3 routes + typed receivers → PHP provider in the multi-repo joiner  — ✅ done
 4. P4 Eloquent/Doctrine entities                              — ✅ done
-5. (follow-on spec) codegen                                   — not started
+5. (follow-on) codegen                                        — planned outside the repo; validation target `synaptixs/aiemr`
 ```

--- a/scripts/sdlc_shapes.py
+++ b/scripts/sdlc_shapes.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Four repository shapes, one plan stage each — the SDLC pipeline's shape matrix.
+
+The reusable workflow (`.github/workflows/spine-sdlc.yml`) promises to work on a single
+repository, a monorepo package, a multi-repo workspace and a superproject with submodules.
+A promise nothing runs is the kind of number STATE-OF-SPINE warns about, so this builds all
+four shapes from scratch — real `git`, real commits, a real `submodule add` — and runs the
+same commands the workflow's `plan` job runs on each, asserting what that shape must hold:
+
+* every shape: `sdlc plan --spec` produces a build document, twice, **byte-identical** —
+  the determinism the plan job is trusted for;
+* multirepo and submodule: every declared root is a clean, populated checkout, the merged
+  graph is trusted, and `investigate --repos` writes the cross-repo brief;
+* multirepo: at least one edge leaves a repository (the `http` join the fixture is for);
+* submodule: the submodule's symbols exist **once**, under its own scope — the
+  double-count this shape used to produce (see `tests/pkg/test_nested_repos.py`).
+
+No model, no credentials, no network. ~1 minute on a laptop.
+
+    uv run python scripts/sdlc_shapes.py            # all four, in a temp dir
+    uv run python scripts/sdlc_shapes.py --keep DIR # build into DIR and leave it for reading
+    uv run python scripts/sdlc_shapes.py --shape submodule
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS_HTTP_JOIN = ROOT / "corpus" / "multirepo" / "http_join"
+
+SHAPES = ("single", "monorepo", "multirepo", "submodule")
+
+# One identity for every fixture commit, and the `file` transport that `submodule add` from a
+# local path needs (git disables it by default since 2.38.1). Set through git's environment
+# config so nothing here depends on the machine's global config.
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "shapes",
+    "GIT_AUTHOR_EMAIL": "shapes@example.com",
+    "GIT_COMMITTER_NAME": "shapes",
+    "GIT_COMMITTER_EMAIL": "shapes@example.com",
+    "GIT_CONFIG_COUNT": "1",
+    "GIT_CONFIG_KEY_0": "protocol.file.allow",
+    "GIT_CONFIG_VALUE_0": "always",
+}
+
+
+@dataclass(frozen=True)
+class Shape:
+    """One fixture: where the graph root is, what to plan, and what a merged graph would read."""
+
+    name: str
+    graph_root: Path
+    spec: Path
+    repos_file: Path | None = None
+
+
+class ShapeError(AssertionError):
+    """A shape did not hold what the pipeline promises for it."""
+
+
+# ---- helpers ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: Path) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=cwd, env={**os.environ, **_GIT_ENV}, capture_output=True, text=True, check=False
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} in {cwd} failed: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def _commit_all(repo: Path, message: str) -> None:
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-q", "-m", message, cwd=repo)
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", "-b", "main", cwd=path)
+    return path
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _spec(path: Path, intent: str, title: str, summary: str, criteria: list[str]) -> Path:
+    _write(
+        path,
+        json.dumps(
+            {"intent_id": intent, "title": title, "summary": summary, "acceptance_criteria": criteria},
+            indent=2,
+        )
+        + "\n",
+    )
+    return path
+
+
+def _orchestrator() -> list[str]:
+    exe = shutil.which("orchestrator")
+    if exe is None:
+        sys.exit("`orchestrator` is not on PATH — run through `uv run python scripts/sdlc_shapes.py`")
+    return [exe]
+
+
+def _run(*args: str, cwd: Path) -> str:
+    proc = subprocess.run([*_orchestrator(), *args], cwd=cwd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise ShapeError(f"orchestrator {' '.join(args)} exited {proc.returncode}:\n{proc.stderr.strip()}")
+    return proc.stdout
+
+
+# ---- the four shapes ---------------------------------------------------------------------
+
+
+def build_single(root: Path) -> Shape:
+    """One repository, one package at its root — the shape everything was written for."""
+    repo = _init_repo(root / "single")
+    _write(repo / "shop" / "__init__.py", "")
+    _write(repo / "shop" / "cart.py", "class Cart:\n    def total(self) -> int:\n        return 0\n")
+    _write(repo / "README.md", "# shop\n\nA cart.\n")
+    _commit_all(repo, "shop")
+    spec = _spec(
+        root / "single-spec.json",
+        "SINGLE-1",
+        "Add a discount to Cart.total",
+        "Cart.total should apply a percentage discount.",
+        ["Cart.total accepts an optional discount", "A discount of 0 leaves the total unchanged"],
+    )
+    return Shape("single", repo, spec)
+
+
+def build_monorepo(root: Path) -> Shape:
+    """One repository, two packages; the graph root is one package, not the repository."""
+    repo = _init_repo(root / "monorepo")
+    _write(repo / "packages" / "api" / "api" / "__init__.py", "")
+    _write(
+        repo / "packages" / "api" / "api" / "orders.py",
+        "def place_order(sku: str) -> dict[str, str]:\n    return {'sku': sku}\n",
+    )
+    _write(repo / "packages" / "web" / "web" / "__init__.py", "")
+    _write(repo / "packages" / "web" / "web" / "pages.py", "def home() -> str:\n    return 'home'\n")
+    _write(repo / "README.md", "# monorepo\n\nTwo packages.\n")
+    _commit_all(repo, "two packages")
+    spec = _spec(
+        root / "monorepo-spec.json",
+        "MONO-1",
+        "Validate the sku in place_order",
+        "place_order should reject an empty sku.",
+        ["place_order raises ValueError on an empty sku"],
+    )
+    return Shape("monorepo", repo / "packages" / "api", spec)
+
+
+def build_multirepo(root: Path) -> Shape:
+    """Two repositories side by side; the consumer declares the workspace in `.spine/repos.yaml`.
+
+    The sources are the accuracy corpus's `http_join` case — a consumer calling paths the
+    provider serves — so the join the multi-repo graph exists for has something to find.
+    """
+    ws = root / "multirepo"
+    web = _init_repo(ws / "web")
+    billing = _init_repo(ws / "billing")
+    shutil.copytree(CORPUS_HTTP_JOIN / ".web", web, dirs_exist_ok=True)
+    shutil.copytree(CORPUS_HTTP_JOIN / ".billing", billing, dirs_exist_ok=True)
+    _commit_all(billing, "billing")
+    # Relative paths resolve against the config's own directory (`.spine/`), so the repo
+    # holding the file is `..` and a sibling checkout is `../../<name>`.
+    _write(
+        web / ".spine" / "repos.yaml",
+        "repos:\n  web: ..\n  billing: ../../billing\n"
+        "joins:\n  - kind: http\n    consumer: web\n    provider: billing\n",
+    )
+    _commit_all(web, "web + workspace")
+    spec = _spec(
+        root / "multirepo-spec.json",
+        "MULTI-1",
+        "Retry fetch_order on a 503",
+        "web's fetch_order should retry once when billing answers 503.",
+        ["fetch_order retries exactly once on 503", "Other status codes are not retried"],
+    )
+    return Shape("multirepo", web, spec, repos_file=web / ".spine" / "repos.yaml")
+
+
+def build_submodule(root: Path) -> Shape:
+    """A superproject pinning a library as a submodule, both declared in `.spine/repos.yaml`."""
+    lib_remote = _init_repo(root / "submodule-remotes" / "lib")
+    _write(lib_remote / "lib" / "__init__.py", "")
+    _write(lib_remote / "lib" / "core.py", "def helper() -> int:\n    return 1\n")
+    _write(lib_remote / "README.md", "# lib\n\nThe library.\n")
+    _commit_all(lib_remote, "lib")
+
+    super_ = _init_repo(root / "submodule")
+    _write(super_ / "app" / "__init__.py", "")
+    _write(
+        super_ / "app" / "main.py",
+        "from lib.core import helper\n\n\ndef run() -> int:\n    return helper()\n",
+    )
+    _write(super_ / "README.md", "# super\n\nThe application.\n")
+    _commit_all(super_, "app")
+    _git("submodule", "add", "-q", str(lib_remote), "libs/lib", cwd=super_)
+    _write(super_ / ".spine" / "repos.yaml", "repos:\n  super: ..\n  lib: ../libs/lib\n")
+    _commit_all(super_, "pin lib + workspace")
+    spec = _spec(
+        root / "submodule-spec.json",
+        "SUB-1",
+        "Log when run falls back",
+        "run should log when helper returns a non-positive value.",
+        ["run logs at WARNING when helper returns 0 or less"],
+    )
+    return Shape("submodule", super_, spec, repos_file=super_ / ".spine" / "repos.yaml")
+
+
+BUILDERS = {
+    "single": build_single,
+    "monorepo": build_monorepo,
+    "multirepo": build_multirepo,
+    "submodule": build_submodule,
+}
+
+
+# ---- what each shape must hold -----------------------------------------------------------
+
+
+def check_plan_is_deterministic(shape: Shape, out: Path) -> Path:
+    """The plan job's whole claim: same commit in, same document out. Run it twice."""
+    docs: list[bytes] = []
+    for attempt in (out / "first", out / "second"):
+        _run(
+            "sdlc",
+            "plan",
+            "--spec",
+            str(shape.spec),
+            "--path",
+            str(shape.graph_root),
+            "--out",
+            str(attempt),
+            "--quiet",
+            cwd=shape.graph_root,
+        )
+        intent = json.loads(shape.spec.read_text(encoding="utf-8"))["intent_id"]
+        doc = attempt / f"{intent}-build.md"
+        if not doc.is_file():
+            raise ShapeError(f"{shape.name}: no build document at {doc}")
+        docs.append(doc.read_bytes())
+    if docs[0] != docs[1]:
+        raise ShapeError(f"{shape.name}: two plan runs on the same commit produced different documents")
+    if b"**Validity:**" not in docs[0]:
+        raise ShapeError(f"{shape.name}: the build document carries no validity verdict")
+    return out / "first"
+
+
+def check_declared_repos(shape: Shape) -> None:
+    """Every declared root is a populated, clean checkout — the workflow's pre-plan guard."""
+    from orchestrator.pkg.persistence import repo_state
+    from orchestrator.pkg.repos import load_repo_config
+
+    assert shape.repos_file is not None
+    for key, root in load_repo_config(shape.repos_file):
+        sha, dirty = repo_state(root)
+        if not sha or dirty or not any(root.iterdir()):
+            raise ShapeError(
+                f"{shape.name}: declared repo {key!r} at {root} is not a clean populated checkout"
+            )
+
+
+def check_merged_graph(shape: Shape, cache: Path) -> None:
+    """The merged graph is trusted, and holds what this shape exists to show."""
+    from orchestrator.pkg.persistence import load_or_extract_repos
+    from orchestrator.pkg.repos import load_repo_config
+
+    assert shape.repos_file is not None
+    merged = load_or_extract_repos(load_repo_config(shape.repos_file), cache_dir=cache)
+    if not merged.trusted:
+        raise ShapeError(f"{shape.name}: merged graph untrusted — {merged.untrusted_keys}")
+    if shape.name == "multirepo":
+        crossing = [
+            e for e in merged.batch.edges if e.src.startswith("py:web@") and e.dst.startswith("py:billing@")
+        ]
+        if not crossing:
+            raise ShapeError("multirepo: no edge leaves `web` for `billing` — the http join found nothing")
+    if shape.name == "submodule":
+        core = sorted(
+            n.id
+            for n in merged.batch.nodes
+            if n.provenance and n.provenance.file and n.provenance.file.endswith("core.py")
+        )
+        if core != ["py:lib@lib.core", "py:lib@lib.core.helper"]:
+            raise ShapeError(f"submodule: the submodule's symbols are not scoped exactly once: {core}")
+
+
+def check_cross_repo_brief(shape: Shape, out: Path) -> None:
+    """`investigate --repos` — the workflow's cross-repo step — writes a brief.
+
+    `investigate` takes a title and body, not a spec file; the workflow lifts them from the
+    spec the same way.
+    """
+    assert shape.repos_file is not None
+    brief = out / "brief-across-repos.md"
+    spec = json.loads(shape.spec.read_text(encoding="utf-8"))
+    _run(
+        "investigate",
+        ".",
+        "--title",
+        spec["title"],
+        "--text",
+        spec.get("summary", ""),
+        "--repos",
+        str(shape.repos_file),
+        "--out",
+        str(brief),
+        cwd=shape.graph_root,
+    )
+    if not brief.is_file() or not brief.read_text(encoding="utf-8").strip():
+        raise ShapeError(f"{shape.name}: investigate --repos wrote no brief")
+
+
+def run_shape(shape: Shape, work: Path) -> str:
+    out = work / f"{shape.name}-out"
+    out.mkdir(parents=True, exist_ok=True)
+    check_plan_is_deterministic(shape, out)
+    notes = ["plan deterministic"]
+    if shape.repos_file is not None:
+        check_declared_repos(shape)
+        check_merged_graph(shape, work / "cache")
+        check_cross_repo_brief(shape, out)
+        notes += ["declared repos clean", "merged graph trusted", "cross-repo brief"]
+    return ", ".join(notes)
+
+
+# ---- entry point -------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--shape", choices=SHAPES, action="append", help="Run only this shape (repeatable).")
+    parser.add_argument("--keep", type=Path, help="Build into this directory and leave it in place.")
+    args = parser.parse_args(argv)
+
+    if shutil.which("git") is None:
+        sys.exit("git is required")
+    chosen = tuple(args.shape) if args.shape else SHAPES
+    work = args.keep.resolve() if args.keep else Path(tempfile.mkdtemp(prefix="sdlc-shapes-"))
+    if args.keep:
+        work.mkdir(parents=True, exist_ok=True)
+
+    failures: list[str] = []
+    print(f"building {len(chosen)} shape(s) under {work}")
+    for name in chosen:
+        shape = BUILDERS[name](work)
+        try:
+            note = run_shape(shape, work)
+        except ShapeError as exc:
+            failures.append(name)
+            print(f"  {name:<10} FAIL  {exc}")
+        else:
+            print(f"  {name:<10} ok    {note}")
+
+    if not args.keep:
+        shutil.rmtree(work, ignore_errors=True)
+    if failures:
+        print(f"\n{len(failures)} shape(s) failed: {', '.join(failures)}")
+        return 1
+    print("\nall shapes hold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/orchestrator/pkg/doc_source.py
+++ b/src/orchestrator/pkg/doc_source.py
@@ -31,7 +31,7 @@ from html.parser import HTMLParser
 from pathlib import Path
 
 from orchestrator.pkg.docs import DocPage
-from orchestrator.pkg.extractor import DEFAULT_IGNORE_DIRS
+from orchestrator.pkg.extractor import DEFAULT_IGNORE_DIRS, is_nested_repo
 from orchestrator.pkg.media import MEDIA_SUFFIXES, read_media_artifact
 
 # Skip absurdly large docs (generated dumps, vendored changelogs) — keep the graph legible.
@@ -154,6 +154,7 @@ def read_doc_pages(root: Path | str, *, sections: bool = True) -> list[DocPage]:
     """Every documentation file under ``root`` as a ``DocPage`` (repo-relative title).
 
     Skips the usual ignored dirs (``.git``, ``node_modules``, build output, hidden dirs),
+    nested git checkouts (a submodule's docs are that repository's, not this one's),
     text files that can't be read as UTF-8 or exceed ``_MAX_DOC_BYTES``, and PDFs that are
     too large or yield no text. Deterministic order.
 
@@ -163,7 +164,12 @@ def read_doc_pages(root: Path | str, *, sections: bool = True) -> list[DocPage]:
     root_path = Path(root).resolve()
     pages: list[DocPage] = []
     for dirpath, dirnames, filenames in os.walk(root_path):
-        dirnames[:] = sorted(d for d in dirnames if d not in DEFAULT_IGNORE_DIRS and not d.startswith("."))
+        here = Path(dirpath)
+        dirnames[:] = sorted(
+            d
+            for d in dirnames
+            if d not in DEFAULT_IGNORE_DIRS and not d.startswith(".") and not is_nested_repo(here, d)
+        )
         for name in sorted(filenames):
             path = Path(dirpath) / name
             reader = _READERS.get(path.suffix.lower())

--- a/src/orchestrator/pkg/extractor.py
+++ b/src/orchestrator/pkg/extractor.py
@@ -596,6 +596,22 @@ def default_extractors(*, sql_dialect: str | None = None) -> list[LanguageExtrac
     return extractors
 
 
+def is_nested_repo(parent: Path, name: str) -> bool:
+    """``parent/name`` is another git checkout — a submodule, a worktree, a vendored clone.
+
+    A submodule's ``.git`` is a *file* (a pointer into the superproject's object store), so a
+    check for the directory alone would miss the common case. Either form marks a boundary.
+
+    Why the walkers stop here: a nested checkout has its own HEAD, its own clean/dirty state
+    and, in a multi-repo graph, its own scope key. Walking through it presents the inner
+    repo's symbols as the outer repo's — and if the inner one is *also* declared in
+    ``.spine/repos.yaml`` every symbol exists twice under two ids. Measured on a
+    superproject with one submodule: ``py:lib@lib.core.helper`` and
+    ``py:super@libs.lib.lib.core.helper`` in the same merged graph, nothing flagging it.
+    """
+    return (parent / name / ".git").exists()
+
+
 class RepoCodeExtractor:
     """Walk a repository → one merged ``FactBatch`` of grounded facts."""
 
@@ -690,15 +706,24 @@ class RepoCodeExtractor:
 
         ``doc_source`` has always sorted its walk for this reason; this is the same
         discipline for code.
+
+        The walk also stops at any nested git checkout (:func:`is_nested_repo`): a submodule
+        is another repository, not a subdirectory of this one.
         """
         for dirpath, dirnames, filenames in os.walk(root):
-            dirnames[:] = sorted(d for d in dirnames if d not in self._ignore_dirs and not d.startswith("."))
+            here = Path(dirpath)
+            dirnames[:] = sorted(
+                d
+                for d in dirnames
+                if d not in self._ignore_dirs and not d.startswith(".") and not is_nested_repo(here, d)
+            )
             for name in sorted(filenames):
                 yield Path(dirpath) / name
 
 
 __all__ = [
     "DEFAULT_IGNORE_DIRS",
+    "is_nested_repo",
     "LanguageExtractor",
     "PythonExtractor",
     "RepoCodeExtractor",

--- a/src/orchestrator/pkg/repos.py
+++ b/src/orchestrator/pkg/repos.py
@@ -176,6 +176,22 @@ def from_mapping(
         seen_paths[root] = key
         roots.append((key, root))
 
+    # A root inside another declared root is fine when the inner one is a git checkout of its
+    # own (a submodule, most often): the outer repo's walk stops at that boundary, so each
+    # file is scoped exactly once. A plain subdirectory has no boundary — the outer walk
+    # reaches every file the inner key also claims, and the merged graph carries every
+    # symbol twice under two ids. Refuse that at load, where the message can name the file.
+    for inner_key, inner in roots:
+        for outer_key, outer in roots:
+            if inner is outer or not inner.is_relative_to(outer):
+                continue
+            if not (inner / ".git").exists():
+                raise RepoConfigError(
+                    f"{where}: repo {inner_key!r} at {inner} is inside repo {outer_key!r} at {outer} "
+                    "but is not a git checkout of its own, so both keys would scope the same files "
+                    "— make it a submodule, or declare only one of them"
+                )
+
     declared = joins_from_list(joins, where=where)
     known = {key for key, _ in roots}
     for join in declared:

--- a/src/orchestrator/sdlc/workspace.py
+++ b/src/orchestrator/sdlc/workspace.py
@@ -134,7 +134,10 @@ class WorkspaceManager:
                 # against a private repo without an ambient credential helper.
                 # Falls back to the bare URL when no token is configured.
                 clone_url = await authenticate_repo_url(self._repo_url)
-                clone_args = ["clone"]
+                # A superproject's submodules come with it. Without this the worktree carries
+                # empty directories where a submodule should be, the test env cannot import
+                # it, and codegen asked to touch it writes into a folder git does not own.
+                clone_args = ["clone", "--recurse-submodules"]
                 if self._base_branch:
                     clone_args += ["--branch", self._base_branch]
                 clone_args += [clone_url or self._repo_url, str(self._base)]
@@ -179,8 +182,19 @@ class WorkspaceManager:
             await _run_git("fetch", "--quiet", "origin", cwd=self._base)
             branch = (await _run_git("rev-parse", "--abbrev-ref", "HEAD", cwd=self._base)).strip()
             await _run_git("reset", "--hard", f"origin/{branch}", cwd=self._base)
+            await self._populate_submodules(self._base)
         except WorkspaceError as exc:
             logger.warning("sdlc.workspace.base_refresh_failed", extra={"error": str(exc)[:200]})
+
+    async def _populate_submodules(self, tree: Path) -> None:
+        """Check out the submodules ``tree``'s pins point at, when it declares any.
+
+        ``git worktree add`` and ``git reset --hard`` move the superproject and leave every
+        submodule directory empty; only ``submodule update`` fills them. Guarded on
+        ``.gitmodules`` so a repository without submodules costs no extra git call.
+        """
+        if (tree / ".gitmodules").is_file():
+            await _run_git("submodule", "update", "--init", "--recursive", "--quiet", cwd=tree)
 
     async def _set_identity(self) -> None:
         """Pin a neutral commit identity on the base repo (worktrees inherit it)."""
@@ -198,6 +212,7 @@ class WorkspaceManager:
         path.parent.mkdir(parents=True, exist_ok=True)
         branch = f"feat/{sdlc_id}/{issue_key}"
         await _run_git("worktree", "add", "-b", branch, str(path), "HEAD", cwd=self._base)
+        await self._populate_submodules(path)
         return path
 
     async def cleanup(self, path: Path) -> None:

--- a/tests/pkg/test_nested_repos.py
+++ b/tests/pkg/test_nested_repos.py
@@ -1,0 +1,103 @@
+"""A nested git checkout is a boundary, not a subdirectory.
+
+A submodule (or a vendored clone, or a worktree) inside a repository has its own HEAD, its
+own clean/dirty state and, in a multi-repo graph, its own scope key. Before this rule both
+walkers descended into it, so the outer repo presented the inner repo's symbols as its own
+— and when both were declared in ``.spine/repos.yaml`` every symbol existed twice under two
+ids, with nothing to flag it. Measured on a superproject with one submodule:
+``py:lib@lib.core.helper`` and ``py:super@libs.lib.lib.core.helper`` in one merged graph.
+
+No real ``git`` here: the boundary marker is the ``.git`` entry, and a submodule's is a
+*file*, so the tests plant both forms by hand and never shell out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestrator.pkg.doc_source import read_doc_pages
+from orchestrator.pkg.extractor import RepoCodeExtractor, is_nested_repo
+from orchestrator.pkg.persistence import load_or_extract_repos
+from orchestrator.pkg.repos import RepoConfigError, from_mapping
+
+
+def _superproject(root: Path, *, git_marker: str = "file") -> Path:
+    """``root/`` with one module of its own and a nested checkout at ``libs/lib``.
+
+    ``git_marker`` picks how the inner checkout announces itself: ``"file"`` as a submodule
+    does (``.git`` is a pointer file), ``"dir"`` as a plain clone does.
+    """
+    (root / "app").mkdir(parents=True)
+    (root / "app" / "main.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+    (root / "README.md").write_text("# super\n\nOuter docs.\n", encoding="utf-8")
+    inner = root / "libs" / "lib"
+    (inner / "lib").mkdir(parents=True)
+    (inner / "lib" / "core.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    (inner / "README.md").write_text("# lib\n\nInner docs.\n", encoding="utf-8")
+    if git_marker == "file":
+        (inner / ".git").write_text("gitdir: ../../.git/modules/libs/lib\n", encoding="utf-8")
+    else:
+        (inner / ".git").mkdir()
+    return inner
+
+
+@pytest.mark.parametrize("marker", ["file", "dir"])
+def test_a_nested_checkout_is_recognised_by_either_git_marker(tmp_path: Path, marker: str) -> None:
+    _superproject(tmp_path, git_marker=marker)
+    assert is_nested_repo(tmp_path / "libs", "lib")
+    assert not is_nested_repo(tmp_path, "app")
+
+
+@pytest.mark.parametrize("marker", ["file", "dir"])
+def test_code_extraction_stops_at_a_nested_checkout(tmp_path: Path, marker: str) -> None:
+    _superproject(tmp_path, git_marker=marker)
+    batch = RepoCodeExtractor().extract(tmp_path)
+    files = {n.provenance.file for n in batch.nodes if n.provenance and n.provenance.file}
+    assert any(f.endswith("app/main.py") for f in files)
+    assert not any(f.endswith("core.py") for f in files), sorted(files)
+
+
+def test_a_plain_subdirectory_is_still_walked(tmp_path: Path) -> None:
+    """The boundary is the ``.git`` entry — a directory without one is part of this repo."""
+    inner = tmp_path / "libs" / "lib" / "lib"
+    inner.mkdir(parents=True)
+    (inner / "core.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    batch = RepoCodeExtractor().extract(tmp_path)
+    files = {n.provenance.file for n in batch.nodes if n.provenance and n.provenance.file}
+    assert any(f.endswith("core.py") for f in files)
+
+
+def test_doc_ingestion_stops_at_a_nested_checkout(tmp_path: Path) -> None:
+    _superproject(tmp_path)
+    titles = {p.source_file for p in read_doc_pages(tmp_path)}
+    assert "README.md" in titles
+    assert not any(t.startswith("libs/lib/") for t in titles), sorted(titles)
+
+
+def test_a_declared_root_inside_another_is_accepted_when_it_is_a_checkout(tmp_path: Path) -> None:
+    """A submodule declared beside its superproject: the outer walk stops at it, so no overlap."""
+    _superproject(tmp_path)
+    repo_set = from_mapping({"super": ".", "lib": "libs/lib"}, base=tmp_path)
+    assert [k for k, _ in repo_set] == ["lib", "super"]
+
+
+def test_a_declared_root_inside_another_is_refused_when_it_is_a_plain_directory(tmp_path: Path) -> None:
+    """No boundary means both keys scope the same files — refused at load, naming both."""
+    (tmp_path / "libs" / "lib").mkdir(parents=True)
+    with pytest.raises(RepoConfigError, match="'lib'.*inside repo 'super'.*not a git checkout"):
+        from_mapping({"super": ".", "lib": "libs/lib"}, base=tmp_path)
+
+
+def test_a_superproject_and_its_submodule_merge_without_a_double_count(tmp_path: Path) -> None:
+    """The measured failure: the same function under two scope keys. Now exactly one."""
+    _superproject(tmp_path)
+    repo_set = from_mapping({"super": ".", "lib": "libs/lib"}, base=tmp_path)
+    merged = load_or_extract_repos(repo_set, cache_dir=tmp_path / "cache")
+    core = sorted(
+        n.id
+        for n in merged.batch.nodes
+        if n.provenance and n.provenance.file and n.provenance.file.endswith("core.py")
+    )
+    assert core == ["py:lib@lib.core", "py:lib@lib.core.helper"]

--- a/tests/sdlc/test_workspace.py
+++ b/tests/sdlc/test_workspace.py
@@ -222,3 +222,46 @@ async def test_a_base_built_for_another_branch_is_not_reused(tmp_path: Path) -> 
         "sdlc2", "KEY-2"
     )
     assert (second / "marker.txt").read_text().strip() == "on-develop"
+
+
+async def _seed_superproject(tmp_path: Path) -> Path:
+    """A local ``super`` remote that pins a local ``lib`` remote as ``libs/lib``."""
+    lib = tmp_path / "lib-remote"
+    lib.mkdir()
+    await _run_git("init", cwd=lib)
+    await _run_git("config", "user.email", "seed@example.com", cwd=lib)
+    await _run_git("config", "user.name", "Seed", cwd=lib)
+    (lib / "core.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    await _run_git("add", "core.py", cwd=lib)
+    await _run_git("commit", "-m", "lib", cwd=lib)
+
+    super_ = tmp_path / "super-remote"
+    await _seed_remote(super_)
+    await _run_git("submodule", "add", str(lib), "libs/lib", cwd=super_)
+    await _run_git("commit", "-m", "pin lib", cwd=super_)
+    return super_
+
+
+async def test_a_superproject_worktree_carries_its_submodules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``git worktree add`` leaves every submodule directory empty; the manager fills them.
+
+    Without this the test env cannot import the submodule and codegen asked to touch it
+    writes into a folder git does not own. Local-path submodules need the ``file``
+    transport, which git disables by default — allowed here through git's environment
+    config so the code under test runs exactly as it does in production.
+    """
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "protocol.file.allow")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", "always")
+    origin = await _seed_superproject(tmp_path)
+
+    manager = WorkspaceManager(root=tmp_path / "ws", repo_url=str(origin))
+    path = await manager.create("s1", "ISSUE-1")
+
+    assert (path / "libs" / "lib" / "core.py").is_file()
+    # And it is a checkout of its own, pinned where the superproject says.
+    pinned = (await _run_git("rev-parse", "HEAD:libs/lib", cwd=path)).strip()
+    actual = (await _run_git("rev-parse", "HEAD", cwd=path / "libs" / "lib")).strip()
+    assert actual == pinned

--- a/tests/test_sdlc_reusable_workflow.py
+++ b/tests/test_sdlc_reusable_workflow.py
@@ -1,0 +1,147 @@
+"""The reusable SDLC workflow — the governed build path as a pipeline.
+
+Like `spine-comprehension.yml`, this file is a **published interface**: other repositories
+reference it by tag. These tests pin the properties that make it safe to hand to a stranger
+and honest about where a human decides. The design is in the workflow's own header.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github/workflows"
+WORKFLOW = WORKFLOWS / "spine-sdlc.yml"
+DOGFOOD = WORKFLOWS / "sdlc-dogfood.yml"
+
+
+def _load(path: Path = WORKFLOW) -> dict[Any, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def _triggers(data: dict[Any, Any]) -> dict[str, Any]:
+    """PyYAML reads a bare ``on:`` key as the boolean ``True`` — YAML 1.1, not a typo."""
+    triggers = data.get("on", data.get(True))
+    assert isinstance(triggers, dict), "no trigger block"
+    return triggers
+
+
+def _steps(job: str) -> list[dict[str, Any]]:
+    steps = _load()["jobs"][job]["steps"]
+    assert isinstance(steps, list) and steps, f"job {job!r} has no steps"
+    return [dict(step) for step in steps]
+
+
+def test_it_is_callable_by_another_repository() -> None:
+    assert "workflow_call" in _triggers(_load())
+
+
+def test_it_is_two_jobs_split_where_the_model_starts() -> None:
+    """`plan` is the deterministic half; `build` waits on it and on a human."""
+    jobs = _load()["jobs"]
+    assert set(jobs) == {"plan", "build"}
+    assert jobs["build"]["needs"] == "plan"
+
+
+def test_the_plan_job_needs_no_model_key() -> None:
+    """The plan job's promise: intake → investigate → validity → design with nothing spent.
+
+    It may read `CHECKOUT_TOKEN` to clone the sibling repositories a multi-repo graph declares,
+    and nothing else. A plan job that touched the model key would be one that could spend.
+    """
+    text = yaml.safe_dump(_load()["jobs"]["plan"])
+    assert "ANTHROPIC_API_KEY" not in text
+
+
+def test_no_secret_is_required() -> None:
+    """Plan-only callers pass nothing. The build job checks for its key at run time and says so."""
+    secrets = _triggers(_load())["workflow_call"]["secrets"]
+    assert secrets, "the build job needs a model key — it must be declarable"
+    assert all(spec.get("required") is False for spec in secrets.values()), secrets
+
+
+def test_the_human_gate_is_a_github_environment() -> None:
+    """Required reviewers on the environment are the plan gate; the job records their decision.
+
+    The environment name is an input so a caller can bind the job to its own reviewers, and
+    the approval is written with `sdlc approve` so `sdlc autorun --plan-gate` — the default —
+    has something to check rather than being switched off.
+    """
+    build = _load()["jobs"]["build"]
+    assert build["environment"] == "${{ inputs.environment }}"
+    scripts = "\n".join(step.get("run") or "" for step in build["steps"])
+    assert "sdlc approve" in scripts
+    assert "--no-plan-gate" not in scripts, (
+        "the gate must not be bypassed by the job that exists to honour it"
+    )
+
+
+def test_permissions_are_least_privilege_per_job() -> None:
+    data = _load()
+    assert data["permissions"] == {"contents": "read"}
+    assert data["jobs"]["plan"]["permissions"] == {"contents": "read"}
+    assert data["jobs"]["build"]["permissions"] == {"contents": "write", "pull-requests": "write"}
+
+
+def test_no_expression_reaches_a_shell_inline() -> None:
+    """Script injection, the failure mode of reusable workflows generally.
+
+    Inputs and event data are caller- or attacker-controlled. Every value a `run:` block needs
+    is passed through `env:` and quoted, so nothing GitHub substitutes before `bash` sees it
+    can execute. Stricter than the comprehension workflow's rule (no `github.event`): here no
+    `${{` at all inside a script, because `inputs.spec` is as attacker-shaped as a PR title.
+    """
+    for job in ("plan", "build"):
+        for step in _steps(job):
+            script = step.get("run") or ""
+            assert "${{" not in script, (
+                f"{job}: step {step.get('name')!r} interpolates an expression into a shell block; "
+                "pass it via env: and quote the variable"
+            )
+
+
+def test_delivery_is_refused_where_the_pipeline_would_build_at_the_wrong_level() -> None:
+    """Delivery into a subdirectory is unsupported (single package root); refuse, do not scaffold.
+
+    The refusal is the build job's first step, before a checkout or an install, so the human
+    who approved the environment is told immediately rather than after a model ran.
+    """
+    first = _steps("build")[0]
+    script = first.get("run") or ""
+    assert "TARGET_DIR" in script and "exit 1" in script
+    assert "sdlc-target-layout-scaffold" in script, (
+        "the refusal must point at the design record that explains it"
+    )
+
+
+def test_submodules_are_checked_out_in_both_jobs() -> None:
+    """A superproject's submodules are part of what is read and what is built."""
+    for job in ("plan", "build"):
+        checkouts = [s for s in _steps(job) if str(s.get("uses", "")).startswith("actions/checkout")]
+        assert checkouts, f"{job}: no checkout"
+        assert all(c["with"].get("submodules") == "recursive" for c in checkouts), job
+
+
+def test_the_multi_repo_guard_runs_before_anything_reads_the_graph() -> None:
+    """An un-initialised submodule is an empty directory that loads without error."""
+    names = [s.get("name") or s.get("uses") for s in _steps("plan")]
+    guard = next(i for i, n in enumerate(names) if "Verify every declared repository" in str(n))
+    brief = next(i for i, n in enumerate(names) if "across repositories" in str(n))
+    plan = next(i for i, n in enumerate(names) if "Build document" in str(n))
+    assert guard < brief < plan, names
+
+
+def test_this_repository_runs_the_workflow_on_its_own_checkout() -> None:
+    """A workflow nothing runs is a claim nobody re-checks. Dogfood uses the local file."""
+    data = _load(DOGFOOD)
+    job = data["jobs"]["spine"]
+    assert job["uses"] == "./.github/workflows/spine-sdlc.yml"
+    assert job["with"]["install-from"].startswith("./repo"), (
+        "must install the checkout under test, not a release"
+    )
+    assert "pull_request" in _triggers(data)
+    assert "workflow_dispatch" in _triggers(data)


### PR DESCRIPTION
## What

- **`.github/workflows/spine-sdlc.yml`** — a reusable (`workflow_call`) SDLC pipeline. `plan` runs intake → investigate → validity → design from a hand-written spec with no credentials and publishes the build document. `build` is bound to a GitHub Environment (`spine-build` by default): its required reviewers are the plan gate, the job records their decision with `sdlc approve`, then runs `sdlc autorun` with the plan gate on, `--safe` unless `live: true`.
- **Three locations named separately** — `path` (graph root), `target-dir`, and the git repo — so single repo, monorepo package, multi-repo workspace (committed `.spine/repos.yaml` + `checkouts` input, option A) and submodules all plan. Delivery into a subdirectory or a submodule is refused before a model runs.
- **Nested checkouts are a walker boundary.** Measured: a superproject's extraction walked into its submodule and a `repos.yaml` declaring both double-counted every symbol under two ids. `is_nested_repo()` stops both walkers at any child holding a `.git` entry (file or dir); `from_mapping` refuses nested roots that are not checkouts of their own; `WorkspaceManager` clones with `--recurse-submodules` and populates submodules in every worktree.
- **`scripts/sdlc_shapes.py`** builds all four shapes with real git and runs the plan stage on each (deterministic, merged graph trusted, submodule symbols scoped once). Runs in `ci.yml`.
- **`sdlc-dogfood.yml`** runs the reusable workflow on this checkout: plan-only on PRs touching it, the gated build on dispatch.

## Gate

`mypy src tests`, ruff check/format, full pytest (3498 passed, 3 skipped), `pkg verify`, `pkg accuracy --check`, `understand .`, matrix count, state numbers, all four shapes — green locally.

## Before the first live run

- Create the `spine-build` environment with required reviewers and add `ANTHROPIC_API_KEY`.
- The approver lookup uses the run approvals API with a fallback to the actor; verify on the first gated run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
