### PR TITLE
docs(contributing): branch from develop, open the PR against develop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,8 @@ the repository keeps the two reference documents and the script, which need no a
 
 ## Opening a pull request
 
-1. Fork the repo and create a branch from `main` (e.g. `fix/email-validator-edge-case`).
+1. Fork the repo and create a branch from **`develop`** (e.g. `fix/email-validator-edge-case`).
+   `main` only moves through a release promotion, so a branch cut from it is already behind.
 2. Make your change with tests; keep it focused — one concern per PR.
 3. Make sure the quality gate is green locally — note `mypy src tests`, **not** just `src`;
    typing `src` alone passes here and fails CI:
@@ -112,7 +113,8 @@ the repository keeps the two reference documents and the script, which need no a
    working rather than a contributor carrying the artifact, so the check skips when the base
    is `main`. Since 3.20.0 that promotion is the **only** way `main`'s bank moves:
    regeneration runs on `develop` alone, and `main` inherits it verbatim.
-4. Open the PR with a clear description of **what** and **why**, linking any issue.
+4. Open the PR **against `develop`** — GitHub pre-selects `main`, the default branch; change
+   it — with a clear description of **what** and **why**, linking any issue.
 5. A maintainer reviews; the `security scan` check must pass.
 
 ### When a check fails on something you didn't change


### PR DESCRIPTION
## What & why

CONTRIBUTING said to create a branch from `main` (step 1) while the same document reviews every change on a PR into `develop`. `develop` is ahead of `main` between releases, so a branch cut from `main` carries a stale `episteme/` and misses everything since the last cut. GitHub also pre-selects `main` as the PR base because it is the default branch, so step 4 now names the target explicitly.

Two lines changed, no code.

## How it was tested

Read-through; no gate applies to a Markdown-only change beyond the docs audit, which is unaffected.

## Checklist
- [x] Quality gate green locally — n/a, docs only
- [x] Tests added/updated where it matters — n/a
- [x] No secrets committed
- [x] Docs updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)